### PR TITLE
fix(packaging): missing runtime deps + editable-install (salvaged from #231)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ __pycache__/
 *.py[cod]
 *$py.class
 *.egg-info/
-dist/
+/dist/
 build/
 .eggs/
 *.egg

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -8,7 +8,8 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
-dist
+dist/*
+!dist/.gitkeep
 dist-ssr
 *.local
 

--- a/dashboard/dist/.gitkeep
+++ b/dashboard/dist/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder so 'pip install -e .' works before 'npm run build' has run.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "fastapi>=0.115",
+    "python-multipart>=0.0.9",
     "uvicorn[standard]>=0.30",
     "httpx>=0.28",
     "httpx-sse>=0.4",
@@ -36,6 +37,7 @@ dependencies = [
     "pyyaml>=6.0",
     "pydantic>=2.9",
     "pydantic-settings>=2.5",
+    "jsonschema>=4.0",
     "aioboto3>=13",
     "python-dotenv>=1.0",
     "simpleeval>=1.0",

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -1496,9 +1496,15 @@ class TestCmdMcp:
     def test_mcp_sets_env_vars(self):
         args = make_args(url="http://custom:9090", api_key="testkey")
         mock_main = MagicMock()
-        with patch("sandcastle.mcp_server.main", mock_main, create=True):
-            with patch.dict("sys.modules", {"sandcastle.mcp_server": MagicMock(main=mock_main)}):
-                cli._cmd_mcp(args)
+        # Inject a fake sandcastle.mcp_server into sys.modules first so the import
+        # inside _cmd_mcp resolves to our mock. patch("sandcastle.mcp_server.main")
+        # can't be used here because that path only resolves once the real module
+        # imports cleanly, which requires the [mcp] extra (absent in plain CI).
+        with patch.dict(
+            "sys.modules",
+            {"sandcastle.mcp_server": MagicMock(main=mock_main)},
+        ):
+            cli._cmd_mcp(args)
         assert os.environ.get("SANDCASTLE_URL") == "http://custom:9090"
         assert os.environ.get("SANDCASTLE_API_KEY") == "testkey"
 

--- a/tests/test_coverage_boost_final.py
+++ b/tests/test_coverage_boost_final.py
@@ -550,6 +550,9 @@ class TestRoutesAdditional:
 class TestMCPResourceHandlers:
     """Cover MCP server resource handler functions."""
 
+    def setup_method(self):
+        pytest.importorskip("mcp", reason="MCP server tests require the [mcp] extra")
+
     def test_resource_workflows_error_path(self):
         """resource_workflows returns error JSON when client fails."""
         from sandcastle.mcp_server import create_mcp_server

--- a/tests/test_crypto_license_wave9.py
+++ b/tests/test_crypto_license_wave9.py
@@ -16,6 +16,12 @@ from datetime import date, datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+pytest.importorskip(
+    "cryptography",
+    reason="license crypto tests require the [security] extra",
+)
+
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
 

--- a/tests/test_mcp_wave7.py
+++ b/tests/test_mcp_wave7.py
@@ -15,6 +15,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytest.importorskip("mcp", reason="MCP server tests require the [mcp] extra")
+
 from sandcastle.mcp_server import (
     _MAX_LIMIT,
     _MAX_PARAM_LENGTH,


### PR DESCRIPTION
Salvages the still-relevant fixes from #231. Its test-assertion changes (memory 503, fake_memory pollution, RUNTIMES, field-count, 17-step-types, cache-key tenant prefix) are already on main via #232 and #234, so #231 is now conflicting and can be closed once this lands.

## What's left that #231 uniquely fixes (verified missing on main)
- **python-multipart** runtime dep - FastAPI Form/UploadFile (routes.py, docparse.py, pdf.py) need it; `pip install sandcastle-ai` was missing it.
- **jsonschema** runtime dep - imported at module top of `engine/tool_search.py`, so importing the package failed without it.
- **editable install** - `dashboard/dist/.gitkeep` + narrowed gitignores so `pip install -e .` works before `npm run build`.
- **pytest.importorskip guards** for the [mcp] / [security] extras so collection survives without them; cli mcp test patches sys.modules directly.

## Verification
Affected tests: 528 passed. python-multipart/jsonschema confirmed imported at runtime. No production logic changed.

Supersedes the unique parts of #231.