### PR TITLE
chore: release v0.32.2 "Your Sandbox, Your Silicon"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.2] - 2026-05-19 - "Your Sandbox, Your Silicon"
+
+Anthropic shipped a managed-agents update on May 19. Most teams will read the blog post and move on. We extracted everything. Self-hosted sandboxes that keep your org key inside your boundary. A Memory MCP server that fills the gap Anthropic left when they declared memory_stores incompatible with self-hosted runs. MCP tunnels with WIF token exchange so your private Jira can be reached by a managed agent without static secrets. Live work-queue telemetry in the dashboard. Three production case-study blueprints. Five sandbox cookbooks. 150 new tests, validated across six iterations. Zero regressions.
+
+You wanted control over where your model runs. Here it is.
+
+### Added - Self-hosted sandboxes (the four blog partners + Docker reference)
+
+- **SelfHostedSandboxConfig** (`sandcastle.engine.self_hosted_sandbox`). Five providers in the enum: `cloudflare`, `daytona`, `modal`, `vercel`, `docker`. Each gets a cookbook under `deploy/cookbooks/`.
+- **Org-key leak guard** (`OrgKeyLeakError`). The worker refuses to start if `ANTHROPIC_API_KEY` is present in the sandbox environment. Only `sk-ant-oat01-` environment-scoped keys make it past the gate. A foot-gun that would have leaked your org budget now raises before the first network call.
+- **MemoryStoresIncompatibleError**. Anthropic explicitly documented that memory_stores cannot be combined with self-hosted sandboxes. The validator catches the combination at session-payload assembly time instead of letting the API 400 you in production.
+- **AWS region warning**. If `ANTHROPIC_REGION=aws-*` or `AWS_REGION=us-*` leaks into worker env, the runtime logs a warning. AWS is not a supported sandbox host for managed-agents per the May 19 spec.
+- **SelfHostedWorker** (`sandcastle.engine.self_hosted_worker`). Async worker that polls `/v1/environments/{id}/work`, claims one work item at a time, reclaims abandoned work after 2 s, executes the default 6-tool toolset (`bash`, `read`, `write`, `edit`, `glob`, `grep`) matching `beta_agent_toolset_20260401`.
+- **SelfHostedSandboxRuntime** registered in `sandcastle.engine.agent_runtime`. `RUNTIMES = {"auto", "anthropic", "local", "agent-sdk", "self-hosted-sandbox"}`.
+
+### Added - Sandbox cookbooks (`deploy/cookbooks/`)
+
+- **`docker/`** - canonical reference. Two-stage Dockerfile, USER 10001, tini entrypoint, `--rm --network=session-net --tmpfs /workspace --read-only --cap-drop=ALL`, exit codes 64/65/124 mapped to Anthropic's reclaim semantics.
+- **`cloudflare/`** - Containers via Workers, environment binding for the env key.
+- **`cf-worker/`** - Durable Object + RAM FakeFS, sub-100 ms cold start.
+- **`daytona/`** - snapshot-based stateful sandboxes (good for long-running research).
+- **`modal/`** - GPU sandboxes (mount `gpu="A10G"` in the Python config).
+- **`vercel/`** - VPC + credential brokering, env key NEVER enters the sandbox (broker injects per-call).
+
+### Added - Memory MCP server (the gap Anthropic left)
+
+- **`sandcastle.engine.memory_mcp_server`** - production-grade MCP server wrapping mem0 + persistent Qdrant + Anthropic Haiku for memory decisions. Four tools: `add(text, user_id, metadata)`, `search(query, user_id, limit)`, `forget(memory_id)`, `list_memories(user_id, limit)`. Two resources: `sandcastle://memory/users`, `sandcastle://memory/health`. One prompt: `memory_qa`. CLI entrypoint via `python -m sandcastle.engine.memory_mcp_server`.
+- **`MemoryMCPError`** with `code='memory_unavailable'` if mem0 missing - lazy import, typed install hint.
+- **Helm chart** at `deploy/mcp-tunnel/memory-mcp/`. Chart.yaml v2, appVersion 0.32.2. 8 templates including deployment with cloudflared sidecar (same pod), Qdrant StatefulSet with 10 Gi PVC, NetworkPolicy egress to Cloudflare CIDR `198.41.192.0/19` + `2606:4700:a0::/44` on TCP+UDP 7844. ServiceAccount, ConfigMap, Secret stub, _helpers.tpl.
+- **docker-compose.yml** for local development - 3 services with healthchecks.
+
+### Added - MCP tunnels prep (gated beta, header `mcp-client-2025-11-20`)
+
+- **WIFTokenExchangeClient** (`sandcastle.engine.mcp_tunnel_wif`). OIDC token exchange against a configured issuer, 60 s skew-cached. `assemble_cloudflared_env(config)` produces the env block for WIF or manual-cert modes.
+- **MCPTunnelConfig** with `TunnelAuthMode.WIF` and `TunnelAuthMode.MANUAL`. Validator rejects empty tunnel_id, missing servers, duplicate server names, non-FQDN hostnames, missing token/CA in manual mode.
+- **`build_mcp_servers_block(cfg, env)`** assembles the `mcp_servers` payload block with `authorization_token` injected from env, `tool_configuration.allowed_tools` whitelist, missing-token warning that still emits the block (lets upstream 401 explicitly).
+- **Reference workflow** at `workflows/case-studies/rogo-analyst-on-private-data.yaml` with `risk_level: high`, mandatory approval gate, eval gate, Vercel sandbox + WIF tunnel.
+
+### Added - Admin environments API + dashboard work-queue panel
+
+- **`/admin/environments` CRUD** in `sandcastle.api.environments_admin`. POST/GET/DELETE proxy to Anthropic `/v1/environments` with beta header `managed-agents-2026-04-01`. Tenant scoping via `metadata.sandcastle_tenant_id`. Audit hook via `engine.audit.append_audit_event`.
+- **`/admin/environments/{id}/work/stats`** with 5 s in-process cache.
+- **`/admin/environments/{id}/work/stream`** SSE feed polling every 2 s.
+- **WorkQueuePanel** (`dashboard/src/components/runs/WorkQueuePanel.tsx`). SSE-driven panel with depth, sparkline (Recharts), pill (green < 5, amber 5-50, red > 50), `aria-live="polite"`, exponential backoff up to 30 s. 7 vitest cases.
+
+### Added - Webhook-driven workers
+
+- New event type **`session.status_run_started`** in `agent_webhooks.SUPPORTED_EVENTS`. Lets a worker run as a webhook handler instead of long-polling - saves RAM, latency, and your AWS bill.
+- HMAC verification round-trips `sha256=` prefix and bare digest forms.
+
+### Added - Three production case-study workflows
+
+- **`workflows/case-studies/amplitude-design-agent.yaml`** - designer template + multiagent + accessibility-review specialist + computer-use step + Cloudflare provider.
+- **`workflows/case-studies/clay-sculptor-gtm.yaml`** - project_manager coordinator + researcher / writer / qualifier specialists + Daytona snapshot sandbox + HTTP + Composio + Slack + report.
+- **`workflows/case-studies/rogo-analyst-on-private-data.yaml`** - financial_analyst + Vercel + WIF tunnel + risk_level high + mandatory approval + eval gate.
+
+### Added - Documentation
+
+- `docs/managed-agents-self-hosted.md` (8 sections, 176 lines).
+- `docs/managed-agents-mcp-tunnels.md` (158 lines).
+- `docs/anthropic-2026-may-19-integration.md` (147 lines, Mermaid diagrams).
+
+### Tested
+
+- **150 new tests** across 10 files: self_hosted_sandbox, self_hosted_worker, mcp_tunnel, mcp_tunnel_wif, memory_mcp_server, environments_admin, agent_runtime_self_hosted, webhook_session_started, workflow_case_studies, self_hosted_cookbooks.
+- **6 iterations** of rigorous validation:
+  1. 5x sequential re-run - 750 / 750 deterministic
+  2. Each file in isolation - 150 / 150
+  3. Random order + pollution cluster - 221 / 221
+  4. pytest-repeat 10x stress on the two heaviest files - 260 / 260
+  5. Module import + CLI smoke across 15 modules - clean
+  6. Consolidated verdict - no flake, no cross-pollution, zero new regression categories
+
+### Versioning
+
+PyPI: `pip install sandcastle-ai==0.32.2`
+
 ## [0.32.0] - 2026-05-16 - "Claude Agents Deep Integration"
 
 You shipped the agent. The client wants the integration. The auditor wants the trail. The user wants you to ask the next question without restarting the whole workflow. v0.32 is the answer to every one of those. Sandcastle now exposes every Anthropic Managed Agents primitive shipped under the managed-agents-2026-04-01 beta umbrella, plus the things Anthropic doesn't ship: a cryptographically verifiable trajectory replay, a Skills publisher that turns workflows into uploadable Claude Skills, and an Agent SDK runtime for teams that want in-process execution. Two weeks of work, 169 new tests, one release.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Describe what you want. Go home. Sandcastle ships it.** Production-ready workflow orchestrator for AI agents. 7 AI providers with auto-failover, 22 step types including Claude Managed Agents, 15 agent templates, 4 OCR engines, EU AI Act compliance, and a full-featured dashboard. Define workflows in YAML or let AI design them for you.
 
-[![PyPI](https://img.shields.io/badge/PyPI-v0.32.0-blue?style=flat-square)](https://pypi.org/project/sandcastle-ai/0.32.0/)
+[![PyPI](https://img.shields.io/badge/PyPI-v0.32.2-blue?style=flat-square)](https://pypi.org/project/sandcastle-ai/0.32.2/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![Tests](https://img.shields.io/badge/tests-15000%2B%20passing-brightgreen?style=flat-square)](https://github.com/gizmax/Sandcastle/actions)
@@ -10,19 +10,19 @@
 [![Website](https://img.shields.io/badge/Website-sandcastle--ai.eu-blue?style=flat-square)](https://sandcastle-ai.eu)
 [![Live Demo](https://img.shields.io/badge/Live%20Demo-Dashboard-F59E0B?style=flat-square)](https://gizmax.github.io/Sandcastle/)
 
-> **v0.32 - "Claude Agents Deep Integration"** Shipped May 16, 2026. Every Anthropic Managed Agents primitive surfaced, plus the things Anthropic doesn't ship.
+> **v0.32.2 - "Your Sandbox, Your Silicon"** Shipped May 19, 2026. Anthropic gave you a model. We gave you a place to put it.
 >
-> - **Memory Stores + Multiagent + Outcomes + Webhooks** wired into the YAML. One workflow can attach versioned memory at /mnt/memory/, spawn 20 parallel specialist agents, define outcomes the eval pipeline reads automatically, and emit lifecycle events to a webhook endpoint.
-> - **Skills Publisher.** `sandcastle publish-skills --upload` converts every workflow into a tar.gz SKILL.md and uploads to `/v1/skills`. Workflows now callable from every Anthropic Skills-aware client.
-> - **Trajectory Replay step type.** SHA-256 over a recorded tool-call sequence + diff against the candidate run. Because the audit trail is a hash chain, the replay is **cryptographically verifiable** - LangSmith and Braintrust don't ship this.
-> - **Agent SDK runtime** as `runtime: "agent-sdk"` alternative. In-process Claude agents for EU sovereignty / air-gapped / regulated teams.
-> - **Computer Use** integration (`computer_20251124` beta) with 8-item safety pre-flight + new `type: computer-use` step.
-> - **MCP Elicitation** (6th primitive, spec rev 2025-11-25). Workflows can ask the user for missing input mid-execution.
-> - **Live Agent Reasoning panel** in the dashboard - SSE stream of agent.thinking, agent.tool_use, agent.message events on the run detail page.
-> - Plus 5 Tier 1 wire fixes (`tools_enabled`, sampling params, `stream`, pricing table, fallback chain).
-> - 15,176 tests passing, 169 new. PyPI: `pip install sandcastle-ai==0.32.0`.
+> - **Self-hosted sandboxes** on the four blog partners + Docker reference (`cloudflare`, `daytona`, `modal`, `vercel`, `docker`). Five cookbooks under `deploy/cookbooks/`. Your org key never leaves your boundary - the worker refuses to start if `ANTHROPIC_API_KEY` is present in the sandbox env, only `sk-ant-oat01-` environment-scoped keys get past the gate.
+> - **Memory MCP server.** Anthropic declared `memory_stores` incompatible with self-hosted sandboxes. We filled the gap: `sandcastle.engine.memory_mcp_server` wraps mem0 + persistent Qdrant + Haiku decisions. Four tools (`add`, `search`, `forget`, `list_memories`), two resources, one prompt. Helm chart + docker-compose included.
+> - **MCP tunnels** (gated beta, header `mcp-client-2025-11-20`). WIF token exchange so your private Jira / Snowflake / Confluence is reachable from a managed agent with no static secrets. `cloudflared` sidecar pattern documented end to end.
+> - **Live work-queue dashboard.** `WorkQueuePanel` on the runs page, SSE-driven depth + sparkline + pill (green < 5, amber 5-50, red > 50), aria-live polite. You see the backlog before the pager fires.
+> - **Webhook workers.** New `session.status_run_started` event lets a worker run as a webhook handler instead of long-polling - saves RAM, latency, and your AWS bill.
+> - **Three production case-study workflows** at `workflows/case-studies/` - Amplitude designer, Clay GTM, Rogo analyst on private data. Not tutorials. Blueprints.
+> - **150 new tests** validated across 6 iterations (sequential / isolation / random + pollution / stress-repeat / smoke / consolidation). Zero regressions.
 >
-> Previous: **v0.31 - "Compliance & Connections"** (May 14, 2026): EU AI Act landing + 10 compliance templates, MCP-first publishing, eval gates, dashboard error boundaries, Codex audit rounds 9+10.
+> PyPI: `pip install sandcastle-ai==0.32.2`.
+>
+> Previous: **v0.32.0 - "Claude Agents Deep Integration"** (May 16, 2026): Memory Stores, Multiagent, Outcomes, Webhooks, Skills Publisher, Trajectory Replay, Agent SDK runtime, Computer Use, MCP Elicitation, Live Agent Reasoning panel.
 >
 
 <p align="center">

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.32.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/site/index.html
+++ b/site/index.html
@@ -1761,7 +1761,7 @@
   <header class="hero" id="hero">
     <div class="container">
       <div class="hero-badge">
-        v0.32 - Claude Agents Deep Integration
+        v0.32.2 - Your Sandbox, Your Silicon
       </div>
       <h1>
         Describe what you want. Go home.<br>
@@ -2725,7 +2725,7 @@
   <footer>
     <div class="container footer-inner">
       <div class="footer-left">
-        <strong>Sandcastle</strong> v0.32 - BSL 1.1 (Apache 2.0 after 2030)<br>
+        <strong>Sandcastle</strong> v0.32.2 - BSL 1.1 (Apache 2.0 after 2030)<br>
         &copy; 2026 Created by <a href="https://github.com/gizmax" target="_blank" rel="noopener">Tomas Pflanzer</a> @gizmax
       </div>
       <div class="footer-links">

--- a/site/whatsnew/index.html
+++ b/site/whatsnew/index.html
@@ -4,20 +4,20 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>What's New - Sandcastle</title>
-  <meta name="description" content="Sandcastle release history. v0.32: Claude Agents Deep Integration. Memory Stores, Multiagent coordinator, Outcomes API, Skills publisher, Agent SDK runtime, Trajectory Replay, Computer Use, MCP Elicitation. Every Anthropic primitive surfaced.">
+  <meta name="description" content="Sandcastle release history. v0.32.2 - Your Sandbox, Your Silicon: self-hosted sandboxes on Cloudflare/Daytona/Modal/Vercel/Docker, Memory MCP server, MCP tunnels with WIF, live work-queue dashboard, webhook workers, 3 production case studies, 150 new tests.">
   <meta name="author" content="Tomas Pflanzer @gizmax">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="What's New - Sandcastle v0.32">
-  <meta property="og:description" content="Claude Agents Deep Integration. Every Anthropic Managed Agents primitive surfaced, plus Skills publisher, Trajectory Replay, Computer Use, Agent SDK runtime.">
+  <meta property="og:title" content="What's New - Sandcastle v0.32.2">
+  <meta property="og:description" content="Your Sandbox, Your Silicon. Self-hosted sandboxes on Cloudflare/Daytona/Modal/Vercel/Docker, Memory MCP server (the gap Anthropic left), MCP tunnels with WIF, live work-queue dashboard. 150 new tests, zero regressions.">
   <meta property="og:image" content="https://raw.githubusercontent.com/gizmax/Sandcastle/main/site/og-image.jpeg">
   <meta property="og:url" content="https://sandcastle-ai.eu/whatsnew/">
   <meta property="og:type" content="website">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="What's New - Sandcastle v0.32">
-  <meta name="twitter:description" content="Claude Agents Deep Integration. Memory Stores, Multiagent, Outcomes, Skills publisher, Trajectory Replay, Computer Use. 169 new tests.">
+  <meta name="twitter:title" content="What's New - Sandcastle v0.32.2">
+  <meta name="twitter:description" content="Your Sandbox, Your Silicon. Self-hosted sandboxes, Memory MCP server, MCP tunnels with WIF, live work-queue dashboard. 150 new tests, zero regressions.">
   <meta name="twitter:image" content="https://raw.githubusercontent.com/gizmax/Sandcastle/main/site/og-image.jpeg">
 
   <link rel="canonical" href="https://sandcastle-ai.eu/whatsnew/">
@@ -194,11 +194,93 @@
   <main>
     <div class="container releases">
 
+      <!-- v0.32.2 -->
+      <div class="release fade-in">
+        <div class="release-header">
+          <span class="release-version">v0.32.2</span>
+          <span class="release-name">Your Sandbox, Your Silicon <span class="badge-latest">Latest</span></span>
+          <span class="release-date">May 19, 2026</span>
+        </div>
+
+        <p style="max-width: 720px; color: var(--text-muted); font-size: 15px; line-height: 1.7; margin-bottom: 28px;">
+          Anthropic shipped a managed-agents update on May 19. Most teams will read the blog post and move on. We extracted everything. Self-hosted sandboxes that keep your org key inside your boundary. A Memory MCP server that fills the gap Anthropic left when they declared memory_stores incompatible with self-hosted runs. MCP tunnels with WIF token exchange so your private Jira can be reached by a managed agent without static secrets. Live work-queue telemetry in the dashboard. Three production case-study blueprints. Five sandbox cookbooks. 150 new tests, validated across six iterations. Zero regressions. You wanted control over where your model runs. Here it is.
+        </p>
+
+        <div class="feature-grid">
+
+          <div class="feature-card wide">
+            <span class="feature-tag amber">Headline</span>
+            <h4>Self-hosted sandboxes - your code, your silicon</h4>
+            <p>Five providers in the runtime enum: <code>cloudflare</code>, <code>daytona</code>, <code>modal</code>, <code>vercel</code>, <code>docker</code>. Each gets a cookbook under <code>deploy/cookbooks/</code> with a copy-paste-ready spawn script and image. Your org key never leaves your boundary - the worker refuses to start if <code>ANTHROPIC_API_KEY</code> is present in the sandbox env. Only <code>sk-ant-oat01-</code> environment-scoped keys get past the gate. A foot-gun that would have leaked your org budget now raises before the first network call.</p>
+          </div>
+
+          <div class="feature-card">
+            <span class="feature-tag green">New</span>
+            <h4>Memory MCP server</h4>
+            <p>Anthropic explicitly documented that <code>memory_stores</code> cannot be combined with self-hosted sandboxes. We filled the gap. <code>sandcastle.engine.memory_mcp_server</code> wraps mem0 + persistent Qdrant + Anthropic Haiku for memory decisions. Four tools, two resources, one prompt. Helm chart + docker-compose. NetworkPolicy egress to Cloudflare CIDR only.</p>
+          </div>
+
+          <div class="feature-card">
+            <span class="feature-tag blue">New</span>
+            <h4>MCP tunnels with WIF auth</h4>
+            <p>Gated beta, header <code>mcp-client-2025-11-20</code>. Your internal Jira / Snowflake / Confluence is reachable from a managed agent through a cloudflared tunnel authenticated with WIF tokens. No static secrets. 60s skew-cached token exchange. Manual cert mode also supported for air-gapped setups.</p>
+          </div>
+
+          <div class="feature-card">
+            <span class="feature-tag green">New</span>
+            <h4>Live work-queue dashboard</h4>
+            <p><code>WorkQueuePanel</code> on the run detail page, SSE-driven. Depth, sparkline (Recharts), pill (green &lt; 5, amber 5-50, red &gt; 50), <code>aria-live="polite"</code>, exponential backoff up to 30 s. You see the backlog before the pager fires.</p>
+          </div>
+
+          <div class="feature-card">
+            <span class="feature-tag blue">New</span>
+            <h4>Webhook-driven workers</h4>
+            <p>New <code>session.status_run_started</code> event in <code>SUPPORTED_EVENTS</code>. A worker can now run as a webhook handler instead of a long-poll loop - saves RAM, latency, and your AWS bill. HMAC verification round-trips <code>sha256=</code> prefix and bare digest forms.</p>
+          </div>
+
+          <div class="feature-card">
+            <span class="feature-tag purple">Templates</span>
+            <h4>Three production case studies</h4>
+            <p>Not tutorials. Blueprints. Amplitude designer (multiagent + accessibility specialist + computer-use + Cloudflare). Clay GTM (project_manager + researcher / writer / qualifier + Daytona). Rogo analyst on private data (Vercel + WIF tunnel + risk_level high + mandatory approval + eval gate).</p>
+          </div>
+
+          <div class="feature-card">
+            <span class="feature-tag amber">Quality</span>
+            <h4>Tested six different ways</h4>
+            <p>150 new tests. Sequential re-run, file isolation, randomized + pollution cluster, pytest-repeat 10x stress, module + CLI smoke, consolidated verdict. Zero flakes. Zero new regression categories. Documented in the PR.</p>
+          </div>
+
+          <div class="feature-card">
+            <span class="feature-tag purple">Milestone</span>
+            <h4>By the numbers</h4>
+            <div class="stat-row">
+              <div class="stat-item">
+                <div class="stat-num">150</div>
+                <div class="stat-label">New v0.32.2 tests</div>
+              </div>
+              <div class="stat-item">
+                <div class="stat-num">5</div>
+                <div class="stat-label">Sandbox cookbooks</div>
+              </div>
+              <div class="stat-item">
+                <div class="stat-num">6</div>
+                <div class="stat-label">Validation iterations</div>
+              </div>
+              <div class="stat-item">
+                <div class="stat-num">0</div>
+                <div class="stat-label">Regressions</div>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
       <!-- v0.32 -->
       <div class="release fade-in">
         <div class="release-header">
           <span class="release-version">v0.32</span>
-          <span class="release-name">Claude Agents Deep Integration <span class="badge-latest">Latest</span></span>
+          <span class="release-name">Claude Agents Deep Integration</span>
           <span class="release-date">May 16, 2026</span>
         </div>
 

--- a/src/sandcastle/__init__.py
+++ b/src/sandcastle/__init__.py
@@ -1,6 +1,6 @@
 """Sandcastle - Production-ready workflow orchestrator for AI agents."""
 
-__version__ = "0.32.0"
+__version__ = "0.32.2"
 
 from sandcastle.sdk import AsyncSandcastleClient, SandcastleClient
 


### PR DESCRIPTION
## Summary

Sandcastle 0.32.2 - extraction of Anthropic May 19 2026 managed-agents update.

- Self-hosted sandboxes on Cloudflare/Daytona/Modal/Vercel/Docker (5 cookbooks)
- Memory MCP server (mem0 + Qdrant + Haiku) - fills the memory_stores gap Anthropic left
- MCP tunnels with WIF token exchange (gated beta)
- Live work-queue SSE panel in the dashboard
- Webhook-driven workers (session.status_run_started)
- 3 production case-study workflows (Amplitude, Clay, Rogo)
- 150 new tests validated across 6 iterations - zero regressions

Engineering content already merged via #227. This PR is the release tag:
CHANGELOG, README hero, site/index.html, site/whatsnew/index.html, version bump 0.32.0 -> 0.32.2.

## Test plan

- [x] 150 new tests green across 6 iterations
- [x] Dashboard build green
- [x] twine check PASSED on both wheel + sdist
- [x] PyPI artifacts ready: sandcastle_ai-0.32.2-py3-none-any.whl + sandcastle_ai-0.32.2.tar.gz