### PR TITLE
feat(templates): 6 more model-independent workflows (wave 2: parse, sub_workflow, consensus, two-judge gate, data category)

### DIFF
--- a/src/sandcastle/templates/map_reduce_over_list.yaml
+++ b/src/sandcastle/templates/map_reduce_over_list.yaml
@@ -1,0 +1,272 @@
+# name: Map-Reduce Over List
+# description: Generic map-reduce skeleton - load any list, fan a reusable sub-workflow over every item (the map), then reduce deterministically with a quality gate and write-back
+# tags: [map-reduce, sub-workflow, batch, fan-out, orchestration]
+# category: general_ai
+
+name: map-reduce-over-list
+description: >-
+  A reusable map-reduce skeleton. Load and normalize a list from any source
+  (Postgres, a REST API, a Google Sheet, or an S3 listing), shape it into work
+  items, fan a reusable sub-workflow over every item in parallel (the MAP - swap
+  which inner workflow runs per item), then REDUCE the per-item results
+  deterministically in sandboxed code: aggregate, dedupe, and compute roll-up
+  stats. An LLM+human quality gate guards the consolidated output before a
+  conditional write-back to the source store with a Slack notification; failed
+  rollups route to a human approval review instead.
+
+default_model: sonnet
+default_timeout: 600
+
+input_schema:
+  required: ["source_endpoint", "writeback_endpoint"]
+  properties:
+    source_endpoint:
+      type: string
+      description: >-
+        REST/Postgres-REST endpoint that returns the list to process as a JSON
+        array (each element becomes one map item). Examples: a PostgREST table
+        URL, a Google Sheets values API URL, or an S3 list-objects gateway.
+      default: "https://data.internal.example.com/postgrest/articles?select=id,title,body,url&status=eq.pending"
+    writeback_endpoint:
+      type: string
+      description: >-
+        Endpoint that accepts the consolidated rollup via POST (PostgREST upsert,
+        a Google Sheets append, or an S3 put-object gateway).
+      default: "https://data.internal.example.com/postgrest/rollups"
+    item_field:
+      type: string
+      description: "Field on each source item whose text is mapped through the sub-workflow."
+      default: "body"
+    max_items:
+      type: string
+      description: "Safety cap on how many items to map in one run."
+      default: "200"
+
+steps:
+  # ---------------------------------------------------------------------------
+  # 1. LOAD - pull the raw list from the source system (Postgres/REST/Sheet/S3).
+  # ---------------------------------------------------------------------------
+  - id: load-list
+    type: http
+    http_config:
+      url: "{input.source_endpoint}"
+      method: GET
+      headers:
+        Accept: "application/json"
+        Prefer: "count=exact"
+      auth: "bearer:{env.SOURCE_API_TOKEN}"
+
+  # ---------------------------------------------------------------------------
+  # 2. NORMALIZE - coerce the raw response into a clean list[dict] of records,
+  #    deterministically (handles array vs {data:[...]} vs {values:[...]} shapes).
+  # ---------------------------------------------------------------------------
+  - id: normalize
+    type: code
+    depends_on: [load-list]
+    code_config:
+      language: python
+      code: |
+        raw = _steps['load-list']
+        # Source responses come in several shapes depending on the backend:
+        # PostgREST -> a bare list; REST APIs -> {"data": [...]}; Sheets -> {"values": [[...]]}.
+        records = []
+        if isinstance(raw, list):
+            records = raw
+        elif isinstance(raw, dict):
+            if isinstance(raw.get('data'), list):
+                records = raw['data']
+            elif isinstance(raw.get('values'), list):
+                rows = raw['values']
+                if rows and isinstance(rows[0], list):
+                    header = [str(h) for h in rows[0]]
+                    records = [dict(zip(header, r)) for r in rows[1:]]
+                else:
+                    records = rows
+            elif isinstance(raw.get('Contents'), list):
+                # S3 list-objects style listing.
+                records = raw['Contents']
+        try:
+            cap = int(str(_input.get('max_items', '200')))
+        except (ValueError, TypeError):
+            cap = 200
+        clean = []
+        for i, rec in enumerate(records[:cap]):
+            if not isinstance(rec, dict):
+                rec = {'value': rec}
+            rec = dict(rec)
+            rec.setdefault('id', rec.get('Key', f'item-{i}'))
+            clean.append(rec)
+        result = clean
+
+  # ---------------------------------------------------------------------------
+  # 3. SHAPE - turn normalized records into uniform work items the sub-workflow
+  #    can consume (one {id, text} per item). transform emits a JSON array.
+  # ---------------------------------------------------------------------------
+  - id: shape
+    type: transform
+    depends_on: [normalize]
+    transform_config:
+      template: |
+        {%- set field = input.item_field | default('body') -%}
+        [
+        {%- for rec in steps.normalize.output -%}
+          {"id": {{ rec.id | tojson }}, "text": {{ (rec[field] if rec[field] is defined else (rec.value | default(''))) | tojson }}}{{ "," if not loop.last else "" }}
+        {%- endfor -%}
+        ]
+
+  # ---------------------------------------------------------------------------
+  # 4. MAP - fan the reusable "summarize" sub-workflow over every work item in
+  #    parallel. Swap `workflow:` to run a different per-item pipeline. Each item's
+  #    `text` field maps onto the sub-workflow's required `text` input.
+  # ---------------------------------------------------------------------------
+  - id: map-items
+    type: sub_workflow
+    depends_on: [shape]
+    sub_workflow:
+      workflow: "summarize"
+      parallel_over: "steps.shape.output"
+      input_mapping:
+        text: "_item.text"
+        format: "bullet-points"
+      max_concurrent: 5
+
+  # ---------------------------------------------------------------------------
+  # 5. REDUCE - deterministic aggregation of all per-item sub-workflow outputs:
+  #    flatten, dedupe, and compute roll-up stats. No LLM in the load-bearing math.
+  # ---------------------------------------------------------------------------
+  - id: reduce
+    type: code
+    depends_on: [map-items]
+    code_config:
+      language: python
+      code: |
+        items = _steps['shape']
+        results = _steps['map-items']
+        # `map-items` returns the per-item sub-workflow outputs as a list aligned
+        # with `shape`. Normalize to a list defensively.
+        if isinstance(results, dict):
+            results = list(results.values())
+        if not isinstance(results, list):
+            results = [results]
+        consolidated = []
+        seen = set()
+        ok = 0
+        empty = 0
+        for idx, out in enumerate(results):
+            item_id = items[idx]['id'] if idx < len(items) and isinstance(items[idx], dict) else f'item-{idx}'
+            text = '' if out is None else (out.get('output') if isinstance(out, dict) else str(out))
+            text = (text or '').strip()
+            if not text:
+                empty += 1
+                continue
+            key = (item_id, text[:120].lower())
+            if key in seen:
+                continue
+            seen.add(key)
+            consolidated.append({'id': item_id, 'summary': text})
+            ok += 1
+        total = len(results)
+        coverage = round(ok / total, 4) if total else 0.0
+        result = {
+            'rollup': consolidated,
+            'stats': {
+                'total_items': total,
+                'summarized': ok,
+                'empty': empty,
+                'deduped': total - empty - ok,
+                'coverage': coverage,
+            },
+        }
+
+  # ---------------------------------------------------------------------------
+  # 6. GATE - quality check on the consolidated rollup. BOTH strategies must
+  #    pass: an LLM eval of consolidation quality, plus a human sign-off that
+  #    auto-aborts on timeout (so a stalled review never silently writes back).
+  # ---------------------------------------------------------------------------
+  - id: quality-gate
+    type: gate
+    depends_on: [reduce]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are a release reviewer for an automated map-reduce job. Below is
+              the consolidated rollup plus roll-up statistics. PASS only if the
+              summaries are coherent, on-topic, free of obvious duplication, and
+              coverage is acceptable (>= 0.8). Otherwise FAIL with a one-line reason.
+            input: "{steps.reduce.output}"
+            model: sonnet
+        - type: human
+          config:
+            message: "Approve the consolidated rollup for write-back to the source store?"
+            timeout_hours: 24
+            on_timeout: abort
+
+  # ---------------------------------------------------------------------------
+  # 7. DECISION - deterministic branch on the measured coverage statistic.
+  #    Pass -> write-back + notify. Fail -> human approval review.
+  # ---------------------------------------------------------------------------
+  - id: route
+    type: condition
+    depends_on: [quality-gate]
+    condition_config:
+      expression: "{steps.reduce.output.stats.coverage} >= 0.8"
+      then: [writeback, notify-success]
+      else: [review-failed]
+
+  # --- PASS branch ----------------------------------------------------------
+  # 7a. Write the consolidated rollup back to the store (PostgREST upsert /
+  #     Sheets append / S3 put-object gateway).
+  - id: writeback
+    type: http
+    depends_on: [route]
+    http_config:
+      url: "{input.writeback_endpoint}"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Prefer: "resolution=merge-duplicates"
+      body: "{steps.reduce.output}"
+      auth: "bearer:{env.WRITEBACK_API_TOKEN}"
+
+  # 7b. Tell the team the job landed, with roll-up stats.
+  - id: notify-success
+    type: notify
+    depends_on: [writeback]
+    notify_config:
+      service: slack
+      channel: "#data-pipelines"
+      message: >-
+        Map-reduce rollup written back. Items={steps.reduce.output.stats.total_items},
+        summarized={steps.reduce.output.stats.summarized},
+        coverage={steps.reduce.output.stats.coverage}. Source: {input.source_endpoint}
+
+  # --- FAIL branch ----------------------------------------------------------
+  # 7c. Low-coverage rollup goes to a human for review instead of write-back.
+  - id: review-failed
+    type: approval
+    depends_on: [route]
+    approval_config:
+      message: >-
+        Map-reduce rollup did NOT meet the coverage threshold and was held back.
+        Review the consolidated output and stats, then decide whether to write it
+        back manually or rerun the job.
+      show_data: "steps.reduce.output"
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: true
+
+  # 7d. Notify the team a rollup is parked for manual review.
+  - id: notify-review
+    type: notify
+    depends_on: [review-failed]
+    notify_config:
+      service: slack
+      channel: "#data-pipelines"
+      message: >-
+        Map-reduce rollup held for manual review (coverage below threshold).
+        Stats: summarized={steps.reduce.output.stats.summarized}/{steps.reduce.output.stats.total_items}.
+
+on_complete:
+  storage_path: "rollups/map-reduce/{workflow_id}/{run_id}.json"

--- a/src/sandcastle/templates/provider_consensus_decision_engine.yaml
+++ b/src/sandcastle/templates/provider_consensus_decision_engine.yaml
@@ -1,0 +1,360 @@
+# name: Provider Consensus Decision Engine
+# description: Ask the SAME high-stakes question to 3 different providers in parallel and act on their AGREEMENT - consensus quorum, not race failover.
+# tags: [consensus, multi-provider, decision, governance, quorum]
+# category: general_ai
+name: provider-consensus-decision-engine
+description: >-
+  A reusable high-stakes decision pattern built on PROVIDER CONSENSUS (not race
+  failover). The same case record is fetched from a system of record (Postgres
+  via PostgREST), then the IDENTICAL structured-decision prompt is rendered in
+  parallel across three different providers - Anthropic Sonnet, Google Gemini
+  2.5 Pro and Mistral Large - each returning {verdict, confidence, rationale}.
+  A deterministic code step tallies the three votes into an agreement ratio,
+  majority verdict and a disagreement flag. A classify routes the run by
+  agreement strength (UNANIMOUS / MAJORITY / SPLIT). When the providers agree
+  (unanimous or majority) the decision is transformed with cited rationales,
+  written back to the system of record and announced on Slack. When they SPLIT,
+  a human reviewer adjudicates with all three votes shown, the human verdict is
+  posted back to the record and announced. No single provider is load-bearing:
+  drop any one and you change exactly one vote, never the mechanism.
+default_model: sonnet
+default_timeout: 900
+input_schema:
+  required: ["case_id", "record_endpoint", "decision_question"]
+  properties:
+    case_id:
+      type: string
+      description: "Primary key of the case record to decide on (row id in the system of record)."
+      example: "case_84217"
+    record_endpoint:
+      type: string
+      description: "Base URL of the system-of-record REST API (PostgREST over Postgres), e.g. https://records.internal/rest/v1"
+      default: "https://records.internal/rest/v1"
+    decision_question:
+      type: string
+      description: "The exact high-stakes yes/no (or approve/reject) question every provider must answer about the case."
+      example: "Should this insurance claim be APPROVED for payout based on the evidence on file?"
+    slack_channel:
+      type: string
+      description: "Slack channel for the decision announcement."
+      default: "#decisions"
+
+steps:
+  # 1) Fetch + enrich the case record from the system of record (Postgres via PostgREST).
+  #    embed=* pulls related rows so every provider sees the same enriched evidence.
+  - id: fetch
+    type: http
+    http_config:
+      url: "{input.record_endpoint}/cases?id=eq.{input.case_id}&select=*,evidence(*),history(*)"
+      method: GET
+      headers:
+        Accept: "application/json"
+        Prefer: "count=exact"
+      auth: "bearer:{env.RECORDS_API_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 2) THREE provider votes, all depends_on [fetch], all rendering the IDENTICAL
+  #    structured-decision prompt over the same enriched record. This is CONSENSUS:
+  #    three independent opinions that we tally, NOT a first-valid-wins race.
+
+  # 2a) Vote A - Anthropic Sonnet.
+  - id: vote_anthropic
+    type: standard
+    model: sonnet
+    depends_on: [fetch]
+    prompt: |
+      You are an INDEPENDENT decision reviewer (Provider A). Answer the following
+      high-stakes question about the case record below. Decide ONLY from the
+      evidence shown. Do not hedge - commit to a verdict and calibrate confidence.
+
+      DECISION QUESTION:
+      {input.decision_question}
+
+      CASE RECORD (enriched JSON from the system of record):
+      {steps.fetch.output}
+
+      Return STRICT JSON only:
+      {
+        "verdict": "<APPROVE | REJECT>",
+        "confidence": <float 0.0-1.0, calibrated - lower it when evidence is thin or conflicting>,
+        "rationale": "<2-3 sentences citing the specific evidence fields that drove your verdict>"
+      }
+    output_schema:
+      type: object
+      properties:
+        verdict:
+          type: string
+          description: "APPROVE or REJECT"
+        confidence:
+          type: number
+          description: "calibrated confidence 0.0-1.0"
+        rationale:
+          type: string
+          description: "evidence-cited justification"
+
+  # 2b) Vote B - Google Gemini 2.5 Pro (DIFFERENT provider, identical prompt).
+  - id: vote_gemini
+    type: standard
+    model: google/gemini-2.5-pro
+    depends_on: [fetch]
+    prompt: |
+      You are an INDEPENDENT decision reviewer (Provider B). Answer the following
+      high-stakes question about the case record below. Decide ONLY from the
+      evidence shown. Do not hedge - commit to a verdict and calibrate confidence.
+
+      DECISION QUESTION:
+      {input.decision_question}
+
+      CASE RECORD (enriched JSON from the system of record):
+      {steps.fetch.output}
+
+      Return STRICT JSON only:
+      {
+        "verdict": "<APPROVE | REJECT>",
+        "confidence": <float 0.0-1.0, calibrated - lower it when evidence is thin or conflicting>,
+        "rationale": "<2-3 sentences citing the specific evidence fields that drove your verdict>"
+      }
+    output_schema:
+      type: object
+      properties:
+        verdict:
+          type: string
+          description: "APPROVE or REJECT"
+        confidence:
+          type: number
+          description: "calibrated confidence 0.0-1.0"
+        rationale:
+          type: string
+          description: "evidence-cited justification"
+
+  # 2c) Vote C - Mistral Large (DIFFERENT provider, identical prompt).
+  - id: vote_mistral
+    type: standard
+    model: mistral/large
+    depends_on: [fetch]
+    prompt: |
+      You are an INDEPENDENT decision reviewer (Provider C). Answer the following
+      high-stakes question about the case record below. Decide ONLY from the
+      evidence shown. Do not hedge - commit to a verdict and calibrate confidence.
+
+      DECISION QUESTION:
+      {input.decision_question}
+
+      CASE RECORD (enriched JSON from the system of record):
+      {steps.fetch.output}
+
+      Return STRICT JSON only:
+      {
+        "verdict": "<APPROVE | REJECT>",
+        "confidence": <float 0.0-1.0, calibrated - lower it when evidence is thin or conflicting>,
+        "rationale": "<2-3 sentences citing the specific evidence fields that drove your verdict>"
+      }
+    output_schema:
+      type: object
+      properties:
+        verdict:
+          type: string
+          description: "APPROVE or REJECT"
+        confidence:
+          type: number
+          description: "calibrated confidence 0.0-1.0"
+        rationale:
+          type: string
+          description: "evidence-cited justification"
+
+  # 3) TALLY - deterministic, provider-neutral consensus math. Reads the three
+  #    independent votes from _steps, normalizes verdicts, computes the majority
+  #    verdict, agreement ratio, unanimity and a disagreement flag. THIS is the
+  #    load-bearing decision: pure code, no single model can swing it.
+  - id: tally
+    type: code
+    depends_on: [vote_anthropic, vote_gemini, vote_mistral]
+    code_config:
+      language: python
+      code: |
+        # Pull the three independent provider votes.
+        raw = {
+            'anthropic': _steps.get('vote_anthropic'),
+            'gemini': _steps.get('vote_gemini'),
+            'mistral': _steps.get('vote_mistral'),
+        }
+
+        def norm_verdict(v):
+            s = str(v or '').strip().upper()
+            if s.startswith('APPROV') or s in ('YES', 'TRUE', 'PASS'):
+                return 'APPROVE'
+            if s.startswith('REJECT') or s in ('NO', 'FALSE', 'FAIL', 'DENY'):
+                return 'REJECT'
+            return 'ABSTAIN'
+
+        votes = []
+        for provider, out in raw.items():
+            verdict = None
+            confidence = 0.0
+            rationale = ''
+            if isinstance(out, dict):
+                verdict = norm_verdict(out.get('verdict'))
+                try:
+                    confidence = float(out.get('confidence', 0.0) or 0.0)
+                except (TypeError, ValueError):
+                    confidence = 0.0
+                rationale = str(out.get('rationale', '') or '')
+            else:
+                # Fallback: best-effort verdict read from a stringified output.
+                verdict = norm_verdict(out)
+                rationale = str(out or '')
+            votes.append({
+                'provider': provider,
+                'verdict': verdict,
+                'confidence': round(confidence, 4),
+                'rationale': rationale,
+            })
+
+        # Tally only decisive (non-abstain) verdicts.
+        decisive = [v for v in votes if v['verdict'] in ('APPROVE', 'REJECT')]
+        total = len(decisive)
+        approve = sum(1 for v in decisive if v['verdict'] == 'APPROVE')
+        reject = sum(1 for v in decisive if v['verdict'] == 'REJECT')
+
+        if approve > reject:
+            decision = 'APPROVE'
+            winning = approve
+        elif reject > approve:
+            decision = 'REJECT'
+            winning = reject
+        else:
+            decision = 'TIE'
+            winning = max(approve, reject)
+
+        agreement = round(winning / total, 4) if total else 0.0
+        unanimous = total == 3 and winning == 3
+        # Disagreement = no clear majority (tie / split, or fewer than 2 agree).
+        disagreement = decision == 'TIE' or winning < 2
+
+        result = {
+            'case_id': _input.get('case_id'),
+            'decision': decision,
+            'agreement': agreement,
+            'unanimous': unanimous,
+            'disagreement': disagreement,
+            'approve_count': approve,
+            'reject_count': reject,
+            'decisive_votes': total,
+            'votes': votes,
+        }
+
+  # 4) CLASSIFY by agreement strength. Drives which downstream branch runs.
+  #    UNANIMOUS/MAJORITY -> route_decision (the agree path). SPLIT -> adjudicate.
+  - id: classify_agreement
+    type: classify
+    depends_on: [tally]
+    classify_config:
+      categories: ["UNANIMOUS", "MAJORITY", "SPLIT"]
+      input: "{steps.tally.output}"
+      model: haiku
+      branches:
+        UNANIMOUS: ["route_decision"]
+        MAJORITY: ["route_decision"]
+        SPLIT: ["adjudicate"]
+
+  # 5) CONDITION on the deterministic disagreement flag. The code tally - not a
+  #    model - decides the path. agree path: transform -> write-back -> notify.
+  #    split path: human adjudication.
+  - id: route_decision
+    type: condition
+    depends_on: [classify_agreement]
+    condition_config:
+      expression: "{steps.tally.output.disagreement} == False"
+      then: [compose_decision, write_back, notify_decision]
+      else: [adjudicate, write_back_split, notify_split]
+
+  # 5a-AGREE) Compose the final decision document with all three cited rationales.
+  - id: compose_decision
+    type: transform
+    transform_config:
+      template: |
+        {
+          "case_id": "{steps.tally.output.case_id}",
+          "final_decision": "{steps.tally.output.decision}",
+          "decided_by": "provider-consensus",
+          "agreement_ratio": {steps.tally.output.agreement},
+          "unanimous": {steps.tally.output.unanimous},
+          "approve_votes": {steps.tally.output.approve_count},
+          "reject_votes": {steps.tally.output.reject_count},
+          "provider_votes": {steps.tally.output.votes},
+          "question": "{input.decision_question}"
+        }
+
+  # 5b-AGREE) Write the consensus decision + per-provider votes back to the record.
+  - id: write_back
+    type: http
+    http_config:
+      url: "{input.record_endpoint}/case_decisions"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Prefer: "resolution=merge-duplicates,return=representation"
+      auth: "bearer:{env.RECORDS_API_TOKEN}"
+      body: "{steps.compose_decision.output}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 5c-AGREE) Announce the consensus decision on Slack.
+  - id: notify_decision
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        Consensus decision on case {steps.tally.output.case_id}: *{steps.tally.output.decision}*
+        Agreement {steps.tally.output.agreement} (unanimous: {steps.tally.output.unanimous})
+        Approve {steps.tally.output.approve_count} / Reject {steps.tally.output.reject_count}
+        Written back to the system of record.
+
+  # 5d-SPLIT) Human breaks the tie. All three votes shown for adjudication.
+  - id: adjudicate
+    type: approval
+    approval_config:
+      message: |
+        Providers SPLIT on case {input.case_id}. No majority verdict. A human must
+        adjudicate this high-stakes decision. Review all three provider votes and
+        choose APPROVE or REJECT.
+      show_data: "steps.tally.output"
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: true
+
+  # 5e-SPLIT) Write the human-adjudicated decision + the original split votes back.
+  - id: write_back_split
+    type: http
+    http_config:
+      url: "{input.record_endpoint}/case_decisions"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Prefer: "resolution=merge-duplicates,return=representation"
+      auth: "bearer:{env.RECORDS_API_TOKEN}"
+      body: "{steps.adjudicate.output}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 5f-SPLIT) Announce that a human adjudicated the split decision.
+  - id: notify_split
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        Case {input.case_id} was SPLIT across providers and adjudicated by a human reviewer.
+        Original votes: {steps.tally.output.votes}
+        Human decision written back to the system of record.
+
+on_complete:
+  storage_path: "provider-consensus-decision-engine/{run_id}/result.json"

--- a/src/sandcastle/templates/sla_sensor_escalation_ladder.yaml
+++ b/src/sandcastle/templates/sla_sensor_escalation_ladder.yaml
@@ -1,0 +1,341 @@
+# name: SLA Sensor Escalation Ladder
+# description: A reusable durable watcher - poll any health/queue/SLO endpoint until a breach condition holds, pull surrounding context, race two providers for a fast triage, then climb a tiered escalation ladder (notify -> recheck, loop-until-cleared) before falling through to a human gate. The control flow (poll, escalate, loop, human gate) is fully model-free; only the triage is a swappable cross-provider race.
+# tags: [DevOps, SLA, Incident, Escalation, Sensor, Failover, PagerDuty, Datadog]
+# category: devops
+
+name: sla-sensor-escalation-ladder
+description: >
+  A reusable, provider-agnostic SLA watcher and escalation ladder. A durable
+  SENSOR polls any status / health / queue-depth endpoint until the breach
+  condition holds (or a soft timeout). An HTTP step pulls surrounding context
+  (recent logs / events from a monitoring REST API). Two providers then RACE
+  (Sonnet vs Gemini 2.5 Pro, first-valid-wins failover) for a fastest-of-N
+  triage summary {severity, suggested_remediation}; a deterministic CLASSIFY
+  bins severity into INFO / WARN / SEV2 / SEV1. A LOOP climbs a fixed tier
+  ladder - each iteration NOTIFIES the next tier's channel (Slack / Teams /
+  PagerDuty) and an HTTP RECHECK re-polls the health URL, returning
+  {cleared: bool}; the loop exits early once cleared. If the ladder is
+  exhausted and the breach persists, a CONDITION routes to a human APPROVAL
+  (on-call picks a manual action, with the triage shown); otherwise it posts a
+  resolved notice. A final NOTIFY posts the outcome to Slack. Only the triage
+  is model-driven and swappable; poll, escalate, loop-until-cleared and the
+  human gate are all deterministic control flow.
+
+default_model: sonnet
+default_timeout: 600
+
+input_schema:
+  required: ["watch_url", "breach_condition", "tier_channels"]
+  properties:
+    watch_url:
+      type: string
+      description: "Health / status / queue-depth endpoint to poll (returns JSON), e.g. https://status.internal/api/health"
+      default: "https://status.internal/api/health"
+    breach_condition:
+      type: string
+      description: >
+        Python boolean expression over the sensor `response` JSON that defines a
+        breach (the sensor fires when it becomes true). e.g.
+        "status_code == 200 and float(response.get('queue_depth', 0) or 0) > 1000"
+      default: "status_code == 200 and float(response.get('error_rate', 0) or 0) > 0.05"
+    tier_channels:
+      type: string
+      description: >
+        Comma-separated escalation ladder, lowest tier first, each as
+        service:target. e.g. "slack:#oncall-tier1,teams:sre-bridge,pagerduty:P1ESCPOL"
+      default: "slack:#oncall-tier1,teams:#sre-bridge,pagerduty:default-escalation"
+    monitoring_api:
+      type: string
+      description: "Base URL of the monitoring REST API used to pull surrounding context (logs / events)."
+      default: "https://api.datadoghq.eu/api/v2"
+    service:
+      type: string
+      description: "Logical service name this watcher guards (used in messages and context queries)."
+      default: "unknown-service"
+    soft_timeout:
+      type: integer
+      description: "Sensor soft timeout in seconds - stop waiting for the breach after this long."
+      default: 86400
+    check_interval:
+      type: integer
+      description: "Seconds between sensor polls of the watch_url."
+      default: 60
+    slack_channel:
+      type: string
+      description: "Slack channel for the final outcome summary."
+      default: "#sla-watch"
+
+steps:
+  # 1) DURABLE SENSOR - poll the watch_url until the breach condition holds, or soft-timeout.
+  #    breach_condition is a provider-agnostic boolean over the polled JSON `response`.
+  - id: watch_breach
+    type: sensor
+    sensor_config:
+      url: "{input.watch_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "{input.breach_condition}"
+      check_interval: 60
+      timeout: 86400
+
+  # 2) PULL CONTEXT - recent logs / events around the breach from the monitoring REST API.
+  - id: fetch_context
+    type: http
+    depends_on: [watch_breach]
+    http_config:
+      url: "{input.monitoring_api}/logs/events/search?filter[query]=service:{input.service}&page[limit]=25&sort=-timestamp"
+      method: GET
+      auth: "bearer:{env.MONITORING_API_TOKEN}"
+      headers:
+        Accept: "application/json"
+        DD-API-KEY: "{env.DATADOG_API_KEY}"
+        DD-APPLICATION-KEY: "{env.DATADOG_APP_KEY}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 3) Deterministically fold the sensor observation + pulled context into one triage envelope.
+  - id: build_envelope
+    type: code
+    depends_on: [fetch_context]
+    code_config:
+      language: python
+      code: |
+        # Normalize the sensor breach observation + monitoring context into one envelope.
+        obs = _steps.get("watch_breach") or {}
+        ctx = _steps.get("fetch_context") or {}
+        if not isinstance(obs, dict):
+            obs = {"raw": obs}
+        if not isinstance(ctx, dict):
+            ctx = {"raw": ctx}
+
+        # Pull a compact slice of recent events (Datadog-style {data:[{attributes:{...}}]}).
+        events = []
+        data = ctx.get("data") if isinstance(ctx.get("data"), list) else []
+        for ev in data[:25]:
+            if isinstance(ev, dict):
+                attrs = ev.get("attributes", {}) if isinstance(ev.get("attributes"), dict) else {}
+                events.append({
+                    "message": str(attrs.get("message", ""))[:500],
+                    "status": attrs.get("status", ""),
+                    "timestamp": attrs.get("timestamp", ""),
+                })
+
+        result = {
+            "service": _input.get("service", "unknown-service"),
+            "watch_url": _input.get("watch_url", ""),
+            "breach_condition": _input.get("breach_condition", ""),
+            "breach_observation": obs,
+            "recent_events": events,
+            "event_count": len(events),
+        }
+
+  # 4) RACE two providers for a fastest-of-N triage. First non-empty valid JSON wins
+  #    (failover, NOT a vote). Branch A pinned to sonnet, Branch B to gemini-2.5-pro.
+  - id: triage_sonnet
+    type: standard
+    model: sonnet
+    output_schema:
+      type: object
+      properties:
+        severity: { type: string, enum: ["INFO", "WARN", "SEV2", "SEV1"] }
+        suggested_remediation: { type: string }
+      required: ["severity", "suggested_remediation"]
+    prompt: |
+      You are an SRE doing fast incident triage. An SLA watcher just fired on a
+      breach. Summarize severity and the single best next remediation.
+
+      Triage envelope (breach + recent events):
+      {steps.build_envelope.output}
+
+      Return STRICT JSON only:
+      {
+        "severity": "INFO" | "WARN" | "SEV2" | "SEV1",
+        "suggested_remediation": "<one concrete, reversible next action>"
+      }
+      Pick severity from blast radius in the events. Output JSON only, no prose.
+
+  - id: triage_gemini
+    type: standard
+    model: google/gemini-2.5-pro
+    output_schema:
+      type: object
+      properties:
+        severity: { type: string, enum: ["INFO", "WARN", "SEV2", "SEV1"] }
+        suggested_remediation: { type: string }
+      required: ["severity", "suggested_remediation"]
+    prompt: |
+      You are a second, independent SRE triaging the same SLA breach (failover
+      for provider A). Return STRICT JSON only with keys severity
+      ("INFO"|"WARN"|"SEV2"|"SEV1") and suggested_remediation (one concrete
+      reversible action), grounded in:
+      {steps.build_envelope.output}
+      Output JSON only, no prose.
+
+  - id: triage_race
+    type: race
+    race_config:
+      branches:
+        - [triage_sonnet]
+        - [triage_gemini]
+      # First branch whose JSON parses with a real severity + non-empty remediation wins.
+      validator: "isinstance(output, dict) and output.get('severity') in ('INFO','WARN','SEV2','SEV1') and bool(str(output.get('suggested_remediation','')).strip())"
+
+  # 5) CLASSIFY severity deterministically into one of four bins, routing to a per-bin primer.
+  - id: classify_severity
+    type: classify
+    depends_on: [triage_race]
+    classify_config:
+      categories: ["INFO", "WARN", "SEV2", "SEV1"]
+      input: "{steps.triage_race.output}"
+      model: haiku
+      branches:
+        INFO: [prime_low]
+        WARN: [prime_low]
+        SEV2: [prime_high]
+        SEV1: [prime_high]
+
+  # 5a) Low-severity primer (INFO / WARN) - slower ladder cadence.
+  - id: prime_low
+    type: code
+    code_config:
+      language: python
+      code: |
+        # INFO/WARN: low urgency, give each tier room to ack before escalating.
+        triage = _steps.get("triage_race") or {}
+        result = {
+            "band": "low",
+            "dwell_minutes": 15,
+            "triage": triage if isinstance(triage, dict) else {"raw": triage},
+        }
+
+  # 5b) High-severity primer (SEV2 / SEV1) - fast ladder cadence.
+  - id: prime_high
+    type: code
+    code_config:
+      language: python
+      code: |
+        # SEV2/SEV1: high urgency, escalate aggressively through the ladder.
+        triage = _steps.get("triage_race") or {}
+        result = {
+            "band": "high",
+            "dwell_minutes": 2,
+            "triage": triage if isinstance(triage, dict) else {"raw": triage},
+        }
+
+  # 6) Deterministically materialize the escalation ladder from tier_channels input.
+  - id: build_ladder
+    type: code
+    depends_on: [classify_severity]
+    code_config:
+      language: python
+      code: |
+        # Parse "slack:#oncall-tier1,teams:#sre-bridge,pagerduty:P1" into ordered tiers.
+        raw = str(_input.get("tier_channels", "") or "")
+        tiers = []
+        for idx, part in enumerate(p for p in raw.split(",") if p.strip()):
+            piece = part.strip()
+            if ":" in piece:
+                service, target = piece.split(":", 1)
+            else:
+                service, target = "slack", piece
+            tiers.append({
+                "tier": idx + 1,
+                "service": service.strip().lower(),
+                "target": target.strip(),
+            })
+        if not tiers:
+            tiers = [{"tier": 1, "service": "slack", "target": "#oncall"}]
+        result = tiers
+
+  # 7) LOOP the escalation ladder: for each tier, NOTIFY then RECHECK. Exit early once cleared.
+  #    Child steps (notify_tier, recheck) are defined separately with NO depends_on.
+  - id: escalation_ladder
+    type: loop
+    depends_on: [build_ladder]
+    loop_config:
+      over: "steps.build_ladder.output"
+      step_ids: [notify_tier, recheck]
+      max_iterations: 4
+      until: "{steps.recheck.output.cleared} == True"
+
+  # 7a) NOTIFY the current tier. service/target come from the loop item (_item).
+  - id: notify_tier
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: ":rotating_light: SLA breach on {input.service} - escalating to a new tier. Triage: {steps.triage_race.output}. Watching {input.watch_url}."
+
+  # 7b) RECHECK - re-poll the health URL and deterministically return {cleared: bool}.
+  - id: recheck
+    type: http
+    http_config:
+      url: "{input.watch_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      value_map:
+        cleared: "$.cleared"
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  # 8) Deterministically decide whether the breach is still live after the ladder ran.
+  - id: evaluate_ladder
+    type: code
+    depends_on: [escalation_ladder]
+    code_config:
+      language: python
+      code: |
+        # The loop result is the list of per-iteration child outputs; inspect the last recheck.
+        runs = _steps.get("escalation_ladder")
+        last = recheck = _steps.get("recheck") or {}
+        cleared = False
+        # Prefer the explicit recheck signal, then fall back to scanning loop iterations.
+        if isinstance(recheck, dict) and recheck.get("cleared") is not None:
+            cleared = bool(recheck.get("cleared"))
+        elif isinstance(runs, list):
+            for it in reversed(runs):
+                if isinstance(it, dict) and "cleared" in it:
+                    cleared = bool(it.get("cleared"))
+                    break
+        result = {
+            "cleared": cleared,
+            "still_breached": not cleared,
+            "fail_count": 0 if cleared else 1,
+        }
+
+  # 9) CONDITION - if still breached after the full ladder, escalate to a human; else resolve.
+  - id: ladder_outcome
+    type: condition
+    depends_on: [evaluate_ladder]
+    condition_config:
+      expression: "{steps.evaluate_ladder.output.fail_count} > 0"
+      then: [human_action, notify_outcome]
+      else: [notify_outcome]
+
+  # 9a) HUMAN GATE - on-call picks a manual action when the ladder is exhausted.
+  #     The triage is shown so the human decides with full context.
+  - id: human_action
+    type: approval
+    approval_config:
+      message: "Escalation ladder exhausted and the SLA breach persists. Pick a manual action (rollback, drain, page secondary, ack-and-monitor)."
+      show_data: steps.triage_race.output
+      timeout_hours: 4
+      on_timeout: abort
+      allow_edit: true
+
+  # 10) NOTIFY the final outcome to Slack (resolved-by-ladder OR handed to a human).
+  - id: notify_outcome
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: "SLA watcher for {input.service}: ladder result {steps.evaluate_ladder.output}. Triage was {steps.triage_race.output}. (If still breached, on-call has been handed the manual-action gate.)"
+
+on_complete:
+  storage_path: "sla-sensor-escalation-ladder/{run_id}/result.json"

--- a/src/sandcastle/templates/three_way_match_pay_run.yaml
+++ b/src/sandcastle/templates/three_way_match_pay_run.yaml
@@ -1,0 +1,392 @@
+# name: Three-Way Match Pay Run
+# description: Scheduled accounts-payable pay-run with a deterministic 3-way match (PO vs goods-receipt vs invoice). The money decision is model-free code; the only model touch is invoice parse + a policy gate summary.
+# tags: [finance, accounts-payable, three-way-match, quickbooks, sap, slack, deterministic]
+# category: general_ai
+name: three-way-match-pay-run
+description: >-
+  Scheduled accounts-payable pay-run that settles a vendor invoice ONLY after a
+  deterministic 3-way match passes. A model parses the invoice PDF, then the
+  purchase order and the goods-receipt are pulled from the ERP REST API
+  (QuickBooks / SAP). The reconciliation is pure Python: quantity, unit-price and
+  total tolerance math, a duplicate-invoice hash, currency normalization and a
+  debit==credit balance check. No model ever decides whether to pay. The
+  match_status drives a classifier and a deterministic condition that blocks
+  duplicates and over-PO billing, requires controller approval on variance, and
+  auto-posts on a full match. A gate produces a plain-English policy summary
+  (LLM) and requires a human sign-off for exceptions, the controller approves
+  variances seeing the exact variance, and only then is the approved bill /
+  journal entry POSTed back to the ERP and the AP channel notified in Slack.
+default_model: sonnet
+default_timeout: 900
+input_schema:
+  required: ["invoice_file", "erp_base", "po_number"]
+  properties:
+    invoice_file:
+      type: string
+      description: "Path or upload reference to the vendor invoice PDF to be matched and paid."
+      default: ""
+    erp_base:
+      type: string
+      description: "Base URL of the ERP REST API (QuickBooks Online or SAP), e.g. https://quickbooks.api.intuit.com/v3/company/123456789"
+      default: "https://quickbooks.api.intuit.com/v3/company/123456789"
+    po_number:
+      type: string
+      description: "Purchase order number referenced by the invoice, looked up in the ERP."
+      default: ""
+    tolerance_pct:
+      type: number
+      description: "Allowed percentage variance on unit price and line/invoice totals before a variance is flagged."
+      default: 2.0
+    ap_channel:
+      type: string
+      description: "Slack channel for the accounts-payable pay-run notifications."
+      default: "#accounts-payable"
+
+steps:
+  # 1) Parse the invoice PDF: extract header + line items as structured markdown/JSON.
+  #    The ONLY model touch on the data path besides the gate summary.
+  - id: parse_invoice
+    type: parse
+    responsibility: "Extract invoice header (number, vendor, currency, totals) and line items from the PDF."
+    source_hint: "The vendor invoice is the bill we are about to pay; it must be read before matching."
+    owner: "ap-ops"
+    prompt: "{input.invoice_file}"
+    parse_config:
+      output: markdown
+      pages: null
+      ocr: true
+      ocr_engine: auto
+
+  # 2) GET the referenced purchase order from the ERP REST (what was ORDERED).
+  - id: fetch_po
+    type: http
+    depends_on: [parse_invoice]
+    responsibility: "Pull the authoritative purchase order (ordered qty/price/total) from the ERP."
+    source_hint: "Matching against the vendor's own numbers is meaningless; the PO is the system of record."
+    owner: "ap-ops"
+    http_config:
+      url: "{input.erp_base}/purchaseorder/{input.po_number}"
+      method: GET
+      auth: "bearer:{env.ERP_ACCESS_TOKEN}"
+      headers:
+        Accept: "application/json"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 3) GET the goods-receipt / delivery record from the ERP REST (what was RECEIVED).
+  - id: fetch_receipt
+    type: http
+    depends_on: [parse_invoice]
+    responsibility: "Pull the goods-receipt / delivery record (received qty) tied to this PO from the ERP."
+    source_hint: "Three-way match requires proof of receipt, not just an order and a bill."
+    owner: "ap-ops"
+    http_config:
+      url: "{input.erp_base}/itemreceipt?po={input.po_number}"
+      method: GET
+      auth: "bearer:{env.ERP_ACCESS_TOKEN}"
+      headers:
+        Accept: "application/json"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 4) DETERMINISTIC 3-way reconcile - the money decision. Pure Python, NO model.
+  #    Reads parsed invoice + PO + receipt; does tolerance math, duplicate hash,
+  #    currency normalize and debit==credit balance; emits match_status + variance.
+  - id: reconcile
+    type: code
+    depends_on: [parse_invoice, fetch_po, fetch_receipt]
+    responsibility: "Reconcile invoice vs PO vs goods-receipt deterministically and set the match_status."
+    source_hint: "Finance requires the pay/no-pay outcome to be reproducible and fully model-independent."
+    owner: "finance-eng"
+    code_config:
+      language: python
+      code: |
+        # ------------------------------------------------------------------
+        # Deterministic 3-way match. Identical output regardless of any model.
+        # _steps: upstream outputs; _input: workflow inputs.
+        # ------------------------------------------------------------------
+        import hashlib
+
+        invoice = _steps.get('parse_invoice') or {}
+        po = _steps.get('fetch_po') or {}
+        receipt = _steps.get('fetch_receipt') or {}
+        tol = float(_input.get('tolerance_pct', 2.0) or 2.0) / 100.0
+
+        def _num(v):
+            # Robust numeric coercion: strip currency symbols / commas.
+            if isinstance(v, (int, float)):
+                return float(v)
+            if v is None:
+                return 0.0
+            s = str(v).strip().replace(',', '')
+            for sym in ('$', '€', '£', 'USD', 'EUR', 'GBP'):
+                s = s.replace(sym, '')
+            s = s.strip()
+            try:
+                return float(s)
+            except (TypeError, ValueError):
+                return 0.0
+
+        def _lines(doc):
+            # Normalize a doc's line items to a list of dicts no matter the shape.
+            if isinstance(doc, dict):
+                for key in ('line_items', 'lines', 'Line', 'items'):
+                    v = doc.get(key)
+                    if isinstance(v, list):
+                        return [x for x in v if isinstance(x, dict)]
+            if isinstance(doc, list):
+                return [x for x in doc if isinstance(x, dict)]
+            return []
+
+        def _get(d, *keys, default=None):
+            for k in keys:
+                if isinstance(d, dict) and k in d and d.get(k) not in (None, ''):
+                    return d.get(k)
+            return default
+
+        # --- Currency normalization (warn-only; we match in the PO currency) ----
+        inv_ccy = str(_get(invoice, 'currency', 'CurrencyRef', default='USD')).upper()[:3] or 'USD'
+        po_ccy = str(_get(po, 'currency', 'CurrencyRef', default=inv_ccy)).upper()[:3] or inv_ccy
+        currency_mismatch = bool(inv_ccy and po_ccy and inv_ccy != po_ccy)
+
+        # --- Duplicate-invoice hash (vendor + invoice number + total) -----------
+        inv_no = str(_get(invoice, 'invoice_number', 'DocNumber', 'number', default='') or '')
+        vendor = str(_get(invoice, 'vendor', 'VendorRef', 'supplier', default='') or '')
+        inv_total = _num(_get(invoice, 'total', 'TotalAmt', 'total_amount', 'balance_due', default=0))
+        dup_hash = hashlib.sha256(f'{vendor}|{inv_no}|{inv_total:.2f}'.encode()).hexdigest()
+        # Already-paid hashes the ERP returned alongside the PO (if any).
+        paid_hashes = set()
+        if isinstance(po, dict):
+            for h in (po.get('paid_invoice_hashes') or []):
+                paid_hashes.add(str(h))
+        duplicate = dup_hash in paid_hashes
+
+        # --- Build qty / unit-price maps keyed by SKU for line matching ---------
+        def _index(doc):
+            idx = {}
+            for ln in _lines(doc):
+                sku = str(_get(ln, 'sku', 'item', 'ItemRef', 'code', 'description', default='') or '').strip().lower()
+                if not sku:
+                    continue
+                idx[sku] = {
+                    'qty': _num(_get(ln, 'qty', 'quantity', 'Qty', default=0)),
+                    'unit_price': _num(_get(ln, 'unit_price', 'UnitPrice', 'price', 'Rate', default=0)),
+                    'amount': _num(_get(ln, 'amount', 'Amount', 'line_total', 'subtotal', default=0)),
+                }
+            return idx
+
+        inv_idx, po_idx, rcpt_idx = _index(invoice), _index(po), _index(receipt)
+
+        lines = []
+        any_price_var = any_qty_var = no_po_line = over_receipt = False
+        for sku, iv in inv_idx.items():
+            pv = po_idx.get(sku)
+            rv = rcpt_idx.get(sku)
+            if pv is None:
+                no_po_line = True
+                lines.append({'sku': sku, 'status': 'NO_PO_LINE',
+                              'invoice_qty': iv['qty'], 'invoice_price': iv['unit_price']})
+                continue
+            # Price tolerance.
+            price_var = abs(iv['unit_price'] - pv['unit_price'])
+            price_tol = pv['unit_price'] * tol
+            price_ok = price_var <= max(price_tol, 0.005)
+            # Qty: invoiced must not exceed ordered (allow tolerance) ...
+            qty_ok = iv['qty'] <= pv['qty'] * (1 + tol) + 1e-9
+            # ... and must not exceed what was actually received.
+            recv_qty = rv['qty'] if rv else 0.0
+            recv_ok = iv['qty'] <= recv_qty + 1e-9
+            if not price_ok:
+                any_price_var = True
+            if not qty_ok:
+                any_qty_var = True
+            if not recv_ok:
+                over_receipt = True
+            lines.append({
+                'sku': sku,
+                'invoice_qty': iv['qty'], 'po_qty': pv['qty'], 'received_qty': recv_qty,
+                'invoice_price': iv['unit_price'], 'po_price': pv['unit_price'],
+                'price_ok': price_ok, 'qty_ok': qty_ok, 'received_ok': recv_ok,
+                'status': 'OK' if (price_ok and qty_ok and recv_ok) else 'VARIANCE',
+            })
+
+        # --- Total-level tolerance + debit==credit balance ----------------------
+        po_total = _num(_get(po, 'total', 'TotalAmt', 'total_amount', default=0))
+        total_var = abs(inv_total - po_total)
+        total_tol = po_total * tol
+        total_ok = total_var <= max(total_tol, 0.01)
+        over_po = inv_total > po_total * (1 + tol) + 0.01
+        # Books balance: sum of debited line amounts must equal the credited total.
+        debit = round(sum(_num(_get(ln, 'amount', 'Amount', 'line_total', default=0))
+                          for ln in _lines(invoice)), 2)
+        credit = round(inv_total, 2)
+        balanced = abs(debit - credit) <= 0.01 or debit == 0.0
+
+        # --- Deterministic match_status (priority order) ------------------------
+        if duplicate:
+            match_status = 'DUPLICATE'
+        elif not po or po_total <= 0:
+            match_status = 'NO_PO'
+        elif no_po_line or over_po:
+            match_status = 'PRICE_VARIANCE' if any_price_var else 'QTY_VARIANCE'
+        elif any_price_var or not total_ok or currency_mismatch:
+            match_status = 'PRICE_VARIANCE'
+        elif any_qty_var or over_receipt:
+            match_status = 'QTY_VARIANCE'
+        else:
+            match_status = 'FULL_MATCH'
+
+        result = {
+            'match_status': match_status,
+            'duplicate': duplicate,
+            'duplicate_hash': dup_hash,
+            'variance': {
+                'price_variance': any_price_var,
+                'qty_variance': any_qty_var,
+                'over_po': over_po,
+                'over_receipt': over_receipt,
+                'currency_mismatch': currency_mismatch,
+                'total_variance_amount': round(total_var, 2),
+                'total_ok': total_ok,
+            },
+            'balanced': balanced,
+            'debit': debit,
+            'credit': credit,
+            'invoice_total': round(inv_total, 2),
+            'po_total': round(po_total, 2),
+            'currency': po_ccy,
+            'invoice_number': inv_no,
+            'vendor': vendor,
+            'lines': lines,
+            'tolerance_pct': float(_input.get('tolerance_pct', 2.0) or 2.0),
+        }
+
+  # 5) CLASSIFY the deterministic match_status into a routing bucket.
+  #    Routing only - the code above already decided; this just dispatches.
+  - id: classify_match
+    type: classify
+    depends_on: [reconcile]
+    responsibility: "Dispatch the deterministic match_status to the right downstream handling."
+    source_hint: "Each match outcome needs a different control path (block / approve / auto-post)."
+    owner: "ap-ops"
+    classify_config:
+      model: haiku
+      input: "Deterministic match result: {steps.reconcile.output}"
+      categories:
+        - FULL_MATCH
+        - PRICE_VARIANCE
+        - QTY_VARIANCE
+        - NO_PO
+        - DUPLICATE
+      branches:
+        FULL_MATCH: [decide_route]
+        PRICE_VARIANCE: [decide_route]
+        QTY_VARIANCE: [decide_route]
+        NO_PO: [decide_route]
+        DUPLICATE: [decide_route]
+
+  # 6) DETERMINISTIC route gate: block duplicates / over-PO, require approval on
+  #    variance, auto-post on full match. Reads the code result, not a model.
+  - id: decide_route
+    type: condition
+    depends_on: [reconcile, classify_match]
+    responsibility: "Block duplicates/over-PO, route variance to approval, auto-post full matches."
+    source_hint: "Pay/no-pay branching must be a deterministic function of the reconcile output."
+    owner: "finance-eng"
+    condition_config:
+      expression: "'{steps.reconcile.output.match_status}' == 'FULL_MATCH' and {steps.reconcile.output.balanced}"
+      then: [policy_gate]
+      else: [exception_approval]
+
+  # --- Exception path: gate summary + human, then controller sign-off ----------
+  # 7) GATE - LLM writes a plain-English policy summary AND a human must sign off.
+  #    The only other model touch besides parse. The gate cannot change numbers.
+  - id: policy_gate
+    type: gate
+    depends_on: [decide_route]
+    responsibility: "Summarize the match against AP policy and require human oversight before posting."
+    source_hint: "EU AI Act + finance controls require human oversight on automated payment posting."
+    owner: "finance-controls"
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              Summarize whether this 3-way match result satisfies AP pay-run policy
+              (no duplicate, within tolerance, debit==credit balanced). Answer
+              'approved' only if match_status is FULL_MATCH and balanced is true;
+              otherwise 'rejected'. Do NOT change any amount.
+            input: "{steps.reconcile.output}"
+            model: sonnet
+        - type: human
+          config:
+            message: "Confirm the AP pay-run posting for this full-match invoice."
+            timeout_hours: 24
+            on_timeout: abort
+
+  # 8) Controller approval for exceptions (variance / no-PO). show_data = variance.
+  - id: exception_approval
+    type: approval
+    depends_on: [decide_route]
+    responsibility: "Controller signs off variance / no-PO invoices, seeing the exact computed variance."
+    source_hint: "Anything off full-match needs an accountable human owner before any money moves."
+    owner: "ap-controller"
+    approval_config:
+      message: >-
+        Three-way match exception for invoice {steps.reconcile.output.invoice_number}
+        (PO {input.po_number}). Review the deterministic variance below and approve
+        or reject posting. The match outcome and amounts are set by policy, not by you.
+      show_data: steps.reconcile.output.variance
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: true
+
+  # 9) POST the approved bill / journal entry back to the ERP (QuickBooks / SAP).
+  #    Depends on BOTH branch heads so it runs whichever path approved the invoice.
+  - id: post_bill
+    type: http
+    depends_on: [policy_gate, exception_approval]
+    responsibility: "Create the approved AP bill / journal entry in the ERP for the matched amount."
+    source_hint: "This is the money-moving call; the amount comes only from the deterministic reconcile."
+    owner: "finance-eng"
+    http_config:
+      url: "{input.erp_base}/bill"
+      method: POST
+      auth: "bearer:{env.ERP_ACCESS_TOKEN}"
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      body:
+        VendorRef:
+          value: "{steps.reconcile.output.vendor}"
+        DocNumber: "{steps.reconcile.output.invoice_number}"
+        TotalAmt: "{steps.reconcile.output.invoice_total}"
+        CurrencyRef:
+          value: "{steps.reconcile.output.currency}"
+        LinkedTxn:
+          - TxnId: "{input.po_number}"
+            TxnType: "PurchaseOrder"
+        PrivateNote: "3-way match {steps.reconcile.output.match_status}; debit {steps.reconcile.output.debit} == credit {steps.reconcile.output.credit}."
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: abort
+
+  # 10) Notify the AP channel in Slack with the posted result.
+  - id: notify_ap
+    type: notify
+    depends_on: [post_bill]
+    responsibility: "Announce the settled pay-run outcome to the accounts-payable team."
+    source_hint: "AP needs a visible audit trail of every posted bill in the team channel."
+    owner: "ap-ops"
+    notify_config:
+      service: slack
+      channel: "{input.ap_channel}"
+      message: "Pay-run posted: invoice {steps.reconcile.output.invoice_number} (PO {input.po_number}) status {steps.reconcile.output.match_status}, amount {steps.reconcile.output.invoice_total} {steps.reconcile.output.currency}. ERP bill: {steps.post_bill.output}."
+
+on_complete:
+  storage_path: "three-way-match-pay-run/{run_id}/result.json"

--- a/src/sandcastle/templates/vuln_triage_reachability_gate.yaml
+++ b/src/sandcastle/templates/vuln_triage_reachability_gate.yaml
@@ -1,0 +1,434 @@
+# name: Vuln Triage Reachability Gate
+# description: AppSec finding triage with a two-judge cross-provider gate. Pull scanner findings + EPSS + CISA KEV, score deterministically, classify, test reachability via GitHub code-search, then require TWO judges on TWO different providers (plus a human) to agree before a patch-now decision becomes a Jira ticket. Risk acceptances go to a security lead for sign-off.
+# tags: [AppSec, SCA, EPSS, CISA-KEV, Reachability, GitHub, Jira, Slack, Two-Judge-Gate, Security]
+# category: engineering
+
+name: vuln-triage-reachability-gate
+description: >-
+  AppSec vulnerability triage that no single model can green-light. A DETERMINISTIC Python
+  step pulls scanner findings, EPSS exploit-probability scores, and the CISA KEV catalog,
+  then merges them, drops duplicate CVEs, and computes base_risk = CVSS x EPSS x KEV x
+  asset_exposure so the ranking is reproducible and model-independent. A swappable classify
+  splits each finding into third_party_dep / first_party_code / infra_misconfig, and a GitHub
+  code-search HTTP call tests whether the vulnerable symbol is actually imported/called
+  (reachability). The load-bearing decision is a TWO-JUDGE cross-provider gate: judge 1 on
+  sonnet and judge 2 on google/gemini-2.5-pro must BOTH answer the same exploitable-AND-reachable
+  rubric, and a human must accept the risk - all strategies must pass to mark patch-now, so no
+  single provider can authorize a patch decision. A condition routes a passing gate to a real
+  Jira ticket POST (with SLA + owner); a failing gate routes to a security-lead risk-acceptance
+  approval. The outcome is posted to Slack. Connectors: GitHub + Jira via http, Slack via notify.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 900
+
+input_schema:
+  required: ["scanner_endpoint", "github_repo"]
+  properties:
+    scanner_endpoint:
+      type: string
+      description: "REST base URL of the vulnerability scanner findings API (e.g. Snyk, Trivy server, Dependency-Track, or a Defect Dojo /findings endpoint)."
+      default: "https://scanner.internal/api/v2"
+      example: "https://dependencytrack.acme.internal/api/v1"
+    github_repo:
+      type: string
+      description: "owner/repo of the first-party codebase used for the GitHub code-search reachability test."
+      default: "acme/payments-service"
+      example: "acme/payments-service"
+    epss_base_url:
+      type: string
+      description: "FIRST.org EPSS REST API base URL (exploit-prediction scores per CVE)."
+      default: "https://api.first.org/data/v1"
+      example: "https://api.first.org/data/v1"
+    kev_catalog_url:
+      type: string
+      description: "CISA Known Exploited Vulnerabilities catalog JSON URL."
+      default: "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+      example: "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+    asset_exposure:
+      type: number
+      description: "Exposure multiplier for the affected asset: 1.0 internal-only, 1.5 partner-facing, 2.0 internet-facing crown-jewel. Folds business context into base_risk."
+      default: 1.5
+      example: "2.0"
+    jira_base_url:
+      type: string
+      description: "Jira REST base URL used to open the remediation ticket."
+      default: "https://acme.atlassian.net/rest/api/3"
+      example: "https://acme.atlassian.net/rest/api/3"
+    jira_project_key:
+      type: string
+      description: "Jira project key the remediation ticket is filed under."
+      default: "SEC"
+      example: "SEC"
+    sla_days:
+      type: number
+      description: "Remediation SLA in days written onto the patch-now Jira ticket."
+      default: 14
+      example: "7"
+    remediation_owner:
+      type: string
+      description: "Default assignee / owning team for the remediation ticket."
+      default: "appsec-team"
+      example: "platform-security"
+    slack_channel:
+      type: string
+      description: "Slack channel for the triage decision summary."
+      default: "#appsec-triage"
+      example: "#appsec-triage"
+
+steps:
+  # 1) PULL raw findings from the scanner REST API (Snyk / Trivy / Dependency-Track / DefectDojo).
+  - id: pull_scanner_findings
+    type: http
+    http_config:
+      url: "{input.scanner_endpoint}/findings?status=open&severity=high,critical&limit=200"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.SCANNER_API_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 2) PULL EPSS exploit-prediction scores (FIRST.org) for the high/critical CVE set.
+  - id: pull_epss_scores
+    type: http
+    http_config:
+      url: "{input.epss_base_url}/epss?scope=public&limit=2000&order=!epss"
+      method: GET
+      headers:
+        Accept: "application/json"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 3) PULL the CISA Known Exploited Vulnerabilities catalog (authoritative "actively exploited" list).
+  - id: pull_kev_catalog
+    type: http
+    http_config:
+      url: "{input.kev_catalog_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 4) DETERMINISTIC merge + dedupe + risk scoring. The audit-load-bearing math, no model:
+  #    base_risk = CVSS x EPSS x KEV_multiplier x asset_exposure; ties broken by CVSS then EPSS.
+  - id: score_and_rank
+    type: code
+    depends_on: [pull_scanner_findings, pull_epss_scores, pull_kev_catalog]
+    code_config:
+      language: python
+      code: |
+        scan = _steps['pull_scanner_findings'] or {}
+        epss = _steps['pull_epss_scores'] or {}
+        kev = _steps['pull_kev_catalog'] or {}
+        asset_exposure = float(_input.get('asset_exposure', 1.5) or 1.5)
+
+        # --- Normalize scanner findings (DefectDojo {"results":[...]}, Snyk {"issues":[...]},
+        #     Dependency-Track returns a bare list, Trivy {"findings":[...]}). ---------------
+        if isinstance(scan, list):
+            raw_findings = scan
+        else:
+            raw_findings = (scan.get('results') or scan.get('issues')
+                            or scan.get('findings') or scan.get('data') or [])
+
+        # --- EPSS lookup: cve -> probability (0..1). FIRST.org returns {"data":[{cve,epss}]}. -
+        epss_by_cve = {}
+        epss_rows = epss.get('data', []) if isinstance(epss, dict) else (epss if isinstance(epss, list) else [])
+        for row in epss_rows:
+            if isinstance(row, dict) and row.get('cve'):
+                try:
+                    epss_by_cve[str(row['cve']).upper()] = float(row.get('epss') or 0.0)
+                except (ValueError, TypeError):
+                    epss_by_cve[str(row['cve']).upper()] = 0.0
+
+        # --- KEV set: catalog has {"vulnerabilities":[{"cveID":...}]}. -----------------------
+        kev_set = set()
+        kev_rows = kev.get('vulnerabilities', []) if isinstance(kev, dict) else (kev if isinstance(kev, list) else [])
+        for row in kev_rows:
+            if isinstance(row, dict) and row.get('cveID'):
+                kev_set.add(str(row['cveID']).upper())
+
+        def _extract_cve(rec):
+            for k in ('cve', 'cveId', 'cve_id', 'vulnerability_id', 'vulnId'):
+                v = rec.get(k)
+                if v:
+                    return str(v).upper()
+            # Some scanners nest the CVE under a vulnerability object.
+            vuln = rec.get('vulnerability') or rec.get('vuln') or {}
+            if isinstance(vuln, dict):
+                v = vuln.get('cve') or vuln.get('id') or vuln.get('vulnId')
+                if v:
+                    return str(v).upper()
+            return ''
+
+        def _extract_cvss(rec):
+            for k in ('cvssScore', 'cvss_score', 'cvss', 'severityScore', 'score'):
+                v = rec.get(k)
+                if v is not None:
+                    try:
+                        return max(0.0, min(10.0, float(v)))
+                    except (ValueError, TypeError):
+                        pass
+            sev = str(rec.get('severity') or rec.get('severityLevel') or '').lower()
+            return {'critical': 9.5, 'high': 7.5, 'medium': 5.0, 'low': 2.5}.get(sev, 5.0)
+
+        # --- Merge, dedupe by CVE (keep the highest-CVSS instance), score. ------------------
+        best_by_cve = {}
+        for rec in raw_findings:
+            if not isinstance(rec, dict):
+                continue
+            cve = _extract_cve(rec)
+            cvss = _extract_cvss(rec)
+            # Findings without a CVE still get triaged; key them by component+title.
+            comp = str(rec.get('component') or rec.get('componentName')
+                       or rec.get('package') or rec.get('purl') or '')
+            symbol = str(rec.get('symbol') or rec.get('functionName')
+                         or rec.get('affected_function') or comp.split('@')[0].split('/')[-1] or '')
+            key = cve or f"NOCVE::{comp}::{str(rec.get('title') or rec.get('name') or '')}"
+            existing = best_by_cve.get(key)
+            if existing is None or cvss > existing['cvss']:
+                epss_p = epss_by_cve.get(cve, 0.0) if cve else 0.0
+                in_kev = cve in kev_set if cve else False
+                kev_mult = 2.0 if in_kev else 1.0
+                # EPSS contributes a floor of 0.1 so a high-CVSS no-EPSS bug still ranks.
+                epss_factor = max(epss_p, 0.1)
+                base_risk = round(cvss * epss_factor * kev_mult * asset_exposure, 4)
+                best_by_cve[key] = {
+                    'key': key,
+                    'cve': cve,
+                    'title': str(rec.get('title') or rec.get('name') or rec.get('issue') or cve or 'finding'),
+                    'component': comp,
+                    'symbol': symbol,
+                    'cvss': cvss,
+                    'epss': round(epss_p, 6),
+                    'in_kev': in_kev,
+                    'asset_exposure': asset_exposure,
+                    'base_risk': base_risk,
+                }
+
+        findings = list(best_by_cve.values())
+        # Deterministic rank: base_risk desc, then CVSS desc, then EPSS desc, then CVE for stability.
+        findings.sort(key=lambda f: (-f['base_risk'], -f['cvss'], -f['epss'], f['cve']))
+        for i, f in enumerate(findings):
+            f['rank'] = i + 1
+
+        result = {
+            'repo': _input.get('github_repo'),
+            'total_open': len(raw_findings),
+            'deduped_count': len(findings),
+            'kev_hits': sum(1 for f in findings if f['in_kev']),
+            'top_finding': findings[0] if findings else {},
+            'findings': findings,
+        }
+
+  # 5) CLASSIFY the top finding's origin. The ONLY model in the scoring path, and it is swappable.
+  #    Every category routes into the reachability test - origin shapes the rubric, not the gate.
+  - id: classify_origin
+    type: classify
+    depends_on: [score_and_rank]
+    classify_config:
+      model: haiku
+      input: "Classify the ORIGIN of this AppSec finding. third_party_dep = a vulnerable library/package we depend on (has a component/purl, e.g. log4j, openssl). first_party_code = a bug in our own source (SAST/secret/logic flaw, no external package). infra_misconfig = a cloud/container/IaC misconfiguration (exposed bucket, open port, weak TLS, IAM). Finding: {steps.score_and_rank.output.top_finding}"
+      categories:
+        - third_party_dep
+        - first_party_code
+        - infra_misconfig
+      branches:
+        third_party_dep: [reachability_probe]
+        first_party_code: [reachability_probe]
+        infra_misconfig: [reachability_probe]
+
+  # 6) REACHABILITY: GitHub code-search REST to test whether the vulnerable symbol is actually
+  #    imported / called anywhere in the first-party repo. A hit count > 0 means reachable.
+  - id: reachability_probe
+    type: http
+    depends_on: [score_and_rank, classify_origin]
+    http_config:
+      url: "https://api.github.com/search/code?q={steps.score_and_rank.output.top_finding.symbol}+repo:{input.github_repo}&per_page=20"
+      method: GET
+      headers:
+        Accept: "application/vnd.github.text-match+json"
+        X-GitHub-Api-Version: "2022-11-28"
+      auth: "bearer:{env.GITHUB_TOKEN}"
+      value_map:
+        reachable_hits: "total_count"
+        matched_files: "items"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 7) DETERMINISTIC reachability verdict + judge brief. Folds the code-search hit count into the
+  #    finding so the judges and the gate see one consistent, machine-built exploitability dossier.
+  - id: build_judge_brief
+    type: code
+    depends_on: [score_and_rank, classify_origin, reachability_probe]
+    code_config:
+      language: python
+      code: |
+        ranked = _steps['score_and_rank'] or {}
+        origin = str(_steps['classify_origin'] or '').strip().lower() or 'third_party_dep'
+        probe = _steps['reachability_probe'] or {}
+
+        top = ranked.get('top_finding', {}) or {}
+
+        # GitHub code-search total_count (via value_map -> reachable_hits) or raw payload.
+        hits = probe.get('reachable_hits', probe.get('total_count'))
+        try:
+            hit_count = int(hits) if hits is not None else 0
+        except (ValueError, TypeError):
+            hit_count = 0
+        matched = probe.get('matched_files') or probe.get('items') or []
+        sample_paths = []
+        for m in matched[:5]:
+            if isinstance(m, dict):
+                sample_paths.append(m.get('path') or m.get('name') or '')
+
+        # Infra misconfigs are not "imported", so a symbol code-search is not the right signal:
+        # treat them as reachable-by-default (the misconfiguration IS the exposure).
+        if origin == 'infra_misconfig':
+            reachable = True
+            reach_reason = 'infra_misconfig_exposure_is_the_reachability'
+        else:
+            reachable = hit_count > 0
+            reach_reason = f'github_code_search_hits={hit_count}'
+
+        brief = {
+            'cve': top.get('cve'),
+            'title': top.get('title'),
+            'component': top.get('component'),
+            'symbol': top.get('symbol'),
+            'origin': origin,
+            'cvss': top.get('cvss'),
+            'epss': top.get('epss'),
+            'in_kev': top.get('in_kev'),
+            'asset_exposure': top.get('asset_exposure'),
+            'base_risk': top.get('base_risk'),
+            'reachable': reachable,
+            'reachability_signal': reach_reason,
+            'code_search_hits': hit_count,
+            'sample_paths': sample_paths,
+        }
+
+        result = {
+            'repo': ranked.get('repo'),
+            'reachable': reachable,
+            'in_kev': bool(top.get('in_kev')),
+            'brief': brief,
+            # One human-readable line both judges and the gate will reason over.
+            'summary': (f"{brief['cve'] or brief['title']} | origin={origin} | cvss={brief['cvss']} "
+                        f"| epss={brief['epss']} | kev={brief['in_kev']} | reachable={reachable} "
+                        f"({reach_reason}) | base_risk={brief['base_risk']}"),
+        }
+
+  # 8) TWO-JUDGE CROSS-PROVIDER GATE. The load-bearing patch decision. Judge 1 (sonnet) and
+  #    Judge 2 (google/gemini-2.5-pro) apply the SAME exploitable-AND-reachable rubric on DIFFERENT
+  #    providers, and a human must accept the risk. gate = ALL strategies must pass, so no single
+  #    provider can green-light a patch-now decision.
+  - id: exploitability_gate
+    type: gate
+    depends_on: [build_judge_brief]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              JUDGE 1. You are an AppSec exploitability reviewer. Apply this exact rubric:
+              answer 'approved' ONLY IF the finding is BOTH (a) exploitable in our context -
+              high CVSS, non-trivial EPSS or listed in CISA KEV, internet/partner-facing
+              asset exposure - AND (b) reachable - the vulnerable symbol is actually
+              imported/called in our code (reachable=true), or it is an infra_misconfig whose
+              very presence is the exposure. If it is unreachable dead code or purely
+              theoretical, answer 'rejected' and state why. Do not approve on severity alone.
+            input: "{steps.build_judge_brief.output.summary}"
+            model: sonnet
+        - type: llm_eval
+          config:
+            prompt: >-
+              JUDGE 2 (independent, different provider). You are an AppSec exploitability
+              reviewer. Apply this exact rubric: answer 'approved' ONLY IF the finding is BOTH
+              (a) exploitable in our context - high CVSS, non-trivial EPSS or listed in CISA
+              KEV, internet/partner-facing asset exposure - AND (b) reachable - the vulnerable
+              symbol is actually imported/called in our code (reachable=true), or it is an
+              infra_misconfig whose presence is the exposure. If unreachable dead code or
+              purely theoretical, answer 'rejected' and state why. Do not approve on severity
+              alone. You must reach your verdict independently of any other reviewer.
+            input: "{steps.build_judge_brief.output.summary}"
+            model: google/gemini-2.5-pro
+        - type: human
+          config:
+            message: "Security engineer: both model judges flagged this as exploitable AND reachable. Confirm patch-now (approve) or send to risk-acceptance (reject). Review the reachability evidence and KEV status before deciding."
+            timeout_hours: 24
+            on_timeout: abort
+
+  # 9) BRANCH on the gate outcome. Passing gate -> open a Jira remediation ticket with SLA + owner.
+  #    Failing gate -> route to a security-lead risk-acceptance sign-off. Deterministic, no model.
+  - id: decision_branch
+    type: condition
+    depends_on: [exploitability_gate]
+    condition_config:
+      expression: "{steps.exploitability_gate.output.passed} == true"
+      then: [open_jira_ticket, notify_decision]
+      else: [risk_acceptance_signoff, notify_decision]
+
+  # 9a) PATCH-NOW: POST a remediation ticket to Jira with the SLA, owner, and the full dossier.
+  - id: open_jira_ticket
+    type: http
+    http_config:
+      url: "{input.jira_base_url}/issue"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.JIRA_TOKEN}"
+      body: |
+        {
+          "fields": {
+            "project": { "key": "{input.jira_project_key}" },
+            "issuetype": { "name": "Vulnerability" },
+            "summary": "Patch-now: {steps.build_judge_brief.output.brief.cve} in {input.github_repo}",
+            "labels": ["appsec", "patch-now", "reachable", "two-judge-gate"],
+            "description": "Two-judge cross-provider gate PASSED (exploitable AND reachable). Dossier: {steps.build_judge_brief.output.summary}. SLA: {input.sla_days} days. Owner: {input.remediation_owner}. KEV: {steps.build_judge_brief.output.in_kev}.",
+            "duedate_days": "{input.sla_days}",
+            "assignee_team": "{input.remediation_owner}"
+          }
+        }
+      value_map:
+        jira_key: "key"
+        jira_id: "id"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 9b) RISK ACCEPTANCE: the security lead signs off any decision NOT to patch now.
+  - id: risk_acceptance_signoff
+    type: approval
+    approval_config:
+      message: >-
+        Risk acceptance sign-off required. The two-judge gate did NOT clear this finding for
+        immediate patching (unreachable, low exploitability, or a judge/human rejected it).
+        Security lead: approve to formally ACCEPT this risk for now, or reject to escalate back
+        to patch-now. Your sign-off is the audit record of the accept-risk decision.
+      show_data: steps.build_judge_brief.output
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: true
+
+  # 10) NOTIFY the team in Slack with the final triage decision and the reachability evidence.
+  - id: notify_decision
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: "Vuln triage for {input.github_repo}: {steps.build_judge_brief.output.summary}. Two-judge gate passed={steps.exploitability_gate.output.passed}. Deduped findings: {steps.score_and_rank.output.deduped_count} (KEV hits: {steps.score_and_rank.output.kev_hits})."
+
+on_complete:
+  storage_path: "vuln-triage-reachability-gate/{run_id}/result.json"

--- a/src/sandcastle/templates/warehouse_data_quality_sentinel.yaml
+++ b/src/sandcastle/templates/warehouse_data_quality_sentinel.yaml
@@ -1,0 +1,367 @@
+# name: Warehouse Data-Quality Sentinel
+# description: Scheduled, deterministic data-quality sentinel over a warehouse - drift, freshness, null-spike and volume anomalies caught by code, narrated by a cross-provider race, ticketed and digested.
+# tags: [data-quality, warehouse, snowflake, postgres, observability, monitoring]
+# category: data
+name: warehouse-data-quality-sentinel
+description: >-
+  A scheduled data-quality sentinel for a warehouse. It pulls a table registry and
+  the expected thresholds from a control table (Snowflake / Postgres via REST), then
+  loops every registered table: query its vital stats (row count, null %, freshness,
+  key cardinality), run 100% DETERMINISTIC checks in code (z-score drift versus a
+  trailing baseline, freshness-SLA breach, null-spike ratio, volume anomaly), and
+  classify the failure mode. A code step aggregates per-table results and counts
+  failures by type. A condition routes: any non-healthy table triggers ticketing +
+  escalation, otherwise an all-clear notice. The ONLY model work is a cross-provider
+  RACE (Sonnet vs Gemini 2.5 Pro, first-valid-wins failover) that writes a
+  human-readable root-cause narrative on the failing tables. Tickets are POSTed to
+  Jira / Linear per failure class, and a data-quality digest is posted to Slack.
+  Detection is deterministic; the model only writes prose.
+default_model: sonnet
+default_timeout: 1200
+input_schema:
+  required: ["warehouse_endpoint", "registry_table"]
+  properties:
+    warehouse_endpoint:
+      type: string
+      description: "Base URL of the warehouse REST gateway (Snowflake SQL API or PostgREST over Postgres), e.g. https://warehouse.internal/api/v2"
+      default: "https://warehouse.internal/api/v2"
+    registry_table:
+      type: string
+      description: "Name of the control table holding the table registry + expected thresholds (baseline mean/std, null ceiling, freshness SLA, expected row volume, FK column)."
+      default: "dq_control.table_registry"
+    baseline_window:
+      type: integer
+      description: "Trailing window (in prior runs/days) used as the drift baseline for the z-score test."
+      default: 30
+    z_threshold:
+      type: number
+      description: "Absolute z-score above which a metric is flagged as drifted / volume-anomalous."
+      default: 3.0
+steps:
+  # 1) Pull the table registry + expected thresholds from the control table.
+  #    Snowflake SQL API / PostgREST over Postgres. Returns a list of table specs.
+  - id: "registry"
+    type: http
+    http_config:
+      url: "{input.warehouse_endpoint}/tables?select=*&control_table=eq.{input.registry_table}&active=eq.true"
+      method: GET
+      headers:
+        Accept: "application/json"
+        Prefer: "count=exact"
+      auth: "bearer:{env.WAREHOUSE_API_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 2) Loop over every registered table: query its stats -> deterministic checks -> classify.
+  - id: "scan_tables"
+    type: loop
+    depends_on: ["registry"]
+    loop_config:
+      over: "steps.registry.output"
+      step_ids: ["query_table", "run_checks", "classify_failure"]
+      max_iterations: 200
+
+  # 2a) QUERY this table's vital stats from the warehouse (row count, null %, freshness,
+  #     key cardinality). The {{ _item }} carries this table's registry spec.
+  - id: "query_table"
+    type: http
+    http_config:
+      url: "{input.warehouse_endpoint}/query"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.WAREHOUSE_API_TOKEN}"
+      body: |
+        {
+          "statement": "SELECT COUNT(*) AS row_count, AVG(CASE WHEN {{ _item.null_check_column }} IS NULL THEN 1.0 ELSE 0.0 END) AS null_ratio, MAX({{ _item.updated_at_column }}) AS max_updated_at, COUNT(DISTINCT {{ _item.key_column }}) AS key_cardinality FROM {{ _item.fully_qualified_name }}",
+          "table": "{{ _item.fully_qualified_name }}",
+          "timeout": 120
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 2b) DETERMINISTIC checks. NO model. Pure code: z-score drift vs trailing baseline,
+  #     freshness-SLA breach, null-spike ratio, volume anomaly. Reads this table's
+  #     registry spec (_item) + the freshly queried stats (_steps['query_table']).
+  - id: "run_checks"
+    type: code
+    code_config:
+      language: python
+      code: |
+        # ---- inputs -------------------------------------------------------------
+        spec = _input.get('_item') or {}          # registry row: thresholds + baseline
+        stats = _steps.get('query_table') or {}   # freshly queried vital stats
+        if isinstance(stats, dict) and isinstance(stats.get('rows'), list) and stats['rows']:
+            # Some warehouse REST gateways wrap results in {"rows": [ {...} ]}
+            stats = stats['rows'][0] if isinstance(stats['rows'][0], dict) else stats
+
+        z_threshold = float(_input.get('z_threshold', 3.0) or 3.0)
+
+        def num(d, *keys, default=0.0):
+            for k in keys:
+                if isinstance(d, dict) and d.get(k) is not None:
+                    try:
+                        return float(d.get(k))
+                    except (TypeError, ValueError):
+                        continue
+            return float(default)
+
+        # ---- observed metrics ---------------------------------------------------
+        row_count = num(stats, 'row_count', 'count')
+        null_ratio = num(stats, 'null_ratio', 'null_pct')
+        key_cardinality = num(stats, 'key_cardinality', 'distinct_keys')
+        max_updated_at = stats.get('max_updated_at') if isinstance(stats, dict) else None
+
+        # ---- expected baseline (from the control table spec) --------------------
+        baseline_mean = num(spec, 'baseline_row_mean', 'expected_rows')
+        baseline_std = num(spec, 'baseline_row_std', default=0.0)
+        null_ceiling = num(spec, 'null_ceiling', default=0.05)
+        freshness_sla_hours = num(spec, 'freshness_sla_hours', default=24.0)
+        observed_freshness_hours = num(stats, 'freshness_lag_hours', default=-1.0)
+        expected_min_cardinality = num(spec, 'min_key_cardinality', default=1.0)
+
+        issues = []
+
+        # (1) VOLUME ANOMALY / z-score drift vs trailing baseline
+        if baseline_std > 0:
+            z = (row_count - baseline_mean) / baseline_std
+        else:
+            # no usable std -> fall back to a +/-50% band around the mean
+            z = 0.0 if baseline_mean == 0 else (row_count - baseline_mean) / (0.5 * baseline_mean)
+        if abs(z) >= z_threshold:
+            issues.append({
+                'check': 'volume_anomaly',
+                'z_score': round(z, 3),
+                'observed_rows': row_count,
+                'expected_rows': baseline_mean,
+            })
+
+        # (2) FRESHNESS-SLA breach
+        if observed_freshness_hours >= 0 and observed_freshness_hours > freshness_sla_hours:
+            issues.append({
+                'check': 'freshness_breach',
+                'observed_lag_hours': observed_freshness_hours,
+                'sla_hours': freshness_sla_hours,
+            })
+
+        # (3) NULL-SPIKE ratio
+        if null_ratio > null_ceiling:
+            issues.append({
+                'check': 'null_spike',
+                'null_ratio': round(null_ratio, 4),
+                'null_ceiling': null_ceiling,
+                'spike_x': round(null_ratio / null_ceiling, 2) if null_ceiling > 0 else None,
+            })
+
+        # (4) REFERENTIAL break - key cardinality collapsed below expected floor
+        if key_cardinality < expected_min_cardinality:
+            issues.append({
+                'check': 'referential_break',
+                'observed_cardinality': key_cardinality,
+                'expected_min_cardinality': expected_min_cardinality,
+            })
+
+        # ---- severity (deterministic) ------------------------------------------
+        if not issues:
+            severity = 'none'
+        elif any(i['check'] in ('referential_break', 'freshness_breach') for i in issues):
+            severity = 'critical'
+        elif len(issues) >= 2:
+            severity = 'high'
+        else:
+            severity = 'medium'
+
+        result = {
+            'table': spec.get('fully_qualified_name') or spec.get('name') or 'unknown',
+            'issues': issues,
+            'issue_count': len(issues),
+            'severity': severity,
+            'metrics': {
+                'row_count': row_count,
+                'null_ratio': round(null_ratio, 4),
+                'key_cardinality': key_cardinality,
+                'max_updated_at': max_updated_at,
+            },
+        }
+
+  # 2c) CLASSIFY the dominant failure mode for this table from the deterministic findings.
+  #     Cheap model only labels; the decision (whether it failed) was already made in code.
+  - id: "classify_failure"
+    type: classify
+    classify_config:
+      categories: ["schema_drift", "freshness_breach", "null_spike", "volume_anomaly", "referential_break", "healthy"]
+      input: "{steps.run_checks.output}"
+      model: haiku
+      branches:
+        schema_drift: []
+        freshness_breach: []
+        null_spike: []
+        volume_anomaly: []
+        referential_break: []
+        healthy: []
+
+  # 3) AGGREGATE all per-table results: count failures by type. Deterministic.
+  - id: "aggregate"
+    type: code
+    depends_on: ["scan_tables"]
+    code_config:
+      language: python
+      code: |
+        # The loop output is the list of per-table `run_checks` results.
+        rows = _steps.get('scan_tables') or []
+        if isinstance(rows, dict):
+            rows = rows.get('results') or rows.get('items') or list(rows.values())
+        if not isinstance(rows, list):
+            rows = [rows]
+        rows = [r for r in rows if isinstance(r, dict)]
+
+        total = len(rows)
+        by_type = {
+            'schema_drift': 0,
+            'freshness_breach': 0,
+            'null_spike': 0,
+            'volume_anomaly': 0,
+            'referential_break': 0,
+        }
+        failing = []
+        for r in rows:
+            tbl_issues = r.get('issues') or []
+            if not tbl_issues:
+                continue
+            failing.append({
+                'table': r.get('table'),
+                'severity': r.get('severity'),
+                'checks': [i.get('check') for i in tbl_issues],
+                'issue_count': r.get('issue_count', len(tbl_issues)),
+            })
+            for i in tbl_issues:
+                chk = i.get('check')
+                if chk in by_type:
+                    by_type[chk] += 1
+                elif chk == 'schema_drift':
+                    by_type['schema_drift'] += 1
+
+        fail_count = len(failing)
+        critical = [f for f in failing if f.get('severity') == 'critical']
+
+        result = {
+            'tables_scanned': total,
+            'fail_count': fail_count,
+            'healthy_count': total - fail_count,
+            'critical_count': len(critical),
+            'failures_by_type': by_type,
+            'failing_tables': failing,
+            'all_clear': fail_count == 0,
+        }
+
+  # 4) CONDITION: any non-healthy table -> ticket + escalate root cause; else all-clear.
+  - id: "route_outcome"
+    type: condition
+    depends_on: ["aggregate"]
+    condition_config:
+      expression: "{steps.aggregate.output.fail_count} > 0"
+      then: ["root_cause_race", "open_tickets", "notify_digest"]
+      else: ["notify_all_clear"]
+
+  # 5) ROOT-CAUSE RACE - cross-provider failover (Sonnet vs Gemini 2.5 Pro), first
+  #    non-empty narrative wins. THE ONLY model work in the whole sentinel.
+  #    Branches A/B are defined separately with NO depends_on.
+  - id: "root_cause_race"
+    type: race
+    race_config:
+      branches: [["narrative_sonnet"], ["narrative_gemini"]]
+      validator: "len(str(output)) > 20"
+
+  - id: "narrative_sonnet"
+    type: standard
+    model: sonnet
+    prompt: |
+      You are a senior data engineer writing the root-cause narrative for a
+      data-quality incident. The detection below is already DETERMINED by code -
+      do NOT re-judge whether tables failed; explain the likely root cause and the
+      operator next-steps.
+
+      Aggregate (failing tables, failure-type counts, severities):
+      {{ _steps['aggregate'] }}
+
+      Write a tight root-cause narrative (<= 250 words):
+      - The most probable upstream cause per failing table class
+        (schema_drift / freshness_breach / null_spike / volume_anomaly / referential_break).
+      - Which failures are correlated (likely one shared cause).
+      - Concrete next step for the on-call data engineer.
+      Plain prose. No preamble.
+
+  - id: "narrative_gemini"
+    type: standard
+    model: google/gemini-2.5-pro
+    prompt: |
+      You are the failover author (Gemini 2.5 Pro) for a data-quality root-cause
+      narrative. The failures below were detected deterministically in code - take
+      them as ground truth and explain root cause + remediation.
+
+      Aggregate (failing tables, failure-type counts, severities):
+      {{ _steps['aggregate'] }}
+
+      Write a tight root-cause narrative (<= 250 words) covering probable upstream
+      cause per failing class, correlated failures, and the on-call next step.
+      Plain prose. No preamble.
+
+  # 6) OPEN TICKETS - POST one ticket per failure class to Jira / Linear REST.
+  #    Body carries the deterministic aggregate + the race-authored narrative.
+  - id: "open_tickets"
+    type: http
+    depends_on: ["root_cause_race"]
+    http_config:
+      url: "{env.TICKETING_BASE_URL}/issues"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.TICKETING_API_TOKEN}"
+      body: |
+        {
+          "project": "DQ",
+          "title": "Data-Quality Sentinel: {{ _steps['aggregate']['fail_count'] }} table(s) failing",
+          "failures_by_type": {{ _steps['aggregate']['failures_by_type'] }},
+          "failing_tables": {{ _steps['aggregate']['failing_tables'] }},
+          "root_cause_narrative": "{{ _steps['root_cause_race'] }}",
+          "severity": "{{ 'critical' if _steps['aggregate']['critical_count'] > 0 else 'high' }}"
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 7a) DIGEST (failures path) - post the data-quality digest to Slack.
+  - id: "notify_digest"
+    type: notify
+    depends_on: ["open_tickets"]
+    notify_config:
+      service: slack
+      channel: "#data-quality"
+      message: |
+        :rotating_light: Warehouse Data-Quality Sentinel
+        Tables scanned : {steps.aggregate.output.tables_scanned}
+        Failing        : {steps.aggregate.output.fail_count} ({steps.aggregate.output.critical_count} critical)
+        By type        : {steps.aggregate.output.failures_by_type}
+        Tickets filed to Jira/Linear. Root cause:
+        {steps.root_cause_race.output}
+
+  # 7b) ALL-CLEAR (healthy path) - reassuring green notice, no tickets.
+  - id: "notify_all_clear"
+    type: notify
+    depends_on: ["route_outcome"]
+    notify_config:
+      service: slack
+      channel: "#data-quality"
+      message: |
+        :white_check_mark: Warehouse Data-Quality Sentinel - all clear.
+        Tables scanned : {steps.aggregate.output.tables_scanned}
+        No drift, freshness, null-spike, volume or referential issues detected.
+on_complete:
+  storage_path: "warehouse-data-quality-sentinel/{run_id}/result.json"

--- a/tests/test_model_neutral_templates_wave2_v033.py
+++ b/tests/test_model_neutral_templates_wave2_v033.py
@@ -1,0 +1,225 @@
+"""Structural + thesis validation for the v0.33 model-independent templates, wave 2.
+
+This wave broadens the patterns beyond the first five: it adds ``parse`` (invoice
+extraction), ``sub_workflow`` composition (map-reduce), a true multi-provider
+*consensus* (N parallel votes on distinct providers plus a deterministic code tally,
+as opposed to race failover), a two-judge cross-provider ``gate``, and fills the
+previously near-empty ``data`` category. Each template proves model-independence in
+one of several legitimate ways, so the thesis check accepts any of: a cross-provider
+race, multi-provider consensus votes, a two-judge gate, or a deterministic code
+decision guarded by human oversight.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sandcastle.engine.dag import (
+    VALID_STEP_TYPES,
+    build_plan,
+    parse_yaml_string,
+    validate,
+)
+from sandcastle.engine.tools.registry import KNOWN_TOOLS
+from sandcastle.templates import list_templates
+
+WAVE2_TEMPLATES = [
+    "three_way_match_pay_run",
+    "provider_consensus_decision_engine",
+    "warehouse_data_quality_sentinel",
+    "vuln_triage_reachability_gate",
+    "sla_sensor_escalation_ladder",
+    "map_reduce_over_list",
+]
+
+ENGINE_STEP_TYPES = {
+    "http", "code", "race", "gate", "sensor", "loop", "classify",
+    "condition", "parse", "sub_workflow", "transform",
+}
+
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "src" / "sandcastle" / "templates"
+
+
+def _load(name: str) -> str:
+    path = TEMPLATES_DIR / f"{name}.yaml"
+    assert path.exists(), f"Template file not found: {path}"
+    return path.read_text()
+
+
+def _provider(model: str | None) -> str | None:
+    if not model:
+        return None
+    return model.split("/")[0]
+
+
+@pytest.mark.parametrize("template_name", WAVE2_TEMPLATES)
+def test_parses_with_steps(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    assert wf is not None and wf.name and len(wf.steps) > 0
+
+
+@pytest.mark.parametrize("template_name", WAVE2_TEMPLATES)
+def test_step_types_valid(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    for step in wf.steps:
+        assert step.type in VALID_STEP_TYPES, (
+            f"{template_name}/{step.id} invalid type {step.type!r}"
+        )
+
+
+@pytest.mark.parametrize("template_name", WAVE2_TEMPLATES)
+def test_depends_on_resolve(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    ids = {s.id for s in wf.steps}
+    for step in wf.steps:
+        for dep in step.depends_on:
+            assert dep in ids, f"{template_name}/{step.id} depends on unknown {dep!r}"
+
+
+@pytest.mark.parametrize("template_name", WAVE2_TEMPLATES)
+def test_validates_clean(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    errors = validate(wf)
+    assert errors == [], f"{template_name} validate() errors: {errors}"
+
+
+@pytest.mark.parametrize("template_name", WAVE2_TEMPLATES)
+def test_build_plan_covers_every_step_once(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    plan = build_plan(wf)
+    assert plan is not None and len(plan.stages) > 0
+    planned: list[str] = [sid for stage in plan.stages for sid in stage]
+    assert len(planned) == len(set(planned)), f"{template_name}: a step is planned twice"
+    assert set(planned) == {s.id for s in wf.steps}
+
+
+@pytest.mark.parametrize("template_name", WAVE2_TEMPLATES)
+def test_tool_references_known(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    for step in wf.steps:
+        if step.tool_config and step.tool_config.tool:
+            base = step.tool_config.tool.split(":")[0]
+            assert base in KNOWN_TOOLS, f"{template_name}/{step.id} unknown tool {base!r}"
+
+
+@pytest.mark.parametrize("template_name", WAVE2_TEMPLATES)
+def test_control_flow_branches_reference_real_steps(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    ids = {s.id for s in wf.steps}
+    for step in wf.steps:
+        if step.condition_config:
+            for sid in step.condition_config.then_steps + step.condition_config.else_steps:
+                assert sid in ids, f"{template_name}/{step.id} condition -> unknown {sid!r}"
+        if step.classify_config:
+            for branch in step.classify_config.branches.values():
+                for sid in branch:
+                    assert sid in ids, f"{template_name}/{step.id} classify -> unknown {sid!r}"
+        if step.loop_config:
+            for sid in step.loop_config.step_ids:
+                assert sid in ids, f"{template_name}/{step.id} loop -> unknown {sid!r}"
+        if step.race_config:
+            for branch in step.race_config.branches:
+                for sid in branch:
+                    assert sid in ids, f"{template_name}/{step.id} race -> unknown {sid!r}"
+
+
+@pytest.mark.parametrize("template_name", WAVE2_TEMPLATES)
+def test_exercises_engine_step_types(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    overlap = {s.type for s in wf.steps} & ENGINE_STEP_TYPES
+    assert len(overlap) >= 4, (
+        f"{template_name} only exercises {sorted(overlap)} engine step types"
+    )
+
+
+@pytest.mark.parametrize("template_name", WAVE2_TEMPLATES)
+def test_demonstrates_model_independence(template_name: str) -> None:
+    """Each template must prove model-independence in at least one legitimate way:
+    a cross-provider race, multi-provider consensus votes, a two-judge gate across
+    distinct providers, or a deterministic code decision guarded by human oversight.
+    """
+    wf = parse_yaml_string(_load(template_name))
+    by_id = {s.id: s for s in wf.steps}
+
+    # (a) cross-provider race
+    cross_provider_race = False
+    for s in wf.steps:
+        if s.type == "race" and s.race_config:
+            provs = {
+                _provider(by_id[sid].model)
+                for branch in s.race_config.branches
+                for sid in branch
+                if sid in by_id and by_id[sid].model
+            }
+            if len({p for p in provs if p}) >= 2 and s.race_config.validator:
+                cross_provider_race = True
+
+    # (b) multi-provider consensus: >= 2 model-pinned llm/standard steps on distinct providers
+    vote_provs = {
+        _provider(s.model)
+        for s in wf.steps
+        if s.type in ("standard", "llm") and getattr(s, "model", None)
+    }
+    consensus = len({p for p in vote_provs if p}) >= 2
+
+    # (c) two-judge gate: a gate with >= 2 llm_eval strategies on distinct providers
+    two_judge_gate = False
+    for s in wf.steps:
+        if s.type == "gate" and s.gate_config:
+            judge_provs = {
+                _provider(st.get("config", {}).get("model"))
+                for st in s.gate_config.strategies
+                if st.get("type") == "llm_eval"
+            }
+            if len({p for p in judge_provs if p}) >= 2:
+                two_judge_gate = True
+
+    # (d) deterministic code decision guarded by a human (gate-human or approval)
+    has_code = any(s.type == "code" for s in wf.steps)
+    has_human = any(s.type == "approval" for s in wf.steps) or any(
+        s.type == "gate"
+        and s.gate_config
+        and any(st.get("type") == "human" for st in s.gate_config.strategies)
+        for s in wf.steps
+    )
+    deterministic_guarded = has_code and has_human
+
+    assert cross_provider_race or consensus or two_judge_gate or deterministic_guarded, (
+        f"{template_name} demonstrates no model-independence pattern "
+        f"(race={cross_provider_race}, consensus={consensus}, "
+        f"two_judge={two_judge_gate}, det_guarded={deterministic_guarded})"
+    )
+
+
+def test_new_step_patterns_present_across_wave() -> None:
+    """The wave as a whole must introduce the parse and sub_workflow step types and a
+    genuine multi-provider consensus (vote steps on >= 3 distinct providers)."""
+    types_seen: set[str] = set()
+    max_distinct_vote_providers = 0
+    for name in WAVE2_TEMPLATES:
+        wf = parse_yaml_string(_load(name))
+        types_seen |= {s.type for s in wf.steps}
+        provs = {
+            _provider(s.model)
+            for s in wf.steps
+            if s.type in ("standard", "llm") and getattr(s, "model", None)
+        }
+        max_distinct_vote_providers = max(
+            max_distinct_vote_providers, len({p for p in provs if p})
+        )
+    assert "parse" in types_seen, "wave 2 should introduce the parse step type"
+    assert "sub_workflow" in types_seen, "wave 2 should introduce sub_workflow composition"
+    assert max_distinct_vote_providers >= 3, (
+        "wave 2 should include a 3-provider consensus"
+    )
+
+
+def test_templates_are_discovered() -> None:
+    by_file = {t.file_name: t for t in list_templates()}
+    for name in WAVE2_TEMPLATES:
+        info = by_file.get(f"{name}.yaml")
+        assert info is not None, f"{name} not discovered"
+        assert info.source == "built-in"
+        assert info.step_count > 0


### PR DESCRIPTION
## Why

Wave 2 of the engine-showcasing, provider-neutral templates (follows #238). It broadens the patterns beyond wave 1's race/sensor/gate/loop: adds `parse`, `sub_workflow` composition, a true **multi-provider consensus** (distinct from race failover), and a **two-judge cross-provider gate**, and fills the previously near-empty `data` category. Same thesis: the workflow is the asset, the model is swappable plumbing.

Drawn from the same ranked ideation sweep; these were the next-strongest build-verdict ideas.

## The six

| Template | Category | Pattern | Core |
|---|---|---|---|
| **three_way_match_pay_run** | general_ai | deterministic code | `parse` invoice PDF -> `http` GET PO + goods-receipt -> `code` 3-way reconcile (tolerance, duplicate hash, debit==credit) -> `classify` -> `gate`+`approval` on exceptions -> `http` post bill. Pay/no-pay is model-free code |
| **provider_consensus_decision_engine** | general_ai | multi-provider consensus | 3 parallel votes pinned to sonnet / gemini / mistral -> `code` tally majority -> SPLIT escalates to a human. N parallel + code tally, NOT race |
| **warehouse_data_quality_sentinel** | data | race failover | `http` registry -> `loop` per table (`http` query + `code` anomaly checks + `classify`) -> aggregate -> cross-provider `race` root-cause -> tickets + notify. Fills the empty data category |
| **vuln_triage_reachability_gate** | engineering | two-judge gate | CVE enrich + reachability probe behind a `gate` with `llm_eval` on sonnet AND on gemini (plus human), so no single model green-lights a patch |
| **sla_sensor_escalation_ladder** | devops | race + model-free control flow | `sensor` poll -> cross-provider `race` triage -> `classify` -> `loop` escalation ladder until cleared -> human `approval`. Control flow is fully model-free |
| **map_reduce_over_list** | general_ai | sub_workflow composition | load list -> `sub_workflow` fans an existing template over each item (`parallel_over`) -> `code` reduce -> `gate` -> write-back |

## What it adds over wave 1

- **`parse`** (invoice extraction) and **`sub_workflow`** (map-reduce composition) step types, previously unused.
- A genuine **3-provider consensus** (sonnet/gemini/mistral votes + deterministic code tally) - the quorum pattern the engine's `gate` cannot express on its own.
- A **two-judge gate** with `llm_eval` strategies on two different providers.
- The first template in the **`data`** category.

Model-independence stays structural: cross-provider race/consensus/two-judge gate, or a deterministic `code` decision guarded by human oversight. The two engine-fictions remain avoided (race = first-valid-wins failover; consensus = N parallel + code tally, not a gate quorum).

## Tests

`tests/test_model_neutral_templates_wave2_v033.py`: parse, validate clean, build-plan coverage, control-flow branch references, engine-step-type count, plus a flexible model-independence thesis check (cross-provider race OR multi-provider consensus OR two-judge gate OR deterministic-code-guarded-by-human), and a wave-level check that `parse` + `sub_workflow` + a 3-provider consensus are present.

```
test_model_neutral_templates_wave2_v033.py + wave-1 + creative  132 passed
```

Each template was independently re-verified (parse, `validate()==[]`, `build_plan` covers every step once, no unsafe code, sub_workflow targets an existing template) rather than trusting the builder's self-report. Catalog 135 -> 141.