### PR TITLE
feat(discovery): add llms.txt + llms-full.txt for code-generating assistants

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,161 @@
+# Sandcastle workflow reference (for code-generating assistants)
+
+This file is enough to author a valid Sandcastle workflow. Sandcastle runs a YAML DAG
+of typed steps. Provider-neutral by design: a step runs on `default_model` unless it
+pins a `model:`, and the load-bearing decision should live in deterministic `code` or
+in a cross-provider pattern (race / consensus / two-judge gate), never in a single
+free-form prompt.
+
+Install: `pip install sandcastle-ai`. Run: `sandcastle serve` then `sandcastle run wf.yaml`.
+
+## File shape
+
+```yaml
+# name: Human Readable Name
+# description: one line
+# tags: [A, B, C]
+# category: general_ai            # one of: general_ai, engineering, sales_crm, hr_legal, support, devops, data, marketing, creative
+name: my-workflow                 # kebab-case
+description: >
+  Multi-line description.
+default_model: sonnet             # swappable default for every step
+default_timeout: 600
+input_schema:
+  required: ["foo"]
+  properties:
+    foo: { type: string, description: "...", default: "" }
+steps:
+  - id: "..."                     # see step types below
+    type: "..."
+on_complete:
+  storage_path: "my-workflow/{run_id}/result.json"
+```
+
+Templates may reference `{input.x}`, `{steps.<id>.output}`, `{run_id}`, and `{env.VAR}`
+inside strings.
+
+## Valid model aliases
+
+`sonnet`, `opus`, `haiku` (anthropic); `openai/codex`, `openai/codex-mini`;
+`google/gemini-2.5-pro`; `mistral/large`, `mistral/small`, `mistral/codestral`;
+`minimax/m2.5`; `ollama`; `omlx/qwen-3`, `omlx/gemma-3`, `omlx/llama-4-scout`,
+`omlx/mistral-small`. Keep `model:` pins to race branches / consensus votes / judges;
+leave everything else on `default_model`.
+
+## Step types
+
+Every step has `id`, `type`, optional `depends_on: [...]`, optional `model:`, optional
+`retry: { max_attempts, backoff: exponential|fixed, on_failure: skip|abort|fallback }`.
+
+- standard / llm: `prompt: |` (+ optional `output_schema`, `parallel_over: "steps.X.output"`).
+- http: `http_config: { url, method, headers: {}, body, auth, value_map }`. `auth` e.g.
+  `"bearer:{env.STRIPE_KEY}"`. Use for reads/writes to any REST system of record.
+- code: `code_config: { code: "result = ...", language: python }`. Sandboxed Python.
+  Read inputs via `_input['k']`, upstream outputs via `_steps['step_id']`, a loop item
+  via `_input.get('_item')`. Assign `result`. BLOCKED anywhere in the code (including
+  comments): `re.compile(`, `eval(`, `exec(`, `open(`, `getattr(`, `setattr(`, `chr(`,
+  `ord(`, `subprocess`, `import os`, `importlib`, `pickle`, dunder attribute access.
+  Use `re.search/match/sub/findall(pattern_string, text)` directly instead of compiling.
+- parse: `type: parse`, `prompt: "{input.file}"`, `parse_config: { output: markdown,
+  pages: null, ocr: false, ocr_engine: auto }`. Extracts text/tables from a document.
+- sensor: `sensor_config: { url, condition: "status_code == 200", check_interval: 60,
+  timeout: 86400, method, headers }`. Polls until the condition holds (durable wait).
+- race: `race_config: { branches: [[stepA], [stepB]], validator: "len(str(output)) > 0" }`.
+  Branch steps are DEFINED SEPARATELY (no `depends_on`). FIRST-VALID-WINS failover, not
+  a vote. For cross-provider failover, pin each branch step a different `model:`.
+  Downstream steps `depends_on` the race step, not the branches.
+- loop: `loop_config: { over: "steps.X.output", step_ids: [child], max_iterations: 50,
+  until: "<opt expr>" }`. Child steps are defined separately and read the current item
+  via `_input.get('_item')`. Downstream `depends_on` the loop step.
+- classify: `classify_config: { categories: [a, b, c], input: "{steps.X.output}",
+  model: haiku, branches: { a: [ids], b: [ids] } }`.
+- gate: `gate_config: { strategies: [ { type: llm_eval, config: { prompt, input:
+  "{steps.X.output}", model } }, { type: human, config: { message, timeout_hours,
+  on_timeout: abort } } ] }`. ALL strategies must pass. Only `llm_eval` / `human` /
+  `timeout` exist (no quorum). A two-judge gate = two `llm_eval` strategies on different
+  `model:`.
+- condition: `condition_config: { expression: "{steps.X.output.fail_count} > 0",
+  then: [ids], else: [ids] }`.
+- transform: `transform_config: { template: '<JSON/Jinja with {steps.X.output}>' }`.
+- approval: `approval_config: { message, show_data: steps.X.output, timeout_hours: 48,
+  on_timeout: abort, allow_edit: true }`. Human-in-the-loop.
+- notify: `notify_config: { service: slack, channel: "#ch", message: "... {steps.X.output}" }`.
+  `service` is a connector name (slack, teams, gmail, ...).
+- report: `report_config: { template: research-report, format: pdf, theme: professional,
+  title, author }`. Renders a branded PDF.
+- sub_workflow: `sub_workflow: { workflow: "summarize", input_mapping: { text: "_item.text" },
+  parallel_over: "steps.Y.output", max_concurrent: 5 }`. `workflow` must be an existing
+  template name. Composes/fan-outs another workflow.
+- tool: `tool_config: { tool: <connector>, function: "...", arguments: [...] }`. Calls a
+  built-in connector (e.g. nano-banana, openai, gemini for image-gen/vision).
+
+## Model-independence patterns
+
+- Cross-provider race (failover): two branch steps on different providers, a `race` with
+  a `validator`. First valid response wins; an outage on one provider fails over.
+- Multi-provider consensus (quorum): N parallel `standard` steps each on a different
+  `model:` (all `depends_on` the same upstream), then a `code` step that reads
+  `_steps['voteA'...]`, tallies agreement, and routes a SPLIT to `approval`. Not a race.
+- Two-judge gate: a `gate` with two `llm_eval` strategies on different providers; both
+  must agree.
+- Deterministic code: the decision math (reconciliation, scoring, eligibility, diffs) in
+  a sandboxed `code` step, so the outcome is identical on any model; a `gate`/`approval`
+  adds human oversight.
+
+## Minimal example
+
+```yaml
+# name: Refund Decision
+# category: support
+name: refund-decision
+description: Compute a refund deterministically, draft the reply via a cross-provider race, gate it, then act.
+default_model: sonnet
+input_schema:
+  required: ["ticket_id"]
+  properties:
+    ticket_id: { type: string }
+    auto_cap: { type: number, default: 50 }
+steps:
+  - id: fetch
+    type: http
+    http_config: { url: "https://api.billing.example/customer?ticket={input.ticket_id}", auth: "bearer:{env.BILLING_TOKEN}" }
+  - id: policy
+    type: code
+    code_config:
+      code: |
+        billing = _steps['fetch'] or {}
+        cap = float(_input.get('auto_cap', 50))
+        amount = float(billing.get('charge', 0))
+        result = {"eligible": amount <= cap, "amount": amount}
+  - id: draft_a
+    type: standard
+    model: sonnet
+    prompt: "Draft a refund decision message for {steps.policy.output}."
+  - id: draft_b
+    type: standard
+    model: google/gemini-2.5-pro
+    prompt: "Draft a refund decision message for {steps.policy.output}."
+  - id: draft
+    type: race
+    depends_on: [policy]
+    race_config: { branches: [[draft_a], [draft_b]], validator: "len(str(output)) > 0" }
+  - id: gate
+    type: gate
+    depends_on: [draft]
+    gate_config:
+      strategies:
+        - { type: llm_eval, config: { prompt: "Is this message policy-compliant? Answer approved or rejected.", input: "{steps.draft.output}", model: sonnet } }
+        - { type: human, config: { message: "Approve refund reply", timeout_hours: 24, on_timeout: abort } }
+  - id: send
+    type: http
+    depends_on: [gate]
+    http_config: { url: "https://api.helpdesk.example/reply", method: POST, auth: "bearer:{env.HELPDESK_TOKEN}", body: "{steps.draft.output}" }
+  - id: notify
+    type: notify
+    depends_on: [send]
+    notify_config: { service: slack, channel: "#support", message: "Refund handled for {input.ticket_id}" }
+```
+
+The dollar decision is deterministic `code`; the message drafting is a cross-provider
+`race` (failover); a two-strategy `gate` (model judge + human) guards the send. Change or
+lose a provider and the refund amount does not move.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,29 @@
+# Sandcastle
+
+> You write YAML. Sandcastle ships AI to production. Any model, any provider, zero lock-in. Sandcastle is an open-source, provider-neutral workflow orchestrator for AI agents: define a workflow once in YAML, and it runs on any of 7 model providers with automatic failover. The workflow is the asset; the model is swappable plumbing.
+
+Sandcastle turns a YAML file into a production AI pipeline. A workflow is a DAG of typed steps. The load-bearing decisions live in deterministic code or in cross-provider patterns (race failover, multi-provider consensus, two-judge gates), so swapping or losing a provider never changes the outcome. It ships with 165 built-in templates, 25 step types, 60+ system connectors, a vision-judge self-healing pattern for media, EU AI Act compliance mode, a SHA-256 audit chain, per-step data-residency enforcement, a React dashboard, and a CLI.
+
+Install: `pip install sandcastle-ai`. CLI: `sandcastle serve` then `sandcastle run <workflow.yaml>`.
+
+## Core concepts
+
+- [Workflow format](https://github.com/gizmax/Sandcastle/blob/main/llms-full.txt): a YAML file with `name`, `description`, `default_model`, `input_schema`, and a `steps` list. Each step has an `id`, a `type`, optional `depends_on`, and a per-type config block. See llms-full.txt for the complete step-type reference and a worked example.
+- [Providers](https://github.com/gizmax/Sandcastle): 7 model providers (anthropic, openai, google, mistral, minimax, ollama, omlx). A step runs on `default_model` unless it pins a `model:`. Provider choice is config, never code.
+- [Model-independence patterns](https://github.com/gizmax/Sandcastle/blob/main/llms-full.txt): `race` (first-valid-wins failover across providers), multi-provider consensus (N parallel votes + a deterministic code tally), two-judge gates (two `llm_eval` strategies on different providers), and deterministic `code` decisions.
+
+## Docs
+
+- [GitHub repository](https://github.com/gizmax/Sandcastle): source, README, templates under `src/sandcastle/templates/`.
+- [Step-type reference and example (llms-full.txt)](https://github.com/gizmax/Sandcastle/blob/main/llms-full.txt): the full YAML schema for all 25 step types, enough to author valid workflows.
+- [Website](https://sandcastle-ai.eu): overview and EU AI Act compliance.
+- [Live dashboard demo](https://gizmax.github.io/Sandcastle/): the workflow UI, no backend required.
+
+## Built-in template categories
+
+- [Templates directory](https://github.com/gizmax/Sandcastle/tree/main/src/sandcastle/templates): 165 ready-to-run workflows across devops/SRE, data engineering, finance/ops, security/GRC, legal/docops, sales/RevOps, support/CX, marketing, and LLMOps. Examples: closed_loop_autoremediator (alert to verified fix), provider_consensus_decision_engine (3-provider vote), three_way_match_pay_run (deterministic AP match), quote_to_cash_orchestrator (closed-won to billed), ugc_studio (image-gen with a vision judge).
+
+## Optional
+
+- [Connectors](https://github.com/gizmax/Sandcastle): 60+ integrations reachable from `http`/`tool`/`notify` steps, including slack, postgresql, snowflake, stripe, github, jira, salesforce, datadog, pagerduty, docusign, s3, qdrant, pinecone.
+- [Compliance](https://sandcastle-ai.eu/eu-ai-act/): EU AI Act mode, audit hash chain, PII redaction, data-residency routing.

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -1,0 +1,161 @@
+# Sandcastle workflow reference (for code-generating assistants)
+
+This file is enough to author a valid Sandcastle workflow. Sandcastle runs a YAML DAG
+of typed steps. Provider-neutral by design: a step runs on `default_model` unless it
+pins a `model:`, and the load-bearing decision should live in deterministic `code` or
+in a cross-provider pattern (race / consensus / two-judge gate), never in a single
+free-form prompt.
+
+Install: `pip install sandcastle-ai`. Run: `sandcastle serve` then `sandcastle run wf.yaml`.
+
+## File shape
+
+```yaml
+# name: Human Readable Name
+# description: one line
+# tags: [A, B, C]
+# category: general_ai            # one of: general_ai, engineering, sales_crm, hr_legal, support, devops, data, marketing, creative
+name: my-workflow                 # kebab-case
+description: >
+  Multi-line description.
+default_model: sonnet             # swappable default for every step
+default_timeout: 600
+input_schema:
+  required: ["foo"]
+  properties:
+    foo: { type: string, description: "...", default: "" }
+steps:
+  - id: "..."                     # see step types below
+    type: "..."
+on_complete:
+  storage_path: "my-workflow/{run_id}/result.json"
+```
+
+Templates may reference `{input.x}`, `{steps.<id>.output}`, `{run_id}`, and `{env.VAR}`
+inside strings.
+
+## Valid model aliases
+
+`sonnet`, `opus`, `haiku` (anthropic); `openai/codex`, `openai/codex-mini`;
+`google/gemini-2.5-pro`; `mistral/large`, `mistral/small`, `mistral/codestral`;
+`minimax/m2.5`; `ollama`; `omlx/qwen-3`, `omlx/gemma-3`, `omlx/llama-4-scout`,
+`omlx/mistral-small`. Keep `model:` pins to race branches / consensus votes / judges;
+leave everything else on `default_model`.
+
+## Step types
+
+Every step has `id`, `type`, optional `depends_on: [...]`, optional `model:`, optional
+`retry: { max_attempts, backoff: exponential|fixed, on_failure: skip|abort|fallback }`.
+
+- standard / llm: `prompt: |` (+ optional `output_schema`, `parallel_over: "steps.X.output"`).
+- http: `http_config: { url, method, headers: {}, body, auth, value_map }`. `auth` e.g.
+  `"bearer:{env.STRIPE_KEY}"`. Use for reads/writes to any REST system of record.
+- code: `code_config: { code: "result = ...", language: python }`. Sandboxed Python.
+  Read inputs via `_input['k']`, upstream outputs via `_steps['step_id']`, a loop item
+  via `_input.get('_item')`. Assign `result`. BLOCKED anywhere in the code (including
+  comments): `re.compile(`, `eval(`, `exec(`, `open(`, `getattr(`, `setattr(`, `chr(`,
+  `ord(`, `subprocess`, `import os`, `importlib`, `pickle`, dunder attribute access.
+  Use `re.search/match/sub/findall(pattern_string, text)` directly instead of compiling.
+- parse: `type: parse`, `prompt: "{input.file}"`, `parse_config: { output: markdown,
+  pages: null, ocr: false, ocr_engine: auto }`. Extracts text/tables from a document.
+- sensor: `sensor_config: { url, condition: "status_code == 200", check_interval: 60,
+  timeout: 86400, method, headers }`. Polls until the condition holds (durable wait).
+- race: `race_config: { branches: [[stepA], [stepB]], validator: "len(str(output)) > 0" }`.
+  Branch steps are DEFINED SEPARATELY (no `depends_on`). FIRST-VALID-WINS failover, not
+  a vote. For cross-provider failover, pin each branch step a different `model:`.
+  Downstream steps `depends_on` the race step, not the branches.
+- loop: `loop_config: { over: "steps.X.output", step_ids: [child], max_iterations: 50,
+  until: "<opt expr>" }`. Child steps are defined separately and read the current item
+  via `_input.get('_item')`. Downstream `depends_on` the loop step.
+- classify: `classify_config: { categories: [a, b, c], input: "{steps.X.output}",
+  model: haiku, branches: { a: [ids], b: [ids] } }`.
+- gate: `gate_config: { strategies: [ { type: llm_eval, config: { prompt, input:
+  "{steps.X.output}", model } }, { type: human, config: { message, timeout_hours,
+  on_timeout: abort } } ] }`. ALL strategies must pass. Only `llm_eval` / `human` /
+  `timeout` exist (no quorum). A two-judge gate = two `llm_eval` strategies on different
+  `model:`.
+- condition: `condition_config: { expression: "{steps.X.output.fail_count} > 0",
+  then: [ids], else: [ids] }`.
+- transform: `transform_config: { template: '<JSON/Jinja with {steps.X.output}>' }`.
+- approval: `approval_config: { message, show_data: steps.X.output, timeout_hours: 48,
+  on_timeout: abort, allow_edit: true }`. Human-in-the-loop.
+- notify: `notify_config: { service: slack, channel: "#ch", message: "... {steps.X.output}" }`.
+  `service` is a connector name (slack, teams, gmail, ...).
+- report: `report_config: { template: research-report, format: pdf, theme: professional,
+  title, author }`. Renders a branded PDF.
+- sub_workflow: `sub_workflow: { workflow: "summarize", input_mapping: { text: "_item.text" },
+  parallel_over: "steps.Y.output", max_concurrent: 5 }`. `workflow` must be an existing
+  template name. Composes/fan-outs another workflow.
+- tool: `tool_config: { tool: <connector>, function: "...", arguments: [...] }`. Calls a
+  built-in connector (e.g. nano-banana, openai, gemini for image-gen/vision).
+
+## Model-independence patterns
+
+- Cross-provider race (failover): two branch steps on different providers, a `race` with
+  a `validator`. First valid response wins; an outage on one provider fails over.
+- Multi-provider consensus (quorum): N parallel `standard` steps each on a different
+  `model:` (all `depends_on` the same upstream), then a `code` step that reads
+  `_steps['voteA'...]`, tallies agreement, and routes a SPLIT to `approval`. Not a race.
+- Two-judge gate: a `gate` with two `llm_eval` strategies on different providers; both
+  must agree.
+- Deterministic code: the decision math (reconciliation, scoring, eligibility, diffs) in
+  a sandboxed `code` step, so the outcome is identical on any model; a `gate`/`approval`
+  adds human oversight.
+
+## Minimal example
+
+```yaml
+# name: Refund Decision
+# category: support
+name: refund-decision
+description: Compute a refund deterministically, draft the reply via a cross-provider race, gate it, then act.
+default_model: sonnet
+input_schema:
+  required: ["ticket_id"]
+  properties:
+    ticket_id: { type: string }
+    auto_cap: { type: number, default: 50 }
+steps:
+  - id: fetch
+    type: http
+    http_config: { url: "https://api.billing.example/customer?ticket={input.ticket_id}", auth: "bearer:{env.BILLING_TOKEN}" }
+  - id: policy
+    type: code
+    code_config:
+      code: |
+        billing = _steps['fetch'] or {}
+        cap = float(_input.get('auto_cap', 50))
+        amount = float(billing.get('charge', 0))
+        result = {"eligible": amount <= cap, "amount": amount}
+  - id: draft_a
+    type: standard
+    model: sonnet
+    prompt: "Draft a refund decision message for {steps.policy.output}."
+  - id: draft_b
+    type: standard
+    model: google/gemini-2.5-pro
+    prompt: "Draft a refund decision message for {steps.policy.output}."
+  - id: draft
+    type: race
+    depends_on: [policy]
+    race_config: { branches: [[draft_a], [draft_b]], validator: "len(str(output)) > 0" }
+  - id: gate
+    type: gate
+    depends_on: [draft]
+    gate_config:
+      strategies:
+        - { type: llm_eval, config: { prompt: "Is this message policy-compliant? Answer approved or rejected.", input: "{steps.draft.output}", model: sonnet } }
+        - { type: human, config: { message: "Approve refund reply", timeout_hours: 24, on_timeout: abort } }
+  - id: send
+    type: http
+    depends_on: [gate]
+    http_config: { url: "https://api.helpdesk.example/reply", method: POST, auth: "bearer:{env.HELPDESK_TOKEN}", body: "{steps.draft.output}" }
+  - id: notify
+    type: notify
+    depends_on: [send]
+    notify_config: { service: slack, channel: "#support", message: "Refund handled for {input.ticket_id}" }
+```
+
+The dollar decision is deterministic `code`; the message drafting is a cross-provider
+`race` (failover); a two-strategy `gate` (model judge + human) guards the send. Change or
+lose a provider and the refund amount does not move.

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -1,0 +1,29 @@
+# Sandcastle
+
+> You write YAML. Sandcastle ships AI to production. Any model, any provider, zero lock-in. Sandcastle is an open-source, provider-neutral workflow orchestrator for AI agents: define a workflow once in YAML, and it runs on any of 7 model providers with automatic failover. The workflow is the asset; the model is swappable plumbing.
+
+Sandcastle turns a YAML file into a production AI pipeline. A workflow is a DAG of typed steps. The load-bearing decisions live in deterministic code or in cross-provider patterns (race failover, multi-provider consensus, two-judge gates), so swapping or losing a provider never changes the outcome. It ships with 165 built-in templates, 25 step types, 60+ system connectors, a vision-judge self-healing pattern for media, EU AI Act compliance mode, a SHA-256 audit chain, per-step data-residency enforcement, a React dashboard, and a CLI.
+
+Install: `pip install sandcastle-ai`. CLI: `sandcastle serve` then `sandcastle run <workflow.yaml>`.
+
+## Core concepts
+
+- [Workflow format](https://github.com/gizmax/Sandcastle/blob/main/llms-full.txt): a YAML file with `name`, `description`, `default_model`, `input_schema`, and a `steps` list. Each step has an `id`, a `type`, optional `depends_on`, and a per-type config block. See llms-full.txt for the complete step-type reference and a worked example.
+- [Providers](https://github.com/gizmax/Sandcastle): 7 model providers (anthropic, openai, google, mistral, minimax, ollama, omlx). A step runs on `default_model` unless it pins a `model:`. Provider choice is config, never code.
+- [Model-independence patterns](https://github.com/gizmax/Sandcastle/blob/main/llms-full.txt): `race` (first-valid-wins failover across providers), multi-provider consensus (N parallel votes + a deterministic code tally), two-judge gates (two `llm_eval` strategies on different providers), and deterministic `code` decisions.
+
+## Docs
+
+- [GitHub repository](https://github.com/gizmax/Sandcastle): source, README, templates under `src/sandcastle/templates/`.
+- [Step-type reference and example (llms-full.txt)](https://github.com/gizmax/Sandcastle/blob/main/llms-full.txt): the full YAML schema for all 25 step types, enough to author valid workflows.
+- [Website](https://sandcastle-ai.eu): overview and EU AI Act compliance.
+- [Live dashboard demo](https://gizmax.github.io/Sandcastle/): the workflow UI, no backend required.
+
+## Built-in template categories
+
+- [Templates directory](https://github.com/gizmax/Sandcastle/tree/main/src/sandcastle/templates): 165 ready-to-run workflows across devops/SRE, data engineering, finance/ops, security/GRC, legal/docops, sales/RevOps, support/CX, marketing, and LLMOps. Examples: closed_loop_autoremediator (alert to verified fix), provider_consensus_decision_engine (3-provider vote), three_way_match_pay_run (deterministic AP match), quote_to_cash_orchestrator (closed-won to billed), ugc_studio (image-gen with a vision judge).
+
+## Optional
+
+- [Connectors](https://github.com/gizmax/Sandcastle): 60+ integrations reachable from `http`/`tool`/`notify` steps, including slack, postgresql, snowflake, stripe, github, jira, salesforce, datadog, pagerduty, docusign, s3, qdrant, pinecone.
+- [Compliance](https://sandcastle-ai.eu/eu-ai-act/): EU AI Act mode, audit hash chain, PII redaction, data-residency routing.

--- a/tests/test_llms_txt.py
+++ b/tests/test_llms_txt.py
@@ -1,0 +1,49 @@
+"""Guards for the llms.txt / llms-full.txt discovery files.
+
+llms.txt is a machine-readable entry point for code-generating assistants. The
+worked example in llms-full.txt teaches the YAML format, so it must stay a valid,
+parseable, model-independent Sandcastle workflow; this test fails if the docs rot.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from sandcastle.engine.dag import build_plan, parse_yaml_string, validate
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_llms_txt_files_exist() -> None:
+    for name in ("llms.txt", "llms-full.txt"):
+        assert (ROOT / name).is_file(), f"{name} missing at repo root"
+
+
+def test_llms_full_example_is_a_valid_workflow() -> None:
+    """The minimal example in llms-full.txt must parse, validate clean, and have a
+    build plan that covers every step - otherwise the reference teaches broken YAML."""
+    text = (ROOT / "llms-full.txt").read_text()
+    blocks = re.findall(r"```yaml\n(.*?)```", text, re.S)
+    assert blocks, "llms-full.txt has no ```yaml example block"
+    example = blocks[-1]
+    wf = parse_yaml_string(example)
+    assert wf.name and len(wf.steps) > 0
+    errors = validate(wf)
+    assert errors == [], f"llms-full.txt example does not validate: {errors}"
+    plan = build_plan(wf)
+    planned = [sid for stage in plan.stages for sid in stage]
+    assert set(planned) == {s.id for s in wf.steps}
+    # It should also demonstrate the thesis: a cross-provider race.
+    races = [s for s in wf.steps if s.type == "race" and s.race_config]
+    by_id = {s.id: s for s in wf.steps}
+    providers = {
+        (by_id[sid].model or "").split("/")[0]
+        for race in races
+        for branch in race.race_config.branches
+        for sid in branch
+        if sid in by_id and by_id[sid].model
+    }
+    assert len({p for p in providers if p}) >= 2, (
+        "llms-full.txt example should show a cross-provider race"
+    )


### PR DESCRIPTION
## What

Adds the [llms.txt](https://llmstxt.org) convention so AI coding assistants (and agents) can discover Sandcastle and generate **valid** workflows.

- **`llms.txt`** - concise overview, the provider-neutral thesis, install/run, and links to the templates and reference.
- **`llms-full.txt`** - the complete step-type YAML reference for all 25 step types, the valid model aliases, the four model-independence patterns, the code-sandbox constraints, and a worked, **dogfooded** example (a refund workflow: deterministic code decision -> cross-provider race draft -> two-strategy gate -> act).

Both are served from the repo root (for GitHub/PyPI) and from `site/` (so they deploy to `sandcastle-ai.eu/llms.txt`).

## Why

This was the cheapest, highest-leverage distribution win on the list: coding assistants increasingly read `llms.txt` to write integration code, and Sandcastle's value is precisely that a workflow authored once is provider-neutral. The reference encodes the real step schemas and the code-sandbox blocklist (`re.compile(`, `subprocess`, `open(`, ...) so assistant-generated code steps actually run instead of failing at runtime.

## Tests

`test_llms_txt.py` guards the files and extracts the embedded example, asserting it parses, `validate()`s clean, has a build plan covering every step, and shows a cross-provider race - so the public reference cannot rot into teaching broken YAML.

```
tests/test_llms_txt.py  2 passed
```