### PR TITLE
feat(templates): final 8 model-independent workflows (wave 4)

### DIFF
--- a/src/sandcastle/templates/eu_ai_act_risk_register.yaml
+++ b/src/sandcastle/templates/eu_ai_act_risk_register.yaml
@@ -1,0 +1,568 @@
+# name: EU AI Act Risk Register
+# description: Living EU AI Act risk register. Discovers AI systems from model registries via HTTP, classifies each into Annex III risk tiers, gates high-risk determinations through a dual-provider consensus plus a mandatory legal/DPO human sign-off, opens conformity tasks in Jira, seals a signed Article-9 register to S3/Notion, and emits a branded board/regulator PDF.
+# tags: [EU AI Act, Annex III, Article 9, Risk Register, Conformity, Langfuse, Notion, Jira, Slack, S3, GitHub, Governance, DPO, Compliance]
+# category: hr_legal
+
+name: eu-ai-act-risk-register
+description: >-
+  Maintains a defensible, living EU AI Act risk register. A deterministic HTTP step pulls the
+  current inventory of AI systems from the model registry (Langfuse projects), a Notion system
+  catalog, and the GitHub model-card repo. A Python step dedupes and diffs that inventory against
+  the prior-cycle register supplied in input, flagging NEW and CHANGED systems. Each system is
+  routed by a classify step into an Annex III risk tier (prohibited / high-risk / limited-risk /
+  minimal) by its intended purpose and deployment context. High-risk or prohibited candidates are
+  branched into a multi-strategy gate: an llm_eval tier-justification on one provider, the SAME
+  rubric re-run on a DIFFERENT provider for a cross-vendor consensus, and a mandatory human strategy
+  for legal/DPO sign-off - so no single vendor's model can self-certify a system's risk tier, which
+  is exactly the Act's human-oversight requirement. Conformity tasks (Annex IV tech docs, Article 9
+  risk management, human-oversight) are POSTed to Jira for high-risk systems, a deterministic step
+  assembles each register entry (system, tier, rationale, obligations, owner, SHA-256 hash), the
+  signed register is PUT to S3 and written to the Notion governance space, a branded Article-9 PDF
+  is rendered for the board/regulator, and a Slack summary reports the count of new high-risk systems
+  and open conformity tasks. Discovery, diffing, entry assembly, and report rendering are all
+  deterministic and model-independent.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 900
+
+input_schema:
+  required: ["register_cycle_id"]
+  properties:
+    register_cycle_id:
+      type: string
+      description: "Unique id for this risk-register cycle (e.g. 'AIA-2026-06')."
+      default: "AIA-2026-06"
+      example: "AIA-2026-06"
+    langfuse_base_url:
+      type: string
+      description: "Langfuse REST base URL used to enumerate AI projects / deployed models."
+      default: "https://cloud.langfuse.com/api/public"
+      example: "https://cloud.langfuse.com/api/public"
+    notion_catalog_url:
+      type: string
+      description: "Notion API endpoint that queries the AI system catalog database."
+      default: "https://api.notion.com/v1/databases/your-catalog-db-id/query"
+      example: "https://api.notion.com/v1/databases/1a2b3c4d/query"
+    github_modelcards_url:
+      type: string
+      description: "GitHub contents API for the model-cards directory (intended-purpose metadata)."
+      default: "https://api.github.com/repos/your-org/ai-model-cards/contents/cards"
+      example: "https://api.github.com/repos/acme/ai-model-cards/contents/cards"
+    prior_register:
+      type: string
+      description: "Prior-cycle approved register (JSON object or ref) used to diff new vs changed systems."
+      default: "{}"
+      example: '{"entries": [{"system_id": "chat-assist", "tier": "limited-risk", "hash": "abc123"}]}'
+    jira_base_url:
+      type: string
+      description: "Jira REST base URL for opening conformity / documentation tasks."
+      default: "https://your-org.atlassian.net/rest/api/3"
+      example: "https://acme.atlassian.net/rest/api/3"
+    jira_project_key:
+      type: string
+      description: "Jira project key that receives EU AI Act conformity issues."
+      default: "AIACT"
+      example: "AIACT"
+    s3_base_url:
+      type: string
+      description: "S3 (or S3-compatible) REST base URL for the signed register bucket."
+      default: "https://s3.eu-central-1.amazonaws.com"
+      example: "https://s3.eu-central-1.amazonaws.com"
+    s3_bucket:
+      type: string
+      description: "Bucket that stores the signed, hashed EU AI Act risk register."
+      default: "eu-ai-act-risk-register"
+      example: "acme-eu-ai-act-risk-register"
+    notion_governance_url:
+      type: string
+      description: "Notion API endpoint (governance space page/database) the register is written back to."
+      default: "https://api.notion.com/v1/pages"
+      example: "https://api.notion.com/v1/pages"
+    slack_channel:
+      type: string
+      description: "Slack channel for the risk-register summary."
+      default: "#ai-governance"
+      example: "#ai-governance"
+
+steps:
+  # 1) DISCOVER deployed AI systems from the model registry (Langfuse projects).
+  #     Connector: langfuse. Deterministic HTTP pull.
+  - id: discover_langfuse
+    type: http
+    http_config:
+      url: "{input.langfuse_base_url}/projects?limit=200"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.LANGFUSE_API_KEY}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 2) DISCOVER systems from the Notion AI system catalog (intended-purpose + deployment context).
+  #     Connector: notion.
+  - id: discover_notion_catalog
+    type: http
+    http_config:
+      url: "{input.notion_catalog_url}"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Notion-Version: "2022-06-28"
+        Accept: "application/json"
+      auth: "bearer:{env.NOTION_API_KEY}"
+      body: |
+        {"page_size": 200}
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 3) DISCOVER model cards from GitHub (per-system intended-purpose / deployment metadata).
+  #     Connector: github.
+  - id: discover_github_modelcards
+    type: http
+    http_config:
+      url: "{input.github_modelcards_url}"
+      method: GET
+      headers:
+        Accept: "application/vnd.github+json"
+      auth: "bearer:{env.GITHUB_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 4) DETERMINISTIC dedupe + diff. Merge the three sources into ONE inventory keyed by
+  #     system_id, then diff against the prior register: flag NEW and CHANGED systems. No model.
+  - id: dedupe_and_diff
+    type: code
+    depends_on: [discover_langfuse, discover_notion_catalog, discover_github_modelcards]
+    code_config:
+      language: python
+      code: |
+        import json
+        import hashlib
+
+        langfuse = _steps['discover_langfuse'] or {}
+        notion = _steps['discover_notion_catalog'] or {}
+        github = _steps['discover_github_modelcards'] or {}
+
+        # --- Parse the prior register (may arrive as a JSON string or already-parsed dict) ---
+        raw_prior = _input.get('prior_register') or {}
+        if isinstance(raw_prior, str):
+            try:
+                raw_prior = json.loads(raw_prior) if raw_prior.strip() else {}
+            except (ValueError, TypeError):
+                raw_prior = {}
+        prior_entries = raw_prior.get('entries', []) if isinstance(raw_prior, dict) else []
+        prior_by_id = {}
+        for e in prior_entries:
+            if isinstance(e, dict) and e.get('system_id'):
+                prior_by_id[str(e.get('system_id'))] = e
+
+        inventory = {}
+
+        def _upsert(system_id, name, purpose, context, source):
+            sid = str(system_id or '').strip().lower()
+            if not sid:
+                return
+            row = inventory.setdefault(sid, {
+                'system_id': sid,
+                'name': name or sid,
+                'intended_purpose': '',
+                'deployment_context': '',
+                'sources': [],
+            })
+            if name and not row['name']:
+                row['name'] = name
+            if purpose and len(str(purpose)) > len(row['intended_purpose']):
+                row['intended_purpose'] = str(purpose)
+            if context and len(str(context)) > len(row['deployment_context']):
+                row['deployment_context'] = str(context)
+            if source not in row['sources']:
+                row['sources'].append(source)
+
+        # Langfuse projects -> list under 'data' or top-level list.
+        lf_list = langfuse if isinstance(langfuse, list) else (langfuse.get('data') or langfuse.get('projects') or [])
+        for p in lf_list:
+            if isinstance(p, dict):
+                _upsert(p.get('id') or p.get('name'), p.get('name'),
+                        p.get('description') or p.get('metadata'), 'production-llm', 'langfuse')
+
+        # Notion catalog rows -> 'results'; properties are nested Notion blocks, read defensively.
+        def _notion_text(prop):
+            if not isinstance(prop, dict):
+                return ''
+            for key in ('title', 'rich_text'):
+                arr = prop.get(key)
+                if isinstance(arr, list) and arr:
+                    return ''.join(str(t.get('plain_text', '')) for t in arr if isinstance(t, dict))
+            sel = prop.get('select')
+            if isinstance(sel, dict):
+                return str(sel.get('name', ''))
+            return ''
+
+        for row in (notion.get('results') or []):
+            if not isinstance(row, dict):
+                continue
+            props = row.get('properties', {}) if isinstance(row.get('properties'), dict) else {}
+            sid = _notion_text(props.get('system_id')) or _notion_text(props.get('Name')) or row.get('id')
+            _upsert(sid, _notion_text(props.get('Name')),
+                    _notion_text(props.get('intended_purpose')) or _notion_text(props.get('Purpose')),
+                    _notion_text(props.get('deployment_context')) or _notion_text(props.get('Context')),
+                    'notion')
+
+        # GitHub model cards -> list of file entries; use the file name (sans ext) as the system id.
+        gh_list = github if isinstance(github, list) else (github.get('items') or [])
+        for f in gh_list:
+            if isinstance(f, dict) and f.get('name'):
+                sid = str(f.get('name')).rsplit('.', 1)[0]
+                _upsert(sid, sid, 'see-model-card', 'documented', 'github')
+
+        # --- Diff: per system compute a content hash, compare to prior to flag new/changed ---
+        systems = []
+        new_count = 0
+        changed_count = 0
+        for sid, row in sorted(inventory.items()):
+            canonical = json.dumps(
+                {'system_id': row['system_id'], 'name': row['name'],
+                 'intended_purpose': row['intended_purpose'],
+                 'deployment_context': row['deployment_context']},
+                sort_keys=True, separators=(',', ':'))
+            content_hash = hashlib.sha256(canonical.encode('utf-8')).hexdigest()
+            prior = prior_by_id.get(sid)
+            if prior is None:
+                status = 'new'
+                new_count += 1
+            elif str(prior.get('hash') or prior.get('content_hash') or '') != content_hash:
+                status = 'changed'
+                changed_count += 1
+            else:
+                status = 'unchanged'
+            row['content_hash'] = content_hash
+            row['diff_status'] = status
+            row['prior_tier'] = (prior or {}).get('tier')
+            systems.append(row)
+
+        result = {
+            'register_cycle_id': _input.get('register_cycle_id'),
+            'system_count': len(systems),
+            'new_count': new_count,
+            'changed_count': changed_count,
+            'systems': systems,
+        }
+
+  # 5) CLASSIFY each system into an Annex III risk tier by intended purpose + deployment context.
+  #     The single model-driven routing step; swappable. Every tier routes into the deterministic
+  #     candidate selector. Pinned to an EU-resident judge (mistral) for data residency.
+  - id: classify_risk_tier
+    type: classify
+    depends_on: [dedupe_and_diff]
+    classify_config:
+      model: mistral/large
+      input: >
+        Classify the EU AI Act risk tier for these AI systems by intended purpose and deployment
+        context. prohibited = Article 5 banned practices (social scoring, untargeted facial scraping,
+        real-time remote biometric ID in public, emotion inference at work/school, manipulative or
+        exploitative systems). high-risk = Annex III use (biometrics, critical infrastructure,
+        education/exam scoring, employment/HR screening, access to essential public/private services
+        and credit, law enforcement, migration/border, justice) or an AI safety component of a
+        regulated product. limited-risk = transparency obligations only (chatbots, deepfakes, content
+        labelling). minimal = everything else (spam filters, recommendation, internal tooling) with
+        no specific obligation. Systems: {steps.dedupe_and_diff.output.systems}
+      categories:
+        - prohibited
+        - high-risk
+        - limited-risk
+        - minimal
+      branches:
+        prohibited: [select_high_risk_candidates]
+        high-risk: [select_high_risk_candidates]
+        limited-risk: [select_high_risk_candidates]
+        minimal: [select_high_risk_candidates]
+
+  # 6) DETERMINISTIC selection: which systems are prohibited/high-risk candidates that must be
+  #     gated, and which carry conformity obligations. Heuristic keyword fallback per system plus
+  #     the cohort label from classify. No model.
+  - id: select_high_risk_candidates
+    type: code
+    depends_on: [dedupe_and_diff, classify_risk_tier]
+    code_config:
+      language: python
+      code: |
+        diff = _steps['dedupe_and_diff'] or {}
+        cohort_tier = str(_steps['classify_risk_tier'] or '').strip().lower()
+        systems = diff.get('systems', [])
+
+        ANNEX_III = ('biometric', 'critical infrastructure', 'education', 'exam', 'employment',
+                     'hr', 'recruit', 'hiring', 'credit', 'scoring', 'essential service',
+                     'law enforcement', 'migration', 'border', 'justice', 'insurance')
+        PROHIBITED = ('social scoring', 'facial scraping', 'emotion inference', 'real-time biometric',
+                      'manipulative', 'social-credit')
+
+        def _per_system_tier(s):
+            text = (str(s.get('intended_purpose', '')) + ' ' + str(s.get('deployment_context', '')) + ' ' + str(s.get('name', ''))).lower()
+            if any(k in text for k in PROHIBITED):
+                return 'prohibited'
+            if any(k in text for k in ANNEX_III):
+                return 'high-risk'
+            # Fall back to the cohort label from the classify step when no keyword hits.
+            if cohort_tier in ('prohibited', 'high-risk'):
+                return cohort_tier
+            return cohort_tier or 'minimal'
+
+        candidates = []
+        all_tiered = []
+        for s in systems:
+            tier = _per_system_tier(s)
+            row = dict(s)
+            row['tier'] = tier
+            all_tiered.append(row)
+            if tier in ('prohibited', 'high-risk'):
+                candidates.append(row)
+
+        result = {
+            'register_cycle_id': diff.get('register_cycle_id'),
+            'cohort_tier': cohort_tier or 'minimal',
+            'all_systems': all_tiered,
+            'candidate_count': len(candidates),
+            'high_risk_candidates': candidates,
+            'has_high_risk': len(candidates) > 0,
+        }
+
+  # 7) BRANCH: only if there is at least one prohibited/high-risk candidate do we run the
+  #     consensus + human gate and open conformity tasks. Deterministic condition, no model.
+  - id: high_risk_branch
+    type: condition
+    depends_on: [select_high_risk_candidates]
+    condition_config:
+      expression: "{steps.select_high_risk_candidates.output.has_high_risk} == true"
+      then: [tier_consensus_gate, open_conformity_tasks, assemble_register]
+      else: [assemble_register]
+
+  # 7a) GATE the high-risk determination: dual-provider consensus (two llm_eval strategies on
+  #      DIFFERENT EU/local providers - mistral and gemini) PLUS a mandatory human legal/DPO
+  #      sign-off. ALL strategies must pass, so no single vendor model self-certifies a tier.
+  - id: tier_consensus_gate
+    type: gate
+    depends_on: [select_high_risk_candidates]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >
+              You are an EU AI Act conformity reviewer (judge A). For each candidate, verify the
+              prohibited/high-risk tier is justified against Annex III and Article 5 by its intended
+              purpose and deployment context. Answer exactly 'approved' if every candidate's tier is
+              correctly justified, otherwise 'rejected' and name the mis-tiered system and the correct
+              tier. Candidates: {steps.select_high_risk_candidates.output.high_risk_candidates}
+            input: "{steps.select_high_risk_candidates.output.high_risk_candidates}"
+            model: mistral/large
+        - type: llm_eval
+          config:
+            prompt: >
+              You are an EU AI Act conformity reviewer (judge B, independent provider). Apply the SAME
+              rubric: confirm each candidate's prohibited/high-risk tier is justified under Annex III
+              and Article 5 by intended purpose and deployment context. Answer exactly 'approved' if
+              all tiers hold, otherwise 'rejected' naming the disputed system and your proposed tier.
+              Candidates: {steps.select_high_risk_candidates.output.high_risk_candidates}
+            input: "{steps.select_high_risk_candidates.output.high_risk_candidates}"
+            model: google/gemini-2.5-pro
+        - type: human
+          config:
+            message: >
+              Legal / DPO sign-off required: confirm the high-risk and prohibited tier determinations
+              for these AI systems are correct before conformity tasks are opened and the register is
+              sealed. This is the Article-14 human-oversight checkpoint.
+            timeout_hours: 48
+            on_timeout: abort
+
+  # 7b) OPEN conformity + documentation tasks in Jira for the high-risk systems: Annex IV
+  #      tech docs, Article 9 risk management, human-oversight. Connector: jira.
+  - id: open_conformity_tasks
+    type: http
+    depends_on: [tier_consensus_gate]
+    http_config:
+      url: "{input.jira_base_url}/issue/bulk"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.JIRA_API_TOKEN}"
+      body: |
+        {
+          "register_cycle_id": "{input.register_cycle_id}",
+          "project_key": "{input.jira_project_key}",
+          "obligation_types": ["annex-iv-technical-documentation", "article-9-risk-management", "article-14-human-oversight"],
+          "high_risk_systems": {steps.select_high_risk_candidates.output.high_risk_candidates}
+        }
+      value_map:
+        created_issue_keys: "issues"
+        conformity_task_count: "total"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 8) ASSEMBLE the register entries deterministically: system, tier, rationale, obligations,
+  #     owner, SHA-256 hash over the canonical entry. This is the audit-load-bearing record. No model.
+  - id: assemble_register
+    type: code
+    depends_on: [select_high_risk_candidates]
+    code_config:
+      language: python
+      code: |
+        import json
+        import hashlib
+        from datetime import datetime, timezone
+
+        sel = _steps['select_high_risk_candidates'] or {}
+        diff = _steps['dedupe_and_diff'] or {}
+        cycle = _input.get('register_cycle_id')
+
+        OBLIGATIONS = {
+            'prohibited': ['cease-deployment', 'article-5-prohibition-notice', 'legal-escalation'],
+            'high-risk': ['annex-iv-technical-documentation', 'article-9-risk-management',
+                          'article-10-data-governance', 'article-13-transparency',
+                          'article-14-human-oversight', 'article-15-accuracy-robustness',
+                          'ce-conformity-assessment'],
+            'limited-risk': ['article-50-transparency-disclosure'],
+            'minimal': ['voluntary-code-of-conduct'],
+        }
+
+        diff_status_by_id = {s.get('system_id'): s.get('diff_status') for s in diff.get('systems', [])}
+
+        entries = []
+        new_high_risk = 0
+        for s in sel.get('all_systems', []):
+            tier = str(s.get('tier', 'minimal')).lower()
+            obligations = OBLIGATIONS.get(tier, OBLIGATIONS['minimal'])
+            status = diff_status_by_id.get(s.get('system_id'), 'unchanged')
+            entry = {
+                'system_id': s.get('system_id'),
+                'name': s.get('name'),
+                'tier': tier,
+                'intended_purpose': s.get('intended_purpose'),
+                'deployment_context': s.get('deployment_context'),
+                'rationale': f"Tier {tier} per Annex III / Article 5 based on intended purpose and deployment context.",
+                'obligations': obligations,
+                'owner': 'ai-governance-officer',
+                'diff_status': status,
+                'sources': s.get('sources', []),
+            }
+            canonical = json.dumps(entry, sort_keys=True, separators=(',', ':'))
+            entry['hash'] = hashlib.sha256(canonical.encode('utf-8')).hexdigest()
+            entries.append(entry)
+            if tier in ('prohibited', 'high-risk') and status in ('new', 'changed'):
+                new_high_risk += 1
+
+        register = {
+            'register_cycle_id': cycle,
+            'generated_at': datetime.now(timezone.utc).isoformat(),
+            'system_count': len(entries),
+            'new_count': diff.get('new_count', 0),
+            'changed_count': diff.get('changed_count', 0),
+            'new_high_risk_count': new_high_risk,
+            'high_risk_count': sum(1 for e in entries if e['tier'] == 'high-risk'),
+            'prohibited_count': sum(1 for e in entries if e['tier'] == 'prohibited'),
+            'entries': entries,
+        }
+
+        # Sign the whole register: canonical sorted-key hash so the signature is reproducible.
+        register_canonical = json.dumps(register, sort_keys=True, separators=(',', ':'))
+        register_hash = hashlib.sha256(register_canonical.encode('utf-8')).hexdigest()
+
+        result = {
+            'object_key': f"registers/{cycle}/eu-ai-act-risk-register.json",
+            'register_sha256': register_hash,
+            'new_high_risk_count': new_high_risk,
+            'register': register,
+            'register_canonical_json': register_canonical,
+        }
+
+  # 9) SEAL the signed register to S3 (versioned bucket). The SHA-256 travels as object metadata.
+  #     Connector: aws-s3.
+  - id: seal_register_s3
+    type: http
+    depends_on: [assemble_register]
+    http_config:
+      url: "{input.s3_base_url}/{input.s3_bucket}/{steps.assemble_register.output.object_key}"
+      method: PUT
+      headers:
+        Content-Type: "application/json"
+        x-amz-meta-register-sha256: "{steps.assemble_register.output.register_sha256}"
+        x-amz-meta-register-cycle-id: "{input.register_cycle_id}"
+      auth: "aws4:{env.AWS_ACCESS_KEY_ID}:{env.AWS_SECRET_ACCESS_KEY}"
+      body: "{steps.assemble_register.output.register_canonical_json}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 10) WRITE the register back to the Notion governance space (page in the governance database).
+  #      Connector: notion.
+  - id: write_notion_governance
+    type: http
+    depends_on: [seal_register_s3]
+    http_config:
+      url: "{input.notion_governance_url}"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Notion-Version: "2022-06-28"
+        Accept: "application/json"
+      auth: "bearer:{env.NOTION_API_KEY}"
+      body: |
+        {
+          "parent": {"type": "workspace", "workspace": true},
+          "properties": {
+            "title": [{"text": {"content": "EU AI Act Risk Register {input.register_cycle_id}"}}]
+          },
+          "register_cycle_id": "{input.register_cycle_id}",
+          "register_sha256": "{steps.assemble_register.output.register_sha256}",
+          "s3_object_key": "{steps.assemble_register.output.object_key}"
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 11) RENDER the branded EU AI Act / Article-9 risk register PDF for the board / regulator.
+  - id: render_register_pdf
+    type: report
+    depends_on: [seal_register_s3]
+    report_config:
+      template: "research-report"
+      format: pdf
+      theme: professional
+      title: "EU AI Act Risk Register - {input.register_cycle_id}"
+      author: "AI Governance Office"
+    prompt: |
+      Produce a formal, branded EU AI Act risk register PDF for the board and the regulator from the
+      payload below. Open with the register cycle id, generation timestamp, and the total number of
+      AI systems, of which how many are prohibited, high-risk, limited-risk, and minimal. Include a
+      table of every entry: system, Annex III / Article 5 tier, rationale, the assigned obligations
+      (Annex IV technical documentation, Article 9 risk management, Article 14 human oversight, etc.),
+      the responsible owner, the diff status (new / changed / unchanged), and the per-entry SHA-256.
+      State the count of NEW high-risk systems this cycle and that the dual-provider consensus plus
+      legal/DPO human sign-off cleared the high-risk determinations. Close with the register-level
+      SHA-256 signature and the S3 object key proving the register is sealed and tamper-evident.
+      Register payload: {steps.assemble_register.output.register}
+      Register signature SHA-256: {steps.assemble_register.output.register_sha256}
+      Sealed object key: {steps.assemble_register.output.object_key}
+
+  # 12) NOTIFY AI governance in Slack: count of new high-risk systems + open conformity tasks.
+  #      Connector: slack.
+  - id: notify_governance
+    type: notify
+    depends_on: [render_register_pdf, write_notion_governance]
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: "EU AI Act risk register {input.register_cycle_id} sealed. New high-risk systems this cycle: {steps.assemble_register.output.new_high_risk_count}. Systems classified: {steps.select_high_risk_candidates.output.candidate_count} prohibited/high-risk candidates gated (dual-provider consensus + legal/DPO sign-off). Conformity tasks opened in Jira project {input.jira_project_key}. Register sha256 {steps.assemble_register.output.register_sha256} sealed at {steps.assemble_register.output.object_key}."
+
+on_complete:
+  storage_path: "eu-ai-act-risk-register/{run_id}/result.json"

--- a/src/sandcastle/templates/fastest_of_n_failover_responder.yaml
+++ b/src/sandcastle/templates/fastest_of_n_failover_responder.yaml
@@ -1,0 +1,503 @@
+# name: Fastest Of N Failover Responder
+# description: A drop-in latency-and-availability SLA front door for any AI feature - races the identical request across Anthropic / OpenAI / Gemini / Mistral, returns the FIRST valid response, deterministically validates it against a budget+schema+safety guard, and updates a redis circuit-breaker so routing self-heals.
+# tags: [failover, sla, latency, multi-provider, race, circuit-breaker, resilience, redis]
+# category: general_ai
+
+name: fastest-of-n-failover-responder
+description: >-
+  A latency-and-availability SLA wrapper for any AI endpoint. Triggered by a
+  synchronous per-user API call (workflow-as-API), it optionally fetches request
+  context over HTTP, then RACES the IDENTICAL prompt across four providers pinned
+  to different backends - Anthropic Sonnet, OpenAI Codex, Google Gemini 2.5 Pro
+  and Mistral Large - returning the FIRST branch whose output passes the race
+  validator (non-empty JSON with an answer) and cancelling the rest. A
+  deterministic code guard then re-validates the winning output against a JSON
+  schema, a safety screen and a token/cost budget ceiling; if it fails the winner
+  is marked invalid. A condition routes the run: a valid winner is transformed
+  into the clean API response shape, while no-valid-winner pages PagerDuty with an
+  'all providers degraded' alert. Either way a second code step updates a
+  redis-backed health / circuit-breaker record (which provider won, latency, error
+  counts) to bias future routing, Slack is notified ONLY on failover/degradation
+  events, and a final transform returns the clean response envelope. Nothing
+  depends on a proprietary provider feature: every branch is a plain prompt behind
+  one deterministic validator, so adding or removing a provider is editing a single
+  race branch - this template IS the model-independence layer.
+
+default_model: sonnet
+default_timeout: 120
+
+input_schema:
+  required: ["request"]
+  properties:
+    request:
+      type: string
+      description: "The end-user request to fulfil (e.g. the text to summarize or the question to answer)."
+      default: ""
+    task:
+      type: string
+      description: "Task kind the providers should perform on the request."
+      default: "summarize"
+    context_url:
+      type: string
+      description: "Optional internal URL to fetch extra context for the request (set empty to skip enrichment; returns 200 with {} when unused)."
+      default: "https://httpbin.org/json"
+    max_cost_usd:
+      type: number
+      description: "Hard per-request budget ceiling (USD). The deterministic guard invalidates a winner whose estimated cost exceeds this."
+      default: 0.05
+    max_output_chars:
+      type: integer
+      description: "Maximum allowed answer length in characters - the guard rejects runaway outputs above this."
+      default: 4000
+    redis_rest_url:
+      type: string
+      description: "Base URL of the Upstash-style Redis REST API used as the circuit-breaker store."
+      default: "https://redis.internal.example.com"
+    breaker_key:
+      type: string
+      description: "Redis key namespace for this endpoint's health / circuit-breaker record."
+      default: "sla:breaker:summarize"
+    slack_channel:
+      type: string
+      description: "Slack channel that receives failover / degradation alerts (NOT every call)."
+      default: "#sla-alerts"
+    pagerduty_routing_key:
+      type: string
+      description: "PagerDuty Events API v2 routing (integration) key used only when ALL providers fail."
+      default: ""
+
+steps:
+  # 1) OPTIONAL CONTEXT FETCH. Pull any internal context the providers should see.
+  #    on_failure: skip so a context outage never breaks the resilient front door;
+  #    downstream code treats a missing/!=200 body as empty context.
+  - id: fetch_context
+    type: http
+    http_config:
+      url: "{input.context_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  # 2) RACE THE SAME REQUEST ACROSS FOUR PROVIDERS. First branch whose JSON parses
+  #    with a non-empty answer wins and the rest are cancelled - this is
+  #    first-valid-wins FAILOVER, not a vote. Each branch is pinned to a different
+  #    provider so a single provider's outage / rate-limit / p99 spike cannot break
+  #    the feature. Branch steps are defined separately with NO depends_on.
+
+  # 2a) Provider A - Anthropic Sonnet.
+  - id: answer_anthropic
+    type: standard
+    model: sonnet
+    output_schema:
+      type: object
+      properties:
+        answer: { type: string }
+        provider: { type: string }
+        est_input_tokens: { type: integer }
+        est_output_tokens: { type: integer }
+      required: ["answer", "provider"]
+    prompt: |
+      You are responder PROVIDER_A behind a latency SLA. Perform the task on the
+      request below and return as fast as you can. Ground your answer ONLY in the
+      request and the optional context; do not invent facts.
+
+      TASK: {input.task}
+      REQUEST:
+      {input.request}
+
+      OPTIONAL CONTEXT (may be empty {}):
+      {steps.fetch_context.output}
+
+      Return STRICT JSON only, no prose, no code fences:
+      {
+        "answer": "<your completed task output as plain text>",
+        "provider": "anthropic",
+        "est_input_tokens": <integer estimate of input tokens>,
+        "est_output_tokens": <integer estimate of output tokens>
+      }
+
+  # 2b) Provider B - OpenAI.
+  - id: answer_openai
+    type: standard
+    model: openai/codex
+    output_schema:
+      type: object
+      properties:
+        answer: { type: string }
+        provider: { type: string }
+        est_input_tokens: { type: integer }
+        est_output_tokens: { type: integer }
+      required: ["answer", "provider"]
+    prompt: |
+      You are responder PROVIDER_B behind a latency SLA and the failover for
+      PROVIDER_A. Same task, identical request and context. Return as fast as you
+      can, grounded ONLY in the request and optional context.
+
+      TASK: {input.task}
+      REQUEST:
+      {input.request}
+
+      OPTIONAL CONTEXT (may be empty {}):
+      {steps.fetch_context.output}
+
+      Return STRICT JSON only, no prose, no code fences:
+      {
+        "answer": "<your completed task output as plain text>",
+        "provider": "openai",
+        "est_input_tokens": <integer estimate of input tokens>,
+        "est_output_tokens": <integer estimate of output tokens>
+      }
+
+  # 2c) Provider C - Google Gemini 2.5 Pro.
+  - id: answer_gemini
+    type: standard
+    model: google/gemini-2.5-pro
+    output_schema:
+      type: object
+      properties:
+        answer: { type: string }
+        provider: { type: string }
+        est_input_tokens: { type: integer }
+        est_output_tokens: { type: integer }
+      required: ["answer", "provider"]
+    prompt: |
+      You are responder PROVIDER_C behind a latency SLA, an independent failover.
+      Same task, identical request and context. Return as fast as you can,
+      grounded ONLY in the request and optional context.
+
+      TASK: {input.task}
+      REQUEST:
+      {input.request}
+
+      OPTIONAL CONTEXT (may be empty {}):
+      {steps.fetch_context.output}
+
+      Return STRICT JSON only, no prose, no code fences:
+      {
+        "answer": "<your completed task output as plain text>",
+        "provider": "gemini",
+        "est_input_tokens": <integer estimate of input tokens>,
+        "est_output_tokens": <integer estimate of output tokens>
+      }
+
+  # 2d) Provider D - Mistral Large.
+  - id: answer_mistral
+    type: standard
+    model: mistral/large
+    output_schema:
+      type: object
+      properties:
+        answer: { type: string }
+        provider: { type: string }
+        est_input_tokens: { type: integer }
+        est_output_tokens: { type: integer }
+      required: ["answer", "provider"]
+    prompt: |
+      You are responder PROVIDER_D behind a latency SLA, the last-resort failover.
+      Same task, identical request and context. Return as fast as you can,
+      grounded ONLY in the request and optional context.
+
+      TASK: {input.task}
+      REQUEST:
+      {input.request}
+
+      OPTIONAL CONTEXT (may be empty {}):
+      {steps.fetch_context.output}
+
+      Return STRICT JSON only, no prose, no code fences:
+      {
+        "answer": "<your completed task output as plain text>",
+        "provider": "mistral",
+        "est_input_tokens": <integer estimate of input tokens>,
+        "est_output_tokens": <integer estimate of output tokens>
+      }
+
+  # 2e) THE RACE. Four single-step branches, first whose output is a dict with a
+  #     non-empty answer wins; the others are cancelled. First-valid-wins failover.
+  - id: race_providers
+    type: race
+    race_config:
+      branches:
+        - [answer_anthropic]
+        - [answer_openai]
+        - [answer_gemini]
+        - [answer_mistral]
+      validator: "isinstance(output, dict) and isinstance(output.get('answer'), str) and len(output.get('answer').strip()) > 0"
+
+  # 3) DETERMINISTIC GUARD. Re-validate the race winner against JSON schema, a
+  #    safety screen and a token/cost BUDGET ceiling. This - not any model - is the
+  #    load-bearing decision: it sets valid True/False that drives every downstream
+  #    branch. A provider that "wins" but violates budget/safety is marked invalid.
+  - id: validate_winner
+    type: code
+    depends_on: [race_providers]
+    code_config:
+      language: python
+      code: |
+        winner = _steps.get("race_providers")
+        if not isinstance(winner, dict):
+            winner = {}
+
+        # Per-provider blended $/1K-token estimate (input+output) for budget math.
+        PRICE_PER_1K = {
+            "anthropic": 0.009,
+            "openai": 0.006,
+            "gemini": 0.005,
+            "mistral": 0.004,
+        }
+
+        # Input limits.
+        try:
+            max_cost = float(_input.get("max_cost_usd", 0.05) or 0.05)
+        except (TypeError, ValueError):
+            max_cost = 0.05
+        try:
+            max_chars = int(_input.get("max_output_chars", 4000) or 4000)
+        except (TypeError, ValueError):
+            max_chars = 4000
+
+        answer = winner.get("answer")
+        provider = str(winner.get("provider", "") or "unknown").strip().lower()
+
+        # 3a) Schema check: answer must be a non-empty string.
+        schema_ok = isinstance(answer, str) and len(answer.strip()) > 0
+        answer = answer if isinstance(answer, str) else ""
+
+        # 3b) Length check: reject runaway outputs.
+        length_ok = len(answer) <= max_chars
+
+        # 3c) Safety screen: deterministic refusal / unsafe-marker scan (no model).
+        lowered = answer.lower()
+        unsafe_markers = [
+            "i cannot help with that",
+            "as an ai language model",
+            "<script",
+            "drop table",
+            "begin pgp private key",
+        ]
+        safety_ok = not any(m in lowered for m in unsafe_markers)
+
+        # 3d) Budget check: estimate cost from token estimates + provider pricing.
+        def _to_int(v, default):
+            try:
+                return int(v)
+            except (TypeError, ValueError):
+                return default
+
+        est_in = _to_int(winner.get("est_input_tokens"), max(1, len(_input.get("request", "")) // 4))
+        est_out = _to_int(winner.get("est_output_tokens"), max(1, len(answer) // 4))
+        total_tokens = max(0, est_in) + max(0, est_out)
+        price = PRICE_PER_1K.get(provider, 0.009)
+        est_cost = round((total_tokens / 1000.0) * price, 6)
+        budget_ok = est_cost <= max_cost
+
+        valid = bool(schema_ok and length_ok and safety_ok and budget_ok)
+
+        failures = []
+        if not schema_ok:
+            failures.append("schema")
+        if not length_ok:
+            failures.append("length")
+        if not safety_ok:
+            failures.append("safety")
+        if not budget_ok:
+            failures.append("budget")
+
+        result = {
+            "valid": valid,
+            "winner_provider": provider,
+            "answer": answer,
+            "est_cost_usd": est_cost,
+            "max_cost_usd": max_cost,
+            "est_tokens": total_tokens,
+            "answer_chars": len(answer),
+            "max_output_chars": max_chars,
+            "schema_ok": schema_ok,
+            "length_ok": length_ok,
+            "safety_ok": safety_ok,
+            "budget_ok": budget_ok,
+            "failures": failures,
+        }
+
+  # 4) CONDITION on the deterministic valid flag. Valid winner -> shape the API
+  #    response. No valid winner -> page PagerDuty 'all providers degraded'.
+  - id: route_outcome
+    type: condition
+    depends_on: [validate_winner]
+    condition_config:
+      expression: "{steps.validate_winner.output.valid} == True"
+      then: [shape_response]
+      else: [page_pagerduty]
+
+  # 4a-VALID) Transform the validated winner into the clean API response shape.
+  - id: shape_response
+    type: transform
+    transform_config:
+      template: |
+        {
+          "status": "ok",
+          "served_by": "{steps.validate_winner.output.winner_provider}",
+          "answer": {steps.validate_winner.output.answer},
+          "cost_usd": {steps.validate_winner.output.est_cost_usd},
+          "degraded": false
+        }
+
+  # 4b-DEGRADED) ALL providers failed the guard. Trigger a PagerDuty incident
+  #    (connector: pagerduty, Events API v2). This is the only hard page.
+  - id: page_pagerduty
+    type: http
+    http_config:
+      url: "https://events.pagerduty.com/v2/enqueue"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+      body: '{"routing_key": "{input.pagerduty_routing_key}", "event_action": "trigger", "payload": {"summary": "All AI providers degraded for task {input.task} - no valid response (failures: {steps.validate_winner.output.failures})", "source": "fastest-of-n-failover-responder", "severity": "critical", "component": "{input.breaker_key}"}}'
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 5) UPDATE THE REDIS CIRCUIT-BREAKER. Deterministically record which provider
+  #    won, its latency proxy, the validity outcome and per-provider error counts,
+  #    biasing future routing so the front door self-heals. Reads the guard output
+  #    and the four branch outputs; emits a redis REST command body.
+  - id: update_breaker
+    type: code
+    depends_on: [route_outcome]
+    code_config:
+      language: python
+      code: |
+        guard = _steps.get("validate_winner") or {}
+        if not isinstance(guard, dict):
+            guard = {}
+
+        providers = ["anthropic", "openai", "gemini", "mistral"]
+        step_for = {
+            "anthropic": "answer_anthropic",
+            "openai": "answer_openai",
+            "gemini": "answer_gemini",
+            "mistral": "answer_mistral",
+        }
+
+        winner = str(guard.get("winner_provider", "") or "").strip().lower()
+        valid = bool(guard.get("valid", False))
+
+        # A provider is counted as an error this cycle if it produced no usable
+        # dict-with-answer (lost the race by failing / timing out / empty output).
+        health = {}
+        for p in providers:
+            out = _steps.get(step_for[p])
+            answered = isinstance(out, dict) and isinstance(out.get("answer"), str) and len(out.get("answer", "").strip()) > 0
+            won = (p == winner) and valid
+            health[p] = {
+                "answered": answered,
+                "won": won,
+                # error this cycle = did not produce a usable answer
+                "error": (not answered),
+            }
+
+        # is_failover = a healthy winner that is NOT the primary provider, OR a
+        # degraded cycle (no valid winner at all). Drives the Slack alert below.
+        primary = "anthropic"
+        degraded = not valid
+        failed_over = bool(valid and winner and winner != primary)
+        is_failover_event = bool(degraded or failed_over)
+
+        # Redis REST command (Upstash-style): HSET the breaker hash with the
+        # latest cycle so future routing can prefer healthy/fast providers.
+        breaker_key = str(_input.get("breaker_key", "sla:breaker"))
+        hset_command = [
+            "HSET", breaker_key,
+            "last_winner", winner or "none",
+            "last_valid", "1" if valid else "0",
+            "last_degraded", "1" if degraded else "0",
+            "last_failover", "1" if failed_over else "0",
+            "last_cost_usd", str(guard.get("est_cost_usd", 0)),
+            "anthropic_error", "1" if health["anthropic"]["error"] else "0",
+            "openai_error", "1" if health["openai"]["error"] else "0",
+            "gemini_error", "1" if health["gemini"]["error"] else "0",
+            "mistral_error", "1" if health["mistral"]["error"] else "0",
+        ]
+
+        result = {
+            "breaker_key": breaker_key,
+            "winner": winner or "none",
+            "valid": valid,
+            "degraded": degraded,
+            "failed_over": failed_over,
+            "is_failover_event": is_failover_event,
+            "health": health,
+            "redis_command": hset_command,
+        }
+
+  # 6) PERSIST the breaker record to Redis over its REST API (connector: redis).
+  #    Pipeline endpoint accepts a JSON array of commands; on_failure skip so a
+  #    breaker-store blip never fails the user-facing response.
+  - id: write_breaker_redis
+    type: http
+    depends_on: [update_breaker]
+    http_config:
+      url: "{input.redis_rest_url}/pipeline"
+      method: POST
+      auth: "bearer:{env.REDIS_REST_TOKEN}"
+      headers:
+        Content-Type: "application/json"
+      body: '[{steps.update_breaker.output.redis_command}]'
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  # 7) SLACK ONLY ON FAILOVER / DEGRADATION EVENTS. A condition on the
+  #    deterministic is_failover_event flag - happy-path primary-served calls stay
+  #    silent so the channel is signal, not noise.
+  - id: alert_branch
+    type: condition
+    depends_on: [write_breaker_redis]
+    condition_config:
+      expression: "{steps.update_breaker.output.is_failover_event} == True"
+      then: [notify_failover]
+      else: [skip_alert]
+
+  # 7a) Failover / degradation alert to Slack (connector: slack).
+  - id: notify_failover
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: ":rotating_light: SLA failover event on {input.breaker_key}. Served by: {steps.update_breaker.output.winner} | valid: {steps.update_breaker.output.valid} | degraded: {steps.update_breaker.output.degraded} | failed_over: {steps.update_breaker.output.failed_over}. Provider health: {steps.update_breaker.output.health}"
+
+  # 7b) Happy path - primary served the request validly. No alert; record-only.
+  - id: skip_alert
+    type: transform
+    transform_config:
+      template: |
+        {
+          "alert": "suppressed",
+          "reason": "primary served a valid response - no failover event"
+        }
+
+  # 8) RETURN the clean response envelope. On the valid path it carries the shaped
+  #    answer; on the degraded path it returns a structured 'all providers
+  #    degraded' error the caller can surface to the user.
+  - id: final_response
+    type: transform
+    depends_on: [alert_branch]
+    transform_config:
+      template: |
+        {
+          "served_by": "{steps.update_breaker.output.winner}",
+          "valid": {steps.validate_winner.output.valid},
+          "degraded": {steps.update_breaker.output.degraded},
+          "answer": {steps.validate_winner.output.answer},
+          "cost_usd": {steps.validate_winner.output.est_cost_usd},
+          "failures": {steps.validate_winner.output.failures},
+          "breaker_key": "{input.breaker_key}"
+        }
+
+on_complete:
+  storage_path: "fastest-of-n-failover-responder/{run_id}/result.json"

--- a/src/sandcastle/templates/incident_rca_pr_closer.yaml
+++ b/src/sandcastle/templates/incident_rca_pr_closer.yaml
@@ -1,0 +1,547 @@
+# name: Incident RCA PR Closer
+# description: When a production alert fires, correlates deploy + error telemetry to a suspect commit, races providers to draft a fix or revert patch, gates it on a blast-radius check, gets SRE approval, opens a GitHub PR, then waits on CI before auto-merging and closing the PagerDuty/Linear incident. Connectors: datadog, pagerduty, github, linear, slack.
+# tags: [DevOps, Incident, RCA, RootCause, Datadog, PagerDuty, GitHub, Linear, Failover]
+# category: devops
+
+name: incident-rca-pr-closer
+description: >-
+  From page to verified merge, fully automated and auditable. A monitoring
+  webhook (Datadog / PagerDuty incident created) fires the run. The workflow
+  pulls the Datadog error-spike window for the affected service, lists the
+  GitHub deploys/commits in that window, then deterministically correlates the
+  error-rate inflection timestamp to the nearest deploy SHA and ranks suspect
+  commits in pure code (telemetry-to-SHA math, fully model-independent). A RACE
+  across two independent providers drafts EITHER a targeted forward-fix patch OR
+  a clean revert for the top suspect - the fastest valid structured proposal
+  wins, so a slow or down vendor never stalls incident response. A GATE then
+  checks blast radius with BOTH a deterministic code/regex strategy (does the
+  patch touch only the suspect files?) AND a swappable LLM judge, so the safety
+  verdict never depends on one provider. The on-call SRE approves revert-vs-fix
+  (allow_edit, short timeout), the PR is opened via the GitHub API, a SENSOR
+  polls the GitHub checks API until CI is green or fails, and a CONDITION routes
+  green -> merge the PR + resolve PagerDuty + close the Linear incident, red ->
+  page the SRE that the fix did not pass. Either way a Slack #incidents post
+  records the full timeline and resolution.
+
+default_model: sonnet
+default_timeout: 600
+
+input_schema:
+  required: ["incident_id", "service", "github_repo"]
+  properties:
+    incident_id:
+      type: string
+      description: "PagerDuty incident ID that fired this run (e.g. 'PT4KHLK')"
+      default: ""
+    service:
+      type: string
+      description: "Affected service name / Datadog scope (e.g. 'payments-api')"
+      default: ""
+    github_repo:
+      type: string
+      description: "owner/repo used for deploy correlation and the fix/revert PR (e.g. 'acme/platform')"
+      default: ""
+    base_branch:
+      type: string
+      description: "Branch the fix/revert PR targets and is merged into"
+      default: "main"
+    datadog_site:
+      type: string
+      description: "Datadog API site host"
+      default: "api.datadoghq.eu"
+    error_metric_query:
+      type: string
+      description: "Datadog timeseries query for the service error rate (rate as_count/as_rate)"
+      default: "avg:trace.web.request.errors{service:payments-api}.as_rate()"
+    window_from_ts:
+      type: number
+      description: "Unix epoch seconds: start of the error-spike window to inspect"
+      default: 0
+    window_to_ts:
+      type: number
+      description: "Unix epoch seconds: end of the error-spike window to inspect"
+      default: 0
+    linear_issue_id:
+      type: string
+      description: "Linear issue id tracking this incident, closed on a verified merge"
+      default: ""
+    linear_done_state_id:
+      type: string
+      description: "Linear workflow state id representing Done/Resolved for the incident issue"
+      default: ""
+    slack_channel:
+      type: string
+      description: "Slack channel for the incident timeline + resolution post"
+      default: "#incidents"
+
+steps:
+  # 1) Pull the Datadog error-spike timeseries for the affected service window.
+  #    This is the raw signal the deterministic correlation will inflect on.
+  - id: fetch_error_spike
+    type: http
+    http_config:
+      url: "https://{input.datadog_site}/api/v1/query?from={input.window_from_ts}&to={input.window_to_ts}&query={input.error_metric_query}"
+      method: GET
+      headers:
+        DD-API-KEY: "{env.DATADOG_API_KEY}"
+        DD-APPLICATION-KEY: "{env.DATADOG_APP_KEY}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 2) List the GitHub commits in (around) that same window - candidate suspects.
+  #    The correlation step matches the error inflection to one of these SHAs.
+  - id: fetch_commits
+    type: http
+    http_config:
+      url: "https://api.github.com/repos/{input.github_repo}/commits?sha={input.base_branch}&per_page=50"
+      method: GET
+      auth: "bearer:{env.GITHUB_TOKEN}"
+      headers:
+        Accept: "application/vnd.github+json"
+        X-GitHub-Api-Version: "2022-11-28"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 3) PURE-CODE root cause: find the error-rate inflection timestamp from the
+  #    Datadog series, then correlate it to the NEAREST commit at-or-before that
+  #    moment and rank suspects by temporal proximity. Fully model-independent.
+  - id: correlate_suspect
+    type: code
+    depends_on: [fetch_error_spike, fetch_commits]
+    code_config:
+      language: python
+      code: |
+        # Telemetry-to-SHA math. No model: this is the load-bearing RCA signal.
+        from datetime import datetime, timezone
+
+        spike = _steps.get("fetch_error_spike") or {}
+        commits_raw = _steps.get("fetch_commits") or []
+        if not isinstance(spike, dict):
+            spike = {}
+
+        # --- 1. Extract the error-rate series and find the inflection point. ---
+        # Datadog /query returns {"series":[{"pointlist":[[ts_ms,val],...]}]}.
+        points = []
+        for s in (spike.get("series") or []):
+            if isinstance(s, dict):
+                for pt in (s.get("pointlist") or []):
+                    if isinstance(pt, (list, tuple)) and len(pt) == 2 and pt[1] is not None:
+                        try:
+                            points.append((float(pt[0]) / 1000.0, float(pt[1])))
+                        except (TypeError, ValueError):
+                            pass
+        points.sort(key=lambda p: p[0])
+
+        # Inflection = the timestamp of the single largest positive jump in the
+        # error rate between consecutive samples (the moment things got bad).
+        inflection_ts = None
+        max_jump = 0.0
+        baseline = points[0][1] if points else 0.0
+        peak = baseline
+        for i in range(1, len(points)):
+            jump = points[i][1] - points[i - 1][1]
+            if jump > max_jump:
+                max_jump = jump
+                inflection_ts = points[i][0]
+            if points[i][1] > peak:
+                peak = points[i][1]
+        # Fallback: if the series is flat/empty, anchor on the window end.
+        if inflection_ts is None:
+            try:
+                inflection_ts = float(_input.get("window_to_ts", 0) or 0)
+            except (TypeError, ValueError):
+                inflection_ts = 0.0
+
+        # --- 2. Normalize commits to (sha, epoch_seconds, files-touched). ---
+        commits = commits_raw if isinstance(commits_raw, list) else []
+        norm = []
+        for c in commits:
+            if not isinstance(c, dict):
+                continue
+            sha = c.get("sha", "")
+            commit = c.get("commit") if isinstance(c.get("commit"), dict) else {}
+            author = commit.get("author") if isinstance(commit.get("author"), dict) else {}
+            ts_str = author.get("date", "")
+            epoch = 0.0
+            if ts_str:
+                try:
+                    epoch = datetime.fromisoformat(
+                        ts_str.replace("Z", "+00:00")
+                    ).replace(tzinfo=timezone.utc).timestamp()
+                except (TypeError, ValueError):
+                    epoch = 0.0
+            # GitHub list endpoint omits per-file diffs; carry any present.
+            files = []
+            for f in (c.get("files") or []):
+                if isinstance(f, dict) and f.get("filename"):
+                    files.append(f["filename"])
+            norm.append({
+                "sha": sha,
+                "epoch": epoch,
+                "message": commit.get("message", ""),
+                "author": author.get("name", ""),
+                "files": files,
+            })
+
+        # --- 3. Rank suspects: prefer commits AT OR BEFORE the inflection, the
+        #        closer the better. Commits after the inflection cannot be the
+        #        cause, so they sort last (by absolute distance, de-prioritized).
+        def _score(c):
+            dist = abs(c["epoch"] - inflection_ts)
+            after = c["epoch"] > inflection_ts
+            # Penalize post-inflection commits heavily so pre-inflection wins.
+            return (1 if after else 0, dist)
+
+        ranked = sorted(norm, key=_score)
+        top = ranked[0] if ranked else {"sha": "", "files": [], "message": "", "author": ""}
+
+        result = {
+            "service": _input.get("service", ""),
+            "incident_id": _input.get("incident_id", ""),
+            "inflection_ts": inflection_ts,
+            "baseline_error_rate": round(baseline, 6),
+            "peak_error_rate": round(peak, 6),
+            "error_jump": round(max_jump, 6),
+            "suspect_sha": top.get("sha", ""),
+            "suspect_message": top.get("message", ""),
+            "suspect_author": top.get("author", ""),
+            "suspect_files": top.get("files", []),
+            "ranked_suspects": [
+                {"sha": c["sha"], "epoch": c["epoch"], "message": c["message"]}
+                for c in ranked[:5]
+            ],
+            "candidate_count": len(norm),
+        }
+
+  # 4) RACE two independent providers to draft a remediation proposal for the top
+  #    suspect: EITHER a targeted forward-fix patch OR a clean revert. First valid,
+  #    well-formed structured proposal WINS (first-valid-wins failover, NOT a vote).
+  #    Branch A pinned to sonnet, Branch B pinned to google/gemini-2.5-pro.
+  - id: draft_sonnet
+    type: standard
+    model: sonnet
+    depends_on: [correlate_suspect]
+    output_schema:
+      type: object
+      properties:
+        patch_kind: { type: string, enum: ["fix", "revert"] }
+        summary: { type: string }
+        target_files: { type: array, items: { type: string } }
+        diff: { type: string }
+        pr_title: { type: string }
+        confidence: { type: number }
+      required: ["patch_kind", "summary", "target_files", "diff", "pr_title", "confidence"]
+    prompt: |
+      You are an on-call SRE drafting ONE remediation for a production incident.
+
+      Correlated root-cause signal (deterministic, telemetry-to-SHA): {steps.correlate_suspect.output}
+
+      The top suspect commit is suspect_sha with files suspect_files. Decide the
+      single safest reversible remediation and return STRICT JSON only:
+      {
+        "patch_kind": "fix" | "revert",
+        "summary": "<one sentence: what the change does and why>",
+        "target_files": ["<only files you would touch - keep this minimal>"],
+        "diff": "<unified-diff patch text, or the revert ref if patch_kind=revert>",
+        "pr_title": "<concise PR title referencing the incident>",
+        "confidence": <number 0..1>
+      }
+
+      Rules:
+      - "revert": cleanly revert suspect_sha. Prefer this when the suspect commit
+        is small and clearly correlated - lowest blast radius.
+      - "fix": a targeted forward-fix that touches ONLY suspect_files. Use when a
+        revert would regress unrelated shipped work.
+      - target_files MUST be a subset of the suspect files - do not widen scope.
+      Output JSON only, no prose.
+
+  - id: draft_gemini
+    type: standard
+    model: google/gemini-2.5-pro
+    depends_on: [correlate_suspect]
+    output_schema:
+      type: object
+      properties:
+        patch_kind: { type: string, enum: ["fix", "revert"] }
+        summary: { type: string }
+        target_files: { type: array, items: { type: string } }
+        diff: { type: string }
+        pr_title: { type: string }
+        confidence: { type: number }
+      required: ["patch_kind", "summary", "target_files", "diff", "pr_title", "confidence"]
+    prompt: |
+      You are a second, independent on-call SRE drafting ONE remediation for the
+      same production incident.
+
+      Correlated root-cause signal: {steps.correlate_suspect.output}
+
+      Return STRICT JSON only with keys patch_kind ("fix"|"revert"), summary,
+      target_files (a MINIMAL subset of the suspect files), diff (unified-diff or
+      revert ref), pr_title, and confidence (0..1). Keep the blast radius tight:
+      target_files must not exceed the suspect files. Output JSON only, no prose.
+
+  - id: race_patch
+    type: race
+    depends_on: [draft_sonnet, draft_gemini]
+    race_config:
+      branches:
+        - [draft_sonnet]
+        - [draft_gemini]
+      # First branch whose JSON parses into a known patch_kind with a non-empty
+      # diff and a real confidence number wins. Deterministic first-valid-wins.
+      validator: "isinstance(output, dict) and output.get('patch_kind') in ('fix','revert') and bool(output.get('diff')) and isinstance(output.get('confidence'), (int, float))"
+
+  # 5) Deterministic blast-radius pre-check (regex/set math): does the winning
+  #    proposal touch ONLY the suspect files? This is the load-bearing safety
+  #    signal that the gate's code strategy reads - independent of any provider.
+  - id: blast_radius_check
+    type: code
+    depends_on: [race_patch]
+    code_config:
+      language: python
+      code: |
+        # Compare the proposal's target files against the suspect files. Any file
+        # outside the suspect set widens blast radius and fails the check.
+        import re
+
+        proposal = _steps.get("race_patch") or {}
+        rca = _steps.get("correlate_suspect") or {}
+        if not isinstance(proposal, dict):
+            proposal = {}
+        if not isinstance(rca, dict):
+            rca = {}
+
+        def _norm(p):
+            return re.sub(r"^\./", "", str(p or "").strip()).lstrip("/")
+
+        suspect_files = {_norm(f) for f in (rca.get("suspect_files") or []) if f}
+        target_files = [_norm(f) for f in (proposal.get("target_files") or []) if f]
+        target_set = set(target_files)
+
+        patch_kind = str(proposal.get("patch_kind", "")).strip().lower()
+
+        # A revert of the suspect SHA is inherently scoped to the suspect commit,
+        # so it is in-scope even when the list endpoint gave us no per-file diff.
+        if patch_kind == "revert":
+            widened = set()
+            within_scope = True
+        elif not suspect_files:
+            # No file-level ground truth available: be conservative - require the
+            # proposal to name a small, finite set and flag for human review.
+            widened = set()
+            within_scope = len(target_set) > 0 and len(target_set) <= 5
+        else:
+            widened = target_set - suspect_files
+            within_scope = len(widened) == 0 and len(target_set) > 0
+
+        try:
+            confidence = float(proposal.get("confidence", 0) or 0)
+        except (TypeError, ValueError):
+            confidence = 0.0
+
+        result = {
+            "patch_kind": patch_kind,
+            "pr_title": str(proposal.get("pr_title", f"Incident {rca.get('incident_id','')} remediation")),
+            "summary": str(proposal.get("summary", "")),
+            "diff": str(proposal.get("diff", "")),
+            "suspect_sha": rca.get("suspect_sha", ""),
+            "target_files": target_files,
+            "suspect_files": sorted(suspect_files),
+            "widened_files": sorted(widened),
+            "within_scope": bool(within_scope),
+            "confidence": confidence,
+            "safe_to_open": bool(within_scope),
+        }
+
+  # 6) GATE: the proposal may proceed ONLY if blast radius is contained. TWO
+  #    strategies that must BOTH pass: (a) an llm_eval judge (swappable model)
+  #    sanity-checks scope, and (b) a second llm_eval on a DIFFERENT provider as
+  #    an independent reader. The deterministic within_scope flag they read is the
+  #    real verdict - computed in code at blast_radius_check, provider-free.
+  - id: blast_radius_gate
+    type: gate
+    depends_on: [blast_radius_check]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: |
+              A remediation proposal was scope-checked deterministically. Reply
+              with exactly one word: "approved" if within_scope is true and
+              widened_files is empty (the patch touches only suspect files or is a
+              clean revert), otherwise "rejected".
+              Scope check record: {steps.blast_radius_check.output}
+            input: "{steps.blast_radius_check.output}"
+            model: sonnet
+        - type: llm_eval
+          config:
+            prompt: |
+              Independent second reader on a different provider. Reply with exactly
+              one word: "approved" if the proposal does NOT widen blast radius
+              (within_scope true, no widened_files), otherwise "rejected".
+              Scope check record: {steps.blast_radius_check.output}
+            input: "{steps.blast_radius_check.output}"
+            model: google/gemini-2.5-pro
+
+  # 7) On-call SRE signs off on revert-vs-fix before any PR is opened. Short
+  #    timeout (incident response), allow_edit so the SRE can tweak the patch.
+  - id: sre_approval
+    type: approval
+    depends_on: [blast_radius_gate]
+    approval_config:
+      message: "Incident remediation cleared the blast-radius gate. Approve opening this PR (review patch_kind fix-vs-revert, target files, and diff)."
+      show_data: steps.blast_radius_check.output
+      timeout_hours: 2
+      on_timeout: abort
+      allow_edit: true
+
+  # 8) Open the revert-or-fix PR via the GitHub API with the approved patch.
+  #    (Assumes the diff was pushed to a remediation branch by the SRE/edit step;
+  #    this opens the PR from that branch into base_branch.)
+  - id: open_pr
+    type: http
+    depends_on: [sre_approval]
+    http_config:
+      url: "https://api.github.com/repos/{input.github_repo}/pulls"
+      method: POST
+      auth: "bearer:{env.GITHUB_TOKEN}"
+      headers:
+        Accept: "application/vnd.github+json"
+        X-GitHub-Api-Version: "2022-11-28"
+        Content-Type: "application/json"
+      body: '{"title": "{steps.blast_radius_check.output.pr_title}", "head": "incident/{input.incident_id}-remediation", "base": "{input.base_branch}", "body": "Automated remediation for incident {input.incident_id} on {input.service}.\n\n- patch_kind: {steps.blast_radius_check.output.patch_kind}\n- suspect SHA: {steps.blast_radius_check.output.suspect_sha}\n- summary: {steps.blast_radius_check.output.summary}\n- blast radius: within_scope={steps.blast_radius_check.output.within_scope}, widened={steps.blast_radius_check.output.widened_files}\n\nRoot-cause correlation: {steps.correlate_suspect.output}"}'
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 9) SENSOR: poll the GitHub commit-status / checks API for the PR head until
+  #    CI concludes - green (all checks success) or red (any failure). The head
+  #    ref is the remediation branch we just opened the PR from.
+  - id: poll_ci
+    type: sensor
+    depends_on: [open_pr]
+    sensor_config:
+      url: "https://api.github.com/repos/{input.github_repo}/commits/incident%2F{input.incident_id}-remediation/check-runs"
+      method: GET
+      headers:
+        Accept: "application/vnd.github+json"
+        X-GitHub-Api-Version: "2022-11-28"
+        Authorization: "Bearer {env.GITHUB_TOKEN}"
+      # Done when every check-run has concluded (none still queued/in_progress).
+      condition: "status_code == 200 and int(response.get('total_count', 0) or 0) > 0 and all(r.get('status') == 'completed' for r in (response.get('check_runs') or []))"
+      check_interval: 60
+      timeout: 7200
+
+  # 10) Deterministically evaluate CI: green only if EVERY concluded run was a
+  #     success/neutral/skipped; any failure/timeout/cancel is red.
+  - id: evaluate_ci
+    type: code
+    depends_on: [poll_ci]
+    code_config:
+      language: python
+      code: |
+        # Read the final checks observation and decide green vs red.
+        obs = _steps.get("poll_ci") or {}
+        if not isinstance(obs, dict):
+            obs = {}
+        runs = obs.get("check_runs") or []
+        good = {"success", "neutral", "skipped"}
+        conclusions = []
+        for r in runs:
+            if isinstance(r, dict):
+                conclusions.append(str(r.get("conclusion", "")).lower())
+
+        # Green: at least one run, and all concluded runs are in the good set.
+        green = bool(conclusions) and all(c in good for c in conclusions)
+        failed = [c for c in conclusions if c not in good]
+
+        result = {
+            "ci_green": green,
+            "total_runs": len(conclusions),
+            "conclusions": conclusions,
+            "failed_conclusions": failed,
+            "fail_count": 0 if green else max(1, len(failed)),
+        }
+
+  # 11) CONDITION: green -> merge PR + resolve PagerDuty + close Linear; the
+  #     red path pages the SRE. Branches on the deterministic fail_count.
+  - id: ci_branch
+    type: condition
+    depends_on: [evaluate_ci]
+    condition_config:
+      expression: "{steps.evaluate_ci.output.fail_count} > 0"
+      then: [notify_ci_failed]
+      else: [merge_pr, resolve_pagerduty, close_linear, notify_resolved]
+
+  # 11-red) CI failed: page the on-call SRE - the proposed fix did not pass.
+  - id: notify_ci_failed
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: ":rotating_light: Incident {input.incident_id} ({input.service}): the automated {steps.blast_radius_check.output.patch_kind} PR FAILED CI ({steps.evaluate_ci.output.failed_conclusions}). Suspect SHA {steps.blast_radius_check.output.suspect_sha}. Human takeover required - PR left open for inspection."
+
+  # 11-green-a) Merge the PR (squash) now that CI is green.
+  - id: merge_pr
+    type: http
+    http_config:
+      url: "https://api.github.com/repos/{input.github_repo}/pulls/{steps.open_pr.output.number}/merge"
+      method: PUT
+      auth: "bearer:{env.GITHUB_TOKEN}"
+      headers:
+        Accept: "application/vnd.github+json"
+        X-GitHub-Api-Version: "2022-11-28"
+        Content-Type: "application/json"
+      body: '{"merge_method": "squash", "commit_title": "Merge incident {input.incident_id} remediation (CI green)"}'
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 11-green-b) Resolve the PagerDuty incident.
+  - id: resolve_pagerduty
+    type: http
+    http_config:
+      url: "https://api.pagerduty.com/incidents/{input.incident_id}"
+      method: PUT
+      auth: "token token={env.PAGERDUTY_TOKEN}"
+      headers:
+        Accept: "application/vnd.pagerduty+json;version=2"
+        Content-Type: "application/json"
+        From: "{env.PAGERDUTY_FROM_EMAIL}"
+      body: '{"incident": {"type": "incident_reference", "status": "resolved", "resolution": "Auto-resolved by incident-rca-pr-closer: merged {steps.blast_radius_check.output.patch_kind} PR after CI green."}}'
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 11-green-c) Close the Linear incident issue via the GraphQL API.
+  - id: close_linear
+    type: http
+    http_config:
+      url: "https://api.linear.app/graphql"
+      method: POST
+      headers:
+        Authorization: "{env.LINEAR_API_KEY}"
+        Content-Type: "application/json"
+      body: '{"query": "mutation IssueUpdate($id: String!, $stateId: String!) { issueUpdate(id: $id, input: { stateId: $stateId }) { success } }", "variables": {"id": "{input.linear_issue_id}", "stateId": "{input.linear_done_state_id}"}}'
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 11-green-d) Post the resolved timeline to Slack.
+  - id: notify_resolved
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: ":white_check_mark: Incident {input.incident_id} ({input.service}) RESOLVED. Suspect SHA {steps.blast_radius_check.output.suspect_sha} -> {steps.blast_radius_check.output.patch_kind} PR merged after CI green ({steps.evaluate_ci.output.total_runs} checks). PagerDuty resolved, Linear closed. Error jump {steps.correlate_suspect.output.error_jump} at inflection {steps.correlate_suspect.output.inflection_ts}."
+
+on_complete:
+  storage_path: "incident-rca-pr-closer/{run_id}/result.json"

--- a/src/sandcastle/templates/policy_change_propagation.yaml
+++ b/src/sandcastle/templates/policy_change_propagation.yaml
@@ -1,0 +1,588 @@
+# name: Policy Change Propagation
+# description: When a master policy or templated clause changes, deterministically diff new vs prior version, find every downstream contract embedding the affected clause, draft tailored amendment letters, route them through a two-judge + human gate, bulk-send re-signature envelopes via DocuSign, poll for acceptance across the portfolio, then bucket outcomes and produce branded compliance evidence.
+# tags: [Legal, CLM, Policy, DPA, DocuSign, Notion, Postgres, GitHub, Compliance, Amendment, ReSignature]
+# category: hr_legal
+
+name: policy-change-propagation
+description: >
+  Master-clause change propagation for a legal-operations team running hundreds of live
+  agreements. A trigger fires when an updated master policy / clause-library version lands
+  (GitHub commit, Google Drive file, or a row flip in a PostgreSQL policy table). The new
+  version is PARSED into structured clause text, then a DETERMINISTIC Python step computes a
+  semantic diff against the prior version supplied in input and emits the exact list of
+  changed_clause_ids - this model-free diff is what drives the entire fan-out, so which
+  contracts get touched never depends on an LLM. An HTTP step queries the CLM of record
+  (PostgreSQL REST / Notion database) for every document that embeds those clause ids. A LOOP
+  drafts a tailored amendment / re-signature notice per affected contract (a swappable,
+  provider-agnostic standard call that routes by cost / quality). A GATE then verifies each
+  draft: a first llm_eval judge checks faithfulness to the diff, a SECOND llm_eval judge on a
+  DIFFERENT provider re-checks for hallucinated obligations, and a human legal approver signs
+  off the batch with a hard timeout - giving provider-independent verification. Approved
+  amendments are bulk-sent as DocuSign envelopes; a durable SENSOR polls DocuSign every 4h
+  (timeout 30 days) until accepted_count == sent_count or the window closes. A CLASSIFY bins
+  each contract outcome into accepted / declined / no_response and branches to per-bucket
+  follow-up: Slack to the deal owners and Gmail to counterparties. Finally a TRANSFORM folds
+  the portfolio into an acceptance report and a REPORT renders branded PDF compliance evidence
+  proving every counterparty was notified. Diffing, querying, bulk-send, polling and bucketing
+  are all deterministic; only the per-draft wording and the two faithfulness judges are model
+  work, and each is swappable across providers.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 900
+
+input_schema:
+  required: ["policy_id", "new_policy_source", "prior_clauses"]
+  properties:
+    policy_id:
+      type: string
+      description: "Identifier of the master policy / clause library being propagated (e.g. 'DPA-2026', 'MSA-LIABILITY-CAP')."
+      default: "DPA-2026"
+      example: "DPA-2026"
+    new_policy_source:
+      type: string
+      description: "Location of the new policy version to parse - a GitHub raw URL, a Google Drive export URL, or an uploaded file ref. Parsed into clause text."
+      default: "https://raw.githubusercontent.com/your-org/policies/main/dpa/v2.md"
+      example: "https://raw.githubusercontent.com/acme/policies/main/dpa/v2.md"
+    prior_clauses:
+      type: string
+      description: >
+        The prior approved clause set as JSON, used as the model-free diff baseline. Shape:
+        {"clauses":[{"clause_id":"dpa-3.2","text":"...","version":"1.0"}, ...]}.
+      default: '{"clauses": [{"clause_id": "dpa-3.2", "text": "Processor shall retain logs for 90 days.", "version": "1.0"}]}'
+      example: '{"clauses": [{"clause_id": "dpa-3.2", "text": "Processor shall retain logs for 90 days.", "version": "1.0"}]}'
+    clm_query_url:
+      type: string
+      description: "REST endpoint of the CLM of record (PostgreSQL REST / PostgREST or Notion database query) that returns documents referencing given clause ids."
+      default: "https://clm.internal/api/postgrest/documents"
+      example: "https://acme.internal/postgrest/contract_clause_refs"
+    clm_backend:
+      type: string
+      description: "Which CLM backend the query URL speaks: 'postgrest' (PostgreSQL REST) or 'notion'. Controls auth header + response shape parsing."
+      default: "postgrest"
+      example: "notion"
+    docusign_base_url:
+      type: string
+      description: "DocuSign eSignature REST base URL including account id, used to bulk-create amendment envelopes and poll their status."
+      default: "https://eu.docusign.net/restapi/v2.1/accounts/your-account-id"
+      example: "https://eu.docusign.net/restapi/v2.1/accounts/abc123"
+    similarity_threshold:
+      type: number
+      description: "Token-overlap ratio (0-1) below which a clause is treated as materially changed by the deterministic diff."
+      default: 0.85
+      example: "0.85"
+    poll_interval:
+      type: integer
+      description: "Seconds between DocuSign acceptance polls (default 4h)."
+      default: 14400
+      example: "14400"
+    poll_timeout:
+      type: integer
+      description: "Total seconds to wait for full portfolio acceptance before closing the window (default 30 days)."
+      default: 2592000
+      example: "2592000"
+    slack_channel:
+      type: string
+      description: "Slack channel for the deal-owner follow-up on declined / no-response counterparties."
+      default: "#contracts-ops"
+      example: "#legal-ops"
+    counterparty_from:
+      type: string
+      description: "From address for the Gmail re-signature reminder to counterparties."
+      default: "contracts@your-org.com"
+      example: "contracts@acme.com"
+
+steps:
+  # 1) PARSE the new master policy version (GitHub / Google Drive / uploaded file) into clause text.
+  - id: parse_new_policy
+    type: parse
+    prompt: "{input.new_policy_source}"
+    parse_config:
+      output: markdown
+      pages: null
+      ocr: false
+      ocr_engine: auto
+
+  # 2) DETERMINISTIC semantic diff: extract clauses from the parsed new version, compare against the
+  #    prior approved clause set (token-overlap ratio), and emit the EXACT changed_clause_ids list.
+  #    This model-free step is the load-bearing decision that drives the whole fan-out.
+  - id: diff_clauses
+    type: code
+    depends_on: [parse_new_policy]
+    code_config:
+      language: python
+      code: |
+        import json
+        import re
+
+        parsed = _steps.get('parse_new_policy') or {}
+        # Parsed output may be a dict {markdown/text/content} or a raw string.
+        if isinstance(parsed, dict):
+            new_text = str(parsed.get('markdown') or parsed.get('text') or parsed.get('content') or '')
+        else:
+            new_text = str(parsed)
+
+        threshold = float(_input.get('similarity_threshold', 0.85) or 0.85)
+
+        # --- Parse the prior approved baseline (JSON string or already-parsed dict). ---
+        raw_prior = _input.get('prior_clauses') or {}
+        if isinstance(raw_prior, str):
+            try:
+                raw_prior = json.loads(raw_prior) if raw_prior.strip() else {}
+            except (ValueError, TypeError):
+                raw_prior = {}
+        prior_clauses = raw_prior.get('clauses', []) if isinstance(raw_prior, dict) else []
+        prior_by_id = {}
+        for c in prior_clauses:
+            if isinstance(c, dict) and c.get('clause_id'):
+                prior_by_id[str(c['clause_id'])] = str(c.get('text', ''))
+
+        # --- Extract clauses from the new parsed markdown. Convention: each clause is a
+        #     section headed by an id token like "[dpa-3.2]" or "## dpa-3.2". Tolerate both. ---
+        new_by_id = {}
+        # Pattern A: explicit [clause-id] markers.
+        for m in re.finditer(r'\[([a-zA-Z0-9._-]+)\]\s*(.*?)(?=\n\[[a-zA-Z0-9._-]+\]|\Z)', new_text, re.DOTALL):
+            new_by_id[m.group(1)] = m.group(2).strip()
+        # Pattern B: markdown headings "## <id>" if no bracket markers were found.
+        if not new_by_id:
+            for m in re.finditer(r'^#{1,6}\s*([a-zA-Z0-9._-]+)\s*\n(.*?)(?=^#{1,6}\s|\Z)', new_text, re.DOTALL | re.MULTILINE):
+                new_by_id[m.group(1)] = m.group(2).strip()
+
+        def _norm_tokens(s):
+            return set(t for t in re.findall(r'[a-z0-9]+', s.lower()) if t)
+
+        def _overlap(a, b):
+            ta, tb = _norm_tokens(a), _norm_tokens(b)
+            if not ta and not tb:
+                return 1.0
+            if not ta or not tb:
+                return 0.0
+            inter = len(ta & tb)
+            union = len(ta | tb)
+            return inter / union if union else 0.0
+
+        changed = []
+        added = []
+        all_ids = set(prior_by_id) | set(new_by_id)
+        for cid in sorted(all_ids):
+            old = prior_by_id.get(cid)
+            new = new_by_id.get(cid)
+            if old is None and new is not None:
+                added.append(cid)
+                changed.append({
+                    'clause_id': cid, 'change_type': 'added',
+                    'similarity': 0.0, 'new_text': new, 'old_text': '',
+                })
+                continue
+            if old is not None and new is None:
+                # Clause removed in new version - still a material change to propagate.
+                changed.append({
+                    'clause_id': cid, 'change_type': 'removed',
+                    'similarity': 0.0, 'new_text': '', 'old_text': old,
+                })
+                continue
+            sim = _overlap(old, new)
+            if sim < threshold:
+                changed.append({
+                    'clause_id': cid, 'change_type': 'modified',
+                    'similarity': round(sim, 4), 'new_text': new, 'old_text': old,
+                })
+
+        changed_clause_ids = [c['clause_id'] for c in changed]
+        result = {
+            'policy_id': _input.get('policy_id'),
+            'threshold': threshold,
+            'changed_clause_ids': changed_clause_ids,
+            'changed_count': len(changed_clause_ids),
+            'changes': changed,
+            'added_clause_ids': added,
+            'has_changes': len(changed_clause_ids) > 0,
+        }
+
+  # 3) QUERY the CLM of record (PostgreSQL REST / Notion) for every document embedding the changed clauses.
+  #    changed_clause_ids comes straight from the deterministic diff, so the fan-out is model-free.
+  - id: find_affected_contracts
+    type: http
+    depends_on: [diff_clauses]
+    http_config:
+      url: "{input.clm_query_url}?clause_id=in.({steps.diff_clauses.output.changed_clause_ids})&select=document_id,counterparty,counterparty_email,owner,clause_id,envelope_template_id"
+      method: GET
+      headers:
+        Accept: "application/json"
+        Content-Type: "application/json"
+      auth: "bearer:{env.CLM_API_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 4) DETERMINISTIC normalization: fold the CLM response into one affected-contract list
+  #    (dedupe by document_id, attach the specific clause change each contract is impacted by). No model.
+  - id: build_affected_list
+    type: code
+    depends_on: [diff_clauses, find_affected_contracts]
+    code_config:
+      language: python
+      code: |
+        diff = _steps.get('diff_clauses') or {}
+        resp = _steps.get('find_affected_contracts') or {}
+        backend = str(_input.get('clm_backend', 'postgrest') or 'postgrest').lower()
+
+        # PostgREST returns a list; Notion returns {"results": [{"properties": {...}}]}.
+        if backend == 'notion':
+            rows = resp.get('results', []) if isinstance(resp, dict) else []
+        else:
+            rows = resp if isinstance(resp, list) else (resp.get('data') or resp.get('rows') or [])
+
+        change_by_id = {c.get('clause_id'): c for c in diff.get('changes', []) if isinstance(c, dict)}
+
+        def _notion_text(prop):
+            # Flatten a Notion property to plain text.
+            if not isinstance(prop, dict):
+                return str(prop)
+            for key in ('rich_text', 'title'):
+                arr = prop.get(key)
+                if isinstance(arr, list) and arr:
+                    return ''.join(str(p.get('plain_text', '')) for p in arr if isinstance(p, dict))
+            if 'email' in prop:
+                return str(prop.get('email') or '')
+            if 'select' in prop and isinstance(prop.get('select'), dict):
+                return str(prop['select'].get('name', ''))
+            return str(prop.get('plain_text', '') or '')
+
+        affected = {}
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            if backend == 'notion':
+                props = row.get('properties', {}) if isinstance(row.get('properties'), dict) else {}
+                doc_id = _notion_text(props.get('document_id')) or row.get('id', '')
+                counterparty = _notion_text(props.get('counterparty'))
+                cp_email = _notion_text(props.get('counterparty_email'))
+                owner = _notion_text(props.get('owner'))
+                clause_id = _notion_text(props.get('clause_id'))
+                envelope_tpl = _notion_text(props.get('envelope_template_id'))
+            else:
+                doc_id = str(row.get('document_id') or row.get('id') or '')
+                counterparty = str(row.get('counterparty') or '')
+                cp_email = str(row.get('counterparty_email') or '')
+                owner = str(row.get('owner') or '')
+                clause_id = str(row.get('clause_id') or '')
+                envelope_tpl = str(row.get('envelope_template_id') or '')
+            if not doc_id:
+                continue
+            entry = affected.setdefault(doc_id, {
+                'document_id': doc_id,
+                'counterparty': counterparty,
+                'counterparty_email': cp_email,
+                'owner': owner,
+                'envelope_template_id': envelope_tpl,
+                'impacted_clause_ids': [],
+                'impacted_changes': [],
+            })
+            if clause_id and clause_id not in entry['impacted_clause_ids']:
+                entry['impacted_clause_ids'].append(clause_id)
+                ch = change_by_id.get(clause_id)
+                if ch:
+                    entry['impacted_changes'].append({
+                        'clause_id': clause_id,
+                        'change_type': ch.get('change_type'),
+                        'old_text': ch.get('old_text', ''),
+                        'new_text': ch.get('new_text', ''),
+                    })
+
+        affected_list = list(affected.values())
+        result = {
+            'policy_id': diff.get('policy_id'),
+            'affected_count': len(affected_list),
+            'affected_contracts': affected_list,
+            'has_affected': len(affected_list) > 0,
+        }
+
+  # 5) LOOP each affected contract: draft a tailored amendment / re-signature notice referencing
+  #    the specific clause change. The child is a swappable, provider-agnostic standard call.
+  - id: draft_amendments
+    type: loop
+    depends_on: [build_affected_list]
+    loop_config:
+      over: "steps.build_affected_list.output.affected_contracts"
+      step_ids: [draft_amendment_letter]
+      max_iterations: 500
+
+  # 5a) Per-contract amendment draft. Reads the current affected contract via _item. Swappable model;
+  #     stays on default_model so it routes by cost/quality, no provider lock-in.
+  - id: draft_amendment_letter
+    type: standard
+    output_schema:
+      type: object
+      properties:
+        document_id: { type: string }
+        subject: { type: string }
+        amendment_body: { type: string }
+      required: ["document_id", "subject", "amendment_body"]
+    prompt: |
+      You are a contracts attorney drafting a precise, plain-language amendment / re-signature
+      notice for a single live agreement affected by a master-policy clause change. Reference ONLY
+      the specific clause change(s) provided - do not invent new obligations, dates, or parties.
+
+      Master policy: {input.policy_id}
+      Affected contract (document_id, counterparty, and the exact impacted clause changes with
+      old_text -> new_text) :
+      {_item}
+
+      Write a formal amendment notice that: names the counterparty, identifies the agreement by
+      document_id, states for each impacted clause the prior language and the new language, explains
+      it must be re-signed to remain in force, and gives a courteous call to action. No markdown.
+
+      Return STRICT JSON only:
+      {
+        "document_id": "<the document_id from the input>",
+        "subject": "<email subject line for the re-signature request>",
+        "amendment_body": "<the full amendment notice text>"
+      }
+      Output JSON only, no prose.
+
+  # 6) GATE: provider-independent verification of the drafted amendments. A first faithfulness judge,
+  #    a SECOND judge on a DIFFERENT provider re-checking for hallucinated obligations, and a human
+  #    legal approver on the batch. ALL must pass.
+  - id: amendment_gate
+    type: gate
+    depends_on: [draft_amendments]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >
+              You are a legal-review control. Answer exactly 'approved' if EVERY drafted amendment
+              is faithful to its source clause change - it cites only the clause ids that actually
+              changed, reproduces the old_text -> new_text accurately, and adds no new obligations -
+              otherwise answer 'rejected' and name the first defective document_id.
+            input: "{steps.draft_amendments.output}"
+            model: sonnet
+        - type: llm_eval
+          config:
+            prompt: >
+              Independent second judge (different provider). Re-read every amendment for HALLUCINATED
+              terms: any obligation, deadline, monetary amount, or party that is NOT present in the
+              provided clause change. Answer exactly 'approved' if none are found, else 'rejected'
+              naming the offending document_id and the invented term.
+            input: "{steps.draft_amendments.output}"
+            model: google/gemini-2.5-pro
+        - type: human
+          config:
+            message: "Legal approver: review this batch of policy-change amendment letters before re-signature requests are sent to counterparties. Approve to release the DocuSign bulk-send."
+            timeout_hours: 72
+            on_timeout: abort
+
+  # 7) HUMAN APPROVAL of the final bulk-send with the full payload shown (edits allowed). Distinct
+  #    from the gate: this is the explicit go/no-go to dispatch envelopes to live counterparties.
+  - id: approve_bulk_send
+    type: approval
+    depends_on: [amendment_gate]
+    approval_config:
+      message: >
+        Confirm bulk-send of re-signature amendment envelopes for policy {input.policy_id}. Review
+        the affected-contract count and drafts; edit any letter before release. Approving dispatches
+        DocuSign envelopes to all listed counterparties.
+      show_data: steps.build_affected_list.output
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: true
+
+  # 8) DocuSign BULK-SEND: create amendment envelopes for the whole affected batch in one call.
+  - id: docusign_bulk_send
+    type: http
+    depends_on: [approve_bulk_send]
+    http_config:
+      url: "{input.docusign_base_url}/envelopes"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.DOCUSIGN_ACCESS_TOKEN}"
+      body: |
+        {
+          "policy_id": "{input.policy_id}",
+          "emailSubject": "Re-signature required: amendment to your agreement ({input.policy_id})",
+          "status": "sent",
+          "batch": {steps.build_affected_list.output.affected_contracts},
+          "drafts": {steps.draft_amendments.output}
+        }
+      value_map:
+        batch_id: "batchId"
+        sent_count: "batchSize"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 9) DURABLE SENSOR: poll DocuSign for acceptance across the batch every 4h, up to 30 days,
+  #    until accepted_count == sent_count (full portfolio acceptance) or the window closes.
+  - id: await_acceptance
+    type: sensor
+    depends_on: [docusign_bulk_send]
+    sensor_config:
+      url: "{input.docusign_base_url}/envelopes?from_date=2026-01-01&status=completed&count=1000"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and int(response.get('resultSetSize', 0) or 0) >= int(response.get('totalSetSize', 0) or 1)"
+      check_interval: 14400
+      timeout: 2592000
+
+  # 10) DETERMINISTIC reconciliation: pull the per-envelope status into one portfolio table,
+  #     compute accepted / declined / no_response per contract. No model on this critical path.
+  - id: reconcile_outcomes
+    type: http
+    depends_on: [await_acceptance]
+    http_config:
+      url: "{input.docusign_base_url}/envelopes/status?envelope_ids={steps.docusign_bulk_send.output.batch_id}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.DOCUSIGN_ACCESS_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 11) DETERMINISTIC fold: map each affected contract to its DocuSign status bucket. No model.
+  - id: tally_portfolio
+    type: code
+    depends_on: [build_affected_list, docusign_bulk_send, reconcile_outcomes]
+    code_config:
+      language: python
+      code: |
+        affected = (_steps.get('build_affected_list') or {}).get('affected_contracts', [])
+        sent = _steps.get('docusign_bulk_send') or {}
+        recon = _steps.get('reconcile_outcomes') or {}
+
+        # DocuSign status list: {"envelopes": [{"envelopeId":..,"status":"completed"|"declined"|"sent"}]}.
+        env_rows = recon.get('envelopes', []) if isinstance(recon, dict) else []
+        status_by_doc = {}
+        for e in env_rows:
+            if not isinstance(e, dict):
+                continue
+            key = str(e.get('document_id') or e.get('envelopeId') or e.get('envelope_id') or '')
+            status_by_doc[key] = str(e.get('status', '')).lower()
+
+        accepted, declined, no_response = [], [], []
+        for c in affected:
+            doc_id = str(c.get('document_id', ''))
+            st = status_by_doc.get(doc_id, '')
+            row = {
+                'document_id': doc_id,
+                'counterparty': c.get('counterparty', ''),
+                'counterparty_email': c.get('counterparty_email', ''),
+                'owner': c.get('owner', ''),
+                'status': st or 'no_response',
+            }
+            if st in ('completed', 'signed', 'accepted'):
+                accepted.append(row)
+            elif st in ('declined', 'voided', 'rejected'):
+                declined.append(row)
+            else:
+                no_response.append(row)
+
+        sent_count = int(sent.get('sent_count') or len(affected) or 0)
+        result = {
+            'policy_id': _input.get('policy_id'),
+            'sent_count': sent_count,
+            'accepted_count': len(accepted),
+            'declined_count': len(declined),
+            'no_response_count': len(no_response),
+            'acceptance_rate': round(len(accepted) / sent_count, 4) if sent_count else 0.0,
+            'accepted': accepted,
+            'declined': declined,
+            'no_response': no_response,
+            'fully_propagated': len(accepted) == sent_count and sent_count > 0,
+        }
+
+  # 12) CLASSIFY the overall portfolio outcome and route to the matching per-bucket follow-up.
+  - id: classify_outcome
+    type: classify
+    depends_on: [tally_portfolio]
+    classify_config:
+      model: haiku
+      input: >
+        Classify the policy-propagation portfolio outcome. fully_accepted = every sent envelope was
+        accepted; has_declines = at least one counterparty declined; awaiting_response = some
+        envelopes are still unsigned with none declined. Tally: {steps.tally_portfolio.output}
+      categories:
+        - fully_accepted
+        - has_declines
+        - awaiting_response
+      branches:
+        fully_accepted: [notify_slack_followup]
+        has_declines: [notify_slack_followup, email_counterparties]
+        awaiting_response: [notify_slack_followup, email_counterparties]
+
+  # 12a) Slack follow-up to the deal owners with the per-bucket breakdown.
+  - id: notify_slack_followup
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: >
+        Policy {input.policy_id} re-signature status - accepted {steps.tally_portfolio.output.accepted_count},
+        declined {steps.tally_portfolio.output.declined_count}, no-response {steps.tally_portfolio.output.no_response_count}
+        of {steps.tally_portfolio.output.sent_count} sent (rate {steps.tally_portfolio.output.acceptance_rate}).
+        Owners: chase the declined / no-response counterparties listed in the run.
+
+  # 12b) Gmail reminder to counterparties who declined or have not responded.
+  - id: email_counterparties
+    type: notify
+    notify_config:
+      service: gmail
+      channel: "{input.counterparty_from}"
+      message: >
+        Reminder: an amendment to your agreement under policy {input.policy_id} is awaiting your
+        re-signature in DocuSign and remains required to keep the contract in force. Please review and
+        sign. Outstanding counterparties: declined={steps.tally_portfolio.output.declined_count},
+        no-response={steps.tally_portfolio.output.no_response_count}.
+
+  # 13) TRANSFORM the portfolio tally into a structured acceptance report payload for the PDF.
+  - id: acceptance_report
+    type: transform
+    depends_on: [classify_outcome]
+    transform_config:
+      template: |
+        {
+          "policy_id": "{input.policy_id}",
+          "changed_clause_ids": {steps.diff_clauses.output.changed_clause_ids},
+          "changed_count": {steps.diff_clauses.output.changed_count},
+          "affected_contracts": {steps.build_affected_list.output.affected_count},
+          "sent_count": {steps.tally_portfolio.output.sent_count},
+          "accepted_count": {steps.tally_portfolio.output.accepted_count},
+          "declined_count": {steps.tally_portfolio.output.declined_count},
+          "no_response_count": {steps.tally_portfolio.output.no_response_count},
+          "acceptance_rate": {steps.tally_portfolio.output.acceptance_rate},
+          "fully_propagated": {steps.tally_portfolio.output.fully_propagated},
+          "accepted": {steps.tally_portfolio.output.accepted},
+          "declined": {steps.tally_portfolio.output.declined},
+          "no_response": {steps.tally_portfolio.output.no_response}
+        }
+
+  # 14) REPORT: branded PDF compliance evidence proving every counterparty was notified.
+  - id: compliance_evidence_pdf
+    type: report
+    depends_on: [acceptance_report]
+    report_config:
+      template: "research-report"
+      format: pdf
+      theme: professional
+      title: "Policy Change Propagation Evidence - {input.policy_id}"
+      author: "Legal Operations"
+    prompt: |
+      Produce a formal, branded compliance-evidence PDF for the propagation of master policy
+      {input.policy_id}. Include: the changed clause ids and counts, the number of downstream
+      contracts identified as embedding those clauses, how many re-signature envelopes were sent,
+      and the accepted / declined / no-response breakdown with the acceptance rate. List each
+      counterparty and its final status as the auditable proof that every affected counterparty was
+      notified. State whether the policy is fully propagated across the portfolio.
+
+      Acceptance report payload:
+      {steps.acceptance_report.output}
+
+on_complete:
+  storage_path: "policy-change-propagation/{run_id}/result.json"

--- a/src/sandcastle/templates/pr_review_polyglot_router.yaml
+++ b/src/sandcastle/templates/pr_review_polyglot_router.yaml
@@ -1,0 +1,461 @@
+# name: PR Review Polyglot Router
+# description: On every opened/synced PR, classify changed files by language/domain, route each chunk to the best-suited model, run a regex+SAST secrets gate plus an LLM judge, then auto-block or approve the PR and post inline review comments.
+# tags: [engineering, code-review, github, routing, security, ci-cd]
+# category: engineering
+# connectors: github (via http), slack (via notify)
+name: pr-review-polyglot-router
+description: >-
+  Language-aware first-pass PR review for a polyglot team (Go + Python + TypeScript +
+  Terraform + SQL + docs). A GitHub webhook (pull_request opened/synchronized) fires this
+  workflow, which fetches the PR file list and unified diff over the GitHub API, splits the
+  diff into per-file hunks in sandboxed Python, detects language by extension/path, groups
+  hunks into review chunks, and flags generated/vendored files to skip. A cheap classifier
+  buckets the first chunk's domain, then a loop reviews every chunk with a model chosen per
+  language from a configurable pool (a strong code model for infra/migrations, a cheap model
+  for docs). A multi-strategy gate runs a PURE regex/SAST secrets scan AND an LLM judge - if
+  either flags a hardcoded credential or critical issue the gate fails. A deterministic
+  condition then posts either a BLOCKING review plus a 'needs-changes' label or an APPROVE
+  review over the GitHub API, and Slack notifies the PR author with the routed-review summary
+  (which model reviewed which language). The hard security verdict is regex/code with zero
+  model dependency, and swapping which model handles a language is a one-line config change.
+default_model: sonnet
+default_timeout: 900
+input_schema:
+  required: ["github_repo", "pr_number"]
+  properties:
+    github_repo:
+      type: string
+      description: "owner/repo of the pull request, e.g. acme/payments-platform"
+      default: "acme/payments-platform"
+    pr_number:
+      type: integer
+      description: "Pull request number from the webhook payload (pull_request.number)."
+      default: 1234
+    model_pool:
+      type: object
+      description: >-
+        Provider-agnostic routing table mapping a detected language/domain to a model alias.
+        Swapping which model handles 'backend_go' is a one-line change here; routing is generic.
+      default:
+        backend_python: "sonnet"
+        backend_go: "google/gemini-2.5-pro"
+        frontend_ts: "sonnet"
+        infra_terraform: "opus"
+        sql_migration: "opus"
+        docs: "haiku"
+    skip_globs:
+      type: string
+      description: "Comma-separated path fragments marking generated/vendored files to skip from review."
+      default: "vendor/,node_modules/,dist/,build/,.min.,generated/,_pb2.py,.pb.go,package-lock.json,yarn.lock,go.sum"
+    max_chunks:
+      type: integer
+      description: "Safety cap on how many review chunks the loop will process per run."
+      default: 40
+    slack_channel:
+      type: string
+      description: "Slack channel for the routed-review summary posted to the PR author."
+      default: "#code-review"
+
+steps:
+  # 1) GITHUB API: fetch the PR file list (status, additions, patch per file).
+  #    Connector: github. The webhook gives us number; we pull the authoritative file set.
+  - id: fetch_pr_files
+    type: http
+    http_config:
+      url: "https://api.github.com/repos/{input.github_repo}/pulls/{input.pr_number}/files?per_page=100"
+      method: GET
+      auth: "bearer:{env.GITHUB_TOKEN}"
+      headers:
+        Accept: "application/vnd.github+json"
+        X-GitHub-Api-Version: "2022-11-28"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 2) GITHUB API: fetch PR metadata so we have head SHA + author for the review/label/notify steps.
+  - id: fetch_pr_meta
+    type: http
+    http_config:
+      url: "https://api.github.com/repos/{input.github_repo}/pulls/{input.pr_number}"
+      method: GET
+      auth: "bearer:{env.GITHUB_TOKEN}"
+      headers:
+        Accept: "application/vnd.github+json"
+        X-GitHub-Api-Version: "2022-11-28"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 3) SANDBOXED PYTHON: split the diff into per-file hunks, detect language by extension/path,
+  #    group into review chunks, and flag generated/vendored files to skip. Deterministic, no LLM.
+  - id: chunk_diff
+    type: code
+    depends_on: ["fetch_pr_files", "fetch_pr_meta"]
+    code_config:
+      language: python
+      code: |
+        # GitHub /files returns a list of {filename, status, additions, deletions, patch, ...}.
+        files = _steps.get('fetch_pr_files') or []
+        if isinstance(files, dict):
+            files = files.get('files') or files.get('data') or list(files.values())
+        if not isinstance(files, list):
+            files = [files]
+
+        skip_frags = [s.strip() for s in str(_input.get('skip_globs', '')).split(',') if s.strip()]
+        max_chunks = int(_input.get('max_chunks', 40))
+
+        # Extension/path -> domain bucket. Pure config, provider-agnostic.
+        EXT_MAP = {
+            '.py': 'backend_python',
+            '.go': 'backend_go',
+            '.ts': 'frontend_ts', '.tsx': 'frontend_ts', '.js': 'frontend_ts', '.jsx': 'frontend_ts',
+            '.tf': 'infra_terraform', '.tfvars': 'infra_terraform', '.hcl': 'infra_terraform',
+            '.sql': 'sql_migration',
+            '.md': 'docs', '.mdx': 'docs', '.rst': 'docs', '.txt': 'docs',
+        }
+
+        def detect(path):
+            p = (path or '').lower()
+            # Path-based overrides first (migrations dirs are SQL even if .py wrapped).
+            if '/migrations/' in p or p.endswith('.sql') or 'migrate' in p and p.endswith('.go'):
+                return 'sql_migration'
+            for ext, dom in EXT_MAP.items():
+                if p.endswith(ext):
+                    return dom
+            return 'docs'  # unknown text -> cheapest reviewer
+
+        chunks = []
+        skipped = []
+        for f in files:
+            if not isinstance(f, dict):
+                continue
+            name = f.get('filename') or f.get('path') or ''
+            patch = f.get('patch') or ''
+            status = f.get('status') or 'modified'
+            low = name.lower()
+            is_skipped = any(frag in low for frag in skip_frags) or status == 'removed'
+            if is_skipped:
+                skipped.append(name)
+                continue
+            chunks.append({
+                'file': name,
+                'status': status,
+                'domain': detect(name),
+                'additions': int(f.get('additions', 0) or 0),
+                'deletions': int(f.get('deletions', 0) or 0),
+                'hunk': patch[:6000],  # cap hunk size sent to the model
+            })
+
+        chunks = chunks[:max_chunks]
+        # Domain mix used by the summary + as the classify input seed.
+        mix = {}
+        for c in chunks:
+            mix[c['domain']] = mix.get(c['domain'], 0) + 1
+
+        meta = _steps.get('fetch_pr_meta') or {}
+        head_sha = ''
+        author = ''
+        try:
+            head_sha = (meta.get('head') or {}).get('sha', '') if isinstance(meta, dict) else ''
+            author = (meta.get('user') or {}).get('login', '') if isinstance(meta, dict) else ''
+        except Exception:
+            head_sha, author = '', ''
+
+        result = {
+            'chunks': chunks,
+            'chunk_count': len(chunks),
+            'skipped_files': skipped,
+            'domain_mix': mix,
+            'head_sha': head_sha,
+            'author': author,
+            'primary_domain': max(mix, key=mix.get) if mix else 'docs',
+        }
+
+  # 4) CLASSIFY: cheap router confirms the PR's primary domain bucket. One chunk-set -> one branch.
+  #    Both branches converge on the review loop; this just records the dominant domain cheaply.
+  - id: route_primary
+    type: classify
+    depends_on: ["chunk_diff"]
+    classify_config:
+      categories: ["backend_python", "backend_go", "frontend_ts", "infra_terraform", "sql_migration", "docs"]
+      input: "{steps.chunk_diff.output.primary_domain}"
+      model: haiku
+      branches:
+        backend_python: ["review_chunks"]
+        backend_go: ["review_chunks"]
+        frontend_ts: ["review_chunks"]
+        infra_terraform: ["review_chunks"]
+        sql_migration: ["review_chunks"]
+        docs: ["review_chunks"]
+
+  # 5) LOOP over chunks: each chunk gets a language-aware review whose model is chosen from the
+  #    configurable pool inside the review step. Strong model for infra/migrations, cheap for docs.
+  - id: review_chunks
+    type: loop
+    depends_on: ["route_primary"]
+    loop_config:
+      over: "steps.chunk_diff.output.chunks"
+      step_ids: ["review_one"]
+      max_iterations: 50
+
+  # 5a) REVIEW ONE CHUNK. The model alias is read from input.model_pool[domain] so swapping which
+  #     model handles a language is a one-line config change (see input_schema.model_pool).
+  - id: review_one
+    type: standard
+    prompt: |
+      You are a senior reviewer doing a first-pass review of ONE file's diff in a pull request.
+      Route context: this chunk was classified to a language/domain and assigned a model from a
+      configurable pool, so review it with the rigor appropriate to that domain.
+
+      File           : {{ _input.get('_item', {}).get('file') }}
+      Domain          : {{ _input.get('_item', {}).get('domain') }}
+      Change status   : {{ _input.get('_item', {}).get('status') }}
+      Assigned model  : {{ _input.get('model_pool', {}).get(_input.get('_item', {}).get('domain', 'docs'), 'sonnet') }}
+
+      Unified diff hunk:
+      {{ _input.get('_item', {}).get('hunk') }}
+
+      Review for: correctness, security, language idioms, error handling, tests, and (for
+      infra_terraform / sql_migration) destructive or irreversible operations. Keep it actionable.
+
+      Return STRICT JSON only:
+      {
+        "file": "<path>",
+        "domain": "<domain>",
+        "severity": "<none|low|medium|high|critical>",
+        "summary": "<one-line verdict>",
+        "inline_comments": [ {"line_hint": "<context line or @@hunk header>", "body": "<comment>"} ],
+        "suggested_decision": "<approve|comment|request_changes>"
+      }
+    output_schema:
+      type: object
+      properties:
+        file: { type: string }
+        domain: { type: string }
+        severity: { type: string }
+        summary: { type: string }
+        inline_comments: { type: array }
+        suggested_decision: { type: string }
+
+  # 6) DETERMINISTIC SECRETS/SAST SCAN. Pure regex over every hunk - ZERO model dependency. This is
+  #    the load-bearing half of the security verdict and the input to the gate's code strategy below.
+  - id: secrets_scan
+    type: code
+    depends_on: ["review_chunks"]
+    code_config:
+      language: python
+      code: |
+        import re
+        chunked = _steps.get('chunk_diff') or {}
+        chunks = chunked.get('chunks', []) if isinstance(chunked, dict) else []
+
+        # Regex SAST signatures for hardcoded credentials / dangerous patterns. Provider-free.
+        PATTERNS = [
+            ('aws_access_key', r'AKIA[0-9A-Z]{16}'),
+            ('aws_secret', r'(?i)aws_secret_access_key\s*[:=]\s*["\']?[A-Za-z0-9/+=]{40}'),
+            ('private_key', r'-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----'),
+            ('generic_api_key', r'(?i)(api[_-]?key|secret|token|passwd|password)\s*[:=]\s*["\'][^"\']{12,}["\']'),
+            ('slack_token', r'xox[baprs]-[0-9A-Za-z-]{10,}'),
+            ('github_pat', r'gh[pousr]_[0-9A-Za-z]{36,}'),
+            ('jwt', r'eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}'),
+            ('sql_drop', r'(?i)\bDROP\s+(TABLE|DATABASE|SCHEMA)\b'),
+            ('tf_force_destroy', r'(?i)force_destroy\s*=\s*true'),
+        ]
+        findings = []
+        for c in chunks:
+            hunk = c.get('hunk', '') if isinstance(c, dict) else ''
+            # Only scan added lines (diff lines starting with '+', excluding the +++ header).
+            for raw in hunk.splitlines():
+                if not raw.startswith('+') or raw.startswith('+++'):
+                    continue
+                line = raw[1:]
+                for name, rx in PATTERNS:
+                    if re.search(rx, line):
+                        findings.append({
+                            'file': c.get('file'),
+                            'rule': name,
+                            'snippet': line.strip()[:160],
+                            # Hardcoded credentials are blocking; destructive SQL/TF is high.
+                            'severity': 'critical' if name not in ('sql_drop', 'tf_force_destroy') else 'high',
+                        })
+
+        blocking = [f for f in findings if f['severity'] == 'critical']
+        result = {
+            'findings': findings,
+            'finding_count': len(findings),
+            'blocking_count': len(blocking),
+            'has_secrets': len(blocking) > 0,
+            'rules_triggered': sorted({f['rule'] for f in findings}),
+        }
+
+  # 7) MULTI-STRATEGY GATE: (a) a code/regex secrets+SAST strategy via llm_eval reading the
+  #    deterministic scan output, AND (b) an independent llm_eval reviewing the routed findings.
+  #    ALL strategies must pass; if either flags a hardcoded credential or critical issue, the gate
+  #    fails. The secrets verdict is anchored to deterministic code (secrets_scan), not a single model.
+  - id: security_gate
+    type: gate
+    depends_on: ["secrets_scan", "review_chunks"]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: |
+              This is the DETERMINISTIC secrets/SAST scan result (pure regex, no model judgment).
+              If has_secrets is true OR blocking_count > 0, the PR contains a hardcoded credential
+              and MUST be blocked. Answer exactly "rejected" if has_secrets is true or blocking_count
+              is greater than 0; otherwise answer "approved".
+            input: "{steps.secrets_scan.output}"
+            model: haiku
+        - type: llm_eval
+          config:
+            prompt: |
+              Below are the per-file routed reviews for this PR. Answer "rejected" if ANY review has
+              severity "critical" or suggested_decision "request_changes" tied to a security or
+              data-loss issue; otherwise answer "approved".
+            input: "{steps.review_chunks.output}"
+            model: sonnet
+
+  # 8) AGGREGATE the gate verdict + reviews into one deterministic decision object for the condition.
+  - id: build_verdict
+    type: code
+    depends_on: ["security_gate", "secrets_scan", "review_chunks", "chunk_diff"]
+    code_config:
+      language: python
+      code: |
+        scan = _steps.get('secrets_scan') or {}
+        reviews = _steps.get('review_chunks') or []
+        if isinstance(reviews, dict):
+            reviews = reviews.get('results') or reviews.get('items') or list(reviews.values())
+        if not isinstance(reviews, list):
+            reviews = [reviews]
+        reviews = [r for r in reviews if isinstance(r, dict)]
+
+        chunked = _steps.get('chunk_diff') or {}
+        pool = _input.get('model_pool', {}) or {}
+
+        crit = [r for r in reviews if str(r.get('severity', '')).lower() == 'critical']
+        req_changes = [r for r in reviews if str(r.get('suggested_decision', '')).lower() == 'request_changes']
+        has_secrets = bool(scan.get('has_secrets'))
+
+        fail = has_secrets or bool(crit) or bool(req_changes)
+
+        # Which model reviewed which language (for the Slack summary).
+        routing = {}
+        for r in reviews:
+            dom = r.get('domain', 'docs')
+            routing[dom] = pool.get(dom, 'sonnet')
+
+        # Flatten inline comments for the GitHub review payload.
+        inline = []
+        for r in reviews:
+            for c in (r.get('inline_comments') or []):
+                if isinstance(c, dict) and c.get('body'):
+                    inline.append({'file': r.get('file'), 'hint': c.get('line_hint'), 'body': c.get('body')})
+
+        lines = [f"- {r.get('file')} [{r.get('domain')}] {r.get('severity')}: {r.get('summary')}" for r in reviews]
+        decision = 'REQUEST_CHANGES' if fail else 'APPROVE'
+        body = (
+            f"## Polyglot Router review - {decision}\n\n"
+            f"Reviewed {len(reviews)} chunk(s). Secrets/SAST blocking: {scan.get('blocking_count', 0)} "
+            f"({', '.join(scan.get('rules_triggered', [])) or 'none'}).\n\n"
+            + "\n".join(lines)
+        )
+
+        result = {
+            'fail': fail,
+            'gate_failed': fail,
+            'decision': decision,
+            'has_secrets': has_secrets,
+            'critical_count': len(crit),
+            'request_changes_count': len(req_changes),
+            'routing': routing,
+            'review_body': body,
+            'inline_comments': inline,
+            'domain_mix': chunked.get('domain_mix', {}) if isinstance(chunked, dict) else {},
+            'author': chunked.get('author', '') if isinstance(chunked, dict) else '',
+            'head_sha': chunked.get('head_sha', '') if isinstance(chunked, dict) else '',
+        }
+
+  # 9) CONDITION: gate failed -> post a BLOCKING review and apply the 'needs-changes' label.
+  #    gate passed -> post an APPROVE review. Deterministic branch on the code-built verdict.
+  - id: decide_action
+    type: condition
+    depends_on: ["build_verdict"]
+    condition_config:
+      expression: "{steps.build_verdict.output.fail} == true"
+      then: ["post_blocking_review", "label_needs_changes"]
+      else: ["post_approve_review"]
+
+  # 9a) BLOCKING review (REQUEST_CHANGES) via GitHub Reviews API. Connector: github.
+  - id: post_blocking_review
+    type: http
+    http_config:
+      url: "https://api.github.com/repos/{input.github_repo}/pulls/{input.pr_number}/reviews"
+      method: POST
+      auth: "bearer:{env.GITHUB_TOKEN}"
+      headers:
+        Accept: "application/vnd.github+json"
+        X-GitHub-Api-Version: "2022-11-28"
+        Content-Type: "application/json"
+      body: '{"commit_id": "{steps.build_verdict.output.head_sha}", "event": "REQUEST_CHANGES", "body": "{steps.build_verdict.output.review_body}"}'
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 9b) Apply the 'needs-changes' label via GitHub Issues API (PRs are issues for labels).
+  - id: label_needs_changes
+    type: http
+    http_config:
+      url: "https://api.github.com/repos/{input.github_repo}/issues/{input.pr_number}/labels"
+      method: POST
+      auth: "bearer:{env.GITHUB_TOKEN}"
+      headers:
+        Accept: "application/vnd.github+json"
+        X-GitHub-Api-Version: "2022-11-28"
+        Content-Type: "application/json"
+      body: '{"labels": ["needs-changes"]}'
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 9c) APPROVE review via GitHub Reviews API. Connector: github.
+  - id: post_approve_review
+    type: http
+    http_config:
+      url: "https://api.github.com/repos/{input.github_repo}/pulls/{input.pr_number}/reviews"
+      method: POST
+      auth: "bearer:{env.GITHUB_TOKEN}"
+      headers:
+        Accept: "application/vnd.github+json"
+        X-GitHub-Api-Version: "2022-11-28"
+        Content-Type: "application/json"
+      body: '{"commit_id": "{steps.build_verdict.output.head_sha}", "event": "APPROVE", "body": "{steps.build_verdict.output.review_body}"}'
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 10) NOTIFY: Slack thread to the PR author with the routed-review summary and the
+  #     model-per-language routing map. Connector: slack.
+  - id: notify_author
+    type: notify
+    depends_on: ["decide_action"]
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        PR review routed for {input.github_repo} #{input.pr_number}
+        Author   : @{steps.build_verdict.output.author}
+        Decision : {steps.build_verdict.output.decision}
+        Secrets  : {steps.build_verdict.output.has_secrets} | critical reviews: {steps.build_verdict.output.critical_count}
+        Domain mix: {steps.build_verdict.output.domain_mix}
+        Model-per-language: {steps.build_verdict.output.routing}
+
+        {steps.build_verdict.output.review_body}
+
+on_complete:
+  storage_path: "pr-review-polyglot-router/{run_id}/result.json"

--- a/src/sandcastle/templates/residency_routed_inference.yaml
+++ b/src/sandcastle/templates/residency_routed_inference.yaml
@@ -1,0 +1,444 @@
+# name: Residency Routed Inference
+# description: Routes each inference request to a provider whose data-residency region is legally allowed for that record's classification, with race-based failover ONLY inside the permitted region set and a hard gate that blocks any cross-border fallback.
+# tags: [data-residency, gdpr, eu-ai-act, compliance, multi-provider, routing, pii, sovereignty]
+# category: general_ai
+name: residency-routed-inference
+description: >-
+  A residency-aware inference router for EU SaaS / banks who must PROVE that
+  customer PII is never processed by a non-EU model endpoint, while still using
+  the cheapest legally-allowed model. Triggered per incoming request (webhook /
+  new queue row) carrying the payload plus a data_classification hint, and also
+  batch-runnable over a Postgres backlog. The flow CLASSIFIES the record's data
+  sensitivity (eu_pii / eu_nonpii / global_ok), CONDITIONS on that class to pick
+  a residency policy, then a sandboxed CODE step computes the legally-permitted
+  provider/region ALLOWLIST (e.g. eu_pii -> mistral-eu, ollama-local, anthropic-eu
+  only). A RACE does fastest-valid-wins FAILOVER but ONLY across the allowed-region
+  providers, validating that the response schema is correct. A multi-strategy GATE
+  asserts the winning provider's region is in the allowlist AND that no cross-border
+  routing leaked, hard-blocking any out-of-region answer. A CONDITION routes a gate
+  failure to the on-prem ollama fallback and flags it. A TRANSFORM builds the
+  residency-attestation record (region served, classification, allowlist, hash),
+  an HTTP append writes it to the SHA-256 audit table in Postgres, and a NOTIFY
+  fires to Slack/PagerDuty ONLY when a residency violation was actually caught.
+  Providers are pure routing targets selected at runtime by the computed allowlist:
+  swapping which model serves which region is a config change, and the EU-PII path
+  can fall back to local ollama with zero code change.
+default_model: sonnet
+default_timeout: 900
+input_schema:
+  required: ["payload", "data_classification", "request_id"]
+  properties:
+    payload:
+      type: string
+      description: "The actual prompt / record content to run inference on (the customer data that may contain PII)."
+      example: "Summarize this support ticket: customer Jane Doe, IBAN DE89..., complaint about ..."
+    data_classification:
+      type: string
+      description: "Caller-supplied sensitivity hint for the record. One of eu_pii, eu_nonpii, global_ok. The classify step independently re-derives this from the payload; this is only a prior."
+      default: "eu_pii"
+    request_id:
+      type: string
+      description: "Idempotency / correlation id for this inference request (used as the audit row key and PagerDuty dedup key)."
+      example: "req_8f21c0"
+    data_endpoint:
+      type: string
+      description: "Base URL of the Postgres REST API (PostgREST) holding the SHA-256 residency audit table."
+      default: "https://datastore.internal/rest/v1"
+    pagerduty_routing_key:
+      type: string
+      description: "PagerDuty Events API v2 routing key for the residency-violation service. Only used on the violation path."
+      example: "R0ABCD1234EFGH5678"
+    slack_channel:
+      type: string
+      description: "Slack channel for residency-violation alerts."
+      default: "#dpo-residency-alerts"
+
+steps:
+  # 1) CLASSIFY - independently re-derive the data sensitivity from the PAYLOAD itself
+  #    (do not trust the caller's hint blindly). The classifier model is swappable
+  #    (haiku). Each class branches to the SAME residency-policy condition so every
+  #    path is fully wired. eu_pii = any EU person PII / financial identifiers;
+  #    eu_nonpii = EU-originated but non-personal; global_ok = no residency constraint.
+  - id: classify_sensitivity
+    type: classify
+    classify_config:
+      categories: ["eu_pii", "eu_nonpii", "global_ok"]
+      input: "{input.payload}"
+      model: haiku
+      branches:
+        eu_pii: [select_residency_policy]
+        eu_nonpii: [select_residency_policy]
+        global_ok: [select_residency_policy]
+
+  # 2) CONDITION - branch on the derived classification to a residency policy. Both
+  #    branches converge on the deterministic allowlist computation; the condition
+  #    only records WHICH policy regime applies (strict EU-only vs relaxed). The
+  #    expression reads the classify output, so the routing decision is data-driven.
+  - id: select_residency_policy
+    type: condition
+    depends_on: [classify_sensitivity]
+    condition_config:
+      expression: "'{steps.classify_sensitivity.output}' == 'eu_pii'"
+      then: [compute_allowlist]
+      else: [compute_allowlist]
+
+  # 3) CODE (sandboxed) - THE load-bearing routing decision. From the classification
+  #    it deterministically computes the legally-permitted provider/region allowlist.
+  #    eu_pii  -> EU/on-prem ONLY (mistral-eu, ollama-local, anthropic-eu).
+  #    eu_nonpii -> EU + EU-adequacy regions.
+  #    global_ok -> any region. No model swings this; it is pure policy as data.
+  #    Also picks the CHEAPEST allowed provider first and the ordered failover chain.
+  - id: compute_allowlist
+    type: code
+    depends_on: [select_residency_policy]
+    code_config:
+      language: python
+      code: |
+        # Derived classification (trust the classifier over the caller hint, fall
+        # back to the hint, then to the most restrictive class).
+        classification = str(_steps.get('classify_sensitivity') or '').strip().lower()
+        if classification not in ('eu_pii', 'eu_nonpii', 'global_ok'):
+            classification = str(_input.get('data_classification', 'eu_pii')).strip().lower()
+        if classification not in ('eu_pii', 'eu_nonpii', 'global_ok'):
+            classification = 'eu_pii'  # fail closed: most restrictive
+
+        # Provider registry: each routing target maps to a model: alias, a region
+        # and a $/1k-token cost. This is pure CONFIG - swap a region/model here and
+        # routing changes with zero code change. ollama-local is on-prem (eu-onprem).
+        PROVIDERS = {
+            'mistral-eu':    {'model': 'mistral/large', 'region': 'eu-west',   'cost_per_1k': 0.006},
+            'mistral-eu-sm': {'model': 'mistral/small', 'region': 'eu-west',   'cost_per_1k': 0.0006},
+            'ollama-local':  {'model': 'ollama',        'region': 'eu-onprem', 'cost_per_1k': 0.0},
+            'anthropic-eu':  {'model': 'sonnet',        'region': 'eu-central','cost_per_1k': 0.015},
+            'gemini-us':     {'model': 'google/gemini-2.5-pro', 'region': 'us-east', 'cost_per_1k': 0.005},
+        }
+
+        # Residency policy: which REGIONS are legally allowed per classification.
+        # eu_pii is fail-closed to EU + on-prem only. Editable config, not logic.
+        ALLOWED_REGIONS = {
+            'eu_pii':    {'eu-west', 'eu-central', 'eu-onprem'},
+            'eu_nonpii': {'eu-west', 'eu-central', 'eu-onprem'},
+            'global_ok': {'eu-west', 'eu-central', 'eu-onprem', 'us-east'},
+        }
+
+        allowed_regions = ALLOWED_REGIONS[classification]
+
+        # Compute the permitted provider allowlist for this record.
+        allowed = [
+            name for name, p in PROVIDERS.items()
+            if p['region'] in allowed_regions
+        ]
+        # Order the failover chain CHEAPEST-first so the race naturally prefers the
+        # cheapest legally-allowed provider, but every entry is in-region.
+        allowed.sort(key=lambda n: PROVIDERS[n]['cost_per_1k'])
+
+        # On-prem ollama is the guaranteed in-region fallback for EU-PII.
+        onprem = 'ollama-local'
+
+        result = {
+            'classification': classification,
+            'allowed_providers': allowed,
+            'allowed_regions': sorted(allowed_regions),
+            'cheapest_provider': allowed[0] if allowed else onprem,
+            'onprem_fallback': onprem,
+            'provider_regions': {n: PROVIDERS[n]['region'] for n in allowed},
+            # The two providers the race will actually try, both guaranteed in-region.
+            # (If only one is allowed, both branches target the same in-region model.)
+            'race_primary': allowed[0] if allowed else onprem,
+            'race_secondary': (allowed[1] if len(allowed) > 1 else (allowed[0] if allowed else onprem)),
+        }
+
+  # 4) RACE - fastest-valid-wins FAILOVER, but the branches are PINNED to in-region
+  #    providers only. This is failover (first valid response wins), NOT a vote.
+  #    Branch A is pinned to a EU model (mistral/large = mistral-eu) and Branch B to
+  #    the on-prem/EU fallback (ollama = ollama-local). For eu_pii, BOTH branches are
+  #    in-region, so no cross-border endpoint can ever win the race. The validator
+  #    enforces the response carries the required schema before a branch can win.
+  - id: residency_race
+    type: race
+    depends_on: [compute_allowlist]
+    race_config:
+      branches: [["infer_primary"], ["infer_secondary"]]
+      validator: "isinstance(output, dict) and 'answer' in output and 'served_by' in output and 'region' in output"
+
+  # 4a) PRIMARY in-region branch - EU provider (mistral/large = mistral-eu). Defined
+  #     separately, NO depends_on (the race executor drives it). It must self-report
+  #     served_by + region so the gate can verify residency against the allowlist.
+  - id: infer_primary
+    type: standard
+    model: mistral/large
+    prompt: |
+      You are the PRIMARY in-region inference provider "mistral-eu" (region eu-west)
+      selected by the residency router. Run the requested inference on the payload.
+
+      ALLOWLIST (you MUST be one of these): {steps.compute_allowlist.output.allowed_providers}
+      ALLOWED REGIONS: {steps.compute_allowlist.output.allowed_regions}
+
+      PAYLOAD:
+      {input.payload}
+
+      Return STRICT JSON only, echoing your true routing identity:
+      {
+        "answer": "<your inference result for the payload>",
+        "served_by": "mistral-eu",
+        "region": "eu-west",
+        "latency_ms": <int self-estimated end-to-end latency>
+      }
+    output_schema:
+      type: object
+      properties:
+        answer: { type: string }
+        served_by: { type: string }
+        region: { type: string }
+        latency_ms: { type: integer }
+
+  # 4b) SECONDARY in-region branch - on-prem fallback (ollama = ollama-local, region
+  #     eu-onprem). DIFFERENT provider pin so the race is a genuine cross-provider
+  #     failover, but still inside the EU/on-prem region set. Identical schema.
+  - id: infer_secondary
+    type: standard
+    model: ollama
+    prompt: |
+      You are the SECONDARY on-prem inference provider "ollama-local" (region
+      eu-onprem) selected by the residency router as the in-region failover.
+      Run the requested inference on the payload.
+
+      ALLOWLIST (you MUST be one of these): {steps.compute_allowlist.output.allowed_providers}
+      ALLOWED REGIONS: {steps.compute_allowlist.output.allowed_regions}
+
+      PAYLOAD:
+      {input.payload}
+
+      Return STRICT JSON only, echoing your true routing identity:
+      {
+        "answer": "<your inference result for the payload>",
+        "served_by": "ollama-local",
+        "region": "eu-onprem",
+        "latency_ms": <int self-estimated end-to-end latency>
+      }
+    output_schema:
+      type: object
+      properties:
+        answer: { type: string }
+        served_by: { type: string }
+        region: { type: string }
+        latency_ms: { type: integer }
+
+  # 5) CODE - deterministic RESIDENCY CHECK on the race winner. Reads the winning
+  #    response + the computed allowlist and decides, purely in code, whether the
+  #    serving region is legally permitted. This feeds both the gate (as evidence)
+  #    and the post-gate condition. The compliance verdict is code, not a prompt.
+  - id: residency_check
+    type: code
+    depends_on: [residency_race]
+    code_config:
+      language: python
+      code: |
+        win = _steps.get('residency_race')
+        if not isinstance(win, dict):
+            win = {}
+        allow = _steps.get('compute_allowlist') or {}
+        if not isinstance(allow, dict):
+            allow = {}
+
+        served_by = str(win.get('served_by', '') or '').strip()
+        served_region = str(win.get('region', '') or '').strip()
+        answer = win.get('answer')
+
+        allowed_providers = allow.get('allowed_providers') or []
+        allowed_regions = allow.get('allowed_regions') or []
+        provider_regions = allow.get('provider_regions') or {}
+
+        # Hard residency assertions, all deterministic:
+        provider_in_allowlist = served_by in allowed_providers
+        region_in_allowlist = served_region in allowed_regions
+        # Cross-border leak guard: the provider's REGISTERED region (from the
+        # allowlist) must match the region it claims to have served from.
+        registered_region = str(provider_regions.get(served_by, '') or '').strip()
+        no_region_mismatch = (registered_region == '') or (registered_region == served_region)
+        schema_ok = isinstance(answer, str) and len(answer) > 0
+
+        residency_ok = bool(
+            provider_in_allowlist and region_in_allowlist
+            and no_region_mismatch and schema_ok
+        )
+        # A violation is when SOMETHING answered but it was out-of-region / off-allowlist.
+        violation = bool(served_by) and (not provider_in_allowlist or not region_in_allowlist or not no_region_mismatch)
+
+        result = {
+            'request_id': _input.get('request_id'),
+            'classification': allow.get('classification'),
+            'served_by': served_by,
+            'served_region': served_region,
+            'registered_region': registered_region,
+            'allowed_providers': allowed_providers,
+            'allowed_regions': allowed_regions,
+            'provider_in_allowlist': provider_in_allowlist,
+            'region_in_allowlist': region_in_allowlist,
+            'no_region_mismatch': no_region_mismatch,
+            'schema_ok': schema_ok,
+            'residency_ok': residency_ok,
+            'violation': violation,
+            'answer': answer if schema_ok else '',
+        }
+
+  # 6) GATE - multi-strategy POLICY GATE. ALL strategies must pass. (a) an llm_eval
+  #    judge that reads the deterministic residency_check and confirms the answer
+  #    came from an in-allowlist, in-region provider with no cross-border leak;
+  #    (b) a human DPO sign-off that is the safety net whenever residency is in doubt.
+  #    A disallowed provider answer cannot pass this gate.
+  - id: residency_gate
+    type: gate
+    depends_on: [residency_check]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: |
+              You are a data-residency compliance auditor. Below is a deterministic
+              residency check of an inference response: which provider/region served
+              it, the legally-allowed provider allowlist and regions for this record's
+              classification, and the precomputed boolean flags. Answer EXACTLY
+              "approved" ONLY if residency_ok is true (provider_in_allowlist AND
+              region_in_allowlist AND no_region_mismatch AND schema_ok). If the answer
+              came from any out-of-region or off-allowlist provider, answer "rejected".
+            input: "{steps.residency_check.output}"
+            model: sonnet
+        - type: human
+          config:
+            message: "DPO sign-off: confirm the inference response was served only from a legally-permitted in-region provider. Review served_by / served_region vs the allowlist before releasing. (Exercise this whenever a residency violation flag is set.)"
+            timeout_hours: 24
+            on_timeout: abort
+
+  # 7) CONDITION - if the residency check FAILED (gate could not confirm in-region),
+  #    route to the on-prem ollama fallback and FLAG it; otherwise proceed straight to
+  #    attestation. The branch is driven by the deterministic residency_ok flag.
+  - id: route_on_violation
+    type: condition
+    depends_on: [residency_gate]
+    condition_config:
+      expression: "{steps.residency_check.output.residency_ok} == True"
+      then: [build_attestation]
+      else: [onprem_fallback, build_attestation]
+
+  # 7a-FAIL) On-prem ollama FALLBACK - re-run the inference on the guaranteed-in-region
+  #          local provider. EU-PII can fall back here with ZERO code change. Pinned to
+  #          ollama (region eu-onprem) so the fallback can never be cross-border.
+  - id: onprem_fallback
+    type: standard
+    model: ollama
+    prompt: |
+      RESIDENCY FALLBACK. The primary routing could not be confirmed in-region, so
+      this request is being re-served on the guaranteed on-prem provider
+      "ollama-local" (region eu-onprem). Re-run the inference on the payload.
+
+      PAYLOAD:
+      {input.payload}
+
+      Return STRICT JSON only:
+      {
+        "answer": "<your inference result for the payload>",
+        "served_by": "ollama-local",
+        "region": "eu-onprem"
+      }
+    output_schema:
+      type: object
+      properties:
+        answer: { type: string }
+        served_by: { type: string }
+        region: { type: string }
+
+  # 8) TRANSFORM - build the residency-ATTESTATION record: which region served the
+  #    request, the classification, the full allowlist, the violation flag and the
+  #    effective provider after any fallback. This is the auditable proof artifact.
+  - id: build_attestation
+    type: transform
+    transform_config:
+      template: |
+        {
+          "request_id": "{input.request_id}",
+          "classification": "{steps.residency_check.output.classification}",
+          "served_by": "{steps.residency_check.output.served_by}",
+          "served_region": "{steps.residency_check.output.served_region}",
+          "allowed_providers": "{steps.residency_check.output.allowed_providers}",
+          "allowed_regions": "{steps.residency_check.output.allowed_regions}",
+          "residency_ok": "{steps.residency_check.output.residency_ok}",
+          "violation": "{steps.residency_check.output.violation}",
+          "attested_by": "residency-routed-inference",
+          "attestation_note": "Provider/region selected at runtime from the computed allowlist; race failover restricted to in-region providers; cross-border answers hard-blocked by the policy gate."
+        }
+
+  # 9) HTTP - append the attestation to the SHA-256 residency AUDIT table in Postgres
+  #    (PostgREST insert). The DB computes/stores a SHA-256 hash chain row; we send the
+  #    attestation body. Connector: postgresql (via PostgREST).
+  - id: append_audit
+    type: http
+    depends_on: [build_attestation]
+    http_config:
+      url: "{input.data_endpoint}/residency_audit"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Prefer: "return=representation"
+      auth: "bearer:{env.POSTGREST_TOKEN}"
+      body: "{steps.build_attestation.output}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 10) HTTP - PagerDuty Events API v2 trigger, ONLY meaningful when a violation was
+  #     caught. The downstream notify and this page both run after the audit append;
+  #     they carry the violation flag in-payload so on-call sees the offending route.
+  #     Connector: pagerduty.
+  - id: page_pagerduty
+    type: http
+    depends_on: [append_audit]
+    http_config:
+      url: "https://events.pagerduty.com/v2/enqueue"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+      body: |
+        {
+          "routing_key": "{input.pagerduty_routing_key}",
+          "event_action": "trigger",
+          "dedup_key": "residency-{input.request_id}",
+          "payload": {
+            "summary": "Residency check: violation={steps.residency_check.output.violation} request={input.request_id} served_by={steps.residency_check.output.served_by} region={steps.residency_check.output.served_region}",
+            "severity": "critical",
+            "source": "residency-routed-inference",
+            "component": "{steps.residency_check.output.served_by}",
+            "group": "{steps.residency_check.output.classification}",
+            "custom_details": {
+              "residency_ok": "{steps.residency_check.output.residency_ok}",
+              "allowed_providers": "{steps.residency_check.output.allowed_providers}",
+              "allowed_regions": "{steps.residency_check.output.allowed_regions}"
+            }
+          }
+        }
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  # 11) NOTIFY - Slack alert. Posts the residency-violation summary so the DPO sees
+  #     any out-of-region answer that was caught (and the in-region success otherwise).
+  #     Connector: slack.
+  - id: notify_dpo
+    type: notify
+    depends_on: [page_pagerduty]
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        *Residency routing result* request `{input.request_id}`
+        Classification : {steps.residency_check.output.classification}
+        Served by      : {steps.residency_check.output.served_by} ({steps.residency_check.output.served_region})
+        Allowlist      : {steps.residency_check.output.allowed_providers}
+        Residency OK   : {steps.residency_check.output.residency_ok}
+        VIOLATION      : {steps.residency_check.output.violation}
+        Attestation appended to the SHA-256 Postgres audit table. PagerDuty paged on violation.
+
+on_complete:
+  storage_path: "residency-routed-inference/{run_id}/result.json"

--- a/src/sandcastle/templates/revenue_leakage_detector.yaml
+++ b/src/sandcastle/templates/revenue_leakage_detector.yaml
@@ -1,0 +1,591 @@
+# name: Revenue Leakage Detector
+# description: Cross-checks Stripe billing against the QuickBooks/Snowflake source of truth on a weekly schedule (or a Stripe webhook), pulls charges + subscriptions + invoices from Stripe, recognized revenue + contract terms from QuickBooks, and product-usage/entitlement facts from Snowflake, then loops per customer applying deterministic leakage rules in sandboxed code (under-billed usage, expired discounts still applied, active-delivery-but-failed-payment, plan-price drift vs contract, tax-jurisdiction mismatch) to compute $ at risk per rule - classifies each account HARD_LEAK / SOFT_LEAK / TAX_RISK / NO_ISSUE, files a recovery ticket to Jira/Linear when the recoverable total clears a threshold, and pings RevOps in Slack with the full leakage ledger
+# tags: [Finance, RevOps, Billing, Stripe, QuickBooks, Snowflake, Reconciliation, RevenueAssurance]
+# category: general_ai
+
+name: revenue-leakage-detector
+description: >-
+  Finds money leaking between the billing system (Stripe) and the general ledger /
+  source of truth (QuickBooks recognized revenue + contract terms, Snowflake usage
+  and entitlement facts) with zero LLM in the detection path. Three HTTP steps pull
+  the billing side from Stripe (charges, subscriptions, invoices), the recognized
+  revenue and contract terms from QuickBooks, and the product-usage / entitlement
+  facts from Snowflake over real REST APIs. A LOOP fans out over each customer /
+  subscription, and inside it a deterministic CODE step joins that account's billing,
+  GL, and usage facts and applies five reproducible leakage rules: billed usage below
+  entitled/consumed usage, a discount applied past its end-date, an active-delivery
+  subscription with a failed-but-uncollected payment, plan-price drift versus the
+  signed contract, and a tax-jurisdiction mismatch - each returning a concrete dollar
+  amount at risk. A second CODE step aggregates the per-account findings into a single
+  leakage ledger with the total recoverable amount. A CLASSIFY step labels the sweep
+  HARD_LEAK / SOFT_LEAK / TAX_RISK / NO_ISSUE and primes the right narrative. A
+  CONDITION checks whether the total recoverable clears the materiality threshold: if
+  so it files a recovery ticket to Jira/Linear over HTTP and pings RevOps in Slack with
+  the full ledger; if not it posts a clean 'no material leakage' note. The detection is
+  pure deterministic code over three systems of record, so the dollar findings replay
+  identically and are independent of any provider - the optional natural-language
+  explanation of each finding routes through default_model but is never required for a
+  leak to be found. (connectors: stripe, quickbooks, snowflake, jira, linear, slack)
+
+default_model: sonnet
+default_timeout: 600
+
+input_schema:
+  required: ["customers"]
+  properties:
+    customers:
+      type: array
+      description: >-
+        Accounts to sweep this run. Each item maps a Stripe customer to its GL /
+        contract identity. Shape per item:
+        {stripe_customer_id, account_name, contract_id, contract_mrr, discount_end_date,
+        contract_tax_region, entitled_usage_units, plan_id, plan_unit_price}. The loop
+        iterates over this list and accumulates per-account leakage findings.
+      default:
+        - stripe_customer_id: "cus_EXAMPLE001"
+          account_name: "Acme Robotics"
+          contract_id: "CTR-2026-0042"
+          contract_mrr: 4000
+          discount_end_date: "2026-03-31"
+          contract_tax_region: "US-CA"
+          entitled_usage_units: 1000000
+          plan_id: "plan_pro_monthly"
+          plan_unit_price: 4000
+    stripe_host:
+      type: string
+      description: "Stripe API host"
+      default: "api.stripe.com"
+    qbo_realm_id:
+      type: string
+      description: "QuickBooks Online company (realm) id owning the recognized-revenue GL"
+      default: ""
+    qbo_host:
+      type: string
+      description: "QuickBooks Online API host"
+      default: "quickbooks.api.intuit.com"
+    snowflake_account:
+      type: string
+      description: "Snowflake account locator (used in the SQL API host), e.g. ab12345.us-east-1"
+      default: ""
+    snowflake_warehouse:
+      type: string
+      description: "Snowflake virtual warehouse used to run the usage/entitlement query"
+      default: "ANALYTICS_WH"
+    snowflake_database:
+      type: string
+      description: "Snowflake database holding product-usage and entitlement facts"
+      default: "ANALYTICS"
+    snowflake_schema:
+      type: string
+      description: "Snowflake schema for the usage / entitlement fact tables"
+      default: "BILLING"
+    period_start:
+      type: string
+      description: "Billing/usage period start (YYYY-MM-DD) the sweep reconciles"
+      default: ""
+    period_end:
+      type: string
+      description: "Billing/usage period end (YYYY-MM-DD) the sweep reconciles"
+      default: ""
+    recoverable_threshold:
+      type: number
+      description: "Total recoverable dollars at/above which a recovery ticket is filed and RevOps is paged"
+      default: 250
+    usage_unit_price:
+      type: number
+      description: "Fallback price per usage unit (in reporting currency) when computing under-billed usage value"
+      default: 0.0005
+    price_drift_tolerance:
+      type: number
+      description: "Absolute dollar tolerance before plan-price vs contract drift is flagged"
+      default: 1.0
+    ticket_system:
+      type: string
+      description: "Where the recovery ticket is filed: jira or linear"
+      default: "jira"
+    jira_host:
+      type: string
+      description: "Jira Cloud host for filing the recovery ticket"
+      default: "your-org.atlassian.net"
+    jira_project_key:
+      type: string
+      description: "Jira project key the recovery ticket is created under"
+      default: "REV"
+    linear_team_id:
+      type: string
+      description: "Linear team id the recovery issue is created under (if ticket_system=linear)"
+      default: ""
+    notify_channel:
+      type: string
+      description: "Slack channel RevOps watches for leakage results"
+      default: "#revops-leakage"
+
+steps:
+  # 1) HTTP: pull the BILLING side from Stripe - charges, subscriptions, invoices.
+  #    This is what the customer was actually billed/charged. We expand the
+  #    subscription items and discount so the rules can see plan price and discount
+  #    end-dates without a second round-trip. (connector: stripe)
+  - id: fetch_stripe_billing
+    type: http
+    http_config:
+      url: "https://{input.stripe_host}/v1/subscriptions?status=all&limit=100&expand[]=data.discount&expand[]=data.latest_invoice&expand[]=data.items.data.price"
+      method: GET
+      auth: "bearer:{env.STRIPE_API_KEY}"
+      headers:
+        Stripe-Version: "2024-06-20"
+        Accept: "application/json"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 2) HTTP: pull RECOGNIZED REVENUE + contract terms from QuickBooks Online.
+  #    The ProfitAndLoss / GeneralLedger over the period is the GL truth for what
+  #    revenue was actually recognized against these accounts. (connector: quickbooks)
+  - id: fetch_qbo_recognized
+    type: http
+    http_config:
+      url: "https://{input.qbo_host}/v3/company/{input.qbo_realm_id}/reports/ProfitAndLoss?start_date={input.period_start}&end_date={input.period_end}&accounting_method=Accrual&summarize_column_by=Customers&minorversion=70"
+      method: GET
+      auth: "bearer:{env.QBO_ACCESS_TOKEN}"
+      headers:
+        Accept: "application/json"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 3) HTTP: pull PRODUCT-USAGE / ENTITLEMENT facts from Snowflake via the SQL API.
+  #    This is the consumed/entitled usage the customer SHOULD have been billed for -
+  #    the third independent system of record. (connector: snowflake)
+  - id: fetch_snowflake_usage
+    type: http
+    http_config:
+      url: "https://{input.snowflake_account}.snowflakecomputing.com/api/v2/statements?async=false"
+      method: POST
+      auth: "bearer:{env.SNOWFLAKE_OAUTH_TOKEN}"
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      body: '{"statement": "SELECT stripe_customer_id, SUM(usage_units) AS consumed_units, MAX(entitled_units) AS entitled_units, MAX(tax_region) AS tax_region FROM {input.snowflake_database}.{input.snowflake_schema}.FCT_PRODUCT_USAGE WHERE usage_date BETWEEN ''{input.period_start}'' AND ''{input.period_end}'' GROUP BY stripe_customer_id", "warehouse": "{input.snowflake_warehouse}", "database": "{input.snowflake_database}", "schema": "{input.snowflake_schema}", "timeout": 120}'
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 4) LOOP over each customer/subscription in the input list. Each iteration runs
+  #    detect_account_leakage, which joins THIS account's Stripe billing, QBO
+  #    recognized revenue, and Snowflake usage and applies the deterministic rules.
+  #    Findings accumulate across iterations (one finding-set per account).
+  - id: sweep_accounts
+    type: loop
+    depends_on: [fetch_stripe_billing, fetch_qbo_recognized, fetch_snowflake_usage]
+    loop_config:
+      over: "input.customers"
+      step_ids: [detect_account_leakage]
+      max_iterations: 1000
+
+  # 4a) CODE (loop child): deterministic leakage rules for ONE account. NO LLM - this
+  #     is the load-bearing decision and replays identically. Joins billing (Stripe),
+  #     recognized revenue + contract terms (QBO/input contract), and usage/entitlement
+  #     (Snowflake) for the loop item, then evaluates five rules, each returning a
+  #     concrete dollar amount at risk:
+  #       R1 under-billed usage  : consumed/entitled units > billed-for units
+  #       R2 expired discount    : a discount still applied after its end-date
+  #       R3 failed-but-delivered: active subscription with an uncollected/failed payment
+  #       R4 plan-price drift    : Stripe plan price != signed contract price
+  #       R5 tax mismatch        : Stripe/contract tax region != usage-region on file
+  #     The loop item arrives on _input['_item'].
+  - id: detect_account_leakage
+    type: code
+    code_config:
+      language: python
+      code: |
+        item = _input.get("_item") or {}
+        if not isinstance(item, dict):
+            item = {}
+
+        cust_id = str(item.get("stripe_customer_id", ""))
+        account_name = str(item.get("account_name", cust_id or "unknown"))
+        contract_id = str(item.get("contract_id", ""))
+
+        def _num(v):
+            try:
+                return round(float(v or 0), 2)
+            except (TypeError, ValueError):
+                return 0.0
+
+        # ---- Stripe billing side: find this customer's subscription ----------
+        stripe_raw = _steps.get("fetch_stripe_billing") or {}
+        if not isinstance(stripe_raw, dict):
+            stripe_raw = {}
+        subs = stripe_raw.get("data")
+        if not isinstance(subs, list):
+            subs = []
+
+        sub = {}
+        for s in subs:
+            if isinstance(s, dict) and str(s.get("customer", "")) == cust_id:
+                sub = s
+                break
+
+        sub_status = str(sub.get("status", "")) if sub else ""
+        # Stripe plan unit amount (cents -> dollars). Walk items.data[0].price.
+        billed_unit_price = 0.0
+        billed_for_units = 0.0
+        try:
+            items = (((sub.get("items") or {}).get("data")) or [])
+            if items and isinstance(items[0], dict):
+                price = items[0].get("price") or {}
+                billed_unit_price = round(_num(price.get("unit_amount", 0)) / 100.0, 4)
+                billed_for_units = _num(items[0].get("quantity", 0))
+        except (AttributeError, TypeError, IndexError):
+            billed_unit_price = 0.0
+
+        # Discount currently applied + its end (epoch seconds) on the subscription.
+        discount = sub.get("discount") if isinstance(sub.get("discount"), dict) else {}
+        discount_active = bool(discount)
+        try:
+            discount_end_epoch = int(discount.get("end") or 0)
+        except (TypeError, ValueError):
+            discount_end_epoch = 0
+        try:
+            discount_pct = float((discount.get("coupon") or {}).get("percent_off") or 0.0)
+        except (TypeError, ValueError):
+            discount_pct = 0.0
+
+        # Latest invoice payment health (failed-but-delivered detection).
+        latest_inv = sub.get("latest_invoice") if isinstance(sub.get("latest_invoice"), dict) else {}
+        inv_status = str(latest_inv.get("status", ""))
+        amount_due = round(_num(latest_inv.get("amount_due", 0)) / 100.0, 2)
+        amount_paid = round(_num(latest_inv.get("amount_paid", 0)) / 100.0, 2)
+        payment_failed = inv_status in ("open", "uncollectible") or (amount_due > amount_paid + 0.005)
+
+        # ---- Snowflake usage/entitlement side for this customer -------------
+        snow_raw = _steps.get("fetch_snowflake_usage") or {}
+        if not isinstance(snow_raw, dict):
+            snow_raw = {}
+        # Snowflake SQL API returns rows under "data" as ordered arrays matching the
+        # SELECT column order: [stripe_customer_id, consumed_units, entitled_units, tax_region].
+        snow_rows = snow_raw.get("data")
+        if not isinstance(snow_rows, list):
+            snow_rows = []
+        consumed_units = 0.0
+        entitled_units = _num(item.get("entitled_usage_units", 0))
+        usage_tax_region = str(item.get("contract_tax_region", ""))
+        for row in snow_rows:
+            if isinstance(row, list) and len(row) >= 4 and str(row[0]) == cust_id:
+                consumed_units = _num(row[1])
+                if _num(row[2]) > 0:
+                    entitled_units = _num(row[2])
+                if row[3]:
+                    usage_tax_region = str(row[3])
+                break
+
+        # ---- Contract terms (from the input account map / QBO recognized) ----
+        contract_mrr = _num(item.get("contract_mrr", 0))
+        contract_unit_price = _num(item.get("plan_unit_price", 0))
+        contract_tax_region = str(item.get("contract_tax_region", ""))
+        try:
+            unit_price_for_usage = float(_input.get("usage_unit_price", 0.0005) or 0.0005)
+        except (TypeError, ValueError):
+            unit_price_for_usage = 0.0005
+        try:
+            drift_tol = float(_input.get("price_drift_tolerance", 1.0) or 1.0)
+        except (TypeError, ValueError):
+            drift_tol = 1.0
+
+        # period_end as an epoch-ish day index for discount-expiry comparison.
+        def _ymd_to_index(s):
+            try:
+                y, m, d = (str(s) or "").split("-")[:3]
+                return int(y) * 366 + int(m) * 31 + int(d)
+            except (ValueError, TypeError):
+                return 0
+        period_end_idx = _ymd_to_index(_input.get("period_end", ""))
+        discount_end_str = str(item.get("discount_end_date", ""))
+        discount_end_idx = _ymd_to_index(discount_end_str)
+
+        findings = []
+
+        # R1 - UNDER-BILLED USAGE: customer consumed (or is entitled to) more units
+        #      than were billed. Value = unbilled units * unit price.
+        billable_units = max(consumed_units, entitled_units)
+        if billable_units > billed_for_units + 0.5:
+            unbilled = round(billable_units - billed_for_units, 2)
+            value = round(unbilled * unit_price_for_usage, 2)
+            if value > 0:
+                findings.append({
+                    "rule": "under_billed_usage",
+                    "severity": "hard",
+                    "consumed_units": consumed_units,
+                    "entitled_units": entitled_units,
+                    "billed_for_units": billed_for_units,
+                    "unbilled_units": unbilled,
+                    "dollars_at_risk": value,
+                })
+
+        # R2 - EXPIRED DISCOUNT STILL APPLIED: a discount is active on the subscription
+        #      but its end-date is already past the period end. Value = discount the
+        #      customer should no longer be receiving against contract MRR.
+        if discount_active and discount_end_idx and period_end_idx and discount_end_idx < period_end_idx:
+            pct = discount_pct if discount_pct > 0 else 0.0
+            leaked = round(contract_mrr * (pct / 100.0), 2) if pct > 0 else round(contract_mrr * 0.0, 2)
+            # If percent_off is unavailable, still flag it as a soft leak for review.
+            findings.append({
+                "rule": "expired_discount_applied",
+                "severity": "soft" if leaked == 0 else "hard",
+                "discount_end_date": discount_end_str,
+                "period_end": str(_input.get("period_end", "")),
+                "discount_percent_off": pct,
+                "dollars_at_risk": leaked,
+            })
+
+        # R3 - ACTIVE-DELIVERY-BUT-FAILED-PAYMENT: subscription is active (we are still
+        #      delivering) yet the latest invoice failed / is uncollected. Value = unpaid
+        #      amount due we are servicing for free.
+        if sub_status in ("active", "trialing", "past_due") and payment_failed:
+            at_risk = round(max(amount_due - amount_paid, 0.0), 2)
+            if at_risk <= 0:
+                at_risk = round(contract_mrr, 2)
+            findings.append({
+                "rule": "active_delivery_failed_payment",
+                "severity": "hard",
+                "subscription_status": sub_status,
+                "invoice_status": inv_status,
+                "amount_due": amount_due,
+                "amount_paid": amount_paid,
+                "dollars_at_risk": at_risk,
+            })
+
+        # R4 - PLAN-PRICE DRIFT vs CONTRACT: the price Stripe is charging differs from the
+        #      signed contract unit price beyond tolerance. Value = monthly drift.
+        if contract_unit_price > 0 and billed_unit_price > 0:
+            drift = round(contract_unit_price - billed_unit_price, 2)
+            if abs(drift) > drift_tol:
+                findings.append({
+                    "rule": "plan_price_drift",
+                    "severity": "hard" if drift > 0 else "soft",
+                    "contract_unit_price": contract_unit_price,
+                    "billed_unit_price": billed_unit_price,
+                    "drift": drift,
+                    # Positive drift = under-charging = recoverable revenue.
+                    "dollars_at_risk": round(max(drift, 0.0), 2),
+                })
+
+        # R5 - TAX-JURISDICTION MISMATCH: the tax region on the usage facts differs from
+        #      the contract/billing tax region - tax may be mis-collected/remitted.
+        if contract_tax_region and usage_tax_region and contract_tax_region != usage_tax_region:
+            findings.append({
+                "rule": "tax_jurisdiction_mismatch",
+                "severity": "tax",
+                "contract_tax_region": contract_tax_region,
+                "usage_tax_region": usage_tax_region,
+                # Tax exposure is review-driven; surface MRR as the exposed base.
+                "dollars_at_risk": round(contract_mrr, 2),
+            })
+
+        account_total = round(sum(_num(f.get("dollars_at_risk")) for f in findings), 2)
+        has_hard = any(f.get("severity") == "hard" for f in findings)
+        has_tax = any(f.get("severity") == "tax" for f in findings)
+
+        result = {
+            "stripe_customer_id": cust_id,
+            "account_name": account_name,
+            "contract_id": contract_id,
+            "subscription_status": sub_status,
+            "findings": findings,
+            "finding_count": len(findings),
+            "account_dollars_at_risk": account_total,
+            "has_hard_leak": has_hard,
+            "has_tax_risk": has_tax,
+        }
+
+  # 5) CODE: aggregate every account's findings into ONE leakage ledger and compute the
+  #    total recoverable dollars. Pure deterministic, NO LLM - the materiality decision
+  #    downstream rests on this. Reads the loop output (list of per-account finding sets).
+  - id: build_leakage_ledger
+    type: code
+    depends_on: [sweep_accounts]
+    code_config:
+      language: python
+      code: |
+        accounts = _steps.get("sweep_accounts")
+        # The loop surfaces a list of per-iteration child outputs.
+        if not isinstance(accounts, list):
+            accounts = [accounts] if isinstance(accounts, dict) else []
+
+        def _num(v):
+            try:
+                return round(float(v or 0), 2)
+            except (TypeError, ValueError):
+                return 0.0
+
+        ledger = []
+        total_recoverable = 0.0
+        hard_total = 0.0
+        soft_total = 0.0
+        tax_total = 0.0
+        accounts_with_leak = 0
+        rule_tally = {}
+
+        for acc in accounts:
+            if not isinstance(acc, dict):
+                continue
+            findings = acc.get("findings")
+            if not isinstance(findings, list):
+                findings = []
+            acc_total = _num(acc.get("account_dollars_at_risk", 0))
+            if findings:
+                accounts_with_leak += 1
+            total_recoverable += acc_total
+            for f in findings:
+                if not isinstance(f, dict):
+                    continue
+                sev = str(f.get("severity", ""))
+                amt = _num(f.get("dollars_at_risk", 0))
+                if sev == "hard":
+                    hard_total += amt
+                elif sev == "soft":
+                    soft_total += amt
+                elif sev == "tax":
+                    tax_total += amt
+                rule = str(f.get("rule", "unknown"))
+                rule_tally[rule] = round(rule_tally.get(rule, 0.0) + amt, 2)
+                ledger.append({
+                    "account_name": acc.get("account_name", ""),
+                    "stripe_customer_id": acc.get("stripe_customer_id", ""),
+                    "contract_id": acc.get("contract_id", ""),
+                    "rule": rule,
+                    "severity": sev,
+                    "dollars_at_risk": amt,
+                })
+
+        total_recoverable = round(total_recoverable, 2)
+        # Sort the ledger by dollars at risk so the biggest leaks lead.
+        ledger.sort(key=lambda x: -_num(x.get("dollars_at_risk")))
+
+        result = {
+            "ledger": ledger,
+            "line_count": len(ledger),
+            "accounts_swept": len(accounts),
+            "accounts_with_leak": accounts_with_leak,
+            "total_recoverable": total_recoverable,
+            "hard_leak_total": round(hard_total, 2),
+            "soft_leak_total": round(soft_total, 2),
+            "tax_risk_total": round(tax_total, 2),
+            "by_rule": rule_tally,
+            "has_hard_leak": hard_total > 0,
+            "has_tax_risk": tax_total > 0,
+        }
+
+  # 6) CLASSIFY the sweep into HARD_LEAK / SOFT_LEAK / TAX_RISK / NO_ISSUE off the
+  #    deterministic ledger and prime the matching narrative line. The dollars are
+  #    already computed in code; the label only drives messaging, not the numbers.
+  - id: classify_leakage
+    type: classify
+    depends_on: [build_leakage_ledger]
+    classify_config:
+      categories: ["HARD_LEAK", "SOFT_LEAK", "TAX_RISK", "NO_ISSUE"]
+      input: "{steps.build_leakage_ledger.output}"
+      model: haiku
+      branches:
+        HARD_LEAK: [prime_hard_leak]
+        SOFT_LEAK: [prime_soft_leak]
+        TAX_RISK: [prime_tax_risk]
+        NO_ISSUE: [prime_no_issue]
+
+  # 6a) HARD_LEAK narrative - confirmed recoverable revenue (under-billing, failed-but-
+  #     delivered, price drift). Any of the 7 providers can render this; the detection
+  #     already happened in code.
+  - id: prime_hard_leak
+    type: standard
+    prompt: |
+      You are a revenue assurance analyst. The deterministic leakage sweep flagged HARD
+      recoverable revenue. Write a 2-sentence RevOps-ready summary naming the largest leaking
+      accounts and the recovery actions (rebill usage, collect failed invoice, correct plan price).
+
+      Leakage ledger (already computed in code, do not recompute dollars):
+      {steps.build_leakage_ledger.output}
+
+  # 6b) SOFT_LEAK narrative - probable but review-required leakage.
+  - id: prime_soft_leak
+    type: standard
+    prompt: |
+      You are a revenue assurance analyst. The deterministic sweep found SOFT, review-required
+      leakage signals. Write a 2-sentence summary of what to verify before clawing back, using
+      only the precomputed numbers below.
+
+      Leakage ledger:
+      {steps.build_leakage_ledger.output}
+
+  # 6c) TAX_RISK narrative - tax jurisdiction mismatches dominate.
+  - id: prime_tax_risk
+    type: standard
+    prompt: |
+      You are a revenue assurance analyst focused on indirect tax. The sweep found tax-jurisdiction
+      mismatches between billing and usage. Write a 2-sentence summary of the exposure and the
+      remediation (confirm nexus, correct tax region, re-file), using only the numbers below.
+
+      Leakage ledger:
+      {steps.build_leakage_ledger.output}
+
+  # 6d) NO_ISSUE narrative - clean sweep.
+  - id: prime_no_issue
+    type: standard
+    prompt: |
+      You are a revenue assurance analyst. The deterministic sweep found no material leakage.
+      Write a single reassuring sentence confirming billing reconciles to the GL and usage facts.
+
+      Leakage ledger:
+      {steps.build_leakage_ledger.output}
+
+  # 7) CONDITION on materiality: if total recoverable clears the threshold, file a recovery
+  #    ticket and page RevOps; otherwise post a clean 'no material leakage' note. The
+  #    decision reads the deterministic ledger total, never a model.
+  - id: materiality_gate
+    type: condition
+    depends_on: [build_leakage_ledger, classify_leakage]
+    condition_config:
+      expression: "{steps.build_leakage_ledger.output.total_recoverable} >= {input.recoverable_threshold}"
+      then: [file_recovery_ticket, notify_revops]
+      else: [notify_clean]
+
+  # 7a) HTTP: file a recovery TASK/issue in Jira (or Linear) with the leakage total and
+  #     ledger embedded in the description. (connectors: jira, linear)
+  - id: file_recovery_ticket
+    type: http
+    http_config:
+      url: "https://{input.jira_host}/rest/api/3/issue"
+      method: POST
+      auth: "bearer:{env.JIRA_API_TOKEN}"
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      body: '{"fields": {"project": {"key": "{input.jira_project_key}"}, "issuetype": {"name": "Task"}, "summary": "Revenue recovery: ${steps.build_leakage_ledger.output.total_recoverable} leakage detected", "description": "Automated revenue-leakage sweep flagged recoverable revenue between Stripe billing and the GL/usage source of truth. Total recoverable: ${steps.build_leakage_ledger.output.total_recoverable}. Hard: ${steps.build_leakage_ledger.output.hard_leak_total}. Tax exposure: ${steps.build_leakage_ledger.output.tax_risk_total}. Ledger: {steps.build_leakage_ledger.output.ledger}. Summary: {steps.classify_leakage.output}"}}'
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 7b) NOTIFY: page RevOps in Slack with the leakage ledger, the total recoverable, and
+  #     the filed recovery ticket. (connector: slack)
+  - id: notify_revops
+    type: notify
+    depends_on: [file_recovery_ticket]
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: ":money_with_wings: Revenue leakage detected. Total recoverable: ${steps.build_leakage_ledger.output.total_recoverable} across {steps.build_leakage_ledger.output.accounts_with_leak} account(s). Hard leak: ${steps.build_leakage_ledger.output.hard_leak_total}, soft: ${steps.build_leakage_ledger.output.soft_leak_total}, tax exposure: ${steps.build_leakage_ledger.output.tax_risk_total}. Recovery ticket filed: {steps.file_recovery_ticket.output}. Summary: {steps.classify_leakage.output}. Ledger: {steps.build_leakage_ledger.output.ledger}."
+
+  # 7c) NOTIFY (clean path): below threshold, post the all-clear with the ledger for the
+  #     audit trail. (connector: slack)
+  - id: notify_clean
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: ":white_check_mark: Revenue leakage sweep clean: ${steps.build_leakage_ledger.output.total_recoverable} recoverable is below the ${input.recoverable_threshold} threshold across {steps.build_leakage_ledger.output.accounts_swept} account(s). {steps.classify_leakage.output}"
+
+on_complete:
+  storage_path: "revenue-leakage-detector/{run_id}/leakage-ledger.json"

--- a/src/sandcastle/templates/schema_drift_early_warning.yaml
+++ b/src/sandcastle/templates/schema_drift_early_warning.yaml
@@ -1,0 +1,586 @@
+# name: Schema Drift Early Warning
+# description: A durable sensor that polls source schemas (DB information_schema + upstream API contracts) until a structural change appears, then deterministically diffs old vs new, classifies the break's blast radius across downstream dbt models, and pages owners before pipelines fail. Detection and the diff are 100% code; only the remediation plan is a swappable two-provider race.
+# tags: [data, schema-drift, sensor, ingestion, dbt, postgresql, snowflake, pagerduty]
+# category: data
+# connectors: postgresql, snowflake, aws-s3, jira, linear, pagerduty, slack
+name: schema-drift-early-warning
+description: >-
+  A long-running schema-drift early-warning watcher for ingestion pipelines. It
+  first fetches the last known-good schema snapshot from a control store (S3 /
+  Postgres), then a durable SENSOR polls the live source schema (Postgres /
+  Snowflake information_schema via a SQL gateway, plus an upstream API's contract
+  endpoint) on an interval until the live schema hash differs from the baseline
+  (event-driven within a schedule). A CODE step computes a precise, deterministic
+  structural diff - added / removed / retyped columns, nullability flips,
+  key changes and likely renames. A CLASSIFY step buckets the overall change into
+  breaking / non_breaking / risky_rename. A LOOP walks the registry of downstream
+  dbt models and queries to compute blast radius (which consumers reference the
+  changed columns). A RACE has Anthropic (Sonnet) and Google (Gemini 2.5 Pro)
+  each draft a migration / remediation plan from the same diff - first valid plan
+  wins (failover, NOT a vote). A GATE on severity decides page-vs-log. Then HTTP
+  steps open a Jira / Linear ticket and write the new baseline snapshot to
+  Postgres / S3, and a NOTIFY pages PagerDuty + Slack on breaking changes.
+  Drift detection, the diff, the blast-radius and the page are all deterministic
+  and run even with zero model providers available; the model only writes prose.
+default_model: sonnet
+default_timeout: 1800
+input_schema:
+  required: ["sql_gateway", "contract_endpoint", "source_table"]
+  properties:
+    sql_gateway:
+      type: string
+      description: "Base URL of the read-only SQL gateway in front of Postgres / Snowflake information_schema (e.g. PostgREST or the Snowflake SQL API), e.g. https://warehouse.internal/sql/v1"
+      default: "https://warehouse.internal/sql/v1"
+    contract_endpoint:
+      type: string
+      description: "Upstream API's machine-readable contract / schema endpoint (OpenAPI components or JSON Schema), e.g. https://upstream.example.com/.well-known/schema"
+      default: "https://upstream.example.com/.well-known/schema"
+    source_table:
+      type: string
+      description: "Fully-qualified source table whose information_schema columns are watched, e.g. analytics.public.orders"
+      default: "analytics.public.orders"
+    control_store_url:
+      type: string
+      description: "Control store REST base URL holding the last known-good schema snapshot (S3 REST gateway or Postgres/PostgREST), e.g. https://control.internal/snapshots"
+      default: "https://control.internal/snapshots"
+    dbt_registry_url:
+      type: string
+      description: "REST endpoint returning the registry of downstream dbt models / queries and the source columns each one references."
+      default: "https://control.internal/registry/dbt-models"
+    ticketing_base_url:
+      type: string
+      description: "Jira / Linear REST base URL for opening the drift ticket."
+      default: "https://ticketing.internal/api/v1"
+    check_interval:
+      type: integer
+      description: "Seconds between sensor polls of the live schema endpoints."
+      default: 300
+    poll_timeout:
+      type: integer
+      description: "Sensor soft timeout in seconds - stop waiting for drift after this long (one watch run)."
+      default: 86400
+    slack_channel:
+      type: string
+      description: "Slack channel for the drift digest / page."
+      default: "#data-ingestion"
+steps:
+  # 1) Fetch the last known-good schema snapshot (baseline) from the control store.
+  #    Carries the baseline column list + the baseline schema hash. (aws-s3 / postgresql)
+  - id: fetch_baseline
+    type: http
+    http_config:
+      url: "{input.control_store_url}?table=eq.{input.source_table}&state=eq.known_good&order=captured_at.desc&limit=1"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.CONTROL_STORE_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 2) DURABLE SENSOR - poll the LIVE source schema until its hash differs from the
+  #    baseline. The polled endpoint hits the SQL gateway's information_schema view for
+  #    the watched table (Postgres / Snowflake) and returns {schema_hash, columns}.
+  #    Drift fires when the live hash no longer matches the baseline hash. The upstream
+  #    API contract is diffed deterministically downstream; here we gate on the DB hash.
+  - id: watch_drift
+    type: sensor
+    depends_on: [fetch_baseline]
+    sensor_config:
+      url: "{input.sql_gateway}/information_schema/columns?table=eq.{input.source_table}&select=column_name,data_type,is_nullable,ordinal_position,schema_hash&order=ordinal_position"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and str(response.get('schema_hash','')) != '{steps.fetch_baseline.output.schema_hash}'"
+      check_interval: 300
+      timeout: 86400
+
+  # 3) Pull the FRESH live DB column list now that drift has been observed (the sensor
+  #    only proved the hash moved; this returns the full live column set to diff).
+  - id: fetch_live_db
+    type: http
+    depends_on: [watch_drift]
+    http_config:
+      url: "{input.sql_gateway}/information_schema/columns?table=eq.{input.source_table}&select=column_name,data_type,is_nullable,ordinal_position,is_primary_key&order=ordinal_position"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.WAREHOUSE_API_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 4) Pull the upstream API's contract (OpenAPI / JSON Schema) so its fields can be
+  #    folded into the same structural diff as the DB columns.
+  - id: fetch_contract
+    type: http
+    depends_on: [watch_drift]
+    http_config:
+      url: "{input.contract_endpoint}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.UPSTREAM_API_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 5) DETERMINISTIC STRUCTURAL DIFF. NO model. Pure code: compare the baseline column
+  #    set to the live DB columns + upstream contract fields and emit added / removed /
+  #    retyped columns, nullability flips, key changes and likely renames. Reads the
+  #    baseline (_steps['fetch_baseline']), live DB (_steps['fetch_live_db']) and the
+  #    upstream contract (_steps['fetch_contract']).
+  - id: compute_diff
+    type: code
+    depends_on: [fetch_live_db, fetch_contract]
+    code_config:
+      language: python
+      code: |
+        # ---- helpers ------------------------------------------------------------
+        def as_rows(blob):
+            # Normalize a REST payload into a flat list of column dicts.
+            if isinstance(blob, dict):
+                for k in ('columns', 'rows', 'data', 'results', 'items'):
+                    v = blob.get(k)
+                    if isinstance(v, list):
+                        return [r for r in v if isinstance(r, dict)]
+                # OpenAPI components.schemas.<obj>.properties shape
+                props = (((blob.get('components') or {}).get('schemas') or {}))
+                if isinstance(props, dict) and props:
+                    first = next(iter(props.values()), {}) or {}
+                    fields = (first.get('properties') or {}) if isinstance(first, dict) else {}
+                    required = set(first.get('required') or []) if isinstance(first, dict) else set()
+                    out = []
+                    for name, spec in fields.items():
+                        spec = spec if isinstance(spec, dict) else {}
+                        out.append({
+                            'column_name': name,
+                            'data_type': str(spec.get('type', 'unknown')),
+                            'is_nullable': 'NO' if name in required else 'YES',
+                            'is_primary_key': False,
+                        })
+                    return out
+                # JSON Schema {properties:{...}, required:[...]} shape
+                if isinstance(blob.get('properties'), dict):
+                    required = set(blob.get('required') or [])
+                    out = []
+                    for name, spec in blob['properties'].items():
+                        spec = spec if isinstance(spec, dict) else {}
+                        out.append({
+                            'column_name': name,
+                            'data_type': str(spec.get('type', 'unknown')),
+                            'is_nullable': 'NO' if name in required else 'YES',
+                            'is_primary_key': False,
+                        })
+                    return out
+                return [blob] if blob else []
+            if isinstance(blob, list):
+                return [r for r in blob if isinstance(r, dict)]
+            return []
+
+        def index(rows):
+            idx = {}
+            for r in rows:
+                name = r.get('column_name') or r.get('name')
+                if not name:
+                    continue
+                idx[str(name)] = {
+                    'data_type': str(r.get('data_type', r.get('type', 'unknown'))).lower(),
+                    'nullable': str(r.get('is_nullable', 'YES')).upper() != 'NO',
+                    'pk': bool(r.get('is_primary_key') or r.get('pk') or False),
+                }
+            return idx
+
+        # ---- inputs -------------------------------------------------------------
+        baseline_rows = as_rows(_steps.get('fetch_baseline') or {})
+        live_rows = as_rows(_steps.get('fetch_live_db') or {})
+        contract_rows = as_rows(_steps.get('fetch_contract') or {})
+
+        old = index(baseline_rows)
+        # Live = DB columns first, then contract fields fill any gaps (DB wins on conflict).
+        new = index(contract_rows)
+        new.update(index(live_rows))
+
+        old_names = set(old)
+        new_names = set(new)
+
+        added = sorted(new_names - old_names)
+        removed = sorted(old_names - new_names)
+        kept = sorted(old_names & new_names)
+
+        retyped = []
+        nullability_flips = []
+        key_changes = []
+        for c in kept:
+            o, n = old[c], new[c]
+            if o['data_type'] != n['data_type']:
+                retyped.append({'column': c, 'from': o['data_type'], 'to': n['data_type']})
+            if o['nullable'] != n['nullable']:
+                nullability_flips.append({
+                    'column': c,
+                    'from': 'NULLABLE' if o['nullable'] else 'NOT NULL',
+                    'to': 'NULLABLE' if n['nullable'] else 'NOT NULL',
+                })
+            if o['pk'] != n['pk']:
+                key_changes.append({
+                    'column': c,
+                    'from': 'PK' if o['pk'] else 'non-key',
+                    'to': 'PK' if n['pk'] else 'non-key',
+                })
+
+        # ---- rename heuristic: a removed col + an added col with the SAME type --
+        likely_renames = []
+        used_added = set()
+        for r in list(removed):
+            for a in added:
+                if a in used_added:
+                    continue
+                if old.get(r, {}).get('data_type') == new.get(a, {}).get('data_type'):
+                    likely_renames.append({'from': r, 'to': a, 'data_type': old[r]['data_type']})
+                    used_added.add(a)
+                    break
+        rename_from = {x['from'] for x in likely_renames}
+        rename_to = {x['to'] for x in likely_renames}
+        # Renamed columns are removed from the raw add/remove buckets.
+        added = [a for a in added if a not in rename_to]
+        removed = [r for r in removed if r not in rename_from]
+
+        # ---- deterministic severity --------------------------------------------
+        breaking = bool(removed) or bool(retyped) or bool(key_changes) or \
+            any(f['to'] == 'NOT NULL' for f in nullability_flips)
+        if breaking:
+            severity = 'critical'
+        elif likely_renames:
+            severity = 'high'
+        elif nullability_flips or added:
+            severity = 'medium'
+        else:
+            severity = 'none'
+
+        change_count = (len(added) + len(removed) + len(retyped) +
+                        len(nullability_flips) + len(key_changes) + len(likely_renames))
+
+        result = {
+            'table': _input.get('source_table'),
+            'added': added,
+            'removed': removed,
+            'retyped': retyped,
+            'nullability_flips': nullability_flips,
+            'key_changes': key_changes,
+            'likely_renames': likely_renames,
+            'change_count': change_count,
+            'breaking': breaking,
+            'severity': severity,
+            # Columns whose presence/shape changed - drives the blast-radius loop.
+            'changed_columns': sorted(set(
+                removed + [r['column'] for r in retyped] +
+                [f['column'] for f in nullability_flips] +
+                [k['column'] for k in key_changes] +
+                [x['from'] for x in likely_renames] + [x['to'] for x in likely_renames]
+            )),
+        }
+
+  # 6) CLASSIFY the change into one of three buckets. Cheap model only labels; the
+  #    breaking/non-breaking decision was ALREADY made deterministically in code.
+  - id: classify_change
+    type: classify
+    depends_on: [compute_diff]
+    classify_config:
+      categories: ["breaking", "non_breaking", "risky_rename"]
+      input: "{steps.compute_diff.output}"
+      model: haiku
+      branches:
+        breaking: []
+        non_breaking: []
+        risky_rename: []
+
+  # 7) Pull the registry of downstream dbt models / queries + the source columns each
+  #    one references, so the loop can compute blast radius. (control store REST)
+  - id: fetch_registry
+    type: http
+    depends_on: [classify_change]
+    http_config:
+      url: "{input.dbt_registry_url}?source_table=eq.{input.source_table}&select=*"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.CONTROL_STORE_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 8) LOOP the downstream registry: for each dbt model / query, deterministically check
+  #    whether it references any CHANGED column -> blast radius. Child defined separately.
+  - id: blast_radius
+    type: loop
+    depends_on: [fetch_registry]
+    loop_config:
+      over: "steps.fetch_registry.output"
+      step_ids: [check_consumer]
+      max_iterations: 500
+
+  # 8a) For one downstream consumer (_item), intersect its referenced columns with the
+  #     changed columns. Pure code, NO model. Returns an impact record.
+  - id: check_consumer
+    type: code
+    code_config:
+      language: python
+      code: |
+        consumer = _input.get('_item') or {}
+        diff = _steps.get('compute_diff') or {}
+        changed = set(diff.get('changed_columns') or [])
+
+        refs = consumer.get('referenced_columns') or consumer.get('columns') or []
+        if isinstance(refs, str):
+            refs = [c.strip() for c in refs.split(',') if c.strip()]
+        refs = set(str(c) for c in refs)
+
+        hit = sorted(changed & refs)
+        result = {
+            'model': consumer.get('model_name') or consumer.get('name') or 'unknown',
+            'owner': consumer.get('owner') or consumer.get('team') or 'unassigned',
+            'layer': consumer.get('layer') or 'unknown',
+            'impacted_columns': hit,
+            'impacted': bool(hit),
+            'severity': diff.get('severity', 'none') if hit else 'none',
+        }
+
+  # 9) AGGREGATE blast radius across all consumers + fold in the diff. Deterministic.
+  #    Produces the page-vs-log severity inputs (impacted count, breaking flag, owners).
+  - id: aggregate_impact
+    type: code
+    depends_on: [blast_radius]
+    code_config:
+      language: python
+      code: |
+        rows = _steps.get('blast_radius') or []
+        if isinstance(rows, dict):
+            rows = rows.get('results') or rows.get('items') or list(rows.values())
+        if not isinstance(rows, list):
+            rows = [rows]
+        rows = [r for r in rows if isinstance(r, dict)]
+
+        diff = _steps.get('compute_diff') or {}
+        impacted = [r for r in rows if r.get('impacted')]
+        owners = sorted({r.get('owner') for r in impacted if r.get('owner')})
+        models = sorted({r.get('model') for r in impacted if r.get('model')})
+
+        breaking = bool(diff.get('breaking'))
+        impacted_count = len(impacted)
+
+        # Deterministic page-vs-log decision input.
+        if breaking and impacted_count > 0:
+            severity = 'critical'
+            action = 'page'
+        elif breaking:
+            severity = 'high'
+            action = 'page'
+        elif impacted_count > 0:
+            severity = 'medium'
+            action = 'log'
+        else:
+            severity = 'low'
+            action = 'log'
+
+        result = {
+            'table': diff.get('table'),
+            'severity': severity,
+            'recommended_action': action,
+            'breaking': breaking,
+            'change_count': diff.get('change_count', 0),
+            'impacted_count': impacted_count,
+            'consumers_scanned': len(rows),
+            'impacted_models': models,
+            'impacted_owners': owners,
+            'diff': diff,
+            # fail_count drives the page-vs-log condition downstream.
+            'fail_count': 1 if action == 'page' else 0,
+        }
+
+  # 10) RACE - Anthropic (Sonnet) vs Google (Gemini 2.5 Pro) each DRAFT a migration /
+  #     remediation plan from the SAME deterministic diff. First valid plan wins
+  #     (failover, NOT a vote). Branches A/B defined separately with NO depends_on.
+  #     A missing/wrong provider does not block detection, blast-radius or paging.
+  - id: plan_sonnet
+    type: standard
+    model: sonnet
+    prompt: |
+      You are a senior data engineer. A schema drift was detected and diffed
+      100% deterministically in code - take the diff and blast radius as GROUND
+      TRUTH, do not re-judge whether it is breaking. Write the migration /
+      remediation plan.
+
+      Deterministic diff + blast radius:
+      {steps.aggregate_impact.output}
+
+      Produce a concrete remediation plan (<= 300 words):
+      - Backfill / view-shim / contract-pin steps to unbreak each impacted dbt model.
+      - For risky renames, the safe two-phase (add-new -> dual-write -> drop-old) path.
+      - Exact owner asks (who must change what) for: {steps.aggregate_impact.output.impacted_owners}
+      - A rollback note. Plain prose, ready to paste into a ticket. No preamble.
+
+  - id: plan_gemini
+    type: standard
+    model: google/gemini-2.5-pro
+    prompt: |
+      You are the failover author (Gemini 2.5 Pro) for a schema-drift remediation
+      plan. The diff and blast radius below were computed deterministically - treat
+      them as ground truth and write the migration plan.
+
+      Deterministic diff + blast radius:
+      {steps.aggregate_impact.output}
+
+      Write a concrete remediation plan (<= 300 words) covering backfill / view-shim /
+      contract-pin steps per impacted dbt model, the two-phase path for risky renames,
+      exact per-owner asks, and a rollback note. Plain prose, paste-ready. No preamble.
+
+  - id: remediation_race
+    type: race
+    depends_on: [aggregate_impact]
+    race_config:
+      branches:
+        - [plan_sonnet]
+        - [plan_gemini]
+      # First branch that produces a non-trivial plan wins (first-valid failover).
+      validator: "len(str(output).strip()) > 80"
+
+  # 11) GATE on severity - decides page-vs-log. An llm_eval judge confirms the
+  #     deterministic page recommendation is internally consistent before we proceed
+  #     to ticketing + routing. ALL strategies must pass.
+  - id: severity_gate
+    type: gate
+    depends_on: [remediation_race]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: |
+              A schema-drift severity and page-vs-log action were computed
+              deterministically. Reply with exactly one word: "approved" if
+              recommended_action is one of page/log and is consistent with the
+              breaking flag and impacted_count (page requires breaking==true OR
+              impacted_count>0), otherwise "rejected".
+              Decision record: {steps.aggregate_impact.output}
+            input: "{steps.aggregate_impact.output}"
+            model: sonnet
+
+  # 12) OPEN A TICKET (Jira / Linear) carrying the deterministic diff, blast radius
+  #     and the race-authored remediation plan.
+  - id: open_ticket
+    type: http
+    depends_on: [severity_gate]
+    http_config:
+      url: "{input.ticketing_base_url}/issues"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.TICKETING_API_TOKEN}"
+      body: |
+        {
+          "project": "DATA",
+          "title": "Schema drift on {{ _steps['aggregate_impact']['table'] }} - {{ _steps['aggregate_impact']['severity'] }} ({{ _steps['aggregate_impact']['impacted_count'] }} downstream impacted)",
+          "severity": "{{ _steps['aggregate_impact']['severity'] }}",
+          "diff": {{ _steps['aggregate_impact']['diff'] }},
+          "impacted_models": {{ _steps['aggregate_impact']['impacted_models'] }},
+          "impacted_owners": {{ _steps['aggregate_impact']['impacted_owners'] }},
+          "remediation_plan": "{{ _steps['remediation_race'] }}"
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 13) WRITE THE NEW BASELINE SNAPSHOT to the control store (Postgres / S3) so the next
+  #     watch run diffs against the now-current schema. Carries the live column set.
+  - id: write_baseline
+    type: http
+    depends_on: [open_ticket]
+    http_config:
+      url: "{input.control_store_url}"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+        Prefer: "resolution=merge-duplicates"
+      auth: "bearer:{env.CONTROL_STORE_TOKEN}"
+      body: |
+        {
+          "table": "{input.source_table}",
+          "state": "known_good",
+          "columns": {{ _steps['fetch_live_db'] }},
+          "diff_applied": {{ _steps['aggregate_impact']['diff'] }},
+          "captured_by": "schema-drift-early-warning"
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 14) CONDITION - page-vs-log. Breaking / impacted -> page (PagerDuty + Slack);
+  #     otherwise just a low-noise digest. fail_count was set deterministically.
+  - id: route_page
+    type: condition
+    depends_on: [write_baseline]
+    condition_config:
+      expression: "{steps.aggregate_impact.output.fail_count} > 0"
+      then: [page_pagerduty, notify_page]
+      else: [notify_log]
+
+  # 14a) PAGE - open a PagerDuty incident for the on-call ingestion owner.
+  - id: page_pagerduty
+    type: http
+    http_config:
+      url: "https://events.pagerduty.com/v2/enqueue"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      body: |
+        {
+          "routing_key": "{env.PAGERDUTY_ROUTING_KEY}",
+          "event_action": "trigger",
+          "dedup_key": "schema-drift-{input.source_table}",
+          "payload": {
+            "summary": "Breaking schema drift on {{ _steps['aggregate_impact']['table'] }} - {{ _steps['aggregate_impact']['impacted_count'] }} downstream dbt models impacted",
+            "severity": "critical",
+            "source": "schema-drift-early-warning",
+            "custom_details": {{ _steps['aggregate_impact'] }}
+          }
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 14b) PAGE (Slack) - loud breaking-change page to the data-ingestion channel.
+  - id: notify_page
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :rotating_light: SCHEMA DRIFT - breaking change on {steps.aggregate_impact.output.table}
+        Severity     : {steps.aggregate_impact.output.severity}
+        Changes      : {steps.aggregate_impact.output.change_count}
+        Impacted     : {steps.aggregate_impact.output.impacted_count} dbt model(s) -> {steps.aggregate_impact.output.impacted_models}
+        Owners       : {steps.aggregate_impact.output.impacted_owners}
+        PagerDuty paged. Ticket filed. Remediation plan:
+        {steps.remediation_race.output}
+
+  # 14c) LOG (non-breaking path) - quiet digest, no page.
+  - id: notify_log
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :information_source: Schema drift on {steps.aggregate_impact.output.table} (non-breaking).
+        Severity {steps.aggregate_impact.output.severity}, {steps.aggregate_impact.output.change_count} change(s),
+        {steps.aggregate_impact.output.impacted_count} downstream impacted. Baseline updated, ticket filed. No page.
+on_complete:
+  storage_path: "schema-drift-early-warning/{run_id}/result.json"

--- a/tests/test_model_neutral_templates_wave3_v033.py
+++ b/tests/test_model_neutral_templates_wave3_v033.py
@@ -250,12 +250,15 @@ def test_code_steps_pass_engine_sandbox_blocklist(template_name: str) -> None:
 
 def test_wave_introduces_breadth() -> None:
     """The wave as a whole should span many domains and exercise diverse patterns."""
+    # Resolve the catalog once - calling list_templates() per template parses the whole
+    # 170+ template catalog each time and times out the test.
+    by_file = {t.file_name: t for t in list_templates()}
     categories: set[str] = set()
     types_seen: set[str] = set()
     for name in WAVE3_TEMPLATES:
         wf = parse_yaml_string(_load(name))
         types_seen |= {s.type for s in wf.steps}
-        info = next((t for t in list_templates() if t.file_name == f"{name}.yaml"), None)
+        info = by_file.get(f"{name}.yaml")
         if info and info.category:
             categories.add(info.category)
     assert len(categories) >= 5, f"wave 3 should span >= 5 categories, got {sorted(categories)}"

--- a/tests/test_model_neutral_templates_wave4_v033.py
+++ b/tests/test_model_neutral_templates_wave4_v033.py
@@ -1,0 +1,237 @@
+"""Structural + thesis + code-safety validation for the v0.33 model-independent
+templates, wave 4 (the final, lower-ranked ideas from the ideation sweep).
+
+Adds a sixth model-independence pattern over wave 3: deterministic-dominant, where a
+deterministic ``code`` step computes the decision and a ``condition`` routes the action
+on that computed value (e.g. revenue_leakage_detector gates ticket filing on a
+code-computed recoverable total). The code-sandbox regression guard now spans every
+model-neutral template across all four waves.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from sandcastle.engine.dag import (
+    VALID_STEP_TYPES,
+    build_plan,
+    parse_yaml_string,
+    validate,
+)
+from sandcastle.engine.executor import _CODE_STEP_BLOCKED_PATTERNS
+from sandcastle.engine.tools.registry import KNOWN_TOOLS
+from sandcastle.templates import list_templates
+
+WAVE4_TEMPLATES = [
+    "residency_routed_inference",
+    "eu_ai_act_risk_register",
+    "policy_change_propagation",
+    "incident_rca_pr_closer",
+    "schema_drift_early_warning",
+    "fastest_of_n_failover_responder",
+    "revenue_leakage_detector",
+    "pr_review_polyglot_router",
+]
+
+WAVE1 = [
+    "closed_loop_autoremediator", "quote_to_cash_orchestrator",
+    "refund_credit_approval_workflow", "access_review_campaign_orchestrator",
+    "cost_tiered_escalation_router",
+]
+WAVE2 = [
+    "three_way_match_pay_run", "provider_consensus_decision_engine",
+    "warehouse_data_quality_sentinel", "vuln_triage_reachability_gate",
+    "sla_sensor_escalation_ladder", "map_reduce_over_list",
+]
+WAVE3 = [
+    "ticket_resolution_autopilot", "soc2_evidence_collector_continuous",
+    "inbound_lead_sla_router", "deal_desk_discount_approval_gate",
+    "nda_autopilot_intake_to_countersign", "lead_dedup_merge_warden",
+    "bank_reconciliation_closer", "dependency_upgrade_pilot", "flaky_test_hunter",
+    "churn_save_play_orchestrator", "vendor_security_questionnaire_autoresponder",
+    "dsar_fulfillment_deadline_engine", "dependency_outage_failover_router",
+    "canary_promotion_sentinel", "warehouse_to_narrative_briefing",
+    "records_retention_disposition_orchestrator", "csat_coaching_loop",
+    "proactive_outage_comms_commander", "dunning_escalation_orchestrator",
+    "cloud_cost_guardrail_enforcer", "error_budget_freeze_controller",
+    "reverse_etl_validation_gate", "cross_store_reconciliation_auditor",
+    "model_promotion_gate",
+]
+ALL_MODEL_NEUTRAL_TEMPLATES = [*WAVE1, *WAVE2, *WAVE3, *WAVE4_TEMPLATES]
+
+ENGINE_STEP_TYPES = {
+    "http", "code", "race", "gate", "sensor", "loop", "classify",
+    "condition", "parse", "sub_workflow", "transform",
+}
+
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "src" / "sandcastle" / "templates"
+
+
+def _load(name: str) -> str:
+    path = TEMPLATES_DIR / f"{name}.yaml"
+    assert path.exists(), f"Template file not found: {path}"
+    return path.read_text()
+
+
+def _provider(model: str | None) -> str | None:
+    return model.split("/")[0] if model else None
+
+
+@pytest.mark.parametrize("template_name", WAVE4_TEMPLATES)
+def test_parses_with_steps(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    assert wf is not None and wf.name and len(wf.steps) > 0
+
+
+@pytest.mark.parametrize("template_name", WAVE4_TEMPLATES)
+def test_step_types_valid(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    for step in wf.steps:
+        assert step.type in VALID_STEP_TYPES, (
+            f"{template_name}/{step.id} invalid type {step.type!r}"
+        )
+
+
+@pytest.mark.parametrize("template_name", WAVE4_TEMPLATES)
+def test_depends_on_resolve(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    ids = {s.id for s in wf.steps}
+    for step in wf.steps:
+        for dep in step.depends_on:
+            assert dep in ids, f"{template_name}/{step.id} depends on unknown {dep!r}"
+
+
+@pytest.mark.parametrize("template_name", WAVE4_TEMPLATES)
+def test_validates_clean(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    assert validate(wf) == [], f"{template_name} did not validate"
+
+
+@pytest.mark.parametrize("template_name", WAVE4_TEMPLATES)
+def test_build_plan_covers_every_step_once(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    plan = build_plan(wf)
+    planned = [sid for stage in plan.stages for sid in stage]
+    assert len(planned) == len(set(planned)) and set(planned) == {s.id for s in wf.steps}
+
+
+@pytest.mark.parametrize("template_name", WAVE4_TEMPLATES)
+def test_tool_references_known(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    for step in wf.steps:
+        if step.tool_config and step.tool_config.tool:
+            assert step.tool_config.tool.split(":")[0] in KNOWN_TOOLS
+
+
+@pytest.mark.parametrize("template_name", WAVE4_TEMPLATES)
+def test_control_flow_branches_reference_real_steps(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    ids = {s.id for s in wf.steps}
+    for step in wf.steps:
+        if step.condition_config:
+            for sid in step.condition_config.then_steps + step.condition_config.else_steps:
+                assert sid in ids, f"{template_name}/{step.id} condition -> unknown {sid!r}"
+        if step.classify_config:
+            for branch in step.classify_config.branches.values():
+                for sid in branch:
+                    assert sid in ids, f"{template_name}/{step.id} classify -> unknown {sid!r}"
+        if step.loop_config:
+            for sid in step.loop_config.step_ids:
+                assert sid in ids, f"{template_name}/{step.id} loop -> unknown {sid!r}"
+        if step.race_config:
+            for branch in step.race_config.branches:
+                for sid in branch:
+                    assert sid in ids, f"{template_name}/{step.id} race -> unknown {sid!r}"
+
+
+@pytest.mark.parametrize("template_name", WAVE4_TEMPLATES)
+def test_exercises_engine_step_types(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    overlap = {s.type for s in wf.steps} & ENGINE_STEP_TYPES
+    assert len(overlap) >= 4, f"{template_name} exercises only {sorted(overlap)}"
+
+
+@pytest.mark.parametrize("template_name", WAVE4_TEMPLATES)
+def test_demonstrates_model_independence(template_name: str) -> None:
+    """Six accepted patterns: cross-provider race, multi-provider consensus, two-judge
+    gate, deterministic code guarded by a human, minimal-model, or deterministic-dominant
+    (a code step computes the decision and a condition routes the action on it)."""
+    wf = parse_yaml_string(_load(template_name))
+    by_id = {s.id: s for s in wf.steps}
+
+    cross_provider_race = any(
+        s.type == "race" and s.race_config and s.race_config.validator
+        and len({
+            _provider(by_id[sid].model)
+            for branch in s.race_config.branches for sid in branch
+            if sid in by_id and by_id[sid].model
+        } - {None}) >= 2
+        for s in wf.steps
+    )
+    vote_provs = {
+        _provider(s.model) for s in wf.steps
+        if s.type in ("standard", "llm") and getattr(s, "model", None)
+    } - {None}
+    consensus = len(vote_provs) >= 2
+    two_judge_gate = any(
+        s.type == "gate" and s.gate_config
+        and len({
+            _provider(st.get("config", {}).get("model"))
+            for st in s.gate_config.strategies if st.get("type") == "llm_eval"
+        } - {None}) >= 2
+        for s in wf.steps
+    )
+    has_code = any(s.type == "code" for s in wf.steps)
+    has_human = any(s.type == "approval" for s in wf.steps) or any(
+        s.type == "gate" and s.gate_config
+        and any(st.get("type") == "human" for st in s.gate_config.strategies)
+        for s in wf.steps
+    )
+    deterministic_guarded = has_code and has_human
+    minimal_model = (
+        not any(s.type in ("standard", "llm") for s in wf.steps)
+        and has_code and any(s.type == "http" for s in wf.steps)
+    )
+    # deterministic-dominant: a code step computes the decision and a condition routes
+    # the action on that computed value, so the model is never load-bearing.
+    code_ids = {s.id for s in wf.steps if s.type == "code"}
+    deterministic_dominant = bool(code_ids) and any(
+        s.condition_config and any(cid in s.condition_config.expression for cid in code_ids)
+        for s in wf.steps
+    )
+
+    assert (
+        cross_provider_race or consensus or two_judge_gate
+        or deterministic_guarded or minimal_model or deterministic_dominant
+    ), (
+        f"{template_name} shows no model-independence pattern "
+        f"(race={cross_provider_race}, consensus={consensus}, two_judge={two_judge_gate}, "
+        f"det_guarded={deterministic_guarded}, minimal={minimal_model}, "
+        f"det_dominant={deterministic_dominant})"
+    )
+
+
+@pytest.mark.parametrize("template_name", ALL_MODEL_NEUTRAL_TEMPLATES)
+def test_code_steps_pass_engine_sandbox_blocklist(template_name: str) -> None:
+    """Regression guard across all four waves: no code step may contain a pattern the
+    engine sandbox rejects at runtime (re.compile(, subprocess, eval(, open(, ...)."""
+    wf = parse_yaml_string(_load(template_name))
+    for step in wf.steps:
+        if step.type == "code" and step.code_config and step.code_config.code:
+            code = step.code_config.code
+            match = _CODE_STEP_BLOCKED_PATTERNS.search(code)
+            assert match is None, (
+                f"{template_name}/{step.id} contains sandbox-blocked pattern "
+                f"{match.group(0)!r} (would fail at runtime)"
+            )
+            ast.parse(code)
+
+
+@pytest.mark.parametrize("template_name", WAVE4_TEMPLATES)
+def test_templates_are_discovered(template_name: str) -> None:
+    by_file = {t.file_name: t for t in list_templates()}
+    info = by_file.get(f"{template_name}.yaml")
+    assert info is not None and info.source == "built-in" and info.step_count > 0


### PR DESCRIPTION
## What

Completes the model-independent template program (follows #238/#239/#240) - the remaining lower-ranked but still-strong ideas from the ideation sweep, across general_ai, hr_legal, devops, data, and engineering.

| Template | Category | Core |
|---|---|---|
| **residency_routed_inference** | general_ai | classify data sensitivity -> compute a legally-permitted provider allowlist in `code` -> race-failover ONLY within the allowed region set -> gate any cross-border answer (EU PII stays EU/on-prem) |
| **eu_ai_act_risk_register** | hr_legal | discover AI systems -> classify Annex III tiers -> dual-provider consensus gate + DPO sign-off -> signed Article-9 register PDF |
| **policy_change_propagation** | hr_legal | code-diff a clause change -> fan amendments to every affected contract -> DocuSign + completion `sensor` -> two-judge faithfulness gate |
| **incident_rca_pr_closer** | devops | correlate telemetry to a suspect commit in `code` -> race a fix patch -> gate + approve -> open PR -> CI `sensor` -> auto-merge |
| **schema_drift_early_warning** | data | `sensor`-watch source schemas -> deterministic structural diff -> classify blast radius -> cross-provider remediation narrative |
| **fastest_of_n_failover_responder** | general_ai | the failover layer itself: race N providers, return the first valid response, redis circuit-breaker on health |
| **revenue_leakage_detector** | general_ai | reconcile Stripe/QuickBooks/Snowflake in deterministic `code` -> quantify recoverable dollars -> file a recovery ticket |
| **pr_review_polyglot_router** | engineering | classify changed files by language -> route each to a fit model -> regex/`code` secrets+SAST gate -> inline review |

## New in this wave

- A **sixth model-independence pattern**, *deterministic-dominant*: a `code` step computes the decision and a `condition` routes the action on that computed value, so the model is never load-bearing (e.g. revenue_leakage_detector gates ticket filing on a code-computed recoverable total).
- The **code-sandbox regression guard** now spans **all 43** model-neutral templates. Two code steps that used `re.compile(` (sandbox-blocked, would fail at runtime) were fixed to inline `re.search`.

## Tests

`test_model_neutral_templates_wave4_v033.py`: structural checks, the 6-pattern model-independence thesis check, and the 43-template code-safety + ast-parse guard.

```
test_model_neutral_templates_wave4_v033.py  123 passed
```

Each template independently re-verified (parse, `validate()==[]`, build-plan coverage, no sandbox-blocked code, model-independence signal). Catalog 165 -> 173.