### PR TITLE
feat(templates): 5 model-independent workflows that showcase the engine (race-failover, sensor, gate, code, real connectors)

### DIFF
--- a/src/sandcastle/templates/access_review_campaign_orchestrator.yaml
+++ b/src/sandcastle/templates/access_review_campaign_orchestrator.yaml
@@ -1,0 +1,546 @@
+# name: Access Review Campaign
+# description: Periodic least-privilege access certification with auditor-grade, tamper-evident evidence. Pull, diff, classify risk, route sensitive grants to owners, deprovision, hash, and lock the evidence in S3.
+# tags: [Okta, Entra, GitHub, Salesforce, Snowflake, S3, ServiceNow, Slack, IGA, SoD, Audit, Compliance]
+# category: hr_legal
+
+name: access-review-campaign-orchestrator
+description: >
+  Auditor-grade periodic access certification (user access review / least-privilege
+  attestation). Pulls every user and group membership from the IdP (Okta / Entra REST)
+  and entitlements per app (GitHub / Salesforce / Snowflake REST), then runs a
+  DETERMINISTIC Python step that normalizes all grants into one table, diffs against the
+  prior-cycle baseline supplied in input, and flags orphaned (no matching identity) and
+  dormant (stale last_login) access. A model is used in exactly one place - classifying
+  each grant's risk (low / standard / sensitive / toxic_combination by Segregation-of-Duties
+  rules) - and that classify is swappable. The sensitive + toxic grants are looped to their
+  resource owners for a keep/revoke approval; revoke decisions branch to a real deprovision
+  call against the IdP/app API. Every decision is sealed deterministically into a SHA-256
+  hashed evidence pack, a compliance gate (LLM eval + human attester) must pass, the pack is
+  PUT to an S3 bucket with object-lock (WORM), and a certification summary is posted to Slack.
+  Pull, diff, deprovision, and hashing are all deterministic and model-independent.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 900
+
+input_schema:
+  required: ["campaign_id", "baseline"]
+  properties:
+    campaign_id:
+      type: string
+      description: "Unique id for this access-review cycle (e.g. 'AR-2026-Q2')."
+      example: "AR-2026-Q2"
+    idp_base_url:
+      type: string
+      description: "IdP REST base URL (Okta org URL or Microsoft Graph)."
+      default: "https://your-org.okta.com/api/v1"
+      example: "https://acme.okta.com/api/v1"
+    app_entitlements_url:
+      type: string
+      description: "App entitlements REST endpoint (GitHub org members, Salesforce PermissionSetAssignment, or Snowflake GRANTS view exposed via REST)."
+      default: "https://api.github.com/orgs/your-org/members?per_page=100"
+      example: "https://api.github.com/orgs/acme/members?per_page=100"
+    baseline:
+      type: string
+      description: "Reference to the prior-cycle approved baseline (JSON object or URL/ref) used to diff new vs removed grants."
+      default: "{}"
+      example: '{"grants": [{"user": "jdoe", "app": "github", "entitlement": "admin"}]}'
+    dormant_days:
+      type: number
+      description: "Days since last_login after which an active grant is flagged dormant."
+      default: 90
+      example: "90"
+    s3_base_url:
+      type: string
+      description: "S3 (or S3-compatible) REST base URL for the object-lock evidence bucket."
+      default: "https://s3.eu-central-1.amazonaws.com"
+      example: "https://s3.eu-central-1.amazonaws.com"
+    s3_bucket:
+      type: string
+      description: "Object-lock (WORM) bucket that stores the tamper-evident evidence pack."
+      default: "access-review-evidence"
+      example: "acme-access-review-evidence"
+    servicenow_base_url:
+      type: string
+      description: "ServiceNow REST base URL used to open a GRC attestation record for the cycle."
+      default: "https://your-instance.service-now.com/api/now"
+      example: "https://acme.service-now.com/api/now"
+    slack_channel:
+      type: string
+      description: "Slack channel for the certification summary."
+      default: "#access-reviews"
+      example: "#access-reviews"
+
+steps:
+  # 1) PULL identities + group memberships from the IdP (Okta / Microsoft Entra REST).
+  - id: pull_idp_users
+    type: http
+    http_config:
+      url: "{input.idp_base_url}/users?limit=200&expand=groups"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.IDP_API_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 2) PULL entitlements per app (GitHub members / Salesforce PermissionSetAssignment / Snowflake GRANTS).
+  - id: pull_app_entitlements
+    type: http
+    http_config:
+      url: "{input.app_entitlements_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.APP_API_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 3) DETERMINISTIC normalize + diff. The audit-load-bearing logic: build one grants table
+  #    from both sources, diff against the prior-cycle baseline, flag orphaned + dormant. No model.
+  - id: normalize_and_diff
+    type: code
+    depends_on: [pull_idp_users, pull_app_entitlements]
+    code_config:
+      language: python
+      code: |
+        import json
+        from datetime import datetime, timezone
+
+        idp = _steps['pull_idp_users'] or {}
+        apps = _steps['pull_app_entitlements'] or {}
+        dormant_days = float(_input.get('dormant_days', 90) or 90)
+
+        # --- Parse the baseline (may arrive as a JSON string or already-parsed dict) ----
+        raw_baseline = _input.get('baseline') or {}
+        if isinstance(raw_baseline, str):
+            try:
+                raw_baseline = json.loads(raw_baseline) if raw_baseline.strip() else {}
+            except (ValueError, TypeError):
+                raw_baseline = {}
+        baseline_grants = raw_baseline.get('grants', []) if isinstance(raw_baseline, dict) else []
+        baseline_keys = set()
+        for g in baseline_grants:
+            if isinstance(g, dict):
+                baseline_keys.add((str(g.get('user', '')), str(g.get('app', '')), str(g.get('entitlement', ''))))
+
+        # --- Normalize IdP users (Okta returns a list; Graph returns {"value": [...]}) ---
+        idp_list = idp if isinstance(idp, list) else (idp.get('value') or idp.get('users') or [])
+        valid_logins = set()
+        last_login_by_user = {}
+        for u in idp_list:
+            if not isinstance(u, dict):
+                continue
+            profile = u.get('profile', u)
+            login = str(profile.get('login') or profile.get('userPrincipalName') or u.get('id') or '').lower()
+            if not login:
+                continue
+            valid_logins.add(login)
+            last_login_by_user[login] = u.get('lastLogin') or u.get('signInActivity') or profile.get('lastLogin')
+
+        # --- Normalize app entitlements (GitHub members list / Salesforce records / Snowflake rows) ---
+        app_list = apps if isinstance(apps, list) else (apps.get('records') or apps.get('data') or apps.get('value') or [])
+        app_name = str(_input.get('app_entitlements_url', '')).split('//')[-1].split('/')[0] or 'app'
+
+        def _parse_epoch(val):
+            # Tolerate ISO8601 strings or epoch seconds; return age in days or None.
+            if val is None:
+                return None
+            try:
+                if isinstance(val, (int, float)):
+                    dt = datetime.fromtimestamp(float(val), tz=timezone.utc)
+                else:
+                    dt = datetime.fromisoformat(str(val).replace('Z', '+00:00'))
+                return max(0, (datetime.now(timezone.utc) - dt).days)
+            except (ValueError, TypeError, OSError):
+                return None
+
+        grants = []
+        flagged = []
+        for rec in app_list:
+            if not isinstance(rec, dict):
+                continue
+            user = str(rec.get('login') or rec.get('AssigneeId') or rec.get('grantee_name') or rec.get('user') or '').lower()
+            entitlement = str(rec.get('role') or rec.get('PermissionSetId') or rec.get('privilege') or rec.get('entitlement') or 'member')
+            key = (user, app_name, entitlement)
+            age = _parse_epoch(last_login_by_user.get(user))
+            orphaned = user not in valid_logins
+            dormant = age is not None and age > dormant_days
+            grant = {
+                'user': user,
+                'app': app_name,
+                'entitlement': entitlement,
+                'last_login_age_days': age,
+                'orphaned': orphaned,
+                'dormant': dormant,
+                'is_new_since_baseline': key not in baseline_keys,
+            }
+            grants.append(grant)
+            if orphaned or dormant or grant['is_new_since_baseline']:
+                reasons = []
+                if orphaned:
+                    reasons.append('orphaned_no_active_identity')
+                if dormant:
+                    reasons.append(f'dormant_gt_{int(dormant_days)}d')
+                if grant['is_new_since_baseline']:
+                    reasons.append('new_since_baseline')
+                flagged.append({**grant, 'flag_reasons': reasons})
+
+        # Grants present in baseline but no longer observed = removed since last cycle.
+        observed_keys = {(g['user'], g['app'], g['entitlement']) for g in grants}
+        removed = [
+            {'user': u, 'app': a, 'entitlement': e}
+            for (u, a, e) in baseline_keys
+            if (u, a, e) not in observed_keys
+        ]
+
+        result = {
+            'campaign_id': _input.get('campaign_id'),
+            'app': app_name,
+            'total_grants': len(grants),
+            'flagged_count': len(flagged),
+            'grants': grants,
+            'flagged': flagged,
+            'removed_since_baseline': removed,
+            'identity_count': len(valid_logins),
+        }
+
+  # 4) CLASSIFY each grant's risk by Segregation-of-Duties rules. The ONLY model in the path,
+  #    and it is swappable. Every category routes into the deterministic owner-set selector.
+  - id: classify_grant_risk
+    type: classify
+    depends_on: [normalize_and_diff]
+    classify_config:
+      model: haiku
+      input: "Classify the access-grant risk for this access review. Use Segregation-of-Duties rules: toxic_combination = a user holding two conflicting entitlements (e.g. create-vendor + approve-payment, or prod-deploy + audit-log-admin); sensitive = admin/owner/privileged or finance/PII data scope; standard = normal write access; low = read-only or already removed. Grants table: {steps.normalize_and_diff.output}"
+      categories:
+        - low
+        - standard
+        - sensitive
+        - toxic_combination
+      branches:
+        low: [select_review_set]
+        standard: [select_review_set]
+        sensitive: [select_review_set]
+        toxic_combination: [select_review_set]
+
+  # 5) DETERMINISTIC selection of what a human must certify: sensitive + toxic + every flagged grant.
+  - id: select_review_set
+    type: code
+    depends_on: [normalize_and_diff, classify_grant_risk]
+    code_config:
+      language: python
+      code: |
+        diff = _steps['normalize_and_diff'] or {}
+        risk_label = str(_steps['classify_grant_risk'] or '').strip().lower()
+        grants = diff.get('grants', [])
+        flagged = diff.get('flagged', [])
+
+        # Anything flagged (orphaned/dormant/new) always needs owner attention.
+        flagged_keys = {(g.get('user'), g.get('app'), g.get('entitlement')) for g in flagged}
+
+        # When the cohort risk is sensitive/toxic, escalate the whole privileged set;
+        # otherwise only the individually flagged grants require certification.
+        escalate_all = risk_label in ('sensitive', 'toxic_combination')
+
+        review_set = []
+        for g in grants:
+            key = (g.get('user'), g.get('app'), g.get('entitlement'))
+            ent = str(g.get('entitlement', '')).lower()
+            privileged = any(t in ent for t in ('admin', 'owner', 'write', 'accountadmin', 'sysadmin'))
+            if key in flagged_keys or (escalate_all and privileged):
+                g2 = dict(g)
+                g2['cohort_risk'] = risk_label or 'standard'
+                review_set.append(g2)
+
+        result = {
+            'campaign_id': diff.get('campaign_id'),
+            'cohort_risk': risk_label or 'standard',
+            'review_count': len(review_set),
+            'review_set': review_set,
+        }
+
+  # 6) LOOP each sensitive/toxic/flagged grant to its resource owner for a keep/revoke decision.
+  #    The child is an approval step; it reads the current grant via _item.
+  - id: owner_review_loop
+    type: loop
+    depends_on: [select_review_set]
+    loop_config:
+      over: "steps.select_review_set.output.review_set"
+      step_ids: [owner_decision]
+      max_iterations: 500
+
+  # 6a) Per-grant approval routed to the resource owner. keep (approve) or revoke (reject).
+  - id: owner_decision
+    type: approval
+    approval_config:
+      message: >
+        Access certification - decide KEEP or REVOKE for this grant. Approve to KEEP the
+        access; reject to REVOKE it. Resource owner: confirm this person still needs this
+        entitlement for their job function. Grant under review: {{ _item }}
+      show_data: steps.select_review_set.output
+      timeout_hours: 72
+      on_timeout: abort
+      allow_edit: true
+
+  # 7) DETERMINISTIC consolidation of the loop outcome into a revoke list. No model.
+  - id: consolidate_decisions
+    type: code
+    depends_on: [owner_review_loop]
+    code_config:
+      language: python
+      code: |
+        loop_out = _steps['owner_review_loop'] or {}
+        review = _steps['select_review_set'] or {}
+
+        # Loop output may be a list of per-item results or a wrapper dict.
+        items = loop_out if isinstance(loop_out, list) else (loop_out.get('results') or loop_out.get('items') or [])
+        review_set = review.get('review_set', [])
+
+        to_revoke = []
+        kept = []
+        for idx, grant in enumerate(review_set):
+            decision_obj = items[idx] if idx < len(items) and isinstance(items[idx], dict) else {}
+            # An approval that was rejected / not approved means REVOKE.
+            approved = bool(decision_obj.get('approved', decision_obj.get('approve', True)))
+            decision = 'keep' if approved else 'revoke'
+            row = {**grant, 'decision': decision, 'approver': decision_obj.get('approver', 'resource_owner')}
+            if decision == 'revoke':
+                to_revoke.append(row)
+            else:
+                kept.append(row)
+
+        result = {
+            'campaign_id': review.get('campaign_id'),
+            'revoke_count': len(to_revoke),
+            'keep_count': len(kept),
+            'to_revoke': to_revoke,
+            'kept': kept,
+            'has_revocations': len(to_revoke) > 0,
+        }
+
+  # 8) BRANCH on whether any revocation was decided. Deterministic gate, no model.
+  - id: revoke_branch
+    type: condition
+    depends_on: [consolidate_decisions]
+    condition_config:
+      expression: "{steps.consolidate_decisions.output.has_revocations} == true"
+      then: [deprovision_call, assemble_evidence]
+      else: [assemble_evidence]
+
+  # 8a) DEPROVISION: POST the revocation to the IdP/app API (Okta lifecycle deactivate /
+  #     GitHub remove-member / Salesforce delete PermissionSetAssignment). Real money path.
+  - id: deprovision_call
+    type: http
+    http_config:
+      url: "{input.idp_base_url}/access-reviews/{input.campaign_id}/revocations"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.IDP_API_TOKEN}"
+      body: |
+        {
+          "campaign_id": "{input.campaign_id}",
+          "action": "revoke",
+          "revocations": {steps.consolidate_decisions.output.to_revoke}
+        }
+      value_map:
+        revocation_batch_id: "id"
+        revocation_status: "status"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 9) ASSEMBLE the tamper-evident evidence pack. Deterministic SHA-256 over the canonical
+  #    decision record (decision, approver, before/after entitlement state, timestamp). No model.
+  - id: assemble_evidence
+    type: code
+    depends_on: [consolidate_decisions]
+    code_config:
+      language: python
+      code: |
+        import json
+        import hashlib
+        from datetime import datetime, timezone
+
+        decisions = _steps['consolidate_decisions'] or {}
+        diff = _steps['normalize_and_diff'] or {}
+        review = _steps['select_review_set'] or {}
+
+        before_state = diff.get('grants', [])
+        revoked = decisions.get('to_revoke', [])
+        revoked_keys = {(r.get('user'), r.get('app'), r.get('entitlement')) for r in revoked}
+
+        # After-state = before-state minus the revoked grants (what the access posture
+        # becomes once deprovisioning is applied). This is the audit before/after pair.
+        after_state = [
+            g for g in before_state
+            if (g.get('user'), g.get('app'), g.get('entitlement')) not in revoked_keys
+        ]
+
+        evidence = {
+            'campaign_id': _input.get('campaign_id'),
+            'generated_at': datetime.now(timezone.utc).isoformat(),
+            'cohort_risk': review.get('cohort_risk'),
+            'totals': {
+                'grants_reviewed': diff.get('total_grants', 0),
+                'flagged': diff.get('flagged_count', 0),
+                'certified_set': review.get('review_count', 0),
+                'kept': decisions.get('keep_count', 0),
+                'revoked': decisions.get('revoke_count', 0),
+            },
+            'decisions': decisions.get('to_revoke', []) + decisions.get('kept', []),
+            'before_state': before_state,
+            'after_state': after_state,
+            'removed_since_baseline': diff.get('removed_since_baseline', []),
+        }
+
+        # Canonical (sorted-key) serialization so the hash is reproducible byte-for-byte.
+        canonical = json.dumps(evidence, sort_keys=True, separators=(',', ':'))
+        digest = hashlib.sha256(canonical.encode('utf-8')).hexdigest()
+
+        result = {
+            'object_key': f"evidence/{_input.get('campaign_id')}/access-review-evidence.json",
+            'sha256': digest,
+            'byte_length': len(canonical),
+            'evidence_pack': evidence,
+            'canonical_json': canonical,
+        }
+
+  # 10) COMPLIANCE GATE: an LLM attestation eval AND a human attester must BOTH pass before
+  #     the evidence is sealed. Gate has only llm_eval + human strategies; all must pass.
+  - id: certification_gate
+    type: gate
+    depends_on: [assemble_evidence]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >
+              You are an access-certification control reviewer. Answer exactly 'approved'
+              if this evidence pack is internally consistent - every revoked grant is absent
+              from after_state, totals add up (kept + revoked == certified_set or less), and a
+              sha256 digest is present - otherwise answer 'rejected' and name the defect.
+            input: "{steps.assemble_evidence.output}"
+            model: sonnet
+        - type: human
+          config:
+            message: "Campaign attester: confirm this access-review evidence pack is complete and accurate before it is sealed to the object-lock bucket."
+            timeout_hours: 48
+            on_timeout: abort
+
+  # 11) WAIT for the S3 object-lock bucket to be reachable / lock-configured before sealing.
+  - id: await_bucket_ready
+    type: sensor
+    depends_on: [certification_gate]
+    sensor_config:
+      url: "{input.s3_base_url}/{input.s3_bucket}?object-lock"
+      method: GET
+      headers:
+        Accept: "application/xml"
+      condition: "status_code == 200"
+      check_interval: 30
+      timeout: 1800
+
+  # 12) SEAL: PUT the evidence pack to S3 with object-lock (WORM) + Compliance retention.
+  #     The SHA-256 travels as object metadata so the pack is tamper-evident at rest.
+  - id: seal_evidence_pack
+    type: http
+    depends_on: [await_bucket_ready]
+    http_config:
+      url: "{input.s3_base_url}/{input.s3_bucket}/{steps.assemble_evidence.output.object_key}"
+      method: PUT
+      headers:
+        Content-Type: "application/json"
+        x-amz-object-lock-mode: "COMPLIANCE"
+        x-amz-object-lock-retain-until-date: "2034-01-01T00:00:00Z"
+        x-amz-meta-sha256: "{steps.assemble_evidence.output.sha256}"
+        x-amz-meta-campaign-id: "{input.campaign_id}"
+      auth: "aws4:{env.AWS_ACCESS_KEY_ID}:{env.AWS_SECRET_ACCESS_KEY}"
+      body: "{steps.assemble_evidence.output.canonical_json}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 13) GRC: open a ServiceNow attestation record linking the sealed evidence (audit trail).
+  - id: servicenow_attestation
+    type: http
+    depends_on: [seal_evidence_pack]
+    http_config:
+      url: "{input.servicenow_base_url}/table/sn_compliance_attestation"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.SERVICENOW_TOKEN}"
+      body: |
+        {
+          "short_description": "Access review {input.campaign_id} certified",
+          "campaign_id": "{input.campaign_id}",
+          "evidence_sha256": "{steps.assemble_evidence.output.sha256}",
+          "evidence_object": "{steps.assemble_evidence.output.object_key}",
+          "revoked_count": "{steps.consolidate_decisions.output.revoke_count}",
+          "state": "certified"
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 14a) Optional NL certification narrative via CROSS-PROVIDER race (first non-empty wins,
+  #      failover not a vote). Branch A=sonnet, B=gemini, C=mistral. No single provider on the path.
+  - id: narrative_sonnet
+    type: standard
+    model: sonnet
+    prompt: |
+      Write a concise (max 4 sentences, no markdown, no emojis) auditor-facing summary of this
+      access-review certification cycle. State grants reviewed, how many were flagged, kept, and
+      revoked, and that the evidence pack is sha256-hashed and sealed to an object-lock bucket.
+      Totals: {steps.assemble_evidence.output.totals}. SHA-256: {steps.assemble_evidence.output.sha256}.
+
+  - id: narrative_gemini
+    type: standard
+    model: google/gemini-2.5-pro
+    prompt: |
+      Write a concise (max 4 sentences, no markdown, no emojis) auditor-facing summary of this
+      access-review certification cycle. State grants reviewed, how many were flagged, kept, and
+      revoked, and that the evidence pack is sha256-hashed and sealed to an object-lock bucket.
+      Totals: {steps.assemble_evidence.output.totals}. SHA-256: {steps.assemble_evidence.output.sha256}.
+
+  - id: narrative_mistral
+    type: standard
+    model: mistral/large
+    prompt: |
+      Write a concise (max 4 sentences, no markdown, no emojis) auditor-facing summary of this
+      access-review certification cycle. State grants reviewed, how many were flagged, kept, and
+      revoked, and that the evidence pack is sha256-hashed and sealed to an object-lock bucket.
+      Totals: {steps.assemble_evidence.output.totals}. SHA-256: {steps.assemble_evidence.output.sha256}.
+
+  - id: certification_narrative
+    type: race
+    depends_on: [seal_evidence_pack]
+    race_config:
+      branches:
+        - [narrative_sonnet]
+        - [narrative_gemini]
+        - [narrative_mistral]
+      validator: "len(str(output).strip()) > 0"
+
+  # 15) NOTIFY the team in Slack with the certification summary + evidence integrity hash.
+  - id: notify_summary
+    type: notify
+    depends_on: [certification_narrative, servicenow_attestation]
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: "Access review {input.campaign_id} certified. {steps.certification_narrative.output} | Revoked: {steps.consolidate_decisions.output.revoke_count} | Kept: {steps.consolidate_decisions.output.keep_count} | Evidence sha256 {steps.assemble_evidence.output.sha256} sealed (object-lock) at {steps.assemble_evidence.output.object_key}."
+
+on_complete:
+  storage_path: "access-review-campaign-orchestrator/{run_id}/result.json"

--- a/src/sandcastle/templates/closed_loop_autoremediator.yaml
+++ b/src/sandcastle/templates/closed_loop_autoremediator.yaml
@@ -1,0 +1,538 @@
+# name: Closed-Loop Auto-Remediator
+# description: Turns a Datadog/PagerDuty alert into a verified fix - pulls incident context, races two LLM providers for a remediation hypothesis, gates it behind LLM + human sign-off, applies the change via Vercel/Cloudflare/GitHub APIs, polls the SLO until recovery, and auto-rolls-back on failure
+# tags: [DevOps, Incident, Remediation, Datadog, PagerDuty, Failover]
+# category: devops
+
+name: closed-loop-autoremediator
+description: >
+  Closed-loop incident auto-remediation. Pulls a live alert plus recent deploys from
+  Datadog, PagerDuty and GitHub, classifies severity, then RACES two independent
+  providers (Sonnet vs Gemini 2.5 Pro) for a remediation hypothesis. The winning
+  hypothesis passes an LLM-confidence + human-approval gate and an explicit human
+  sign-off, then a deterministic classifier routes the action to the correct apply
+  path (Vercel rollback, Cloudflare route-shift, or a GitHub revert PR). A sensor
+  polls the Datadog SLO until the error rate recovers; if it does not, the workflow
+  auto-rolls-back via the Vercel API and pages Slack, otherwise it posts success.
+  The model only ever decides the hypothesis - apply, verify and rollback are
+  deterministic control flow.
+
+default_model: sonnet
+default_timeout: 600
+
+input_schema:
+  required: ["incident_id", "service"]
+  properties:
+    incident_id:
+      type: string
+      description: "PagerDuty incident ID driving this remediation (e.g. 'PT4KHLK')"
+      default: ""
+    service:
+      type: string
+      description: "Affected service / Datadog monitor scope (e.g. 'payments-api')"
+      default: ""
+    datadog_site:
+      type: string
+      description: "Datadog API site host"
+      default: "api.datadoghq.eu"
+    datadog_monitor_id:
+      type: string
+      description: "Datadog monitor id backing the alert (numeric)"
+      default: "0"
+    datadog_slo_id:
+      type: string
+      description: "Datadog SLO id polled for recovery after the fix is applied"
+      default: ""
+    github_repo:
+      type: string
+      description: "owner/repo used for deploy correlation and revert PRs (e.g. 'acme/platform')"
+      default: ""
+    bad_sha:
+      type: string
+      description: "Suspect commit SHA to revert when action_kind == revert"
+      default: ""
+    vercel_project_id:
+      type: string
+      description: "Vercel project id used for rollback / auto-rollback"
+      default: ""
+    last_good_deployment_id:
+      type: string
+      description: "Vercel deployment id to roll back to (last known-good)"
+      default: ""
+    cloudflare_account_id:
+      type: string
+      description: "Cloudflare account id owning the Worker route"
+      default: ""
+    cloudflare_dispatch_namespace:
+      type: string
+      description: "Cloudflare Workers-for-Platforms dispatch namespace to shift traffic in"
+      default: "production"
+    failover_worker:
+      type: string
+      description: "Name of the known-good Worker to route traffic to on a route-shift action"
+      default: ""
+    slack_channel:
+      type: string
+      description: "Slack channel for remediation status updates"
+      default: "#incident-bridge"
+    min_confidence:
+      type: number
+      description: "Minimum hypothesis confidence (0-1) required to proceed with an automated change"
+      default: 0.7
+
+steps:
+  # 1) Pull live incident context from PagerDuty + Datadog + GitHub (real REST APIs).
+  - id: fetch_pagerduty
+    type: http
+    http_config:
+      url: "https://api.pagerduty.com/incidents/{input.incident_id}"
+      method: GET
+      auth: "token token={env.PAGERDUTY_TOKEN}"
+      headers:
+        Accept: "application/vnd.pagerduty+json;version=2"
+        Content-Type: "application/json"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  - id: fetch_datadog_monitor
+    type: http
+    http_config:
+      url: "https://{input.datadog_site}/api/v1/monitor/{input.datadog_monitor_id}"
+      method: GET
+      headers:
+        DD-API-KEY: "{env.DATADOG_API_KEY}"
+        DD-APPLICATION-KEY: "{env.DATADOG_APP_KEY}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  - id: fetch_recent_deploys
+    type: http
+    http_config:
+      url: "https://api.github.com/repos/{input.github_repo}/deployments?per_page=10"
+      method: GET
+      auth: "bearer:{env.GITHUB_TOKEN}"
+      headers:
+        Accept: "application/vnd.github+json"
+        X-GitHub-Api-Version: "2022-11-28"
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  # 2) Deterministically normalize the three payloads into one incident envelope.
+  - id: build_envelope
+    type: code
+    depends_on: [fetch_pagerduty, fetch_datadog_monitor, fetch_recent_deploys]
+    code_config:
+      language: python
+      code: |
+        # Normalize PagerDuty + Datadog + GitHub payloads into a single envelope.
+        pd = _steps.get("fetch_pagerduty") or {}
+        dd = _steps.get("fetch_datadog_monitor") or {}
+        gh = _steps.get("fetch_recent_deploys") or {}
+
+        def _dig(obj, *path, default=None):
+            cur = obj
+            for key in path:
+                if isinstance(cur, dict):
+                    cur = cur.get(key)
+                else:
+                    return default
+            return cur if cur is not None else default
+
+        incident = _dig(pd, "incident", default=pd if isinstance(pd, dict) else {})
+        pd_urgency = str(_dig(incident, "urgency", default="low")).lower()
+        pd_title = _dig(incident, "title", default="unknown incident")
+
+        dd_status = str(_dig(dd, "overall_state", default="Alert")).lower()
+        dd_name = _dig(dd, "name", default="")
+
+        deploys = gh if isinstance(gh, list) else _dig(gh, "deployments", default=[]) or []
+        recent = []
+        for d in deploys[:10]:
+            if isinstance(d, dict):
+                recent.append({
+                    "sha": d.get("sha", ""),
+                    "ref": d.get("ref", ""),
+                    "environment": d.get("environment", ""),
+                    "created_at": d.get("created_at", ""),
+                })
+
+        # Deterministic blast-radius hint: production deploy in last window is a prime suspect.
+        prod_deploys = [d for d in recent if str(d.get("environment", "")).startswith("prod")]
+
+        result = {
+            "incident_id": _input.get("incident_id", ""),
+            "service": _input.get("service", ""),
+            "pd_title": pd_title,
+            "pd_urgency": pd_urgency,
+            "dd_monitor": dd_name,
+            "dd_status": dd_status,
+            "recent_deploys": recent,
+            "suspect_deploys": prod_deploys,
+            "has_suspect_deploy": bool(prod_deploys),
+        }
+
+  # 3) Classify severity SEV1/SEV2/SEV3 and route to a per-severity context primer.
+  - id: classify_severity
+    type: classify
+    depends_on: [build_envelope]
+    classify_config:
+      categories: ["SEV1", "SEV2", "SEV3"]
+      input: "{steps.build_envelope.output}"
+      model: haiku
+      branches:
+        SEV1: [prime_sev1]
+        SEV2: [prime_sev2]
+        SEV3: [prime_sev3]
+
+  - id: prime_sev1
+    type: code
+    code_config:
+      language: python
+      code: |
+        # SEV1: customer-facing outage - widest blast radius, fastest action budget.
+        env = _steps.get("build_envelope") or {}
+        result = {
+            "severity": "SEV1",
+            "action_budget_minutes": 10,
+            "require_human": True,
+            "guidance": "Customer-facing outage. Prefer instant rollback / route-shift over code revert.",
+            "envelope": env,
+        }
+
+  - id: prime_sev2
+    type: code
+    code_config:
+      language: python
+      code: |
+        # SEV2: degraded service - moderate action budget.
+        env = _steps.get("build_envelope") or {}
+        result = {
+            "severity": "SEV2",
+            "action_budget_minutes": 30,
+            "require_human": True,
+            "guidance": "Degraded service. Rollback or revert acceptable; verify SLO before closing.",
+            "envelope": env,
+        }
+
+  - id: prime_sev3
+    type: code
+    code_config:
+      language: python
+      code: |
+        # SEV3: minor / internal - longest budget, lowest urgency.
+        env = _steps.get("build_envelope") or {}
+        result = {
+            "severity": "SEV3",
+            "action_budget_minutes": 120,
+            "require_human": True,
+            "guidance": "Minor impact. A scoped revert PR is usually the cleanest fix.",
+            "envelope": env,
+        }
+
+  # 4) RACE two providers for a remediation hypothesis. First valid + confident wins.
+  #    Branch A pinned to sonnet, Branch B pinned to google/gemini-2.5-pro.
+  - id: hypo_sonnet
+    type: standard
+    model: sonnet
+    output_schema:
+      type: object
+      properties:
+        root_cause: { type: string }
+        action_kind: { type: string, enum: ["rollback", "route-shift", "revert"] }
+        change_ref: { type: string }
+        confidence: { type: number }
+      required: ["root_cause", "action_kind", "change_ref", "confidence"]
+    prompt: |
+      You are an SRE generating ONE remediation hypothesis for an active incident.
+
+      Incident envelope: {steps.build_envelope.output}
+      Severity routing (SEV1 primer): {steps.prime_sev1.output}
+      Severity routing (SEV2 primer): {steps.prime_sev2.output}
+      Severity routing (SEV3 primer): {steps.prime_sev3.output}
+
+      Decide the single safest reversible action. Return STRICT JSON only:
+      {
+        "root_cause": "<one-sentence proximate cause grounded in the deploys/monitor>",
+        "action_kind": "rollback" | "route-shift" | "revert",
+        "change_ref": "<deployment id, worker name, or commit SHA the action targets>",
+        "confidence": <number 0..1>
+      }
+
+      Rules:
+      - "rollback": redeploy the last known-good Vercel deployment (fastest, use for SEV1 deploy-correlated outages).
+      - "route-shift": shift Cloudflare Worker traffic to a known-good worker (use when the bad path is edge-routable).
+      - "revert": open a GitHub revert PR for the suspect SHA (use when a specific commit is the cause).
+      - confidence must reflect how strongly the recent deploys explain the alert.
+      Output JSON only, no prose.
+
+  - id: hypo_gemini
+    type: standard
+    model: google/gemini-2.5-pro
+    output_schema:
+      type: object
+      properties:
+        root_cause: { type: string }
+        action_kind: { type: string, enum: ["rollback", "route-shift", "revert"] }
+        change_ref: { type: string }
+        confidence: { type: number }
+      required: ["root_cause", "action_kind", "change_ref", "confidence"]
+    prompt: |
+      You are a second, independent SRE generating ONE remediation hypothesis.
+
+      Incident envelope: {steps.build_envelope.output}
+      Severity primers: {steps.prime_sev1.output} {steps.prime_sev2.output} {steps.prime_sev3.output}
+
+      Return STRICT JSON only with keys root_cause, action_kind
+      ("rollback"|"route-shift"|"revert"), change_ref, confidence (0..1).
+      Pick the safest reversible action that the recent deploys best explain.
+      Output JSON only, no prose.
+
+  - id: race_hypothesis
+    type: race
+    race_config:
+      branches:
+        - [hypo_sonnet]
+        - [hypo_gemini]
+      # First branch whose JSON parses with a non-empty action_kind and a real
+      # confidence number wins. Deterministic - not a vote tally.
+      validator: "isinstance(output, dict) and bool(output.get('action_kind')) and isinstance(output.get('confidence'), (int, float))"
+
+  # 5) Deterministically score the winning hypothesis against min_confidence.
+  - id: score_hypothesis
+    type: code
+    depends_on: [race_hypothesis]
+    code_config:
+      language: python
+      code: |
+        # Read the race winner and decide if it clears the automated-change bar.
+        hyp = _steps.get("race_hypothesis") or {}
+        if not isinstance(hyp, dict):
+            hyp = {}
+        action_kind = str(hyp.get("action_kind", "")).strip().lower()
+        try:
+            confidence = float(hyp.get("confidence", 0) or 0)
+        except (TypeError, ValueError):
+            confidence = 0.0
+        try:
+            min_conf = float(_input.get("min_confidence", 0.7) or 0.7)
+        except (TypeError, ValueError):
+            min_conf = 0.7
+
+        valid_actions = {"rollback", "route-shift", "revert"}
+        confident = confidence >= min_conf
+        actionable = action_kind in valid_actions
+
+        result = {
+            "action_kind": action_kind if actionable else "rollback",
+            "raw_action_kind": action_kind,
+            "change_ref": str(hyp.get("change_ref", "")),
+            "root_cause": str(hyp.get("root_cause", "")),
+            "confidence": confidence,
+            "min_confidence": min_conf,
+            "confident": confident,
+            "actionable": actionable,
+            "proceed": confident and actionable,
+        }
+
+  # 6) GATE: an LLM confidence judge AND a human must both approve before any change.
+  - id: remediation_gate
+    type: gate
+    depends_on: [score_hypothesis]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: |
+              A remediation hypothesis was scored. Reply with exactly one word:
+              "approved" if proceed is true and the action_kind is a reversible
+              action (rollback/route-shift/revert), otherwise "rejected".
+              Scored hypothesis: {steps.score_hypothesis.output}
+            input: "{steps.score_hypothesis.output}"
+            model: sonnet
+        - type: human
+          config:
+            message: "Remediation hypothesis cleared automated scoring. Approve applying the proposed change to production?"
+            timeout_hours: 4
+            on_timeout: abort
+
+  # 7) Explicit human sign-off on the exact change about to be applied.
+  - id: change_approval
+    type: approval
+    depends_on: [remediation_gate]
+    approval_config:
+      message: "Final sign-off: apply this remediation to production. Review action_kind, change_ref and confidence before approving."
+      show_data: steps.score_hypothesis.output
+      timeout_hours: 4
+      on_timeout: abort
+      allow_edit: true
+
+  # 8) Route by action_kind to exactly one apply path (deterministic control flow).
+  - id: route_action
+    type: classify
+    depends_on: [change_approval]
+    classify_config:
+      categories: ["rollback", "route-shift", "revert"]
+      input: "{steps.score_hypothesis.output}"
+      model: haiku
+      branches:
+        rollback: [apply_vercel_rollback]
+        route-shift: [apply_cloudflare_route]
+        revert: [apply_github_revert]
+
+  # 8a) Vercel rollback - redeploy the last known-good deployment.
+  - id: apply_vercel_rollback
+    type: http
+    http_config:
+      url: "https://api.vercel.com/v9/projects/{input.vercel_project_id}/rollback/{input.last_good_deployment_id}"
+      method: POST
+      auth: "bearer:{env.VERCEL_TOKEN}"
+      headers:
+        Content-Type: "application/json"
+      body: '{"reason": "closed-loop-autoremediator: {steps.score_hypothesis.output}"}'
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: abort
+
+  # 8b) Cloudflare route-shift - point the dispatch namespace at the known-good worker.
+  - id: apply_cloudflare_route
+    type: http
+    http_config:
+      url: "https://api.cloudflare.com/client/v4/accounts/{input.cloudflare_account_id}/workers/dispatch/namespaces/{input.cloudflare_dispatch_namespace}/scripts/{input.failover_worker}"
+      method: PUT
+      auth: "bearer:{env.CLOUDFLARE_TOKEN}"
+      headers:
+        Content-Type: "application/json"
+      body: '{"enabled": true, "tags": ["autoremediator", "route-shift"]}'
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: abort
+
+  # 8c) GitHub revert - open a revert PR-equivalent (create a revert ref) for the bad SHA.
+  - id: apply_github_revert
+    type: http
+    http_config:
+      url: "https://api.github.com/repos/{input.github_repo}/merges"
+      method: POST
+      auth: "bearer:{env.GITHUB_TOKEN}"
+      headers:
+        Accept: "application/vnd.github+json"
+        X-GitHub-Api-Version: "2022-11-28"
+      body: '{"base": "main", "head": "{input.bad_sha}", "commit_message": "Revert suspect change for incident {input.incident_id} (autoremediator)"}'
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: abort
+
+  # 9) Join the three apply paths back into one deterministic outcome record.
+  - id: apply_result
+    type: code
+    depends_on: [route_action]
+    code_config:
+      language: python
+      code: |
+        # Exactly one apply branch ran (classify routed it). Collect whichever responded.
+        scored = _steps.get("score_hypothesis") or {}
+        vercel = _steps.get("apply_vercel_rollback")
+        cloudflare = _steps.get("apply_cloudflare_route")
+        github = _steps.get("apply_github_revert")
+
+        applied = None
+        provider = None
+        if vercel is not None:
+            applied, provider = vercel, "vercel"
+        elif cloudflare is not None:
+            applied, provider = cloudflare, "cloudflare-workers"
+        elif github is not None:
+            applied, provider = github, "github"
+
+        result = {
+            "action_kind": scored.get("action_kind", ""),
+            "change_ref": scored.get("change_ref", ""),
+            "applied_via": provider,
+            "apply_response": applied,
+            "applied": applied is not None,
+        }
+
+  # 10) SENSOR: poll the Datadog SLO until the error budget recovers, or time out.
+  - id: verify_slo_recovery
+    type: sensor
+    depends_on: [apply_result]
+    sensor_config:
+      url: "https://{input.datadog_site}/api/v1/slo/{input.datadog_slo_id}/history?from_ts=0&to_ts=0"
+      method: GET
+      headers:
+        DD-API-KEY: "{env.DATADOG_API_KEY}"
+        DD-APPLICATION-KEY: "{env.DATADOG_APP_KEY}"
+      # Recovered when the rolling SLI is back above its threshold.
+      condition: "status_code == 200 and float(response.get('data', {}).get('overall', {}).get('sli_value', 0) or 0) >= float(response.get('data', {}).get('thresholds', {}).get('7d', {}).get('target', 100) or 100)"
+      check_interval: 30
+      timeout: 1800
+
+  # 11) Did it recover? Determine recovery deterministically from the sensor result.
+  - id: evaluate_recovery
+    type: code
+    depends_on: [verify_slo_recovery]
+    code_config:
+      language: python
+      code: |
+        # The sensor returns its final observation (and whether the condition was met).
+        obs = _steps.get("verify_slo_recovery") or {}
+        if not isinstance(obs, dict):
+            obs = {}
+        # Sensors surface a boolean-ish recovery signal; fall back to inspecting the payload.
+        recovered = bool(obs.get("condition_met", obs.get("met", obs.get("recovered", False))))
+        result = {
+            "recovered": recovered,
+            "observation": obs,
+            "fail_count": 0 if recovered else 1,
+        }
+
+  # 12) Branch on recovery: success path vs auto-rollback path.
+  - id: recovery_branch
+    type: condition
+    depends_on: [evaluate_recovery]
+    condition_config:
+      expression: "{steps.evaluate_recovery.output.fail_count} > 0"
+      then_steps: [auto_rollback, notify_failure]
+      else_steps: [notify_success]
+
+  # 12a) Not recovered -> auto-rollback to last known-good Vercel deployment.
+  - id: auto_rollback
+    type: http
+    http_config:
+      url: "https://api.vercel.com/v9/projects/{input.vercel_project_id}/rollback/{input.last_good_deployment_id}"
+      method: POST
+      auth: "bearer:{env.VERCEL_TOKEN}"
+      headers:
+        Content-Type: "application/json"
+      body: '{"reason": "closed-loop-autoremediator AUTO-ROLLBACK: SLO did not recover after {steps.apply_result.output}"}'
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 12b) Page the bridge: the automated fix failed and we auto-rolled-back.
+  - id: notify_failure
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: ":rotating_light: AUTO-REMEDIATION FAILED for {input.service} (incident {input.incident_id}). Applied {steps.apply_result.output} but SLO did not recover - auto-rollback triggered. Human takeover required."
+
+  # 12c) Recovered: post the success summary with the full closed-loop record.
+  - id: notify_success
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: ":white_check_mark: AUTO-REMEDIATION VERIFIED for {input.service} (incident {input.incident_id}). Applied {steps.apply_result.output}; Datadog SLO recovered: {steps.evaluate_recovery.output}."
+
+on_complete:
+  storage_path: "closed-loop-autoremediator/{run_id}/result.json"

--- a/src/sandcastle/templates/cost_tiered_escalation_router.yaml
+++ b/src/sandcastle/templates/cost_tiered_escalation_router.yaml
@@ -1,0 +1,318 @@
+# name: Cost-Tiered Escalation Router
+# description: Cheapest model first, escalate only the hard cases - a reusable multi-provider cost ladder for LLMOps.
+# tags: [llmops, cost-optimization, routing, failover, escalation]
+# category: general_ai
+name: cost-tiered-escalation-router
+description: >
+  A reusable, provider-neutral cost ladder. Pull a batch of work items from a
+  queue store (Postgres via PostgREST), try the CHEAPEST model first and let it
+  self-report confidence, then a measured classify decides which items are
+  easy_pass / borderline / hard. Only borderline + hard items pay for a mid-tier
+  RACE across two providers (first-valid-wins failover). A deterministic code
+  step tags the serving tier/provider/cost per item, a second code step
+  aggregates cost-per-item, tier mix and dollars saved versus an all-frontier
+  baseline, a quality gate spot-checks a sample of escalated answers (LLM judge
+  plus a human sign-off), and the savings report is written back to the queue
+  store and posted to Slack as a daily cost-savings digest.
+default_model: sonnet
+default_timeout: 900
+input_schema:
+  required: ["queue_endpoint", "frontier_model"]
+  properties:
+    queue_endpoint:
+      type: string
+      description: "Base URL of the queue store REST API (PostgREST over Postgres), e.g. https://queue.internal/rest/v1"
+      default: "https://queue.internal/rest/v1"
+    min_confidence:
+      type: number
+      description: "Cheap-tier self-reported confidence floor; below this an item is treated as not-easy."
+      default: 0.75
+    frontier_model:
+      type: string
+      description: "Name of the all-frontier baseline model used for the $-saved comparison (cost-modeling only)."
+      default: "opus"
+    batch_limit:
+      type: integer
+      description: "Max number of queued items to pull per run."
+      default: 50
+    frontier_cost_per_item:
+      type: number
+      description: "Assumed USD cost per item if EVERY item ran on the frontier model (baseline)."
+      default: 0.090
+steps:
+  # 1) Pull the batch of pending items from the queue store (Postgres via PostgREST).
+  - id: "fetch_batch"
+    type: http
+    http_config:
+      url: "{input.queue_endpoint}/routing_queue?status=eq.pending&order=priority.desc&limit={input.batch_limit}"
+      method: GET
+      headers:
+        Accept: "application/json"
+        Prefer: "count=exact"
+      auth: "bearer:{env.QUEUE_API_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 2) Loop over each queued item: cheap try -> route -> (maybe) race -> record.
+  - id: "process_batch"
+    type: loop
+    depends_on: ["fetch_batch"]
+    loop_config:
+      over: "steps.fetch_batch.output"
+      step_ids: ["cheap_try", "route", "escalate_race", "record"]
+      max_iterations: 200
+
+  # 2a) CHEAP tier - attempt the task on the cheapest model and self-report confidence.
+  - id: "cheap_try"
+    type: standard
+    model: haiku
+    prompt: |
+      You are the CHEAP tier of a cost-tiered router. Solve the task on this work item
+      as well as you can, then HONESTLY self-report your confidence.
+
+      Work item (JSON):
+      {{ _item }}
+
+      Return STRICT JSON only:
+      {
+        "answer": "<your best answer to the item's task>",
+        "confidence": <float 0.0-1.0, calibrated - low if the item is ambiguous or hard>,
+        "reasoning_brief": "<one sentence on why this confidence>"
+      }
+    output_schema:
+      type: object
+      properties:
+        answer: { type: string }
+        confidence: { type: number }
+        reasoning_brief: { type: string }
+
+  # 2b) ROUTE - a cheap classifier decides easy_pass / borderline / hard from the cheap result.
+  - id: "route"
+    type: classify
+    classify_config:
+      categories: ["easy_pass", "borderline", "hard"]
+      input: "{steps.cheap_try.output}"
+      model: haiku
+      branches:
+        easy_pass: ["record"]
+        borderline: ["escalate_race", "record"]
+        hard: ["escalate_race", "record"]
+
+  # 2c) MID tier RACE - two providers, first non-empty answer wins (failover, not a vote).
+  #     Branch A and Branch B are defined separately below with NO depends_on.
+  - id: "escalate_race"
+    type: race
+    race_config:
+      branches: [["mid_provider_a"], ["mid_provider_b"]]
+      validator: "len(str(output)) > 0"
+
+  - id: "mid_provider_a"
+    type: standard
+    model: sonnet
+    prompt: |
+      You are MID-TIER provider A (Anthropic Sonnet). The cheap tier was not confident
+      on this item. Produce a high-quality, final answer.
+
+      Work item (JSON):
+      {{ _item }}
+
+      Cheap-tier attempt (for context, may be wrong):
+      {{ _steps['cheap_try'] }}
+
+      Return STRICT JSON: {"answer": "<final high-quality answer>", "tier": "mid", "provider": "sonnet"}
+
+  - id: "mid_provider_b"
+    type: standard
+    model: google/gemini-2.5-pro
+    prompt: |
+      You are MID-TIER provider B (Gemini 2.5 Pro), the failover for provider A.
+      Produce a high-quality, final answer for this item.
+
+      Work item (JSON):
+      {{ _item }}
+
+      Cheap-tier attempt (for context, may be wrong):
+      {{ _steps['cheap_try'] }}
+
+      Return STRICT JSON: {"answer": "<final high-quality answer>", "tier": "mid", "provider": "gemini-2.5-pro"}
+
+  # 2d) RECORD - deterministic per-item tagging: which tier/provider served it + cost.
+  #     Cheap/mid tier prices are pure config here (USD/item). Decision already happened
+  #     upstream (classify + race); this step just measures and tags it.
+  - id: "record"
+    type: code
+    code_config:
+      language: python
+      code: |
+        # Per-item accounting. Read this iteration's item + the cheap attempt; the
+        # race output is only present for borderline/hard items.
+        item = _input.get('_item') or {}
+        cheap = _steps.get('cheap_try') or {}
+        race = _steps.get('escalate_race')  # None when the item was easy_pass
+
+        # Pure-config tier prices (USD per item). Swap freely without touching logic.
+        CHEAP_PRICE = 0.004
+        MID_PRICE = 0.030
+
+        min_conf = float(_input.get('min_confidence', 0.75))
+        try:
+            conf = float(cheap.get('confidence', 0.0)) if isinstance(cheap, dict) else 0.0
+        except (TypeError, ValueError):
+            conf = 0.0
+
+        escalated = race is not None and bool(str(race).strip())
+        if escalated:
+            tier = 'mid'
+            served_cost = CHEAP_PRICE + MID_PRICE  # cheap attempt was still paid for
+            # Best-effort provider read from the winning race branch.
+            provider = 'sonnet'
+            try:
+                if isinstance(race, dict) and race.get('provider'):
+                    provider = str(race.get('provider'))
+                elif 'gemini' in str(race).lower():
+                    provider = 'gemini-2.5-pro'
+            except Exception:
+                provider = 'sonnet'
+            final_answer = race.get('answer') if isinstance(race, dict) else str(race)
+        else:
+            tier = 'cheap'
+            served_cost = CHEAP_PRICE
+            provider = 'haiku'
+            final_answer = cheap.get('answer') if isinstance(cheap, dict) else str(cheap)
+
+        result = {
+            'item_id': item.get('id'),
+            'tier': tier,
+            'provider': provider,
+            'cheap_confidence': conf,
+            'met_min_confidence': conf >= min_conf,
+            'escalated': escalated,
+            'cost_usd': round(served_cost, 6),
+            'final_answer': final_answer,
+        }
+
+  # 3) AGGREGATE - cost-per-item, tier mix, and $ saved vs an all-frontier baseline.
+  - id: "aggregate"
+    type: code
+    depends_on: ["process_batch"]
+    code_config:
+      language: python
+      code: |
+        # The loop output is the list of per-item `record` results.
+        rows = _steps.get('process_batch') or []
+        if isinstance(rows, dict):
+            rows = rows.get('results') or rows.get('items') or list(rows.values())
+        if not isinstance(rows, list):
+            rows = [rows]
+        rows = [r for r in rows if isinstance(r, dict)]
+
+        n = len(rows) or 1
+        cheap_n = sum(1 for r in rows if r.get('tier') == 'cheap')
+        mid_n = sum(1 for r in rows if r.get('tier') == 'mid')
+        escalated_ids = [r.get('item_id') for r in rows if r.get('escalated')]
+
+        total_cost = round(sum(float(r.get('cost_usd', 0.0) or 0.0) for r in rows), 4)
+        cost_per_item = round(total_cost / n, 5)
+
+        frontier_unit = float(_input.get('frontier_cost_per_item', 0.090))
+        baseline_cost = round(frontier_unit * len(rows), 4)
+        saved = round(baseline_cost - total_cost, 4)
+        saved_pct = round((saved / baseline_cost * 100.0), 1) if baseline_cost > 0 else 0.0
+
+        result = {
+            'items': len(rows),
+            'cheap_count': cheap_n,
+            'mid_count': mid_n,
+            'pct_cheap': round(cheap_n / n * 100.0, 1),
+            'pct_mid': round(mid_n / n * 100.0, 1),
+            'total_cost_usd': total_cost,
+            'cost_per_item_usd': cost_per_item,
+            'baseline_frontier_cost_usd': baseline_cost,
+            'frontier_model': _input.get('frontier_model', 'opus'),
+            'dollars_saved': saved,
+            'savings_pct': saved_pct,
+            'escalated_item_ids': escalated_ids,
+            'per_item': rows,
+        }
+
+  # 4) QUALITY GATE - LLM judge spot-checks escalated answers AND a human signs off.
+  - id: "quality_gate"
+    type: gate
+    depends_on: ["aggregate"]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: |
+              You are auditing a cost-tiered router. Below is the routing/cost
+              aggregate, including a sample of escalated (mid-tier) answers under
+              per_item. Spot-check the escalated answers for quality and confirm
+              the cheap->mid escalations look justified (cheap confidence was low).
+              Answer exactly "approved" if quality holds and the savings are not
+              coming from under-serving hard items; otherwise answer "rejected".
+            input: "{steps.aggregate.output}"
+            model: sonnet
+        - type: human
+          config:
+            message: "Approve today's cost-tier routing run? Review tier mix + escalated-answer sample before the digest goes out."
+            timeout_hours: 12
+            on_timeout: abort
+
+  # 5) APPROVAL - explicit human ack of the dollar figures before they are published/written back.
+  - id: "approve_publish"
+    type: approval
+    depends_on: ["quality_gate"]
+    approval_config:
+      message: "Confirm publishing the cost-savings digest and writing per-item routing/cost back to the queue store."
+      show_data: "steps.aggregate.output"
+      timeout_hours: 24
+      on_timeout: abort
+      allow_edit: true
+
+  # 6) REPORT - build the human-readable savings + routing report.
+  - id: "build_report"
+    type: transform
+    depends_on: ["approve_publish"]
+    transform_config:
+      template: |
+        Cost-Tiered Escalation Router - Daily Digest
+        ============================================
+        Items processed : {steps.aggregate.output.items}
+        Tier mix        : {steps.aggregate.output.pct_cheap}% cheap (haiku) / {steps.aggregate.output.pct_mid}% mid (sonnet|gemini-2.5-pro)
+        Cost / item     : ${steps.aggregate.output.cost_per_item_usd}
+        Total spend     : ${steps.aggregate.output.total_cost_usd}
+        Frontier baseline ({steps.aggregate.output.frontier_model}) : ${steps.aggregate.output.baseline_frontier_cost_usd}
+        Dollars saved   : ${steps.aggregate.output.dollars_saved} ({steps.aggregate.output.savings_pct}% vs all-frontier)
+        Escalated items : {steps.aggregate.output.escalated_item_ids}
+
+  # 7) WRITE-BACK - persist per-item routing + cost to the queue store (Postgres via PostgREST).
+  - id: "write_back"
+    type: http
+    depends_on: ["build_report"]
+    http_config:
+      url: "{input.queue_endpoint}/routing_results"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Prefer: "resolution=merge-duplicates"
+      auth: "bearer:{env.QUEUE_API_TOKEN}"
+      body: "{steps.aggregate.output}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 8) NOTIFY - post the daily cost-savings digest to Slack.
+  - id: "notify_digest"
+    type: notify
+    depends_on: ["write_back"]
+    notify_config:
+      service: slack
+      channel: "#llmops-cost"
+      message: |
+        Daily cost-tier routing digest:
+        {steps.build_report.output}
+on_complete:
+  storage_path: "cost-tiered-escalation-router/{run_id}/result.json"

--- a/src/sandcastle/templates/quote_to_cash_orchestrator.yaml
+++ b/src/sandcastle/templates/quote_to_cash_orchestrator.yaml
@@ -1,0 +1,391 @@
+# name: Quote-to-Cash Orchestrator
+# description: Drive a closed-won opportunity to cash - render order form, e-sign, poll DocuSign, bill in Stripe, write back to CRM. Spine is deterministic (transform + approval + sensor + http), almost no model in the path.
+# tags: [Salesforce, HubSpot, DocuSign, Stripe, Slack, Quote-to-Cash, RevOps, Billing]
+# category: sales_crm
+
+name: quote-to-cash-orchestrator
+description: >
+  Closed-won opportunity to cash with almost no model in the critical path - the purest
+  model-independence proof. Pulls the won opportunity, account, and agreed terms from the CRM
+  (Salesforce/HubSpot REST), deterministically renders the order-form / quote payload via a
+  Jinja template (no model), routes it to the deal owner for an edit-and-approve gate, creates
+  and sends a DocuSign e-sign envelope, polls the envelope status until it settles, then branches:
+  voided/expired -> notify owner + patch the CRM 'signature_lost' and stop; completed -> create
+  the customer and subscription/invoice in Stripe from the agreed terms, write the contract and
+  Stripe ids back to the CRM, and Slack a win + billing summary. The only optional model use is a
+  short natural-language billing blurb in the final notification, computed via a cross-provider
+  race so no single LLM provider is on the path.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 600
+
+input_schema:
+  required: ["opportunity_id"]
+  properties:
+    opportunity_id:
+      type: string
+      description: "CRM id of the closed-won opportunity to convert to cash"
+      example: "0065g00000XyZ12AAB"
+    crm_base_url:
+      type: string
+      description: "Base URL of the CRM REST API (Salesforce or HubSpot)"
+      default: "https://your-instance.my.salesforce.com/services/data/v60.0"
+      example: "https://your-instance.my.salesforce.com/services/data/v60.0"
+    docusign_base_url:
+      type: string
+      description: "DocuSign eSignature REST base URL including account id"
+      default: "https://demo.docusign.net/restapi/v2.1/accounts/{account_id}"
+      example: "https://demo.docusign.net/restapi/v2.1/accounts/12345"
+    docusign_template_id:
+      type: string
+      description: "DocuSign server template id used to build the envelope"
+      default: "00000000-0000-0000-0000-000000000000"
+      example: "a1b2c3d4-0000-0000-0000-000000000000"
+    stripe_base_url:
+      type: string
+      description: "Stripe REST API base URL"
+      default: "https://api.stripe.com/v1"
+      example: "https://api.stripe.com/v1"
+    slack_channel:
+      type: string
+      description: "Slack channel to post the win + billing summary to"
+      default: "#revenue-wins"
+      example: "#revenue-wins"
+
+steps:
+  # 1) PULL - read the won opportunity + account + agreed terms from the CRM (Salesforce/HubSpot REST).
+  - id: pull_opportunity
+    type: http
+    http_config:
+      url: "{input.crm_base_url}/sobjects/Opportunity/{input.opportunity_id}?fields=Id,Name,StageName,Amount,CurrencyIsoCode,AccountId,Account.Name,Account.BillingAddress,Pricebook2Id,ContractTerm__c,BillingFrequency__c,Quantity__c,UnitPrice__c,ContactEmail__c"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.CRM_ACCESS_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 2) NORMALIZE - deterministic sanity check + canonical terms object. Load-bearing logic lives in
+  #    Python (no model): validate the opp is actually closed-won and has billable terms.
+  - id: normalize_terms
+    type: code
+    depends_on: [pull_opportunity]
+    code_config:
+      language: python
+      code: |
+        opp = _steps['pull_opportunity'] or {}
+        # CRM REST returns a flat record; tolerate both Salesforce and HubSpot field shapes.
+        stage = str(opp.get('StageName') or opp.get('dealstage') or '').lower()
+        amount = float(opp.get('Amount') or opp.get('amount') or 0)
+        qty = int(opp.get('Quantity__c') or opp.get('quantity') or 1)
+        unit_price = float(opp.get('UnitPrice__c') or opp.get('unit_price') or (amount / qty if qty else 0))
+        term_months = int(opp.get('ContractTerm__c') or opp.get('contract_term') or 12)
+        billing_freq = str(opp.get('BillingFrequency__c') or opp.get('billing_frequency') or 'monthly').lower()
+        currency = str(opp.get('CurrencyIsoCode') or opp.get('currency') or 'USD').upper()
+        account = (opp.get('Account') or {})
+        is_won = 'closed won' in stage or stage in ('closedwon', 'won')
+        # Stripe wants the smallest currency unit; zero-decimal currencies are billed as-is.
+        zero_decimal = currency in ('JPY', 'KRW', 'VND', 'CLP')
+        unit_amount_minor = int(round(unit_price if zero_decimal else unit_price * 100))
+        interval = 'year' if 'annual' in billing_freq or 'year' in billing_freq else 'month'
+        blockers = []
+        if not is_won:
+            blockers.append(f"opportunity is not closed-won (stage={stage!r})")
+        if amount <= 0:
+            blockers.append("opportunity amount is zero or missing")
+        if not (opp.get('ContactEmail__c') or opp.get('contact_email')):
+            blockers.append("no signer contact email on opportunity")
+        result = {
+            'eligible': len(blockers) == 0,
+            'blockers': blockers,
+            'opportunity_id': opp.get('Id') or opp.get('id'),
+            'opportunity_name': opp.get('Name') or opp.get('dealname') or 'Untitled deal',
+            'account_id': opp.get('AccountId') or opp.get('account_id'),
+            'account_name': account.get('Name') or opp.get('account_name') or 'Unknown account',
+            'signer_email': opp.get('ContactEmail__c') or opp.get('contact_email') or '',
+            'currency': currency,
+            'quantity': qty,
+            'unit_price': unit_price,
+            'unit_amount_minor': unit_amount_minor,
+            'term_months': term_months,
+            'interval': interval,
+            'total_amount': round(unit_price * qty, 2),
+        }
+
+  # 3) GATE - eligibility must pass deterministically AND a cheap LLM eval double-checks there are
+  #    no blockers before we ever touch DocuSign/Stripe. ALL strategies must pass.
+  - id: eligibility_gate
+    type: gate
+    depends_on: [normalize_terms]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: "You are a deal-desk control. Given this normalized order record, answer exactly 'approved' if the JSON field eligible is true and blockers is empty, otherwise answer 'rejected' and name the blocker. Record: {steps.normalize_terms.output}"
+            input: "{steps.normalize_terms.output}"
+            model: haiku
+        - type: human
+          config:
+            message: "Deal desk: confirm this closed-won opportunity is clear to convert to an order form (no legal hold, terms look right)."
+            timeout_hours: 12
+            on_timeout: abort
+
+  # 4) RENDER - deterministic order-form / quote payload from the opportunity. Pure Jinja, no model.
+  - id: render_order_form
+    type: transform
+    depends_on: [eligibility_gate]
+    transform_config:
+      template: |
+        {
+          "order_form": {
+            "title": "Order Form - {{ steps.normalize_terms.output.opportunity_name }}",
+            "account": {
+              "id": "{{ steps.normalize_terms.output.account_id }}",
+              "name": "{{ steps.normalize_terms.output.account_name }}"
+            },
+            "signer_email": "{{ steps.normalize_terms.output.signer_email }}",
+            "line_items": [
+              {
+                "description": "Subscription - {{ steps.normalize_terms.output.opportunity_name }}",
+                "quantity": {{ steps.normalize_terms.output.quantity }},
+                "unit_price": {{ steps.normalize_terms.output.unit_price }},
+                "currency": "{{ steps.normalize_terms.output.currency }}"
+              }
+            ],
+            "billing": {
+              "interval": "{{ steps.normalize_terms.output.interval }}",
+              "term_months": {{ steps.normalize_terms.output.term_months }},
+              "total_contract_value": {{ steps.normalize_terms.output.total_amount }}
+            }
+          }
+        }
+
+  # 5) APPROVAL - the deal owner reviews the rendered order form and may edit it before signature.
+  - id: owner_review
+    type: approval
+    depends_on: [render_order_form]
+    approval_config:
+      message: "Deal owner: review the rendered order form for this closed-won deal. Edit pricing, quantity, or term if needed before we send it for e-signature."
+      show_data: steps.render_order_form.output
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: true
+
+  # 6) SEND ENVELOPE - create + send the e-sign envelope via DocuSign REST.
+  - id: create_envelope
+    type: http
+    depends_on: [owner_review]
+    http_config:
+      url: "{input.docusign_base_url}/envelopes"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.DOCUSIGN_ACCESS_TOKEN}"
+      body: |
+        {
+          "templateId": "{input.docusign_template_id}",
+          "status": "sent",
+          "emailSubject": "Please sign your order form",
+          "templateRoles": [
+            {
+              "roleName": "Signer",
+              "name": "{steps.normalize_terms.output.account_name}",
+              "email": "{steps.normalize_terms.output.signer_email}"
+            }
+          ],
+          "customFields": {
+            "textCustomFields": [
+              {"name": "opportunity_id", "value": "{input.opportunity_id}"},
+              {"name": "order_form", "value": "rendered"}
+            ]
+          }
+        }
+      value_map:
+        envelope_id: "envelopeId"
+        envelope_status: "status"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 7) WAIT - poll the DocuSign envelope status until the signer settles it. Long timeout (24h).
+  - id: await_signature
+    type: sensor
+    depends_on: [create_envelope]
+    sensor_config:
+      url: "{input.docusign_base_url}/envelopes/{steps.create_envelope.output.envelope_id}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "json.get('status') in ('completed', 'voided', 'declined', 'expired')"
+      check_interval: 120
+      timeout: 86400
+
+  # 8) BRANCH - terminal envelope state decides everything from here. Deterministic, no model.
+  - id: classify_signature
+    type: code
+    depends_on: [await_signature]
+    code_config:
+      language: python
+      code: |
+        env = _steps['await_signature'] or {}
+        status = str(env.get('status') or '').lower()
+        completed = status == 'completed'
+        result = {
+            'status': status or 'unknown',
+            'completed': completed,
+            'lost': status in ('voided', 'declined', 'expired'),
+            'envelope_id': env.get('envelopeId') or _steps['create_envelope'].get('envelope_id'),
+        }
+
+  - id: signature_outcome
+    type: condition
+    depends_on: [classify_signature]
+    condition_config:
+      expression: "{steps.classify_signature.output.completed} == true"
+      then:
+        - provision_stripe_customer
+        - create_subscription
+        - billing_summary_race
+        - crm_writeback_won
+        - notify_win
+      else:
+        - crm_writeback_lost
+        - notify_lost
+
+  # ---- LOST PATH: signer voided/declined/expired -> mark CRM signature_lost + tell the owner. ----
+  - id: crm_writeback_lost
+    type: http
+    http_config:
+      url: "{input.crm_base_url}/sobjects/Opportunity/{input.opportunity_id}"
+      method: PATCH
+      headers:
+        Content-Type: "application/json"
+      auth: "bearer:{env.CRM_ACCESS_TOKEN}"
+      body: |
+        {
+          "Signature_Status__c": "signature_lost",
+          "Envelope_Status__c": "{steps.classify_signature.output.status}",
+          "DocuSign_Envelope_Id__c": "{steps.classify_signature.output.envelope_id}"
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  - id: notify_lost
+    type: notify
+    depends_on: [crm_writeback_lost]
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: "Signature lost on '{steps.normalize_terms.output.opportunity_name}' ({steps.normalize_terms.output.account_name}). DocuSign envelope ended as {steps.classify_signature.output.status}. CRM marked signature_lost - no billing created."
+
+  # ---- WON PATH: signed -> Stripe customer + subscription, CRM writeback, Slack win. ----
+  - id: provision_stripe_customer
+    type: http
+    http_config:
+      url: "{input.stripe_base_url}/customers"
+      method: POST
+      headers:
+        Content-Type: "application/x-www-form-urlencoded"
+      auth: "bearer:{env.STRIPE_SECRET_KEY}"
+      body: "name={steps.normalize_terms.output.account_name}&email={steps.normalize_terms.output.signer_email}&metadata[opportunity_id]={input.opportunity_id}&metadata[crm_account_id]={steps.normalize_terms.output.account_id}"
+      value_map:
+        customer_id: "id"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  - id: create_subscription
+    type: http
+    depends_on: [provision_stripe_customer]
+    http_config:
+      url: "{input.stripe_base_url}/subscription_items_and_invoice"
+      method: POST
+      headers:
+        Content-Type: "application/x-www-form-urlencoded"
+      auth: "bearer:{env.STRIPE_SECRET_KEY}"
+      body: "customer={steps.provision_stripe_customer.output.customer_id}&items[0][price_data][currency]={steps.normalize_terms.output.currency}&items[0][price_data][unit_amount]={steps.normalize_terms.output.unit_amount_minor}&items[0][price_data][recurring][interval]={steps.normalize_terms.output.interval}&items[0][price_data][product_data][name]={steps.normalize_terms.output.opportunity_name}&items[0][quantity]={steps.normalize_terms.output.quantity}"
+      value_map:
+        subscription_id: "id"
+        invoice_id: "latest_invoice"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # Optional NL billing blurb via CROSS-PROVIDER race (first-valid-wins failover, no single
+  # provider on the path). This is the ONLY model use on the success spine and it is non-blocking.
+  - id: summary_sonnet
+    prompt: |
+      Write one upbeat sentence (max 30 words) summarizing this new billing for a Slack post.
+      Account: {steps.normalize_terms.output.account_name}.
+      Total contract value: {steps.normalize_terms.output.total_amount} {steps.normalize_terms.output.currency}.
+      Billing interval: {steps.normalize_terms.output.interval}. No emojis, no markdown.
+    model: sonnet
+
+  - id: summary_gemini
+    prompt: |
+      Write one upbeat sentence (max 30 words) summarizing this new billing for a Slack post.
+      Account: {steps.normalize_terms.output.account_name}.
+      Total contract value: {steps.normalize_terms.output.total_amount} {steps.normalize_terms.output.currency}.
+      Billing interval: {steps.normalize_terms.output.interval}. No emojis, no markdown.
+    model: google/gemini-2.5-pro
+
+  - id: summary_mistral
+    prompt: |
+      Write one upbeat sentence (max 30 words) summarizing this new billing for a Slack post.
+      Account: {steps.normalize_terms.output.account_name}.
+      Total contract value: {steps.normalize_terms.output.total_amount} {steps.normalize_terms.output.currency}.
+      Billing interval: {steps.normalize_terms.output.interval}. No emojis, no markdown.
+    model: mistral/large
+
+  - id: billing_summary_race
+    type: race
+    depends_on: [create_subscription]
+    race_config:
+      branches:
+        - [summary_sonnet]
+        - [summary_gemini]
+        - [summary_mistral]
+      validator: "len(str(output).strip()) > 0"
+
+  - id: crm_writeback_won
+    type: http
+    depends_on: [create_subscription]
+    http_config:
+      url: "{input.crm_base_url}/sobjects/Opportunity/{input.opportunity_id}"
+      method: PATCH
+      headers:
+        Content-Type: "application/json"
+      auth: "bearer:{env.CRM_ACCESS_TOKEN}"
+      body: |
+        {
+          "Signature_Status__c": "signed",
+          "DocuSign_Envelope_Id__c": "{steps.classify_signature.output.envelope_id}",
+          "Stripe_Customer_Id__c": "{steps.provision_stripe_customer.output.customer_id}",
+          "Stripe_Subscription_Id__c": "{steps.create_subscription.output.subscription_id}",
+          "Stripe_Invoice_Id__c": "{steps.create_subscription.output.invoice_id}",
+          "Billing_Status__c": "active"
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  - id: notify_win
+    type: notify
+    depends_on: [billing_summary_race, crm_writeback_won]
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: "Closed-won converted to cash: {steps.billing_summary_race.output} | Deal: {steps.normalize_terms.output.opportunity_name} | TCV {steps.normalize_terms.output.total_amount} {steps.normalize_terms.output.currency} | Stripe sub {steps.create_subscription.output.subscription_id} | CRM updated."
+
+on_complete:
+  storage_path: "quote-to-cash-orchestrator/{run_id}/result.json"

--- a/src/sandcastle/templates/refund_credit_approval_workflow.yaml
+++ b/src/sandcastle/templates/refund_credit_approval_workflow.yaml
@@ -1,0 +1,417 @@
+# name: Refund and Credit Approval
+# description: Policy-driven refund/credit pipeline where the money decision is deterministic code, not a model.
+# tags: [support, refunds, stripe, zendesk, quickbooks, policy-engine, finance]
+# category: support
+name: refund-credit-approval
+description: >
+  Policy-driven refund and credit approval pipeline for customer support.
+  Pulls the refund request plus Stripe billing history and Zendesk ticket
+  context, then runs a DETERMINISTIC Python policy engine (eligibility window,
+  prior-refund count, plan terms) that computes the auto-approvable amount and
+  the required approval tier. A model never decides the dollar outcome - it only
+  classifies the reason and drafts the customer-facing message. Below the auto
+  cap with an auto-eligible reason and no fraud signal the refund executes
+  automatically; otherwise it routes to a tiered human sign-off. The decision
+  message is drafted by racing two providers (first non-empty wins), gated for
+  policy-faithfulness, then the actual refund/credit is executed in Stripe, a
+  credit memo is posted to QuickBooks, the Zendesk ticket is closed with the
+  full audit trail, and the team is notified in Slack.
+default_model: sonnet
+default_timeout: 600
+input_schema:
+  required: ["ticket_id", "customer_id", "auto_cap"]
+  properties:
+    ticket_id:
+      type: string
+      description: "Zendesk ticket ID for the refund request."
+      default: ""
+    customer_id:
+      type: string
+      description: "Stripe customer ID whose billing history is evaluated."
+      default: ""
+    auto_cap:
+      type: number
+      description: "Maximum USD amount that may be auto-approved without a human."
+      default: 50
+    stripe_api_base:
+      type: string
+      description: "Stripe REST API base URL."
+      default: "https://api.stripe.com/v1"
+    zendesk_api_base:
+      type: string
+      description: "Zendesk REST API base URL (https://<subdomain>.zendesk.com/api/v2)."
+      default: "https://acme.zendesk.com/api/v2"
+    quickbooks_api_base:
+      type: string
+      description: "QuickBooks Online REST API base URL."
+      default: "https://quickbooks.api.intuit.com/v3"
+    quickbooks_realm_id:
+      type: string
+      description: "QuickBooks company (realm) ID for the credit-memo post."
+      default: ""
+    slack_channel:
+      type: string
+      description: "Slack channel for refund decision notifications."
+      default: "#refunds"
+
+steps:
+  # 1. Pull customer billing history from Stripe (charges in the eligibility window).
+  - id: fetch_stripe_billing
+    type: http
+    responsibility: "Pull the customer's recent Stripe charges to evaluate refund eligibility."
+    source_hint: "Refund decisions require the real charge ledger, not the customer's claim."
+    owner: "support-ops"
+    http_config:
+      url: "{input.stripe_api_base}/charges?customer={input.customer_id}&limit=100"
+      method: GET
+      auth: "bearer:{env.STRIPE_API_KEY}"
+      headers:
+        Accept: "application/json"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 2. Pull the refund request + ticket context from Zendesk.
+  - id: fetch_zendesk_ticket
+    type: http
+    responsibility: "Fetch the Zendesk ticket holding the customer's refund request and context."
+    source_hint: "The requested amount and stated reason live on the support ticket."
+    owner: "support-ops"
+    http_config:
+      url: "{input.zendesk_api_base}/tickets/{input.ticket_id}.json"
+      method: GET
+      auth: "bearer:{env.ZENDESK_API_TOKEN}"
+      headers:
+        Accept: "application/json"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 3. DETERMINISTIC policy engine - the money decision. Pure rules, NO model.
+  - id: policy_engine
+    type: code
+    depends_on: [fetch_stripe_billing, fetch_zendesk_ticket]
+    responsibility: "Apply refund policy deterministically: eligibility window, prior-refund count, plan terms."
+    source_hint: "Finance/Legal require the dollar outcome to be reproducible and model-independent."
+    owner: "finance-eng"
+    code_config:
+      language: python
+      code: |
+        # Deterministic refund policy engine. The dollar outcome is identical
+        # regardless of any model. Reads upstream HTTP outputs via _steps and
+        # workflow inputs via _input.
+        billing = _steps['fetch_stripe_billing'] or {}
+        ticket = _steps['fetch_zendesk_ticket'] or {}
+        auto_cap = float(_input.get('auto_cap', 50) or 50)
+
+        # --- Normalize Stripe charges -------------------------------------
+        charges = billing.get('data', []) if isinstance(billing, dict) else []
+        # Total amount paid (Stripe amounts are in cents).
+        total_paid = sum(
+            (c.get('amount', 0) or 0)
+            for c in charges
+            if isinstance(c, dict) and c.get('paid') and not c.get('refunded')
+        ) / 100.0
+        # Prior refunds already issued to this customer.
+        prior_refunds = sum(
+            1 for c in charges
+            if isinstance(c, dict) and (c.get('refunded') or (c.get('amount_refunded', 0) or 0) > 0)
+        )
+        # Most recent eligible charge (newest first as Stripe returns).
+        eligible_charge = next(
+            (c for c in charges
+             if isinstance(c, dict) and c.get('paid') and not c.get('refunded')),
+            {},
+        )
+        charge_amount = (eligible_charge.get('amount', 0) or 0) / 100.0
+        charge_age_days = 0
+        created = eligible_charge.get('created')
+        now = billing.get('_now_epoch')  # optional injected clock; falls back below
+        if isinstance(created, (int, float)):
+            # 30-day window: derive age from charge metadata if a clock is present,
+            # otherwise trust an explicit age field, else treat as in-window (0).
+            if isinstance(now, (int, float)):
+                charge_age_days = max(0, int((now - created) / 86400))
+            else:
+                charge_age_days = int(eligible_charge.get('_age_days', 0) or 0)
+
+        # --- Ticket-stated requested amount -------------------------------
+        tkt = ticket.get('ticket', ticket) if isinstance(ticket, dict) else {}
+        requested = 0.0
+        for fld in (tkt.get('custom_fields') or []):
+            if isinstance(fld, dict) and str(fld.get('id')) == 'requested_amount':
+                try:
+                    requested = float(fld.get('value') or 0)
+                except (TypeError, ValueError):
+                    requested = 0.0
+        if requested <= 0:
+            requested = charge_amount  # default to refunding the last charge
+
+        # Plan terms: enterprise plans allow a wider window + higher cap.
+        plan = str(tkt.get('plan') or 'standard').lower()
+        window_days = 60 if plan in ('enterprise', 'business') else 30
+        max_prior_refunds = 5 if plan in ('enterprise', 'business') else 2
+
+        # --- Deterministic eligibility rules ------------------------------
+        reasons = []
+        eligible = True
+        if charge_amount <= 0:
+            eligible = False
+            reasons.append('no_refundable_charge_found')
+        if charge_age_days > window_days:
+            eligible = False
+            reasons.append(f'outside_{window_days}d_eligibility_window')
+        if prior_refunds >= max_prior_refunds:
+            eligible = False
+            reasons.append(f'prior_refund_limit_{max_prior_refunds}_reached')
+
+        # Cap the refundable amount at what was actually charged.
+        amount = min(requested, charge_amount) if eligible else 0.0
+
+        # Required approval tier is a deterministic function of the amount.
+        if not eligible:
+            tier = 'none'
+        elif amount <= auto_cap:
+            tier = 'auto'
+        elif amount <= auto_cap * 5:
+            tier = 'supervisor'
+        else:
+            tier = 'director'
+
+        if eligible and not reasons:
+            reasons.append('within_policy')
+
+        result = {
+            'eligible': eligible,
+            'amount': round(amount, 2),
+            'tier': tier,
+            'reasons': reasons,
+            'plan': plan,
+            'window_days': window_days,
+            'prior_refunds': prior_refunds,
+            'total_paid': round(total_paid, 2),
+            'eligible_charge_id': eligible_charge.get('id', ''),
+            'auto_cap': auto_cap,
+        }
+
+  # 4. Classify the stated refund reason (routing only - does NOT set the amount).
+  - id: classify_reason
+    type: classify
+    depends_on: [policy_engine]
+    responsibility: "Categorize the refund reason to drive auto-eligibility and fraud routing."
+    source_hint: "Some reasons (fraud_suspect) must never auto-approve regardless of amount."
+    owner: "support-ops"
+    classify_config:
+      model: haiku
+      input: "Refund reason from ticket: {steps.fetch_zendesk_ticket.output}. Policy: {steps.policy_engine.output}"
+      categories:
+        - billing_error
+        - outage_credit
+        - dissatisfaction
+        - duplicate_charge
+        - fraud_suspect
+      branches:
+        billing_error: [decide_route]
+        outage_credit: [decide_route]
+        dissatisfaction: [decide_route]
+        duplicate_charge: [decide_route]
+        fraud_suspect: [decide_route]
+
+  # 5. Deterministic route gate: auto vs escalate. Combines amount + reason + fraud.
+  - id: decide_route
+    type: condition
+    depends_on: [policy_engine, classify_reason]
+    responsibility: "Choose auto-refund vs human escalation from amount, reason and fraud signal."
+    source_hint: "Auto path only when amount <= cap, tier auto, reason auto-eligible, no fraud."
+    owner: "finance-eng"
+    condition_config:
+      expression: "{steps.policy_engine.output.tier} == 'auto' and '{steps.classify_reason.output}' in ['billing_error','outage_credit','duplicate_charge']"
+      then: [draft_decision_message]
+      else: [escalation_approval]
+
+  # --- Escalation path: tiered human sign-off before the message is drafted ---
+  - id: escalation_approval
+    type: approval
+    depends_on: [decide_route]
+    responsibility: "Tiered human sign-off for refunds above the auto cap or flagged reasons."
+    source_hint: "Finance policy mandates supervisor/director approval beyond the auto cap."
+    owner: "finance-approvers"
+    approval_config:
+      message: >
+        Refund escalation for ticket {input.ticket_id} (customer {input.customer_id}).
+        Review the deterministic policy decision below and approve or reject the
+        refund/credit. Required tier and amount are set by policy, not by you.
+      show_data: steps.policy_engine.output
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: true
+
+  # 6. RACE the customer-facing decision message across two providers.
+  #    First non-empty draft wins (failover, NOT a vote). Branch A=sonnet, B=mistral/large.
+  - id: draft_decision_message
+    type: race
+    depends_on: [policy_engine, classify_reason]
+    responsibility: "Draft the customer decision message, failing over across two providers."
+    source_hint: "Message wording must never block the refund on a single provider outage."
+    owner: "support-ops"
+    race_config:
+      branches:
+        - [draft_msg_sonnet]
+        - [draft_msg_mistral]
+      validator: "len(str(output)) > 0"
+
+  - id: draft_msg_sonnet
+    type: standard
+    model: sonnet
+    responsibility: "Primary draft of the customer-facing refund decision message."
+    source_hint: "Race branch A - default provider."
+    owner: "support-ops"
+    prompt: |
+      Write a concise, empathetic customer-facing message explaining the refund
+      decision. State the POLICY BASIS explicitly (eligibility window, plan terms,
+      prior-refund count) and the exact amount. Make NO promise beyond what the
+      policy authorizes. Do not invent amounts.
+
+      Policy decision (authoritative, do not change the numbers):
+      {steps.policy_engine.output}
+      Reason category: {steps.classify_reason.output}
+
+  - id: draft_msg_mistral
+    type: standard
+    model: mistral/large
+    responsibility: "Failover draft of the customer-facing refund decision message."
+    source_hint: "Race branch B - cross-provider failover so wording never blocks on one vendor."
+    owner: "support-ops"
+    prompt: |
+      Write a concise, empathetic customer-facing message explaining the refund
+      decision. State the POLICY BASIS explicitly (eligibility window, plan terms,
+      prior-refund count) and the exact amount. Make NO promise beyond what the
+      policy authorizes. Do not invent amounts.
+
+      Policy decision (authoritative, do not change the numbers):
+      {steps.policy_engine.output}
+      Reason category: {steps.classify_reason.output}
+
+  # 7. Gate the drafted message: it must be policy-faithful AND human-approved for escalations.
+  - id: message_gate
+    type: gate
+    depends_on: [draft_decision_message]
+    responsibility: "Block any message that misstates policy or makes an unauthorized promise."
+    source_hint: "Customer-facing financial promises require eval + human oversight."
+    owner: "support-leads"
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >
+              Answer 'approved' only if the message states the policy basis
+              (eligibility window / plan terms / prior-refund count) and makes no
+              promise beyond the authorized amount in the policy decision.
+              Otherwise answer 'rejected'.
+            input: "{steps.draft_decision_message.output} :: policy {steps.policy_engine.output}"
+            model: sonnet
+        - type: human
+          config:
+            message: "Confirm the customer-facing refund message before it is sent."
+            timeout_hours: 24
+            on_timeout: abort
+
+  # 8. Wait for the Stripe charge to be in a refundable, settled state before executing.
+  - id: await_charge_settled
+    type: sensor
+    depends_on: [message_gate]
+    responsibility: "Poll Stripe until the target charge is settled and refundable."
+    source_hint: "Refunding an unsettled/pending charge fails; wait for settlement first."
+    owner: "finance-eng"
+    sensor_config:
+      url: "{input.stripe_api_base}/charges/{steps.policy_engine.output.eligible_charge_id}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200"
+      check_interval: 30
+      timeout: 1800
+
+  # 9. Execute the actual refund/credit in Stripe.
+  - id: execute_stripe_refund
+    type: http
+    depends_on: [await_charge_settled]
+    responsibility: "Create the refund against the eligible Stripe charge for the policy amount."
+    source_hint: "This is the money-moving call; amount comes only from the policy engine."
+    owner: "finance-eng"
+    http_config:
+      url: "{input.stripe_api_base}/refunds"
+      method: POST
+      auth: "bearer:{env.STRIPE_API_KEY}"
+      headers:
+        Content-Type: "application/x-www-form-urlencoded"
+      body: "charge={steps.policy_engine.output.eligible_charge_id}&amount={steps.policy_engine.output.amount}&metadata[ticket_id]={input.ticket_id}&metadata[tier]={steps.policy_engine.output.tier}"
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: abort
+
+  # 10. Post the credit memo to QuickBooks for the books.
+  - id: post_quickbooks_memo
+    type: http
+    depends_on: [execute_stripe_refund]
+    responsibility: "Record the refund as a credit memo in QuickBooks Online."
+    source_hint: "Finance reconciliation requires every refund mirrored as a QBO credit memo."
+    owner: "finance-eng"
+    http_config:
+      url: "{input.quickbooks_api_base}/company/{input.quickbooks_realm_id}/creditmemo"
+      method: POST
+      auth: "bearer:{env.QUICKBOOKS_ACCESS_TOKEN}"
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      body:
+        CustomerRef:
+          value: "{input.customer_id}"
+        TotalAmt: "{steps.policy_engine.output.amount}"
+        PrivateNote: "Refund for Zendesk ticket {input.ticket_id}; Stripe refund {steps.execute_stripe_refund.output}"
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  # 11. Close the Zendesk ticket with the full audit trail.
+  - id: close_zendesk_ticket
+    type: http
+    depends_on: [post_quickbooks_memo]
+    responsibility: "Close the Zendesk ticket and attach the policy + execution audit trail."
+    source_hint: "Auditors need the policy reasons and refund IDs on the originating ticket."
+    owner: "support-ops"
+    http_config:
+      url: "{input.zendesk_api_base}/tickets/{input.ticket_id}.json"
+      method: PUT
+      auth: "bearer:{env.ZENDESK_API_TOKEN}"
+      headers:
+        Content-Type: "application/json"
+      body:
+        ticket:
+          status: "solved"
+          comment:
+            public: false
+            body: "Refund processed. Policy: {steps.policy_engine.output}. Stripe refund: {steps.execute_stripe_refund.output}. QuickBooks memo: {steps.post_quickbooks_memo.output}."
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 12. Notify the team in Slack.
+  - id: notify_slack
+    type: notify
+    depends_on: [close_zendesk_ticket]
+    responsibility: "Announce the completed refund decision to the support/finance team."
+    source_hint: "Refunds need a visible trail in the team channel for awareness."
+    owner: "support-ops"
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: "Refund settled for ticket {input.ticket_id} (customer {input.customer_id}). Decision: {steps.policy_engine.output}. Stripe refund: {steps.execute_stripe_refund.output}."
+
+on_complete:
+  storage_path: "refund-credit-approval/{run_id}/result.json"

--- a/tests/test_model_neutral_templates_v033.py
+++ b/tests/test_model_neutral_templates_v033.py
@@ -1,0 +1,186 @@
+"""Structural + thesis validation for the v0.33 model-independent workflow templates.
+
+These five templates exist to prove Sandcastle is a real workflow engine, not a
+prompt wrapper: each one puts its load-bearing decision in deterministic ``code`` or
+in a cross-provider ``race``/``gate`` pattern, drives real action through ``http`` and
+``notify``, waits on external state with ``sensor``, and escalates to a human via
+``approval``. The checks below mirror the top-20 e2e suite (parse, step types,
+depends_on, no cycles, build-plan coverage) and add thesis-specific assertions: every
+template fans a ``race`` across at least two distinct providers and gates the result.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sandcastle.engine.dag import (
+    VALID_STEP_TYPES,
+    build_plan,
+    parse_yaml_string,
+    validate,
+)
+from sandcastle.engine.tools.registry import KNOWN_TOOLS
+from sandcastle.templates import list_templates
+
+MODEL_NEUTRAL_TEMPLATES = [
+    "closed_loop_autoremediator",
+    "quote_to_cash_orchestrator",
+    "refund_credit_approval_workflow",
+    "access_review_campaign_orchestrator",
+    "cost_tiered_escalation_router",
+]
+
+# Control-flow step types whose presence proves the templates exercise the engine
+# rather than chaining plain prompts. The inventory found these unused across the
+# original 130 templates.
+ENGINE_STEP_TYPES = {"http", "code", "race", "gate", "sensor", "loop", "classify", "condition"}
+
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "src" / "sandcastle" / "templates"
+
+
+def _load(name: str) -> str:
+    path = TEMPLATES_DIR / f"{name}.yaml"
+    assert path.exists(), f"Template file not found: {path}"
+    return path.read_text()
+
+
+@pytest.mark.parametrize("template_name", MODEL_NEUTRAL_TEMPLATES)
+def test_parses_with_steps(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    assert wf is not None
+    assert wf.name, f"{template_name} has no name"
+    assert len(wf.steps) > 0, f"{template_name} has no steps"
+
+
+@pytest.mark.parametrize("template_name", MODEL_NEUTRAL_TEMPLATES)
+def test_step_types_valid(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    for step in wf.steps:
+        assert step.type in VALID_STEP_TYPES, (
+            f"{template_name}/{step.id} invalid type {step.type!r}"
+        )
+
+
+@pytest.mark.parametrize("template_name", MODEL_NEUTRAL_TEMPLATES)
+def test_depends_on_resolve(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    ids = {s.id for s in wf.steps}
+    for step in wf.steps:
+        for dep in step.depends_on:
+            assert dep in ids, f"{template_name}/{step.id} depends on unknown {dep!r}"
+
+
+@pytest.mark.parametrize("template_name", MODEL_NEUTRAL_TEMPLATES)
+def test_validates_clean(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    errors = validate(wf)
+    assert errors == [], f"{template_name} validate() errors: {errors}"
+
+
+@pytest.mark.parametrize("template_name", MODEL_NEUTRAL_TEMPLATES)
+def test_build_plan_covers_every_step_once(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    plan = build_plan(wf)
+    assert plan is not None and len(plan.stages) > 0
+    planned: list[str] = [sid for stage in plan.stages for sid in stage]
+    assert len(planned) == len(set(planned)), f"{template_name}: a step is planned twice"
+    assert set(planned) == {s.id for s in wf.steps}
+
+
+@pytest.mark.parametrize("template_name", MODEL_NEUTRAL_TEMPLATES)
+def test_tool_references_known(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    for step in wf.steps:
+        if step.tool_config and step.tool_config.tool:
+            base = step.tool_config.tool.split(":")[0]
+            assert base in KNOWN_TOOLS, f"{template_name}/{step.id} unknown tool {base!r}"
+
+
+@pytest.mark.parametrize("template_name", MODEL_NEUTRAL_TEMPLATES)
+def test_control_flow_branches_reference_real_steps(template_name: str) -> None:
+    """Every condition/classify/loop/race child reference must point to a real step."""
+    wf = parse_yaml_string(_load(template_name))
+    ids = {s.id for s in wf.steps}
+    for step in wf.steps:
+        if step.condition_config:
+            for sid in step.condition_config.then_steps + step.condition_config.else_steps:
+                assert sid in ids, f"{template_name}/{step.id} condition -> unknown {sid!r}"
+        if step.classify_config:
+            for branch in step.classify_config.branches.values():
+                for sid in branch:
+                    assert sid in ids, f"{template_name}/{step.id} classify -> unknown {sid!r}"
+        if step.loop_config:
+            for sid in step.loop_config.step_ids:
+                assert sid in ids, f"{template_name}/{step.id} loop -> unknown {sid!r}"
+        if step.race_config:
+            for branch in step.race_config.branches:
+                for sid in branch:
+                    assert sid in ids, f"{template_name}/{step.id} race -> unknown {sid!r}"
+
+
+@pytest.mark.parametrize("template_name", MODEL_NEUTRAL_TEMPLATES)
+def test_exercises_engine_step_types(template_name: str) -> None:
+    """Each template must use several of the control-flow step types the inventory
+    found unused, not collapse into a plain prompt chain."""
+    wf = parse_yaml_string(_load(template_name))
+    used = {s.type for s in wf.steps}
+    overlap = used & ENGINE_STEP_TYPES
+    assert len(overlap) >= 4, (
+        f"{template_name} only exercises {sorted(overlap)} of the engine step types"
+    )
+
+
+@pytest.mark.parametrize("template_name", MODEL_NEUTRAL_TEMPLATES)
+def test_race_fans_across_distinct_providers(template_name: str) -> None:
+    """The model-independence thesis: every template has a race whose branches are
+    pinned to at least two DISTINCT providers (cross-provider failover), with a
+    validator (first-valid-wins, not a vote tally)."""
+    wf = parse_yaml_string(_load(template_name))
+    by_id = {s.id: s for s in wf.steps}
+    races = [s for s in wf.steps if s.type == "race" and s.race_config]
+    assert races, f"{template_name} has no race step (model-independence not demonstrated)"
+    found_cross_provider = False
+    for race in races:
+        models = {
+            by_id[sid].model
+            for branch in race.race_config.branches
+            for sid in branch
+            if sid in by_id and by_id[sid].model
+        }
+        # provider is the part before '/', or the bare alias for anthropic tiers
+        providers = {m.split("/")[0] for m in models}
+        if len(providers) >= 2:
+            found_cross_provider = True
+            assert race.race_config.validator, (
+                f"{template_name}/{race.id} cross-provider race must have a validator"
+            )
+    assert found_cross_provider, (
+        f"{template_name} race branches are not pinned to >= 2 distinct providers"
+    )
+
+
+@pytest.mark.parametrize("template_name", MODEL_NEUTRAL_TEMPLATES)
+def test_has_gate_with_llm_and_human(template_name: str) -> None:
+    """Decisions are gated by a measured llm_eval plus human oversight, not a single
+    model's unilateral say."""
+    wf = parse_yaml_string(_load(template_name))
+    gates = [s for s in wf.steps if s.type == "gate" and s.gate_config]
+    assert gates, f"{template_name} has no gate step"
+    strat_types = {
+        st.get("type")
+        for gate in gates
+        for st in gate.gate_config.strategies
+    }
+    assert "llm_eval" in strat_types, f"{template_name} gate has no llm_eval strategy"
+    assert "human" in strat_types, f"{template_name} gate has no human strategy"
+
+
+def test_templates_are_discovered() -> None:
+    by_file = {t.file_name: t for t in list_templates()}
+    for name in MODEL_NEUTRAL_TEMPLATES:
+        info = by_file.get(f"{name}.yaml")
+        assert info is not None, f"{name} not discovered"
+        assert info.source == "built-in"
+        assert info.step_count > 0


### PR DESCRIPTION
## Why

An inventory of the existing 130 templates found they are shallow as an engine showcase: ~662 of ~710 steps are plain `standard` LLM prompts. Of 25 step types only ~8 were used; of 63 connectors only 3 (all image/vision). The templates mostly "ask a model to write X" and do not demonstrate Sandcastle as a real, provider-neutral **workflow engine**.

These five fill that gap. The thesis: **the workflow is the asset, the model is swappable plumbing.** Each template puts its load-bearing decision in deterministic `code` or in a cross-provider `race`/`gate` pattern, drives real action through `http` + `notify`, waits on external state with `sensor`, and escalates to a human via `approval`. Swap or lose a provider and the financial / compliance / remediation outcome does not move.

These came out of a multi-agent ideation sweep (40 candidates across 10 domains, adversarially scored on model-independence + buildability); these were the build-first set.

## The five

| Template | Category | What it does |
|---|---|---|
| **closed_loop_autoremediator** | devops | Datadog/PagerDuty alert -> http enrich -> classify severity -> **race two providers** for a remediation hypothesis -> gate (llm_eval + human) -> approval -> http apply (Vercel rollback / Cloudflare route / GitHub revert) -> sensor-poll the SLO until recovery -> auto-rollback if it does not recover |
| **quote_to_cash_orchestrator** | sales_crm | Closed-won -> transform order form -> approval -> DocuSign http -> sensor-wait for signature -> Stripe billing -> CRM write-back. The spine has **no model in the critical path** |
| **refund_credit_approval_workflow** | support | Deterministic `code` policy engine computes the refund (**model-invariant dollar outcome**) -> tiered approval -> Stripe refund + QuickBooks credit memo + Zendesk close |
| **access_review_campaign_orchestrator** | hr_legal | Pull entitlements -> classify SoD risk -> loop per-owner approval -> deprovision -> sha256 evidence pack to S3. Leans the audit/compliance moat |
| **cost_tiered_escalation_router** | general_ai | Cheap model first -> classify -> escalate only hard cases via a **two-provider race** -> gate -> cost-savings report |

## Model-independence is structural, not narrated

- Every `race` fans across 2-3 **distinct providers** (sonnet / google-gemini / mistral) with a first-valid-wins **validator** (failover, not a vote tally).
- Every `gate` pairs an `llm_eval` strategy with **human** oversight, so no single model unilaterally decides.
- Load-bearing math (refund eligibility, 3-way reconcile, entitlement diff, cost tally) lives in sandboxed deterministic `code`.
- Only race branches and classify/gate judges pin a model; everything else stays on the swappable `default_model`.

Two engine-fictions were deliberately avoided (confirmed against the parser/executor): `race` is first-valid-wins failover (never a vote aggregator), and any real consensus is N parallel steps + a deterministic code tally (`gate` has no quorum field).

## What it exercises

Together the five use **all 11 previously-unused control-flow step types**: `http`, `code`, `classify`, `race`, `gate`, `sensor`, `loop`, `condition`, `transform`, `notify`, `approval`. External systems are reached via `http` (with `auth` env refs) and `notify`, keeping everything provider-neutral and valid.

## Tests

`tests/test_model_neutral_templates_v033.py` mirrors the top-20 e2e checks (parse, step types, depends_on, no cycles, build-plan coverage, tool refs, control-flow branch references) and adds thesis-specific assertions: every template fans a `race` across >= 2 distinct providers with a validator, and gates with `llm_eval` + `human`.

```
tests/test_model_neutral_templates_v033.py + test_creative_templates_v033.py + test_template_e2e_v28.py  356 passed
```

Each template parses, `validate()` returns clean, and `build_plan` covers every step exactly once (independently re-verified, not just self-reported by the builder). Templates are auto-discovered and served via `/templates`. Catalog 130 -> 135.