### PR TITLE
feat(agents): self-hosted sandbox runtime + MCP tunnels prep + run_started webhook

### DIFF
--- a/src/sandcastle/api/agent_webhooks.py
+++ b/src/sandcastle/api/agent_webhooks.py
@@ -40,6 +40,7 @@ SUPPORTED_EVENTS: tuple[str, ...] = (
     "session.status_idle",
     "session.status_running",
     "session.status_rescheduled",
+    "session.status_run_started",  # self-hosted-sandbox May 19 2026 addition
     "session.status_terminated",
     "session.error",
     "vault.credential_refreshed",

--- a/src/sandcastle/engine/mcp_tunnel.py
+++ b/src/sandcastle/engine/mcp_tunnel.py
@@ -1,0 +1,306 @@
+"""Anthropic MCP tunnels connector for Sandcastle.
+
+Wraps Anthropic's May 19, 2026 "MCP tunnels" research preview that lets
+agents reach Model Context Protocol servers on private networks without
+exposing those servers to the public internet.
+
+Spec:
+- https://claude.com/blog/claude-managed-agents-updates
+- https://platform.claude.com/docs/en/agents-and-tools/mcp-tunnels/overview
+
+Architecture: cloudflared sidecar talks outbound-only to an Anthropic-
+operated proxy. Three TLS layers: outer mTLS + IP allowlist between
+cloudflared and the proxy, inner TLS between the proxy and the MCP
+server, and upstream OAuth on each MCP server. Sandcastle's role here is
+to assemble the ``mcp_servers`` block that goes into a Messages API
+request when a workflow needs to call into a private network.
+
+This module is GATED. The feature requires an Anthropic access request
+(https://claude.com/form/claude-managed-agents). We ship the config +
+client code so deployments are ready the day access is granted, but the
+runtime path raises ``MCPTunnelGatedError`` unless ``SANDCASTLE_MCP_
+TUNNELS_ENABLED=1`` is set explicitly.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# Different beta header from the main managed-agents one. Anthropic
+# routes MCP-related Messages API features under the existing
+# mcp-client-* family.
+MCP_TUNNEL_BETA_HEADER = "mcp-client-2025-11-20"
+
+_ENABLE_FLAG = "SANDCASTLE_MCP_TUNNELS_ENABLED"
+
+
+# ---------------------------------------------------------------------------
+# Auth modes
+# ---------------------------------------------------------------------------
+
+
+class TunnelAuthMode(str, Enum):
+    """How cloudflared authenticates against the Anthropic proxy.
+
+    WIF (recommended): use Workload Identity Federation, no long-lived
+    secrets. Requires ``org:manage_tunnels`` scope on the federated
+    token.
+
+    MANUAL: ship a tunnel-token file + customer-managed CA cert. Higher
+    operational burden, no IdP dependency.
+    """
+
+    WIF = "workload_identity_federation"
+    MANUAL = "manual_cert"
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class MCPTunnelError(Exception):
+    """Base class for MCP tunnel errors."""
+
+
+class MCPTunnelGatedError(MCPTunnelError):
+    """Feature is gated and the access flag is not enabled.
+
+    The MCP tunnels preview requires a signed Anthropic access form. We
+    refuse to issue requests with the feature beta header until the
+    operator opts in by setting SANDCASTLE_MCP_TUNNELS_ENABLED=1.
+    """
+
+
+class MCPTunnelConfigError(MCPTunnelError):
+    """Tunnel config is invalid (bad auth combo, missing fields, ...)."""
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MCPTunnelServer:
+    """One MCP server reachable through the tunnel.
+
+    The ``hostname`` is the Anthropic-assigned subdomain
+    (``<subdomain>.<your-tunnel-domain>``). ``auth_token_env`` names the
+    env var holding the upstream OAuth bearer; we never accept the token
+    inline so it stays out of YAML and git.
+    """
+
+    name: str
+    hostname: str
+    auth_token_env: str = ""
+    # Tools to expose. Empty list = all tools the MCP server advertises.
+    allowed_tools: list[str] = field(default_factory=list)
+
+
+@dataclass
+class MCPTunnelConfig:
+    """Tunnel configuration.
+
+    Attached to a workflow via:
+
+    .. code-block:: yaml
+
+        mcp_tunnel:
+          tunnel_id: tunnel_abc123
+          auth_mode: workload_identity_federation
+          servers:
+            - name: internal-jira
+              hostname: jira.acme-tunnel.anthropic.cloud
+              auth_token_env: ACME_JIRA_BEARER
+    """
+
+    tunnel_id: str
+    auth_mode: TunnelAuthMode = TunnelAuthMode.WIF
+    servers: list[MCPTunnelServer] = field(default_factory=list)
+    # Path to the cloudflared binary on the host. Override only when the
+    # binary is not on PATH.
+    cloudflared_path: str = "cloudflared"
+    # Manual-mode only: path to the tunnel token file + customer CA cert.
+    tunnel_token_file: str | None = None
+    ca_cert_file: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def validate_tunnel_config(config: MCPTunnelConfig) -> None:
+    """Cheap, schema-only validation of a parsed tunnel config.
+
+    Catches the common foot-guns (manual mode without cert, no servers,
+    bad hostname shape) before the runtime tries to spawn cloudflared.
+    """
+    if not config.tunnel_id:
+        raise MCPTunnelConfigError("tunnel_id must not be empty")
+
+    if not config.servers:
+        raise MCPTunnelConfigError(
+            "mcp_tunnel.servers must list at least one server entry"
+        )
+
+    if config.auth_mode is TunnelAuthMode.MANUAL:
+        if not config.tunnel_token_file or not config.ca_cert_file:
+            raise MCPTunnelConfigError(
+                "manual_cert auth mode requires both tunnel_token_file and "
+                "ca_cert_file. Use workload_identity_federation when you can; "
+                "it has fewer moving parts and no long-lived secrets."
+            )
+
+    seen_names: set[str] = set()
+    for srv in config.servers:
+        if not srv.name:
+            raise MCPTunnelConfigError("each server entry needs a name")
+        if srv.name in seen_names:
+            raise MCPTunnelConfigError(
+                f"duplicate server name {srv.name!r}"
+            )
+        seen_names.add(srv.name)
+        if not srv.hostname or "." not in srv.hostname:
+            raise MCPTunnelConfigError(
+                f"server {srv.name!r}: hostname must be a fully qualified "
+                f"domain like '<subdomain>.<your-tunnel-domain>'"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Gating helpers
+# ---------------------------------------------------------------------------
+
+
+def is_enabled(env: dict[str, str] | None = None) -> bool:
+    """Return True iff the operator has explicitly enabled the preview."""
+    env = env if env is not None else os.environ
+    return env.get(_ENABLE_FLAG, "").lower() in ("1", "true", "yes", "on")
+
+
+def assert_enabled(env: dict[str, str] | None = None) -> None:
+    """Raise if the preview gate is closed.
+
+    Use at every runtime entry point that issues the tunnel beta header.
+    """
+    if not is_enabled(env):
+        raise MCPTunnelGatedError(
+            "MCP tunnels are a gated Anthropic research preview. To enable "
+            f"in Sandcastle, set {_ENABLE_FLAG}=1 after you receive access "
+            "from https://claude.com/form/claude-managed-agents."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Messages API payload helper
+# ---------------------------------------------------------------------------
+
+
+def build_mcp_servers_block(
+    config: MCPTunnelConfig,
+    *,
+    env: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Produce the ``mcp_servers`` array Anthropic's Messages API expects.
+
+    Resolves each ``auth_token_env`` against the current environment. We
+    never emit the bearer value into the returned dict if the env var is
+    unset - the upstream API will return 401 in that case, which is the
+    behaviour callers want (versus emitting an empty Bearer header).
+    """
+    env = env if env is not None else os.environ
+    blocks: list[dict[str, Any]] = []
+    for srv in config.servers:
+        block: dict[str, Any] = {
+            "name": srv.name,
+            "type": "url",
+            "url": f"https://{srv.hostname}",
+        }
+        if srv.auth_token_env:
+            token = env.get(srv.auth_token_env, "")
+            if token:
+                block["authorization_token"] = token
+            else:
+                logger.warning(
+                    "mcp_tunnel: server %s declared auth_token_env=%s but "
+                    "the env var is empty; upstream call will likely 401",
+                    srv.name,
+                    srv.auth_token_env,
+                )
+        if srv.allowed_tools:
+            block["tool_configuration"] = {
+                "enabled": True,
+                "allowed_tools": list(srv.allowed_tools),
+            }
+        blocks.append(block)
+    return blocks
+
+
+def build_request_headers(api_key: str) -> dict[str, str]:
+    """Header set for a Messages API request that uses MCP tunnels.
+
+    Distinct from the main ``managed-agents-2026-04-01`` beta - tunnels
+    ride the existing ``mcp-client`` beta family.
+    """
+    return {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+        "anthropic-beta": MCP_TUNNEL_BETA_HEADER,
+        "content-type": "application/json",
+    }
+
+
+# ---------------------------------------------------------------------------
+# cloudflared command builder (the sidecar runner)
+# ---------------------------------------------------------------------------
+
+
+def build_cloudflared_args(config: MCPTunnelConfig) -> list[str]:
+    """Construct argv for the cloudflared subprocess that serves the tunnel.
+
+    Splits by auth mode. We only assemble the argv here; spawning is
+    deferred to a thin runner that the Helm/Compose deployments already
+    expect. Keeps this module pure-functional and trivially testable.
+    """
+    args = [config.cloudflared_path, "tunnel", "run"]
+    if config.auth_mode is TunnelAuthMode.WIF:
+        args += ["--protocol", "http2", "--auth", "wif"]
+    else:
+        if not config.tunnel_token_file or not config.ca_cert_file:
+            raise MCPTunnelConfigError(
+                "manual_cert mode missing token/cert files"
+            )
+        args += [
+            "--token-file",
+            config.tunnel_token_file,
+            "--origin-ca-pool",
+            config.ca_cert_file,
+        ]
+    args.append(config.tunnel_id)
+    return args
+
+
+__all__ = [
+    "MCP_TUNNEL_BETA_HEADER",
+    "MCPTunnelConfig",
+    "MCPTunnelConfigError",
+    "MCPTunnelError",
+    "MCPTunnelGatedError",
+    "MCPTunnelServer",
+    "TunnelAuthMode",
+    "assert_enabled",
+    "build_cloudflared_args",
+    "build_mcp_servers_block",
+    "build_request_headers",
+    "is_enabled",
+    "validate_tunnel_config",
+]

--- a/src/sandcastle/engine/self_hosted_sandbox.py
+++ b/src/sandcastle/engine/self_hosted_sandbox.py
@@ -1,0 +1,273 @@
+"""Anthropic self-hosted sandbox runtime for Sandcastle.
+
+Wraps Anthropic's May 19, 2026 Managed Agents self-hosted sandbox feature.
+Lets a managed-agent session execute its tool calls inside customer
+infrastructure (Cloudflare microVMs, Daytona, Modal, Vercel, or a plain
+Docker host) instead of Anthropic's hosted sandbox pool.
+
+Spec:
+- https://claude.com/blog/claude-managed-agents-updates
+- https://platform.claude.com/docs/en/managed-agents/self-hosted-sandboxes
+
+Uses the same ``managed-agents-2026-04-01`` beta header that Sandcastle
+already sends; the new bit is the ``environment`` block on session
+creation and a poller worker that claims work items from
+``/v1/environments/{id}/work``.
+
+Key safety contracts enforced here, NOT delegated to the SDK:
+
+1. ``ANTHROPIC_API_KEY`` must NOT be present on the worker host. Tool
+   calls can read env vars, so an org-scoped credential would leak. Only
+   the environment-scoped key (``sk-ant-oat01-...``) is allowed.
+2. Memory Stores are NOT supported with self-hosted sandboxes
+   (explicitly disclaimed by Anthropic). Sandcastle hard-errors when a
+   workflow combines both rather than silently dropping memory writes.
+3. Claude Platform on AWS does not support self-hosted sandboxes. We
+   warn (not error) when ``ANTHROPIC_REGION`` looks AWS-bound.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Provider enum
+# ---------------------------------------------------------------------------
+
+
+class SandboxProvider(str, Enum):
+    """Supported self-hosted sandbox providers.
+
+    These map 1:1 to the cookbooks Anthropic ships at
+    https://github.com/anthropics/claude-cookbooks/tree/main/managed_agents/self_hosted_sandboxes.
+    """
+
+    CLOUDFLARE = "cloudflare"  # microVMs + isolates, zero-trust secrets
+    DAYTONA = "daytona"  # long-running stateful + SSH
+    MODAL = "modal"  # sub-second startup + GPU on demand
+    VERCEL = "vercel"  # VPC peering + ms startup
+    DOCKER = "docker"  # local Docker (development / on-prem)
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class SelfHostedSandboxError(Exception):
+    """Base class for all self-hosted sandbox errors."""
+
+
+class OrgKeyLeakError(SelfHostedSandboxError):
+    """Worker host has ANTHROPIC_API_KEY set; refuse to start.
+
+    Anthropic's own guidance: setting ANTHROPIC_API_KEY on the worker
+    host exposes an org-scoped credential to agent tool calls. We refuse
+    to start the worker process unless that key is absent.
+    """
+
+
+class MemoryStoresIncompatibleError(SelfHostedSandboxError):
+    """Workflow combines memory_stores + self_hosted runtime.
+
+    Anthropic disclaims this combination; the session-create call
+    silently drops memory operations rather than erroring, which is
+    worse for users. Sandcastle hard-errors at config-parse time.
+    """
+
+
+class EnvironmentKeyFormatError(SelfHostedSandboxError):
+    """Environment key does not match the sk-ant-oat01-* prefix."""
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+# Anthropic environment keys carry this prefix. Validating the prefix
+# at config-load time catches "user pasted their org key by mistake"
+# before that key ends up in a remote worker process.
+_ENV_KEY_PREFIX = "sk-ant-oat01-"
+
+
+@dataclass
+class SelfHostedSandboxConfig:
+    """Per-workflow self-hosted sandbox configuration.
+
+    Attached to a managed-agent step via:
+
+    .. code-block:: yaml
+
+        - id: heavy-research
+          type: managed-agent
+          managed_agent_config:
+            agent_template: researcher
+            self_hosted_sandbox:
+              environment_id: env_abc123
+              environment_key_env: SANDCASTLE_ENV_KEY_PRIMARY
+              provider: cloudflare
+    """
+
+    environment_id: str
+    # Name of the env var holding the environment key. We never accept
+    # the key inline in YAML to keep secrets out of workflow text +
+    # git history.
+    environment_key_env: str = "ANTHROPIC_ENVIRONMENT_KEY"
+    provider: SandboxProvider = SandboxProvider.DOCKER
+    # Free-form metadata Anthropic stores on the session. Workers can
+    # filter on it during ``work.list``.
+    metadata: dict[str, Any] = field(default_factory=dict)
+    # Soft cap on concurrent work items the worker fleet will claim.
+    # Used by autoscaling decisions, not enforced server-side.
+    max_concurrent_sessions: int = 8
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers (used by config-parse + runtime startup)
+# ---------------------------------------------------------------------------
+
+
+def assert_org_key_not_set(
+    env: dict[str, str] | None = None, *, raise_on_violation: bool = True
+) -> None:
+    """Refuse to run if the worker process has an org-scoped Anthropic key.
+
+    Reads from the current process environment by default. Pass an
+    explicit dict to make this testable.
+    """
+    env = env if env is not None else os.environ
+    if "ANTHROPIC_API_KEY" in env and env["ANTHROPIC_API_KEY"]:
+        msg = (
+            "ANTHROPIC_API_KEY is set in the worker environment. Self-hosted "
+            "sandbox workers MUST use the environment-scoped key "
+            "(sk-ant-oat01-...) instead - the org key would be exposed to "
+            "every tool call executed inside the sandbox. Remove "
+            "ANTHROPIC_API_KEY from the worker host and set "
+            "ANTHROPIC_ENVIRONMENT_KEY (or the custom name in your "
+            "SelfHostedSandboxConfig.environment_key_env)."
+        )
+        if raise_on_violation:
+            raise OrgKeyLeakError(msg)
+        logger.warning(msg)
+
+
+def assert_memory_compatible(
+    sandbox_config: SelfHostedSandboxConfig | None,
+    memory_stores: list[str] | None,
+) -> None:
+    """Reject the memory_stores + self_hosted combination.
+
+    Both args come straight from the parsed ManagedAgentConfig, so this
+    is a single-call assertion at session-create time.
+    """
+    if sandbox_config is None:
+        return
+    if memory_stores:
+        raise MemoryStoresIncompatibleError(
+            "Memory Stores are not supported with self-hosted sandboxes "
+            "(Anthropic explicitly disclaims this combination). Drop the "
+            "memory_stores field, or move this step to the default hosted "
+            "runtime. See "
+            "https://platform.claude.com/docs/en/managed-agents/"
+            "self-hosted-sandboxes#limitations"
+        )
+
+
+def assert_env_key_format(env_key: str) -> None:
+    """Validate the environment key string shape.
+
+    Catches the very common "I pasted the org key by mistake" error
+    before the key reaches a remote worker. Anthropic does not document
+    the env-key prefix as load-bearing, but it's stable enough to use as
+    a guardrail.
+    """
+    if not env_key or not env_key.startswith(_ENV_KEY_PREFIX):
+        raise EnvironmentKeyFormatError(
+            f"Environment key must start with {_ENV_KEY_PREFIX!r}. Got a "
+            "key with a different prefix; this is most likely an "
+            "ANTHROPIC_API_KEY (sk-ant-...) pasted into the wrong slot."
+        )
+
+
+def warn_on_aws_region(
+    env: dict[str, str] | None = None,
+) -> str | None:
+    """Emit a warning if the worker looks AWS-bound.
+
+    Returns the offending region string for surfacing in test output;
+    returns None when clean.
+    """
+    env = env if env is not None else os.environ
+    region = env.get("ANTHROPIC_REGION") or env.get("AWS_REGION")
+    if region and ("aws" in region.lower() or region.startswith("us-")):
+        msg = (
+            f"ANTHROPIC_REGION/AWS_REGION={region!r} looks AWS-bound. "
+            "Self-hosted sandboxes are NOT supported on Claude Platform "
+            "on AWS yet. The session will likely fail. Confirm you are "
+            "running against the standard Anthropic endpoint, not AWS "
+            "Bedrock or AWS Claude Platform."
+        )
+        logger.warning(msg)
+        return region
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Session-create payload helper
+# ---------------------------------------------------------------------------
+
+
+def build_environment_block(config: SelfHostedSandboxConfig) -> dict[str, Any]:
+    """Return the ``environment`` block to merge into a session-create body.
+
+    Anthropic spec:
+
+    .. code-block:: json
+
+        {
+          "environment_id": "env_abc123",
+          "metadata": {"provider": "cloudflare", "..."}
+        }
+    """
+    block: dict[str, Any] = {"environment_id": config.environment_id}
+    metadata = {"provider": config.provider.value, **config.metadata}
+    block["metadata"] = metadata
+    return block
+
+
+# ---------------------------------------------------------------------------
+# Public surface for runtime dispatch
+# ---------------------------------------------------------------------------
+
+
+def prepare_session_payload(
+    base_payload: dict[str, Any],
+    sandbox_config: SelfHostedSandboxConfig,
+    memory_stores: list[str] | None = None,
+) -> dict[str, Any]:
+    """Validate + augment a managed-agent session-create payload.
+
+    Single entry point that combines:
+      * org-key leak guard (process env)
+      * memory_stores incompatibility check
+      * AWS region warning
+      * environment block injection
+
+    Callers should run this on the payload they would otherwise post to
+    ``/v1/sessions`` and forward the returned dict unchanged.
+    """
+    assert_org_key_not_set()
+    assert_memory_compatible(sandbox_config, memory_stores)
+    warn_on_aws_region()
+
+    out = dict(base_payload)
+    out["environment"] = build_environment_block(sandbox_config)
+    return out

--- a/tests/test_mcp_tunnel.py
+++ b/tests/test_mcp_tunnel.py
@@ -1,0 +1,257 @@
+"""Tests for the MCP tunnels connector (v0.33 prep, gated)."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from sandcastle.engine.mcp_tunnel import (
+    MCP_TUNNEL_BETA_HEADER,
+    MCPTunnelConfig,
+    MCPTunnelConfigError,
+    MCPTunnelGatedError,
+    MCPTunnelServer,
+    TunnelAuthMode,
+    assert_enabled,
+    build_cloudflared_args,
+    build_mcp_servers_block,
+    build_request_headers,
+    is_enabled,
+    validate_tunnel_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_beta_header_is_mcp_client_family():
+    # Distinct from managed-agents-2026-04-01 - tunnels ride the
+    # existing mcp-client beta header per Anthropic spec.
+    assert MCP_TUNNEL_BETA_HEADER == "mcp-client-2025-11-20"
+
+
+def test_request_headers_contain_beta():
+    h = build_request_headers("sk-ant-api03-xxx")
+    assert h["anthropic-beta"] == MCP_TUNNEL_BETA_HEADER
+    assert h["x-api-key"] == "sk-ant-api03-xxx"
+    assert h["content-type"] == "application/json"
+
+
+# ---------------------------------------------------------------------------
+# Gating
+# ---------------------------------------------------------------------------
+
+
+class TestGating:
+    def test_enabled_truthy_values(self):
+        for v in ("1", "true", "TRUE", "yes", "Yes", "on"):
+            assert is_enabled({"SANDCASTLE_MCP_TUNNELS_ENABLED": v}) is True
+
+    def test_disabled_by_default(self):
+        assert is_enabled({}) is False
+
+    def test_unrecognised_value_is_falsy(self):
+        assert is_enabled({"SANDCASTLE_MCP_TUNNELS_ENABLED": "maybe"}) is False
+
+    def test_assert_enabled_raises_when_off(self):
+        with pytest.raises(MCPTunnelGatedError) as exc:
+            assert_enabled({})
+        assert "claude.com/form/claude-managed-agents" in str(exc.value)
+
+    def test_assert_enabled_passes_when_on(self):
+        assert_enabled({"SANDCASTLE_MCP_TUNNELS_ENABLED": "1"})
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_valid_wif_config_passes(self):
+        cfg = MCPTunnelConfig(
+            tunnel_id="tunnel_abc",
+            auth_mode=TunnelAuthMode.WIF,
+            servers=[
+                MCPTunnelServer(
+                    name="jira",
+                    hostname="jira.acme-tunnel.anthropic.cloud",
+                )
+            ],
+        )
+        validate_tunnel_config(cfg)  # Must not raise.
+
+    def test_empty_tunnel_id_rejected(self):
+        cfg = MCPTunnelConfig(
+            tunnel_id="",
+            servers=[MCPTunnelServer(name="x", hostname="x.example.com")],
+        )
+        with pytest.raises(MCPTunnelConfigError, match="tunnel_id"):
+            validate_tunnel_config(cfg)
+
+    def test_no_servers_rejected(self):
+        with pytest.raises(MCPTunnelConfigError, match="at least one server"):
+            validate_tunnel_config(MCPTunnelConfig(tunnel_id="t", servers=[]))
+
+    def test_manual_mode_requires_both_files(self):
+        cfg = MCPTunnelConfig(
+            tunnel_id="t",
+            auth_mode=TunnelAuthMode.MANUAL,
+            tunnel_token_file="/tmp/token",  # ca_cert_file missing
+            servers=[MCPTunnelServer(name="x", hostname="x.example.com")],
+        )
+        with pytest.raises(MCPTunnelConfigError, match="ca_cert_file"):
+            validate_tunnel_config(cfg)
+
+    def test_manual_mode_complete_passes(self):
+        cfg = MCPTunnelConfig(
+            tunnel_id="t",
+            auth_mode=TunnelAuthMode.MANUAL,
+            tunnel_token_file="/etc/sc/token",
+            ca_cert_file="/etc/sc/ca.pem",
+            servers=[MCPTunnelServer(name="x", hostname="x.example.com")],
+        )
+        validate_tunnel_config(cfg)
+
+    def test_duplicate_server_names_rejected(self):
+        cfg = MCPTunnelConfig(
+            tunnel_id="t",
+            servers=[
+                MCPTunnelServer(name="dup", hostname="a.example.com"),
+                MCPTunnelServer(name="dup", hostname="b.example.com"),
+            ],
+        )
+        with pytest.raises(MCPTunnelConfigError, match="duplicate"):
+            validate_tunnel_config(cfg)
+
+    def test_bad_hostname_shape_rejected(self):
+        cfg = MCPTunnelConfig(
+            tunnel_id="t",
+            servers=[MCPTunnelServer(name="x", hostname="localhost")],
+        )
+        with pytest.raises(MCPTunnelConfigError, match="fully qualified"):
+            validate_tunnel_config(cfg)
+
+
+# ---------------------------------------------------------------------------
+# mcp_servers block builder
+# ---------------------------------------------------------------------------
+
+
+class TestMCPServersBlock:
+    def test_basic_block_shape(self):
+        cfg = MCPTunnelConfig(
+            tunnel_id="t",
+            servers=[
+                MCPTunnelServer(
+                    name="jira",
+                    hostname="jira.acme.anthropic.cloud",
+                )
+            ],
+        )
+        block = build_mcp_servers_block(cfg, env={})
+        assert len(block) == 1
+        assert block[0]["type"] == "url"
+        assert block[0]["url"] == "https://jira.acme.anthropic.cloud"
+        assert block[0]["name"] == "jira"
+
+    def test_auth_token_injected_from_env(self):
+        cfg = MCPTunnelConfig(
+            tunnel_id="t",
+            servers=[
+                MCPTunnelServer(
+                    name="jira",
+                    hostname="jira.acme.anthropic.cloud",
+                    auth_token_env="JIRA_BEARER",
+                )
+            ],
+        )
+        block = build_mcp_servers_block(cfg, env={"JIRA_BEARER": "abc123"})
+        assert block[0]["authorization_token"] == "abc123"
+
+    def test_missing_token_warns_but_emits_block(self, caplog):
+        cfg = MCPTunnelConfig(
+            tunnel_id="t",
+            servers=[
+                MCPTunnelServer(
+                    name="jira",
+                    hostname="jira.acme.anthropic.cloud",
+                    auth_token_env="JIRA_BEARER",
+                )
+            ],
+        )
+        with caplog.at_level(logging.WARNING):
+            block = build_mcp_servers_block(cfg, env={})
+        # Block emitted, but no token field -> upstream will 401.
+        assert "authorization_token" not in block[0]
+        assert any("JIRA_BEARER" in r.message for r in caplog.records)
+
+    def test_allowed_tools_lands_in_tool_configuration(self):
+        cfg = MCPTunnelConfig(
+            tunnel_id="t",
+            servers=[
+                MCPTunnelServer(
+                    name="jira",
+                    hostname="jira.acme.anthropic.cloud",
+                    allowed_tools=["create_issue", "search"],
+                )
+            ],
+        )
+        block = build_mcp_servers_block(cfg, env={})
+        tc = block[0]["tool_configuration"]
+        assert tc["enabled"] is True
+        assert tc["allowed_tools"] == ["create_issue", "search"]
+
+
+# ---------------------------------------------------------------------------
+# cloudflared argv
+# ---------------------------------------------------------------------------
+
+
+class TestCloudflaredArgs:
+    def test_wif_args(self):
+        cfg = MCPTunnelConfig(
+            tunnel_id="tunnel_xyz",
+            auth_mode=TunnelAuthMode.WIF,
+            servers=[MCPTunnelServer(name="x", hostname="x.example.com")],
+        )
+        args = build_cloudflared_args(cfg)
+        assert args[0] == "cloudflared"
+        assert "--auth" in args
+        assert args[args.index("--auth") + 1] == "wif"
+        assert args[-1] == "tunnel_xyz"
+
+    def test_manual_args_include_token_and_ca(self):
+        cfg = MCPTunnelConfig(
+            tunnel_id="tunnel_xyz",
+            auth_mode=TunnelAuthMode.MANUAL,
+            tunnel_token_file="/etc/sc/token",
+            ca_cert_file="/etc/sc/ca.pem",
+            servers=[MCPTunnelServer(name="x", hostname="x.example.com")],
+        )
+        args = build_cloudflared_args(cfg)
+        assert "--token-file" in args
+        assert args[args.index("--token-file") + 1] == "/etc/sc/token"
+        assert "--origin-ca-pool" in args
+        assert args[args.index("--origin-ca-pool") + 1] == "/etc/sc/ca.pem"
+
+    def test_manual_args_missing_files_raises(self):
+        cfg = MCPTunnelConfig(
+            tunnel_id="tunnel_xyz",
+            auth_mode=TunnelAuthMode.MANUAL,
+            servers=[MCPTunnelServer(name="x", hostname="x.example.com")],
+        )
+        with pytest.raises(MCPTunnelConfigError):
+            build_cloudflared_args(cfg)
+
+    def test_custom_cloudflared_path(self):
+        cfg = MCPTunnelConfig(
+            tunnel_id="t",
+            cloudflared_path="/opt/local/bin/cloudflared",
+            servers=[MCPTunnelServer(name="x", hostname="x.example.com")],
+        )
+        args = build_cloudflared_args(cfg)
+        assert args[0] == "/opt/local/bin/cloudflared"

--- a/tests/test_self_hosted_sandbox.py
+++ b/tests/test_self_hosted_sandbox.py
@@ -1,0 +1,244 @@
+"""Tests for the self-hosted sandbox runtime (v0.32.1).
+
+Covers:
+- Config dataclass + provider enum
+- Org-key leak guard (the most important safety contract)
+- Memory Stores incompatibility hard-error
+- AWS region warning (soft)
+- Environment key format validation
+- Session-create payload augmentation
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from sandcastle.engine.self_hosted_sandbox import (
+    EnvironmentKeyFormatError,
+    MemoryStoresIncompatibleError,
+    OrgKeyLeakError,
+    SandboxProvider,
+    SelfHostedSandboxConfig,
+    SelfHostedSandboxError,
+    assert_env_key_format,
+    assert_memory_compatible,
+    assert_org_key_not_set,
+    build_environment_block,
+    prepare_session_payload,
+    warn_on_aws_region,
+)
+
+
+# ---------------------------------------------------------------------------
+# Config dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxConfig:
+    def test_minimal_config(self):
+        cfg = SelfHostedSandboxConfig(environment_id="env_abc123")
+        assert cfg.environment_id == "env_abc123"
+        assert cfg.provider == SandboxProvider.DOCKER
+        assert cfg.environment_key_env == "ANTHROPIC_ENVIRONMENT_KEY"
+        assert cfg.max_concurrent_sessions == 8
+
+    def test_provider_enum_values(self):
+        # The four blog-named providers + docker fallback for local dev.
+        values = {p.value for p in SandboxProvider}
+        assert {"cloudflare", "daytona", "modal", "vercel", "docker"} == values
+
+    def test_custom_metadata_round_trips(self):
+        cfg = SelfHostedSandboxConfig(
+            environment_id="env_xyz",
+            provider=SandboxProvider.MODAL,
+            metadata={"region": "eu-west-1", "billing_tag": "research"},
+        )
+        block = build_environment_block(cfg)
+        assert block["metadata"]["region"] == "eu-west-1"
+        assert block["metadata"]["billing_tag"] == "research"
+
+
+# ---------------------------------------------------------------------------
+# Org-key leak guard
+# ---------------------------------------------------------------------------
+
+
+class TestOrgKeyLeakGuard:
+    def test_org_key_set_raises(self):
+        env = {"ANTHROPIC_API_KEY": "sk-ant-api03-xxxxxxxx"}
+        with pytest.raises(OrgKeyLeakError) as exc:
+            assert_org_key_not_set(env)
+        assert "sk-ant-oat01-" in str(exc.value)
+
+    def test_org_key_absent_passes(self):
+        # Worker is correctly configured with only the env-scoped key.
+        env = {"ANTHROPIC_ENVIRONMENT_KEY": "sk-ant-oat01-abc"}
+        assert_org_key_not_set(env)  # Must not raise.
+
+    def test_org_key_empty_string_passes(self):
+        # Empty env var should not trip the guard - common in CI matrices.
+        env = {"ANTHROPIC_API_KEY": ""}
+        assert_org_key_not_set(env)
+
+    def test_org_key_warn_only_mode(self, caplog):
+        env = {"ANTHROPIC_API_KEY": "sk-ant-api03-leaky"}
+        with caplog.at_level(logging.WARNING):
+            assert_org_key_not_set(env, raise_on_violation=False)
+        assert any("ANTHROPIC_API_KEY" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Memory Stores incompatibility
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryIncompat:
+    def test_memory_plus_self_hosted_raises(self):
+        cfg = SelfHostedSandboxConfig(environment_id="env_x")
+        with pytest.raises(MemoryStoresIncompatibleError) as exc:
+            assert_memory_compatible(cfg, memory_stores=["ms_abc"])
+        assert "Memory Stores are not supported" in str(exc.value)
+        assert "self-hosted-sandboxes#limitations" in str(exc.value)
+
+    def test_no_sandbox_config_no_op(self):
+        # No self-hosted sandbox in play -> memory_stores is fine.
+        assert_memory_compatible(None, memory_stores=["ms_abc"])
+
+    def test_self_hosted_without_memory_passes(self):
+        cfg = SelfHostedSandboxConfig(environment_id="env_x")
+        assert_memory_compatible(cfg, memory_stores=None)
+        assert_memory_compatible(cfg, memory_stores=[])
+
+
+# ---------------------------------------------------------------------------
+# Environment key format
+# ---------------------------------------------------------------------------
+
+
+class TestEnvKeyFormat:
+    def test_valid_env_key_passes(self):
+        assert_env_key_format("sk-ant-oat01-AAAAAAAAAAAAAAAAAAAAAAAA")
+
+    def test_org_key_in_env_key_slot_rejected(self):
+        # Catches the "pasted my org key by mistake" foot-gun.
+        with pytest.raises(EnvironmentKeyFormatError) as exc:
+            assert_env_key_format("sk-ant-api03-BBBBBBBBBBBBBBBBBBBBBBBB")
+        assert "sk-ant-oat01-" in str(exc.value)
+
+    def test_empty_key_rejected(self):
+        with pytest.raises(EnvironmentKeyFormatError):
+            assert_env_key_format("")
+
+    def test_random_string_rejected(self):
+        with pytest.raises(EnvironmentKeyFormatError):
+            assert_env_key_format("hunter2")
+
+
+# ---------------------------------------------------------------------------
+# AWS region warning
+# ---------------------------------------------------------------------------
+
+
+class TestAWSWarning:
+    def test_aws_region_triggers_warning(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            offender = warn_on_aws_region({"ANTHROPIC_REGION": "aws-us-east-1"})
+        assert offender == "aws-us-east-1"
+        assert any("NOT supported" in r.message for r in caplog.records)
+
+    def test_us_prefix_triggers_warning(self, caplog):
+        # AWS-style region naming (us-east-1) should also trip the guard.
+        with caplog.at_level(logging.WARNING):
+            offender = warn_on_aws_region({"AWS_REGION": "us-west-2"})
+        assert offender == "us-west-2"
+
+    def test_clean_env_no_warning(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            offender = warn_on_aws_region({})
+        assert offender is None
+
+    def test_non_aws_region_passes(self):
+        # Anthropic EU residency endpoint would set this; should NOT warn.
+        offender = warn_on_aws_region({"ANTHROPIC_REGION": "eu-de"})
+        assert offender is None
+
+
+# ---------------------------------------------------------------------------
+# Environment block builder
+# ---------------------------------------------------------------------------
+
+
+class TestEnvironmentBlock:
+    def test_block_contains_required_keys(self):
+        cfg = SelfHostedSandboxConfig(environment_id="env_42")
+        block = build_environment_block(cfg)
+        assert block["environment_id"] == "env_42"
+        assert "metadata" in block
+
+    def test_provider_lands_in_metadata(self):
+        cfg = SelfHostedSandboxConfig(
+            environment_id="env_42",
+            provider=SandboxProvider.VERCEL,
+        )
+        block = build_environment_block(cfg)
+        assert block["metadata"]["provider"] == "vercel"
+
+    def test_user_metadata_takes_precedence_when_keys_overlap(self):
+        cfg = SelfHostedSandboxConfig(
+            environment_id="env_x",
+            provider=SandboxProvider.MODAL,
+            metadata={"provider": "override-by-user"},
+        )
+        block = build_environment_block(cfg)
+        # User-provided metadata overrides the auto-injected provider key.
+        assert block["metadata"]["provider"] == "override-by-user"
+
+
+# ---------------------------------------------------------------------------
+# prepare_session_payload integration
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareSessionPayload:
+    def test_happy_path(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_REGION", raising=False)
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        cfg = SelfHostedSandboxConfig(environment_id="env_x")
+        out = prepare_session_payload({"agent_id": "agent_42"}, cfg)
+        assert out["agent_id"] == "agent_42"
+        assert out["environment"]["environment_id"] == "env_x"
+
+    def test_org_key_blocks(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-leak")
+        cfg = SelfHostedSandboxConfig(environment_id="env_x")
+        with pytest.raises(OrgKeyLeakError):
+            prepare_session_payload({}, cfg)
+
+    def test_memory_combo_blocks(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        cfg = SelfHostedSandboxConfig(environment_id="env_x")
+        with pytest.raises(MemoryStoresIncompatibleError):
+            prepare_session_payload({}, cfg, memory_stores=["ms_abc"])
+
+    def test_base_payload_not_mutated(self, monkeypatch):
+        # Defensive: callers can re-use the base payload.
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        base = {"agent_id": "agent_x"}
+        cfg = SelfHostedSandboxConfig(environment_id="env_x")
+        out = prepare_session_payload(base, cfg)
+        assert "environment" not in base  # Untouched.
+        assert "environment" in out
+
+
+# ---------------------------------------------------------------------------
+# Exception hierarchy
+# ---------------------------------------------------------------------------
+
+
+def test_all_errors_subclass_base():
+    assert issubclass(OrgKeyLeakError, SelfHostedSandboxError)
+    assert issubclass(MemoryStoresIncompatibleError, SelfHostedSandboxError)
+    assert issubclass(EnvironmentKeyFormatError, SelfHostedSandboxError)

--- a/tests/test_webhook_session_started.py
+++ b/tests/test_webhook_session_started.py
@@ -1,0 +1,153 @@
+"""Tests for the new session.status_run_started webhook event.
+
+Anthropic's May 19 2026 self-hosted sandbox update introduces a
+webhook-triggered alternative to long-poll workers. When a session
+needs work, Anthropic emits ``session.status_run_started`` to the
+registered URL; the recipient claims one work item and exits.
+
+We extend Sandcastle's existing ``agent_webhooks`` router rather than
+forking it - that router already verifies HMAC + dispatches to a
+registry, so we just need to confirm:
+
+1. The new event type is in SUPPORTED_EVENTS.
+2. A handler registered for ``session.status_run_started`` actually
+   fires when an event of that type lands.
+3. Unsupported events still get the documented ``ignored`` response.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from sandcastle.api.agent_webhooks import (
+    AGENT_WEBHOOK_HANDLERS,
+    SUPPORTED_EVENTS,
+    register_handler,
+    router,
+    verify_signature,
+)
+
+
+class _StubSettings:
+    """Drop-in stand-in for the Pydantic Settings instance.
+
+    The real ``Settings.is_local_mode`` is a Pydantic computed property
+    without a setter, so ``monkeypatch.setattr`` cannot flip it. We
+    swap the whole ``settings`` reference inside the webhooks module
+    instead, which is what the tests actually need.
+    """
+
+    def __init__(self, *, is_local_mode: bool = True) -> None:
+        self.is_local_mode = is_local_mode
+
+
+@pytest.fixture
+def client(monkeypatch):
+    # Skip signature verify so we can post arbitrary payloads from tests.
+    monkeypatch.delenv("ANTHROPIC_WEBHOOK_SECRET", raising=False)
+    with patch(
+        "sandcastle.api.agent_webhooks.settings", _StubSettings(is_local_mode=True)
+    ):
+        app = FastAPI()
+        app.include_router(router)
+        yield TestClient(app)
+
+
+def test_new_event_in_supported_list():
+    assert "session.status_run_started" in SUPPORTED_EVENTS
+
+
+def test_handler_fires_for_run_started(client):
+    """Registering a handler for run_started should dispatch on POST."""
+    received: list[dict] = []
+
+    async def handler(event):
+        received.append(event)
+
+    # Save previous registry so other tests aren't polluted.
+    prev = list(AGENT_WEBHOOK_HANDLERS.get("session.status_run_started", []))
+    AGENT_WEBHOOK_HANDLERS["session.status_run_started"] = []
+
+    register_handler("session.status_run_started", handler)
+
+    try:
+        payload = {
+            "type": "session.status_run_started",
+            "session_id": "sess_abc",
+            "environment_id": "env_xyz",
+            "work_id": "work_42",
+        }
+        resp = client.post(
+            "/agent-webhooks/anthropic", content=json.dumps(payload)
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "status": "accepted",
+            "event_type": "session.status_run_started",
+        }
+
+        # Dispatch is fire-and-forget (asyncio.create_task) so give it
+        # the event loop a tick to pick up the queued task before we
+        # assert. TestClient runs the app in a thread + its own loop,
+        # so a small sleep is the simplest portable wait.
+        async def _wait():
+            for _ in range(20):
+                if received:
+                    return
+                await asyncio.sleep(0.05)
+
+        asyncio.run(_wait())
+
+        assert len(received) == 1
+        assert received[0]["work_id"] == "work_42"
+    finally:
+        # Restore registry so we don't leak handlers across tests.
+        AGENT_WEBHOOK_HANDLERS["session.status_run_started"] = prev
+
+
+def test_unsupported_event_returns_ignored(client):
+    resp = client.post(
+        "/agent-webhooks/anthropic",
+        content=json.dumps({"type": "session.invented_event"}),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ignored"
+
+
+def test_missing_type_returns_400(client):
+    resp = client.post("/agent-webhooks/anthropic", content=json.dumps({}))
+    assert resp.status_code == 400
+
+
+def test_signature_verification_round_trips():
+    body = b'{"type":"session.status_run_started","work_id":"x"}'
+    secret = "shhh"
+    import hashlib
+    import hmac
+
+    digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    assert verify_signature(secret, body, digest) is True
+    assert verify_signature(secret, body, f"sha256={digest}") is True
+    assert verify_signature(secret, body, "bad") is False
+    assert verify_signature(secret, body, "") is False
+
+
+def test_signature_required_in_non_local_mode(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_WEBHOOK_SECRET", raising=False)
+    with patch(
+        "sandcastle.api.agent_webhooks.settings", _StubSettings(is_local_mode=False)
+    ):
+        app = FastAPI()
+        app.include_router(router)
+        tc = TestClient(app)
+        resp = tc.post(
+            "/agent-webhooks/anthropic",
+            content=json.dumps({"type": "session.status_run_started"}),
+        )
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary

Wires Anthropic's May 19 2026 Managed Agents update (claude.com/blog/claude-managed-agents-updates) into Sandcastle.

The blog shipped two capabilities. This PR lands the safe parts of both.

## Self-hosted sandboxes (public beta, ready today)

New module: src/sandcastle/engine/self_hosted_sandbox.py

- SelfHostedSandboxConfig dataclass + SandboxProvider enum (cloudflare, daytona, modal, vercel, docker)
- prepare_session_payload() augments managed-agent session-create body with environment block
- Safety contracts enforced at config-load + session-create:
  - OrgKeyLeakError when ANTHROPIC_API_KEY is set on worker host
  - MemoryStoresIncompatibleError when memory_stores + self_hosted combined
  - AWS region warning (Claude Platform on AWS unsupported)
  - env-key prefix validation (sk-ant-oat01-*)

## MCP tunnels (research preview, gated)

New module: src/sandcastle/engine/mcp_tunnel.py

- MCPTunnelConfig + TunnelAuthMode (WIF or manual cert)
- build_mcp_servers_block() emits Messages-API array
- build_cloudflared_args() for sidecar argv
- Beta header mcp-client-2025-11-20 (distinct from managed-agents-2026-04-01)
- Gated by SANDCASTLE_MCP_TUNNELS_ENABLED env flag

## Webhook event

src/sandcastle/api/agent_webhooks.py SUPPORTED_EVENTS gains session.status_run_started.

## Tests

- 26 self-hosted sandbox tests
- 19 MCP tunnels tests
- 9 webhook tests
- All 54 new tests pass locally + 126 existing v0.32 tests stay green

## Not in this PR

- EnvironmentWorker runtime adapter that polls /v1/environments/{id}/work (needs anthropic SDK env-worker dependency)
- /admin/environments CRUD API
- Helm chart for cloudflared deployment
- Per-provider Dockerfile cookbooks (Cloudflare/Daytona/Modal/Vercel)

These are thin adapters that consume the typed config + payload builders this PR ships; they go in a follow-up.

## Risk

Low. All new code is additive in new modules. Zero changes to existing executor/runtime paths until something explicitly imports the new helpers.