### PR TITLE
feat(models): 2026-06 model refresh - GPT Image 2, Gemini 3.5, GPT-5.2

### DIFF
--- a/src/sandcastle/engine/generator.py
+++ b/src/sandcastle/engine/generator.py
@@ -673,7 +673,7 @@ ADVISOR_MODEL_TIERS: dict[str, dict[str, str]] = {
         "low": "mistral-small-latest",
     },
     "openai": {
-        "high": "gpt-4o",
+        "high": "gpt-5.2",
         "medium": "gpt-4o-mini",
         "low": "gpt-4o-mini",
     },
@@ -731,7 +731,7 @@ _PROVIDER_CONFIGS = {
     },
     "openai": {
         "api_url": "https://api.openai.com/v1/chat/completions",
-        "model": "gpt-4o",
+        "model": "gpt-5.2",
         "api_key_env": "OPENAI_API_KEY",
         "region": "us",
         "headers_fn": lambda key: {

--- a/src/sandcastle/engine/tools/connectors/gemini.mjs
+++ b/src/sandcastle/engine/tools/connectors/gemini.mjs
@@ -46,7 +46,7 @@ async function imagePart(ref, signal) {
  * Vision analysis / judging. Sends image(s) + a text prompt to a Gemini vision
  * model and returns the answer. Returns parsed JSON when the model replies JSON.
  *
- * options: model (default gemini-2.5-flash), images (string[] paths or URLs),
+ * options: model (default gemini-3.5-flash), images (string[] paths or URLs),
  *   max_output_tokens.
  */
 export async function analyze_image(prompt, options = "{}") {
@@ -58,7 +58,7 @@ export async function analyze_image(prompt, options = "{}") {
   if (images.length === 0) throw new Error("analyze_image requires options.images (>=1)");
   if (!API_KEY) throw new Error("Gemini API key not set (TOOL_GEMINI_API_KEY / GEMINI_API_KEY)");
 
-  const model = opts.model || "gemini-2.5-flash";
+  const model = opts.model || "gemini-3.5-flash";
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), TIMEOUT);
   try {

--- a/src/sandcastle/engine/tools/connectors/openai.mjs
+++ b/src/sandcastle/engine/tools/connectors/openai.mjs
@@ -35,7 +35,7 @@ async function api(path, method = "POST", body = null) {
   } finally { clearTimeout(timer); }
 }
 
-export async function chat_completion(messages, model = "gpt-4o", options = "{}") {
+export async function chat_completion(messages, model = "gpt-5.2", options = "{}") {
   const parsed = typeof messages === "string" ? JSON.parse(messages) : messages;
   const opts = typeof options === "string" ? JSON.parse(options) : options;
   const data = await api("/chat/completions", "POST", {
@@ -62,7 +62,8 @@ export async function create_embedding(input, model = "text-embedding-3-small") 
   };
 }
 
-// Map a common aspect ratio to a gpt-image-1 supported size.
+// Map a common aspect ratio to a size (all gpt-image-2 valid: divisible by 16,
+// aspect within 1:3..3:1).
 const ASPECT_TO_SIZE = {
   "1:1": "1024x1024",
   "4:5": "1024x1536",
@@ -80,9 +81,9 @@ const MIME_BY_EXT = {
   png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg", webp: "image/webp",
 };
 
-// Rough per-image cost estimate for gpt-image-1 by quality.
+// Rough per-image cost estimate for the gpt-image-* family by quality.
 function estimateImageCost(model, quality, n) {
-  if (model !== "gpt-image-1") return 0.04 * n; // dall-e-3 standard ~$0.04
+  if (!model.startsWith("gpt-image")) return 0.04 * n; // dall-e-3 standard ~$0.04
   const perImage = quality === "high" ? 0.17 : quality === "low" ? 0.02 : 0.07;
   return perImage * n;
 }
@@ -105,21 +106,22 @@ function writeImage(b64, opts, index) {
 }
 
 /**
- * Generate one or more images. Defaults to gpt-image-1.
+ * Generate one or more images. Defaults to gpt-image-2 (4K-capable, ~99% text
+ * accuracy, reasoning-powered; gpt-image-1 / dall-e-3 still selectable via model).
  * If options.reference_images is provided, uses the /images/edits endpoint
  * (multipart) so the product photo(s) steer the result - the path for faithful
  * product UGC. Otherwise uses /images/generations. Images are written to disk
  * and the returned shape matches the nano-banana connector ({ ok, files, ... }).
  *
- * options: model (default gpt-image-1), size or aspect, quality (low|medium|high),
- *   n, output, output_dir, reference_images (string[]).
+ * options: model (default gpt-image-2), size or aspect, quality (low|medium|high),
+ *   n, output, output_dir, reference_images (string[], up to 16).
  */
 export async function generate_image(prompt, options = "{}") {
   if (!prompt || typeof prompt !== "string") {
     throw new Error("prompt is required and must be a string");
   }
   const opts = typeof options === "string" ? JSON.parse(options) : options;
-  const model = opts.model || "gpt-image-1";
+  const model = opts.model || "gpt-image-2";
   const size = resolveSize(opts);
   const n = opts.n || 1;
   const refs = Array.isArray(opts.reference_images) ? opts.reference_images : [];
@@ -131,7 +133,7 @@ export async function generate_image(prompt, options = "{}") {
     if (refs.length > 0) {
       // Reference-image editing - multipart form-data.
       const form = new FormData();
-      form.append("model", "gpt-image-1");
+      form.append("model", model);
       form.append("prompt", prompt);
       form.append("n", String(n));
       form.append("size", size);
@@ -153,8 +155,8 @@ export async function generate_image(prompt, options = "{}") {
         model, prompt, n, size,
         ...(opts.quality ? { quality: opts.quality } : {}),
       };
-      // gpt-image-1 always returns b64_json; dall-e-* needs it requested.
-      if (model !== "gpt-image-1") body.response_format = "b64_json";
+      // The gpt-image-* family always returns b64_json; dall-e-* needs it asked for.
+      if (!model.startsWith("gpt-image")) body.response_format = "b64_json";
       resp = await fetch(`${BASE}/images/generations`, {
         method: "POST",
         headers: { Authorization: `Bearer ${API_KEY}`, "Content-Type": "application/json" },
@@ -197,11 +199,11 @@ function imageBlock(ref) {
 
 /**
  * Vision analysis / judging. Sends one or more images plus a text prompt to a
- * vision model (default gpt-4o) and returns the model's answer. Lets a workflow
+ * vision model (default gpt-5.2) and returns the model's answer. Lets a workflow
  * actually SEE generated images - e.g. score a UGC shot against the original
  * product reference. Returns parsed JSON when the model replies with JSON.
  *
- * options: model (default gpt-4o), images (string[] of local paths or URLs),
+ * options: model (default gpt-5.2), images (string[] of local paths or URLs),
  *   max_tokens, json (hint the model to return JSON).
  */
 export async function analyze_image(prompt, options = "{}") {
@@ -220,7 +222,7 @@ export async function analyze_image(prompt, options = "{}") {
       method: "POST",
       headers: { Authorization: `Bearer ${API_KEY}`, "Content-Type": "application/json" },
       body: JSON.stringify({
-        model: opts.model || "gpt-4o",
+        model: opts.model || "gpt-5.2",
         max_tokens: opts.max_tokens || 1024,
         messages: [{ role: "user", content }],
       }),

--- a/src/sandcastle/engine/tools/registry.py
+++ b/src/sandcastle/engine/tools/registry.py
@@ -1653,7 +1653,7 @@ TOOL_REGISTRY: dict[str, ToolDefinition] = {
             ToolFunction(
                 name="generate_image",
                 description=(
-                    "Generate image(s) with gpt-image-1 (default) or dall-e-3. "
+                    "Generate image(s) with gpt-image-2 (default) or dall-e-3. "
                     "Writes files to disk and returns their paths. Pass "
                     "reference_images for faithful product/UGC editing."
                 ),
@@ -1664,7 +1664,7 @@ TOOL_REGISTRY: dict[str, ToolDefinition] = {
                         "options": {
                             "type": "object",
                             "description": (
-                                "model (gpt-image-1/dall-e-3), size or aspect "
+                                "model (gpt-image-2/dall-e-3), size or aspect "
                                 "(1:1/4:5/9:16/16:9), quality (low/medium/high), n, "
                                 "output, output_dir, reference_images (string[])"
                             ),
@@ -1677,7 +1677,7 @@ TOOL_REGISTRY: dict[str, ToolDefinition] = {
                 name="analyze_image",
                 description=(
                     "Vision analysis/judging - send image(s) + a prompt to a vision "
-                    "model (default gpt-4o) and get the answer. Use to score generated "
+                    "model (default gpt-5.2) and get the answer. Use to score generated "
                     "images against a reference. Returns JSON when the model replies JSON."
                 ),
                 parameters={
@@ -1688,7 +1688,7 @@ TOOL_REGISTRY: dict[str, ToolDefinition] = {
                             "type": "object",
                             "description": (
                                 "images (string[] of local paths or URLs), "
-                                "model (default gpt-4o), max_tokens"
+                                "model (default gpt-5.2), max_tokens"
                             ),
                         },
                     },
@@ -2313,7 +2313,7 @@ TOOL_REGISTRY: dict[str, ToolDefinition] = {
                             "type": "object",
                             "description": (
                                 "images (string[] of local paths or URLs), "
-                                "model (default gemini-2.5-flash), max_output_tokens"
+                                "model (default gemini-3.5-flash), max_output_tokens"
                             ),
                         },
                     },
@@ -3342,7 +3342,7 @@ TOOL_REGISTRY: dict[str, ToolDefinition] = {
                     "properties": {
                         "trace_id": {"type": "string", "description": "Parent trace ID"},
                         "name": {"type": "string", "description": "Generation name"},
-                        "model": {"type": "string", "description": "Model name (e.g. gpt-4o)"},
+                        "model": {"type": "string", "description": "Model name (e.g. gpt-5.2)"},
                         "input": {"type": "object", "description": "Input messages/prompt"},
                         "output": {"type": "object", "description": "Model output"},
                         "usage": {

--- a/src/sandcastle/templates/ugc_studio.yaml
+++ b/src/sandcastle/templates/ugc_studio.yaml
@@ -1,5 +1,5 @@
 # name: UGC Studio
-# description: Drop a product photo, pick a mode, get N platform-ready UGC shots. Reference-image generation keeps the product faithful; a vision judge scores every shot and failed ones are regenerated. Switchable nano-banana / gpt-image-1 backend.
+# description: Drop a product photo, pick a mode, get N platform-ready UGC shots. Reference-image generation keeps the product faithful; a vision judge scores every shot and failed ones are regenerated. Switchable nano-banana / gpt-image-2 backend.
 # tags: [Marketing, UGC, Product-Photography, Social-Media, E-Commerce, AI-Studio]
 # category: creative
 
@@ -7,7 +7,7 @@ name: ugc-studio
 description: >
   Fast, high-quality UGC. One product photo in -> N platform-ready shots out.
   The real product photo is passed as a reference image to the generator
-  (nano-banana Gemini or OpenAI gpt-image-1), so the product stays faithful while
+  (nano-banana Gemini or OpenAI gpt-image-2), so the product stays faithful while
   the prompt drives authentic, mode-specific styling. A Gemini vision judge scores
   every shot against the original; anything that fails is regenerated with an
   improved prompt. Pick a mode and a count - everything else is derived.
@@ -42,7 +42,7 @@ input_schema:
     image_backend:
       type: string
       enum: ["nano-banana", "openai"]
-      description: "Image generator: nano-banana (Gemini 3 Pro Image) or openai (gpt-image-1). Both use the product photo as a reference."
+      description: "Image generator: nano-banana (Gemini 3 Pro Image) or openai (gpt-image-2). Both use the product photo as a reference."
       default: "nano-banana"
     min_score:
       type: number
@@ -154,7 +154,7 @@ steps:
         aspect: { type: string }
 
   # ============================================================
-  # 3. BACKEND ROUTER - nano-banana (default) vs openai gpt-image-1
+  # 3. BACKEND ROUTER - nano-banana (default) vs openai gpt-image-2
   # ============================================================
   - id: "backend-router"
     depends_on: ["compose-prompts"]
@@ -193,7 +193,7 @@ steps:
       function: "generate_image"
       arguments:
         - "{input._item.prompt}"
-        - model: "gpt-image-1"
+        - model: "gpt-image-2"
           aspect: "{input._item.aspect}"
           quality: "high"
           reference_images: ["{input.product_photo}"]

--- a/tests/test_advisor_v22.py
+++ b/tests/test_advisor_v22.py
@@ -266,7 +266,7 @@ class TestGetAdvisorConfig:
         cfg = _get_advisor_config()
         assert cfg["api_key_env"] == "OPENAI_API_KEY"
         assert "openai" in cfg["api_url"]
-        assert cfg["model"] == "gpt-4o"
+        assert cfg["model"] == "gpt-5.2"
 
     @patch.dict(os.environ, {"SANDCASTLE_ADVISOR_PROVIDER": "ollama"}, clear=True)
     def test_ollama_provider(self):

--- a/tests/test_generator_deep.py
+++ b/tests/test_generator_deep.py
@@ -216,7 +216,7 @@ class TestGetAdvisorConfig:
              patch("sandcastle.config.settings", SETTINGS_NO_RESIDENCY):
             config = _get_advisor_config()
             assert "openai.com" in config["api_url"]
-            assert config["model"] == "gpt-4o"
+            assert config["model"] == "gpt-5.2"
 
     def test_model_override(self):
         with patch.dict("os.environ", {

--- a/tests/test_slo_routing.py
+++ b/tests/test_slo_routing.py
@@ -95,8 +95,8 @@ class TestAdvisorModelTiers:
     def test_mistral_low_is_small(self):
         assert "small" in ADVISOR_MODEL_TIERS["mistral"]["low"]
 
-    def test_openai_high_is_gpt4o(self):
-        assert "gpt-4o" in ADVISOR_MODEL_TIERS["openai"]["high"]
+    def test_openai_high_is_gpt5(self):
+        assert "gpt-5.2" in ADVISOR_MODEL_TIERS["openai"]["high"]
 
     def test_openai_low_is_mini(self):
         assert "mini" in ADVISOR_MODEL_TIERS["openai"]["low"]


### PR DESCRIPTION
Refreshes default models to the current (June 2026) generation after a web check of what moved.

## Changes
- **GPT Image 2** (`openai.mjs` generate_image): `gpt-image-1` -> `gpt-image-2` (4K, ~99% text accuracy, reasoning, up to 16 reference images; same /images/edits multipart path). Also fixed a latent bug where reference-image edits hard-coded `gpt-image-1` and ignored the `model` option.
- **GPT-5.2** for OpenAI text/vision: chat_completion + analyze_image default `gpt-4o` -> `gpt-5.2`; advisor 'high' tier + openai provider config too.
- **Gemini 3.5** vision judge (`gemini.mjs`): `gemini-2.5-flash` -> `gemini-3.5-flash`.
- registry tool descriptions + `ugc_studio.yaml` updated; 3 tests that pinned old default IDs updated.

Older models remain selectable via the `model` option. Claude (Opus 4.8 / Sonnet 4.6 / Haiku 4.5) is already current.

## Verification
1879 model-area tests pass; all 127 templates validate; .mjs syntax + Python compile clean. Full suite running.

## Separate (already shipped this session, outside the repo)
The nano-banana CLI (UGC image pipeline, in ~/.bun) was patched off the deprecated `gemini-3-pro-image-preview` / `gemini-3.1-flash-image-preview` (Google shuts them down **2026-06-25**) to the GA `gemini-3-pro-image` / `gemini-3.1-flash-image`.

## Follow-up
Anthropic context-editing (`clear_tool_uses_20250919`) + memory tool for long-running agent loops - a larger agent-runtime change, deferred.