### PR TITLE
feat(templates): 6 provider-neutral browser/computer-use RPA workflows

### DIFF
--- a/src/sandcastle/templates/act_then_sensor_verify_submission_skeleton.yaml
+++ b/src/sandcastle/templates/act_then_sensor_verify_submission_skeleton.yaml
@@ -1,0 +1,445 @@
+# name: Act Then Sensor Verify Submission Skeleton
+# description: The act-then-verify RPA skeleton for submitting into a third-party web portal that has no write API - drive the UI to FILL a form (stopping before submit), deterministically validate the filled preview, gate the irreversible submit behind a human approval, click submit only after sign-off, then poll the portal's own status page with a sensor until the action provably took effect (status accepted / reference number rendered) before declaring success. The fill and verify-poll steps are provider-neutral playwright/dom mode where the model authors the script; the irreversible click is gated by a human, not by trust in any one model, so reasoning providers swap freely without weakening safety. The load-bearing correctness is deterministic code + an engine-native sensor, never a single model's opinion; a silently-failed submit can never be mistaken for a win.
+# tags: [RPA, BrowserAutomation, Playwright, FormSubmission, HumanApproval, Sensor, ActThenVerify, PortalSubmission, NoAPI, ProviderNeutral]
+# category: general_ai
+
+name: act-then-sensor-verify-submission-skeleton
+description: >-
+  A provider-neutral act-then-verify skeleton for operations teams who must SUBMIT something
+  into a third-party web portal that exposes no write API - filing a regulatory return, posting
+  an invoice to a customer's AP portal, updating a marketplace back-office listing, or scheduling
+  a carrier pickup - and need proof the submission was ACCEPTED, not merely clicked. Triggered by
+  an upstream workflow that hands in the approved payload (an invoice, a filing draft) or by a
+  deadline-driven scheduled run. Step 1 drives the portal in playwright mode: it logs in via
+  credentials_env, navigates to the submission form, and FILLS every field from the input payload
+  - but STOPS before clicking submit, returning a structured preview via output_schema
+  (field_values, computed_total, target_entity_id, confirmation_required). Step 2 is deterministic
+  sandboxed Python that VALIDATES the preview with no model: totals reconcile to the expected
+  amount, required fields are non-empty, and the target entity id matches what was expected -
+  rejecting on any mismatch so nothing is submitted on a bad read. Step 3 is a mandatory human
+  approval that shows the validated preview plus the fill-time screenshot and BLOCKS until a person
+  authorizes the irreversible submit. Only on approval does step 4 (a second playwright browser step
+  under captcha_strategy=pause, capture_screenshots on for audit) click submit. Step 5 is an
+  engine-native sensor that re-drives a cheap dom-mode read of the portal's status page on each poll
+  until status == accepted or a reference number appears, with a hard timeout. Step 6 deterministically
+  decides the outcome, and a condition either pages on-call and leaves the run in a needs-attention
+  state (never a false success) on sensor timeout, or emits the portal reference number on confirmed
+  acceptance. Splitting fill (read) from submit (write) means the approval gate sees the exact state
+  the human authorizes; the sensor refuses to report success until the portal itself confirms, so a
+  silently-failed submit cannot be mistaken for a win. Both browser steps ride default_model and stay
+  swappable across providers; the approval and sensor safety are model-independent and engine-native.
+
+default_model: sonnet
+default_max_turns: 8
+default_timeout: 1200
+
+input_schema:
+  required: ["portal_form_url", "portal_status_url", "submission_payload"]
+  properties:
+    portal_form_url:
+      type: string
+      description: "URL of the portal's submission form to drive and fill (logged-in SPA, no write API). Templated into the fill browser step's start_url."
+      example: "https://ap-portal.customer.example/invoices/new"
+    portal_status_url:
+      type: string
+      description: "URL of the portal's own status page for THIS submission; the verify sensor and the post-submit read re-drive a cheap dom read of it to confirm acceptance."
+      example: "https://ap-portal.customer.example/invoices/INV-2026-00412/status"
+    submission_payload:
+      type: string
+      description: "The approved payload to submit, handed in by the upstream workflow (e.g. an approved invoice or filing draft) as a JSON string - drives the form fill."
+      example: '{"target_entity_id":"AP-CUST-77","line_items":[{"desc":"Consulting","amount":4200.00},{"desc":"Travel","amount":318.50}],"currency":"USD"}'
+    expected_total:
+      type: number
+      description: "The total the upstream system expects the portal to compute from the payload; the validate step reconciles the portal's computed_total against this and rejects on mismatch."
+      default: 0
+      example: "4518.50"
+    expected_entity_id:
+      type: string
+      description: "The target entity id the submission MUST land against (customer/account/filing id). The validate step rejects if the portal-rendered target_entity_id differs - prevents submitting to the wrong account."
+      default: ""
+      example: "AP-CUST-77"
+    total_tolerance:
+      type: number
+      description: "Absolute currency tolerance allowed when reconciling computed_total vs expected_total (covers rounding/fees)."
+      default: 0.01
+      example: "0.01"
+    portal_credentials_env:
+      type: string
+      description: "Name of the environment variable holding the portal login credentials (NEVER inline secrets). Passed to the browser step's credentials_env."
+      default: "PORTAL_CREDS"
+      example: "PORTAL_CREDS"
+    approval_timeout_hours:
+      type: integer
+      description: "Hours the human submit-approval waits before its timeout fires (on_timeout: abort - never auto-submit)."
+      default: 24
+      example: "24"
+    sensor_poll_interval_seconds:
+      type: integer
+      description: "Seconds between status-page polls while waiting for the portal to confirm acceptance."
+      default: 60
+      example: "60"
+    sensor_timeout_seconds:
+      type: integer
+      description: "Hard ceiling in seconds the verify sensor waits for portal confirmation before it gives up and the run is routed to needs-attention (never reported as success)."
+      default: 3600
+      example: "3600"
+    oncall_channel:
+      type: string
+      description: "Slack channel paged when the sensor times out without confirmation, or when submit could not be confirmed - the run is left in a needs-attention state."
+      default: "#submission-oncall"
+      example: "#submission-oncall"
+    submission_label:
+      type: string
+      description: "Human-readable label for this submission used in the approval message and notifications (e.g. invoice number or filing name)."
+      default: "portal submission"
+      example: "Invoice INV-2026-00412 to AP-CUST-77"
+
+steps:
+  # 1) FILL (READ pass) - drive the portal in provider-neutral PLAYWRIGHT mode: log in via
+  #    credentials_env (no inline secrets), navigate to the form, fill EVERY field from the
+  #    payload, and STOP before clicking submit. Returns a structured preview via output_schema
+  #    so downstream validation is on JSON, not screen-scraping. max_actions caps the form fill;
+  #    captcha_strategy=pause hands off to a human if a CAPTCHA appears. No write happens here.
+  - id: fill_form_preview
+    type: browser
+    prompt: >-
+      Log into the submission portal using the credentials provided via the environment, then
+      navigate to the submission form at the start URL. Fill EVERY required field of the form
+      from this approved payload (a JSON string): {input.submission_payload}. Set each line item,
+      the target entity / account id, and the currency exactly as given. Let the portal compute
+      its own total. CRITICAL: do NOT click Submit, Send, File, Pay, or any final/confirm button
+      - stop at the filled-but-unsubmitted state. Read back the values the form now shows and the
+      portal's computed total. Return ONLY the structured object described by the output schema:
+      the field_values you entered, the portal's computed_total, the target_entity_id the form is
+      bound to, and confirmation_required=true. If a CAPTCHA or unexpected login wall appears,
+      pause for a human rather than guessing.
+    browser_config:
+      mode: playwright
+      start_url: "{input.portal_form_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 50
+      headless: true
+      credentials_env: "{input.portal_credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          field_values:
+            type: object
+            description: "Map of form field name to the value entered (the exact filled state)."
+          computed_total:
+            type: number
+            description: "The total the portal itself computed from the entered line items."
+          target_entity_id:
+            type: string
+            description: "The customer/account/filing entity id the form is currently bound to."
+          required_fields_filled:
+            type: array
+            items:
+              type: string
+            description: "Names of required fields that were successfully filled (non-empty)."
+          missing_fields:
+            type: array
+            items:
+              type: string
+            description: "Names of required fields the form still reports as empty/invalid."
+          confirmation_required:
+            type: boolean
+            description: "True when the form is filled and awaiting a final submit click (never auto-clicked here)."
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: abort
+
+  # 2) VALIDATE the preview DETERMINISTICALLY (no model) - this is the load-bearing correctness
+  #    check that gates the human approval. Totals must reconcile to expected_total within
+  #    tolerance, all required fields non-empty, and the portal-bound entity id must match the
+  #    expected target. ANY mismatch/empty read => ok=False and a human-readable reason; nothing
+  #    is ever submitted on a bad read.
+  - id: validate_preview
+    type: code
+    depends_on: [fill_form_preview]
+    code_config:
+      language: python
+      code: |
+        # Deterministic gate over the browser READ pass. No model decides correctness here.
+        preview = _steps.get("fill_form_preview") or {}
+        if not isinstance(preview, dict):
+            preview = {"raw": preview}
+        # The browser step may nest its structured payload under "output" or "data".
+        for key in ("output", "data", "result"):
+            inner = preview.get(key)
+            if isinstance(inner, dict) and ("computed_total" in inner or "field_values" in inner):
+                preview = inner
+                break
+
+        reasons = []
+
+        def _num(v, default=0.0):
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return default
+
+        # --- Totals reconcile to what the upstream system expects (within tolerance) ---
+        computed_total = _num(preview.get("computed_total"), 0.0)
+        expected_total = _num(_input.get("expected_total"), 0.0)
+        tolerance = abs(_num(_input.get("total_tolerance"), 0.01))
+        total_ok = abs(computed_total - expected_total) <= tolerance
+        if expected_total <= 0:
+            total_ok = False
+            reasons.append("expected_total not provided (cannot reconcile portal computed_total)")
+        elif not total_ok:
+            reasons.append(
+                "total mismatch: portal computed " + str(round(computed_total, 2))
+                + " vs expected " + str(round(expected_total, 2))
+            )
+
+        # --- Required fields non-empty ---
+        field_values = preview.get("field_values")
+        if not isinstance(field_values, dict):
+            field_values = {}
+        missing = preview.get("missing_fields")
+        if not isinstance(missing, list):
+            missing = []
+        empty_fields = [k for k, v in field_values.items() if v in (None, "", [], {})]
+        fields_ok = (len(missing) == 0) and (len(empty_fields) == 0) and (len(field_values) > 0)
+        if len(field_values) == 0:
+            reasons.append("no field_values returned by the fill step (empty read)")
+        if missing:
+            reasons.append("portal reports missing/invalid required fields: " + ", ".join(str(m) for m in missing))
+        if empty_fields:
+            reasons.append("filled fields came back empty: " + ", ".join(str(m) for m in empty_fields))
+
+        # --- Target entity id matches the expected account/filing ---
+        got_entity = str(preview.get("target_entity_id", "") or "").strip()
+        want_entity = str(_input.get("expected_entity_id", "") or "").strip()
+        if want_entity:
+            entity_ok = (got_entity == want_entity)
+            if not entity_ok:
+                reasons.append("target entity mismatch: form bound to '" + got_entity + "' but expected '" + want_entity + "'")
+        else:
+            # No expected entity pinned: require the form to at least report a non-empty target.
+            entity_ok = bool(got_entity)
+            if not entity_ok:
+                reasons.append("form reported no target_entity_id and none was pinned")
+
+        # --- Confirmation must still be pending (the fill step must NOT have submitted) ---
+        confirmation_required = bool(preview.get("confirmation_required", False))
+        if not confirmation_required:
+            reasons.append("fill step did not return confirmation_required=true (state unsafe to approve)")
+
+        ok = bool(total_ok and fields_ok and entity_ok and confirmation_required)
+
+        result = {
+            "ok": ok,
+            "total_ok": total_ok,
+            "fields_ok": fields_ok,
+            "entity_ok": entity_ok,
+            "computed_total": round(computed_total, 2),
+            "expected_total": round(expected_total, 2),
+            "target_entity_id": got_entity,
+            "field_count": len(field_values),
+            "reasons": reasons,
+            "reason_summary": "; ".join(reasons) if reasons else "all checks passed",
+        }
+
+  # 3) Deterministic CONDITION - only route to the human approval when the preview is clean.
+  #    On a bad read, skip approval entirely and page on-call (no submit can possibly happen).
+  - id: preview_gate
+    type: condition
+    depends_on: [validate_preview]
+    condition_config:
+      expression: "{steps.validate_preview.output.ok} == True"
+      then: [approve_submit]
+      else: [notify_bad_preview]
+
+  # 3a) BAD-READ PATH - the validated preview failed; tell on-call exactly why and STOP.
+  #     The run is left needing attention; nothing was ever submitted.
+  - id: notify_bad_preview
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.oncall_channel}"
+      message: >-
+        BLOCKED before submit: {input.submission_label}. The deterministically-validated form
+        preview FAILED, so the human approval was not even offered and nothing was submitted.
+        Reason(s): {steps.validate_preview.output.reason_summary}. Portal computed
+        {steps.validate_preview.output.computed_total} vs expected
+        {steps.validate_preview.output.expected_total}; target entity
+        {steps.validate_preview.output.target_entity_id}. Fix the payload or portal state and re-run.
+
+  # 4) MANDATORY HUMAN APPROVAL before the irreversible submit. Shows the deterministically
+  #    validated preview AND the fill-time screenshot, and BLOCKS until a person authorizes.
+  #    Nothing is submitted on the model's word alone; on_timeout: abort means a missed approval
+  #    NEVER auto-submits.
+  - id: approve_submit
+    type: approval
+    approval_config:
+      message: >-
+        AUTHORIZE IRREVERSIBLE SUBMIT for {input.submission_label}. The form is filled and is
+        awaiting a final submit click. Validated preview: total
+        {steps.validate_preview.output.computed_total} (expected
+        {steps.validate_preview.output.expected_total}), target entity
+        {steps.validate_preview.output.target_entity_id}, {steps.validate_preview.output.field_count}
+        fields filled, checks: {steps.validate_preview.output.reason_summary}. Review the attached
+        fill-time screenshot - this is the EXACT state you are authorizing. Approve to click submit;
+        reject to abort with nothing submitted.
+      show_data: steps.validate_preview.output
+      show_images: ["steps.fill_form_preview.output.screenshot"]
+      timeout_hours: 24
+      on_timeout: abort
+      allow_edit: false
+
+  # 5) SUBMIT (WRITE pass) - only reached AFTER human approval. A second PLAYWRIGHT browser step
+  #    re-opens the filled form and clicks the single final submit button. captcha_strategy=pause
+  #    in case a CAPTCHA appears at the final wall; capture_screenshots on for an audit trail of
+  #    the write; max_actions tightly capped (one confirm click, no runaway). Returns whatever
+  #    immediate acknowledgement the portal renders - but acceptance is NOT trusted from here; the
+  #    sensor below re-reads the portal's own status page to confirm.
+  - id: click_submit
+    type: browser
+    depends_on: [approve_submit]
+    prompt: >-
+      A human has authorized this irreversible submission: {input.submission_label}. Log into the
+      portal using the environment credentials, return to the submission form, confirm the filled
+      values still match the approved preview (target entity
+      {steps.validate_preview.output.target_entity_id}, total
+      {steps.validate_preview.output.computed_total}), then click the SINGLE final submit/file/send
+      button ONCE to submit. Do not re-edit fields and do not click submit more than once. If a
+      CAPTCHA or step-up auth appears at this final wall, PAUSE for a human - do not attempt to
+      solve it. Capture a screenshot of the post-submit screen. Return any immediate reference
+      number or acknowledgement text the portal shows, plus submitted=true if the click was
+      accepted by the UI. Treat this only as an attempt - final acceptance is confirmed separately
+      by re-reading the status page.
+    browser_config:
+      mode: playwright
+      start_url: "{input.portal_form_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 12
+      headless: true
+      credentials_env: "{input.portal_credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          submitted:
+            type: boolean
+            description: "True if the UI accepted the final submit click without an error."
+          acknowledgement_text:
+            type: string
+            description: "Any immediate on-screen acknowledgement the portal rendered after submit."
+          reference_number:
+            type: string
+            description: "A reference/confirmation number if the portal printed one immediately (may be empty until the status page updates)."
+    retry:
+      max_attempts: 1
+      backoff: fixed
+      on_failure: abort
+
+  # 6) VERIFY (engine-native SENSOR) - the act-then-VERIFY core. Poll the portal's OWN status page
+  #    until the action PROVABLY took effect: the status reads accepted/processed OR a reference
+  #    number is present. This re-drives a cheap dom-mode read of the status URL each interval. A
+  #    provider-agnostic boolean over the polled JSON - pure control flow, no model. Hard timeout
+  #    so we never wait forever; a timeout is NOT treated as success.
+  - id: verify_acceptance
+    type: sensor
+    depends_on: [click_submit]
+    sensor_config:
+      url: "{input.portal_status_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and (str(response.get('status', '')).strip().lower() in ('accepted', 'processed', 'confirmed', 'received') or bool(str(response.get('reference_number', '') or response.get('reference', '') or '').strip()))"
+      check_interval: 60
+      timeout: 3600
+
+  # 7) Deterministically decide acceptance from the sensor's last polled status payload. No model.
+  #    A missing confirmation (sensor timed out) yields confirmed=False so a silent failure can
+  #    NEVER be reported as a win.
+  - id: evaluate_acceptance
+    type: code
+    depends_on: [verify_acceptance]
+    code_config:
+      language: python
+      code: |
+        watch = _steps.get("verify_acceptance") or {}
+        if not isinstance(watch, dict):
+            watch = {"raw": watch}
+        # The sensor surfaces the last polled `response` payload.
+        resp = watch.get("response") if isinstance(watch.get("response"), dict) else watch
+        if not isinstance(resp, dict):
+            resp = {}
+
+        status = str(resp.get("status", "") or "").strip().lower()
+        reference = str(resp.get("reference_number", "") or resp.get("reference", "") or "").strip()
+
+        accepted_states = ("accepted", "processed", "confirmed", "received")
+        confirmed = (status in accepted_states) or bool(reference)
+
+        # Whether the sensor itself reported it satisfied its condition vs timed out.
+        sensor_satisfied = bool(watch.get("satisfied", watch.get("met", confirmed)))
+        timed_out = bool(watch.get("timed_out", False)) or (not sensor_satisfied and not confirmed)
+
+        result = {
+            "confirmed": bool(confirmed and not timed_out),
+            "status": status,
+            "reference_number": reference,
+            "timed_out": timed_out,
+            # fail_count > 0 routes the run to the needs-attention path (never false success).
+            "fail_count": 0 if (confirmed and not timed_out) else 1,
+            "submission_label": _input.get("submission_label", "portal submission"),
+        }
+
+  # 8) CONDITION - emit the portal reference on confirmed acceptance, OR page on-call and leave
+  #    the run in a needs-attention state on timeout/no-confirmation. We NEVER report a false win.
+  - id: acceptance_outcome
+    type: condition
+    depends_on: [evaluate_acceptance]
+    condition_config:
+      expression: "{steps.evaluate_acceptance.output.fail_count} > 0"
+      then: [notify_needs_attention]
+      else: [emit_reference]
+
+  # 8a) NEEDS-ATTENTION PATH - the sensor never saw the portal confirm acceptance (timeout or
+  #     non-accepted status). Page on-call; the run stays unresolved. A silently-failed submit is
+  #     surfaced, never mistaken for success.
+  - id: notify_needs_attention
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.oncall_channel}"
+      message: >-
+        NEEDS ATTENTION: {input.submission_label} was SUBMITTED but the portal has NOT confirmed
+        acceptance within the timeout (last status '{steps.evaluate_acceptance.output.status}',
+        reference '{steps.evaluate_acceptance.output.reference_number}',
+        timed_out={steps.evaluate_acceptance.output.timed_out}). Do NOT assume success - manually
+        check the portal status page and resolve. The run is left in a needs-attention state.
+
+  # 8b) SUCCESS PATH - the portal itself confirmed acceptance. Emit the portal reference number
+  #     deterministically as the authoritative proof of a landed submission.
+  - id: emit_reference
+    type: code
+    depends_on: [evaluate_acceptance]
+    code_config:
+      language: python
+      code: |
+        ev = _steps.get("evaluate_acceptance") or {}
+        if not isinstance(ev, dict):
+            ev = {}
+        result = {
+            "submission": _input.get("submission_label", "portal submission"),
+            "accepted": True,
+            "portal_reference_number": str(ev.get("reference_number", "") or ""),
+            "portal_status": str(ev.get("status", "") or ""),
+            "proof": "Portal status page confirmed acceptance; reference is the landed-submission proof.",
+        }
+
+on_complete:
+  storage_path: "act-then-sensor-verify-submission-skeleton/{run_id}/result.json"

--- a/src/sandcastle/templates/browser_flow_trajectory_replay_harness.yaml
+++ b/src/sandcastle/templates/browser_flow_trajectory_replay_harness.yaml
@@ -1,0 +1,326 @@
+# name: Browser Flow Trajectory Replay Harness
+# description: Drop-in regression harness that re-drives a recorded browser RPA flow against a golden trajectory and fails the run on UI drift or cost blowup - the reliability layer that makes fragile RPA testable in CI.
+# tags: [rpa, browser, trajectory-replay, regression, ci, reliability, playwright, drift-detection]
+# category: engineering
+
+name: browser-flow-trajectory-replay-harness
+description: >-
+  A read-only regression harness for fleets of business-critical browser RPA
+  flows. Given a {golden_run_id} and the target flow's inputs, it re-drives the
+  recorded flow against the LIVE site, captures the candidate action/extraction
+  trajectory (Playwright mode, screenshots on every action so the diff is
+  deterministic and vendor-free), then trajectory-replays it against the golden
+  run. The run FAILS when the replay score drops below fail_below_score or cost
+  exceeds the allowed delta / budget. A deterministic code step turns the replay
+  diff into a human-readable drift report (which selector / step diverged), a
+  condition routes regressions to an on-call notification that fails CI, and a
+  sub-workflow archives the certified-or-drifted verdict. This skeleton performs
+  NO outbound writes - it is a pure verification wrapper, so no approval gate is
+  needed. The same harness scores any flow authored by any reasoning model,
+  because it compares observable actions and extracted outputs, never provider
+  internals.
+
+default_model: sonnet
+default_timeout: 900
+
+input_schema:
+  required: ["golden_run_id", "target_flow", "target_start_url"]
+  properties:
+    golden_run_id:
+      type: string
+      description: >-
+        ID of the known-good recorded run to diff against. The trajectory-replay
+        step loads this golden trajectory and scores the candidate run against it.
+      default: "golden-portal-login-2fa-extract-2026-05-01"
+    target_flow:
+      type: string
+      description: >-
+        Name of the existing browser RPA workflow template whose live trajectory
+        we re-drive and certify (e.g. the recorded login+2FA+extract flow).
+      default: "portal_login_2fa_extract_skeleton"
+    target_start_url:
+      type: string
+      description: >-
+        Entry URL of the third-party portal the recorded flow drives. The
+        re-driven smoke run starts here. Provider-neutral - any portal works.
+      default: "https://portal.vendor.example.com/login"
+    flow_inputs_json:
+      type: string
+      description: >-
+        JSON object of inputs the target flow needs (account id, date range,
+        etc.), forwarded verbatim into the re-driven run. NEVER put secrets here -
+        credentials come from credentials_env inside the browser step.
+      default: '{"account_id": "ACME-001", "report": "monthly-statement"}'
+    fail_below_score:
+      type: string
+      description: "Replay similarity floor (0..1). Below this the flow is drifted and CI fails."
+      default: "0.85"
+    allow_cost_delta_pct:
+      type: string
+      description: "Max % cost increase vs the golden run before the replay is rejected."
+      default: "15.0"
+    cost_budget_usd:
+      type: string
+      description: "Hard per-replay cost cap. Exceeding it fails the run regardless of score."
+      default: "0.50"
+    oncall_channel:
+      type: string
+      description: "Slack channel the drift alert is posted to when a regression is detected."
+      default: "#rpa-oncall"
+
+steps:
+  # ---------------------------------------------------------------------------
+  # 1. DELEGATE - re-execute the target browser RPA flow against the LIVE site.
+  #    Hands the recorded flow off to its own existing workflow so the harness
+  #    stays a thin wrapper. Produces the candidate run referenced by replay.
+  # ---------------------------------------------------------------------------
+  - id: re-execute-target-flow
+    type: delegate
+    delegate_config:
+      workflow: "{input.target_flow}"
+      task_description: >-
+        Re-drive the recorded RPA flow against the live portal at
+        {input.target_start_url} using inputs {input.flow_inputs_json}. Run it
+        exactly as recorded so its trajectory can be diffed against golden run
+        {input.golden_run_id}. This is a read-only smoke test - extract only,
+        perform NO submit / pay / send actions.
+      timeout: 600
+
+  # ---------------------------------------------------------------------------
+  # 2. BROWSER - the candidate re-driver. Playwright mode (provider-neutral: the
+  #    model AUTHORS a Playwright script, swappable). capture_screenshots=true
+  #    records every action so the trajectory diff is deterministic and vendor-
+  #    free. output_schema makes this a structured READ pass (extract only).
+  #    Credentials via credentials_env (never inline). captcha_strategy: pause
+  #    hands CAPTCHA to a human. max_actions caps runaway clicking.
+  # ---------------------------------------------------------------------------
+  - id: drive-candidate-trajectory
+    type: browser
+    depends_on: [re-execute-target-flow]
+    prompt: >-
+      Re-drive the recorded portal smoke path step by step and emit a structured
+      trajectory. Open {input.target_start_url}, authenticate using the
+      credentials in the PORTAL_CREDS environment variable, complete any 2FA
+      challenge, navigate to the same report the golden run reached, and extract
+      the same fields. Record each action (selector + action type) and each
+      extracted value. Do NOT submit forms, pay, send, or mutate anything - this
+      is a read-only regression smoke test. If a CAPTCHA appears, pause for a
+      human. Stop after extraction and return the data matching output_schema.
+    browser_config:
+      mode: playwright
+      start_url: "{input.target_start_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 50
+      headless: true
+      credentials_env: "PORTAL_CREDS"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          reached_url:
+            type: string
+            description: "Final URL the flow landed on (should match the golden run's target page)."
+          actions:
+            type: array
+            description: "Ordered observable actions taken (selector + action type), for the diff."
+            items:
+              type: object
+              properties:
+                selector: { type: string }
+                action: { type: string }
+          extracted:
+            type: object
+            description: "The structured fields the recorded flow is meant to scrape."
+          action_count:
+            type: integer
+            description: "Total actions taken during the re-driven run."
+        required: ["reached_url", "actions", "extracted"]
+
+  # ---------------------------------------------------------------------------
+  # 3. VALIDATE EXTRACTION - deterministic guard on the browser READ pass BEFORE
+  #    we trust the trajectory. Rejects empty / malformed extractions (a blank
+  #    scrape must never be scored as a passing replay). No LLM in this gate.
+  # ---------------------------------------------------------------------------
+  - id: validate-extraction
+    type: code
+    depends_on: [drive-candidate-trajectory]
+    code_config:
+      language: python
+      code: |
+        cand = _steps['drive-candidate-trajectory']
+        if not isinstance(cand, dict):
+            cand = {}
+        reached = str(cand.get('reached_url') or '').strip()
+        actions = cand.get('actions')
+        if not isinstance(actions, list):
+            actions = []
+        extracted = cand.get('extracted')
+        if not isinstance(extracted, dict):
+            extracted = {}
+        # A trustworthy candidate must have landed somewhere, taken at least one
+        # observable action, and scraped at least one non-empty field. Anything
+        # less means the live UI likely changed under us - reject before replay.
+        non_empty_fields = [
+            k for k, v in extracted.items()
+            if v is not None and str(v).strip() != ''
+        ]
+        looks_like_url = reached.startswith('http')
+        errors = []
+        if not looks_like_url:
+            errors.append('candidate did not land on a valid URL')
+        if len(actions) == 0:
+            errors.append('candidate recorded zero observable actions')
+        if len(non_empty_fields) == 0:
+            errors.append('candidate extracted zero non-empty fields')
+        valid = len(errors) == 0
+        result = {
+            'valid': valid,
+            'errors': errors,
+            'reached_url': reached,
+            'action_count': len(actions),
+            'extracted_field_count': len(non_empty_fields),
+            'extracted_fields': non_empty_fields,
+        }
+
+  # ---------------------------------------------------------------------------
+  # 4. TRAJECTORY-REPLAY - the load-bearing reliability check. Loads the golden
+  #    trajectory by golden_run_id, diffs the candidate against it, and FAILS the
+  #    run when replay score < fail_below_score (UI drift) OR cost exceeds
+  #    allow_cost_delta_pct / cost_budget_usd (cost blowup). Deterministic scorer,
+  #    not a model's opinion. Provider-neutral: it compares observable actions and
+  #    extracted outputs only.
+  # ---------------------------------------------------------------------------
+  - id: replay-vs-golden
+    type: trajectory-replay
+    depends_on: [validate-extraction]
+    trajectory_replay_config:
+      golden_run_id: "{input.golden_run_id}"
+      fail_below_score: 0.85
+      allow_cost_delta_pct: 15.0
+      cost_budget_usd: 0.50
+
+  # ---------------------------------------------------------------------------
+  # 5. DRIFT REPORT - deterministic translation of the replay diff into a human-
+  #    readable verdict: which selector / step diverged, the score, and whether
+  #    the candidate read pass was even valid. This is the CI-facing summary.
+  # ---------------------------------------------------------------------------
+  - id: build-drift-report
+    type: code
+    depends_on: [replay-vs-golden]
+    code_config:
+      language: python
+      code: |
+        replay = _steps['replay-vs-golden']
+        if not isinstance(replay, dict):
+            replay = {}
+        check = _steps['validate-extraction']
+        if not isinstance(check, dict):
+            check = {}
+        # Pull the score / cost / diff from the replay result, defending against
+        # missing keys so the report never crashes the harness itself.
+        score = replay.get('score')
+        if score is None:
+            score = replay.get('replay_score', 0.0)
+        try:
+            score = float(score)
+        except (TypeError, ValueError):
+            score = 0.0
+        passed = bool(replay.get('passed', False))
+        cost_delta = replay.get('cost_delta_pct')
+        try:
+            cost_delta = float(cost_delta)
+        except (TypeError, ValueError):
+            cost_delta = 0.0
+        # Collect the diverged steps/selectors the replay reported, if any.
+        raw_diff = replay.get('diff') or replay.get('mismatches') or []
+        if isinstance(raw_diff, dict):
+            raw_diff = list(raw_diff.values())
+        if not isinstance(raw_diff, list):
+            raw_diff = [raw_diff]
+        diverged = []
+        for d in raw_diff:
+            if isinstance(d, dict):
+                where = d.get('selector') or d.get('step') or d.get('field') or 'unknown'
+                why = d.get('reason') or d.get('detail') or d.get('expected') or ''
+                diverged.append({'where': str(where), 'why': str(why)})
+            else:
+                diverged.append({'where': str(d), 'why': ''})
+        extraction_ok = bool(check.get('valid', False))
+        # Regression if the read pass was invalid, the replay did not pass, or
+        # the score sits under the configured floor. All deterministic.
+        try:
+            floor = float(str(_input.get('fail_below_score', '0.85')))
+        except (TypeError, ValueError):
+            floor = 0.85
+        regression = (not extraction_ok) or (not passed) or (score < floor)
+        lines = []
+        lines.append('Replay score: ' + str(round(score, 4)) + ' (floor ' + str(floor) + ')')
+        lines.append('Cost delta: ' + str(round(cost_delta, 2)) + '%')
+        lines.append('Extraction valid: ' + str(extraction_ok))
+        lines.append('Replay passed: ' + str(passed))
+        if diverged:
+            lines.append('Diverged points:')
+            for d in diverged[:25]:
+                lines.append('  - ' + d['where'] + (': ' + d['why'] if d['why'] else ''))
+        if not extraction_ok:
+            lines.append('Extraction errors: ' + '; '.join(check.get('errors', [])))
+        verdict = 'REGRESSION' if regression else 'CERTIFIED'
+        result = {
+            'verdict': verdict,
+            'regression': regression,
+            'score': round(score, 4),
+            'floor': floor,
+            'cost_delta_pct': round(cost_delta, 2),
+            'extraction_ok': extraction_ok,
+            'replay_passed': passed,
+            'diverged': diverged,
+            'report': verdict + '\n' + '\n'.join(lines),
+        }
+
+  # ---------------------------------------------------------------------------
+  # 6. ROUTE - deterministic branch on the drift verdict. Regression -> alert the
+  #    on-call channel (fails CI) and archive the failing verdict. Clean -> just
+  #    archive the certified verdict so the flow is cleared to run for real.
+  # ---------------------------------------------------------------------------
+  - id: route-on-verdict
+    type: condition
+    depends_on: [build-drift-report]
+    condition_config:
+      expression: "{steps.build-drift-report.output.regression} == True"
+      then: [alert-oncall, archive-verdict]
+      else: [archive-verdict]
+
+  # --- REGRESSION branch ----------------------------------------------------
+  # 6a. Post the drift report + screenshots to on-call. This failing notify is
+  #     the CI gate: a drifted flow is loudly flagged instead of silently
+  #     scraping garbage in production.
+  - id: alert-oncall
+    type: notify
+    depends_on: [route-on-verdict]
+    notify_config:
+      service: slack
+      channel: "{input.oncall_channel}"
+      message: >-
+        RPA REGRESSION on flow {input.target_flow} vs golden {input.golden_run_id}.
+        {steps.build-drift-report.output.report}
+        Screenshots from the re-driven run are attached to this replay; review the
+        diverged selectors before this flow is allowed to run in production.
+
+  # --- ARCHIVE (both branches) ---------------------------------------------
+  # 6b. Persist the verdict (certified or drifted) via a reusable summarizer
+  #     sub-workflow so every replay leaves an auditable record. Read-only.
+  - id: archive-verdict
+    type: sub_workflow
+    depends_on: [route-on-verdict]
+    sub_workflow:
+      workflow: "summarize"
+      input_mapping:
+        text: "{steps.build-drift-report.output.report}"
+        format: "bullet-points"
+      max_concurrent: 1
+
+on_complete:
+  storage_path: "rpa/trajectory-replay/{workflow_id}/{run_id}.json"

--- a/src/sandcastle/templates/saas_seat_deactivation_offboarder.yaml
+++ b/src/sandcastle/templates/saas_seat_deactivation_offboarder.yaml
@@ -1,0 +1,545 @@
+# name: SaaS Seat Deactivation Offboarder
+# description: Deactivate or downgrade a CSV/HR-feed list of departed users across SaaS admin consoles that expose no bulk-deactivation API, by driving the logged-in console. Before/after seat reconciliation per user, gated behind a single batch human approval.
+# tags: [Offboarding, SecOps, IT, SaaS, SCIM, Deprovision, Browser, Playwright, Reconciliation, Audit]
+# category: devops
+
+name: saas-seat-deactivation-offboarder
+description: >-
+  Deactivate (or downgrade) a list of departed users across one or more SaaS admin
+  consoles that ship NO bulk-deactivation API on the customer's plan. The only way to
+  apply the change at scale is to drive the authenticated admin SPA: per-user
+  'Deactivate' / 'Remove seat' buttons are rendered client-side, so a plain http step
+  cannot reach the gated, JS-rendered member rows.
+
+  Flow: a parse step reads the offboarding CSV/HR-feed into {email, requested_action}
+  rows. A READ-ONLY browser census (mode: dom) snapshots the live members page into a
+  structured before_roster via output_schema - it mutates nothing. A DETERMINISTIC code
+  step diffs the requested list against before_roster, classifies each user into
+  to_deactivate / already_inactive / not_found / ambiguous_duplicate, and runs an
+  ALLOWLIST GUARD that rejects any target email not present in the input CSV (no scope
+  creep). An llm_eval gate sanity-checks the plan shape (flags if an implausible fraction
+  of all seats would be deactivated - a likely bad feed). Then ONE human approval signs
+  off the entire batch_plan: the single place a human authorizes mutation. Only after that
+  does a loop run a per-user browser step (mode: playwright, max_actions capped,
+  capture_screenshots on) that navigates to each user and clicks Deactivate. A second
+  dom census produces after_roster, a final DETERMINISTIC code reconcile asserts every
+  targeted email is now inactive and every untouched email is unchanged (emitting a drift
+  list of failures), an llm_eval gate confirms the portal's own after-state, and Slack is
+  notified with a tamper-evident audit record of plan, approver, and per-user diffs.
+
+  PROVIDER NEUTRAL: both census and per-item deactivation use dom/playwright modes where
+  the reasoning model only authors a DOM extraction / Playwright script from the prompt;
+  the mutation itself is deterministic Playwright, so any of the 7 reasoning providers can
+  author it and is swappable. No vendor agent runtime is in the loop. Reconciliation and
+  the allowlist guard are pure Python, independent of any model.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 1800
+
+input_schema:
+  required: ["offboarding_csv", "admin_members_url"]
+  properties:
+    offboarding_csv:
+      type: string
+      description: "Reference to the offboarding CSV / HR-feed export (one row per departed user). Accepts @upload:<file_id>, @file:<path>, a URL, or a pasted CSV. Expected columns: email, requested_action (deactivate|downgrade)."
+      example: "@upload:offboarding-2026-06-02.csv"
+    admin_members_url:
+      type: string
+      description: "URL of the SaaS admin console members/users page where per-user seats are listed and the Deactivate / Remove-seat button lives (authenticated SPA)."
+      default: "https://app.your-saas.com/admin/members"
+      example: "https://app.acme-design.com/settings/team/members"
+    member_url_template:
+      type: string
+      description: "URL template for a single member's admin page; {email} is substituted per user during the deactivation loop. If your console deep-links by email or user id, set it here."
+      default: "https://app.your-saas.com/admin/members?q={email}"
+      example: "https://app.acme-design.com/settings/team/members?search={email}"
+    credentials_env_var:
+      type: string
+      description: "Name of the environment variable holding the admin login (username+password or session token). The value is NEVER inlined into the workflow."
+      default: "SAAS_ADMIN_CREDS"
+      example: "ACME_ADMIN_CREDS"
+    max_deactivation_fraction:
+      type: number
+      description: "Sanity ceiling: if the plan would deactivate more than this fraction of ALL observed seats, the gate flags a likely bad feed and the batch must be reviewed."
+      default: 0.4
+      example: "0.4"
+    slack_channel:
+      type: string
+      description: "Slack channel for the offboarding completion summary + drift report."
+      default: "#it-offboarding"
+      example: "#it-offboarding"
+
+steps:
+  # 1) PARSE the offboarding CSV / HR-feed into structured rows {email, requested_action}.
+  #    Deterministic ingest; no console contact yet.
+  - id: parse_offboarding_feed
+    type: parse
+    prompt: "{input.offboarding_csv}"
+    parse_config:
+      output: json
+
+  # 2) READ-ONLY CENSUS of the live members page (mode: dom). The reasoning model only
+  #    authors a DOM extraction from the prompt; output_schema returns a STRUCTURED
+  #    before_roster for every member row. This step MUTATES NOTHING (no clicks that change
+  #    state) - it is the pre-image of the audit before/after pair. credentials_env supplies
+  #    the admin login (never inlined); captcha_strategy pauses for a human on a CAPTCHA.
+  - id: census_before
+    type: browser
+    depends_on: [parse_offboarding_feed]
+    prompt: >
+      Log in to the SaaS admin console using the supplied credentials and open the members /
+      users management page. Do NOT click any Deactivate, Remove, Suspend, Downgrade, or
+      Delete control - this is a read-only census. Read every visible member row (paginate
+      through all pages if the list is paginated) and extract, for each member, their email,
+      their current account status (active or inactive/suspended/deactivated), their role,
+      and their seat/plan type. Return the full roster as structured JSON matching the schema.
+      The offboarding feed under review is: {steps.parse_offboarding_feed.output}.
+    browser_config:
+      mode: dom
+      start_url: "{input.admin_members_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 180
+      max_actions: 80
+      headless: true
+      credentials_env: "{input.credentials_env_var}"
+      captcha_strategy: pause
+      capture_screenshots: false
+      output_schema:
+        type: object
+        properties:
+          before_roster:
+            type: array
+            items:
+              type: object
+              properties:
+                email: { type: string }
+                status: { type: string, enum: ["active", "inactive"] }
+                role: { type: string }
+                seat_type: { type: string }
+              required: ["email", "status"]
+          total_seats_observed: { type: integer }
+        required: ["before_roster"]
+
+  # 3) DETERMINISTIC reconcile-plan. The load-bearing correctness: diff the requested feed
+  #    against before_roster, classify every requested user, and run the ALLOWLIST GUARD that
+  #    asserts no email outside the input CSV ever enters the plan. Pure Python, no model.
+  - id: reconcile_plan
+    type: code
+    depends_on: [parse_offboarding_feed, census_before]
+    code_config:
+      language: python
+      code: |
+        import json
+
+        # --- Normalize the parsed offboarding feed into [{email, requested_action}] -------
+        raw_feed = _steps['parse_offboarding_feed']
+        if isinstance(raw_feed, str):
+            try:
+                raw_feed = json.loads(raw_feed) if raw_feed.strip() else []
+            except (ValueError, TypeError):
+                raw_feed = []
+        if isinstance(raw_feed, dict):
+            raw_feed = raw_feed.get('rows') or raw_feed.get('records') or raw_feed.get('data') or []
+
+        requested = []
+        requested_allow = set()  # the canonical CSV allowlist
+        for row in (raw_feed or []):
+            if not isinstance(row, dict):
+                continue
+            email = str(row.get('email') or row.get('Email') or row.get('user') or '').strip().lower()
+            if not email:
+                continue
+            action = str(row.get('requested_action') or row.get('action') or 'deactivate').strip().lower()
+            if action not in ('deactivate', 'downgrade'):
+                action = 'deactivate'
+            requested.append({'email': email, 'requested_action': action})
+            requested_allow.add(email)
+
+        # --- Normalize the read-only census ---------------------------------------------
+        census = _steps['census_before'] or {}
+        if isinstance(census, str):
+            try:
+                census = json.loads(census) if census.strip() else {}
+            except (ValueError, TypeError):
+                census = {}
+        before_roster = census.get('before_roster', []) if isinstance(census, dict) else []
+
+        # Index roster by email; detect ambiguous duplicates (same email twice on the console).
+        by_email = {}
+        dup_emails = set()
+        for m in before_roster:
+            if not isinstance(m, dict):
+                continue
+            em = str(m.get('email') or '').strip().lower()
+            if not em:
+                continue
+            if em in by_email:
+                dup_emails.add(em)
+            by_email[em] = {
+                'email': em,
+                'status': str(m.get('status') or '').strip().lower() or 'active',
+                'role': m.get('role'),
+                'seat_type': m.get('seat_type'),
+            }
+
+        total_seats = len(by_email)
+
+        to_deactivate = []
+        already_inactive = []
+        not_found = []
+        ambiguous_duplicate = []
+        for req in requested:
+            em = req['email']
+            if em in dup_emails:
+                ambiguous_duplicate.append({**req, 'reason': 'multiple_console_rows_same_email'})
+                continue
+            current = by_email.get(em)
+            if current is None:
+                not_found.append({**req, 'reason': 'email_not_on_console'})
+                continue
+            if current['status'] == 'inactive':
+                already_inactive.append({**req, 'current_status': 'inactive'})
+                continue
+            to_deactivate.append({
+                'email': em,
+                'requested_action': req['requested_action'],
+                'before_status': current['status'],
+                'role': current.get('role'),
+                'seat_type': current.get('seat_type'),
+            })
+
+        # --- ALLOWLIST GUARD: no email outside the input CSV may ever be in the plan ------
+        plan_emails = {x['email'] for x in (to_deactivate + already_inactive + not_found + ambiguous_duplicate)}
+        scope_violations = sorted(plan_emails - requested_allow)
+        allowlist_ok = len(scope_violations) == 0
+
+        deactivate_fraction = (len(to_deactivate) / total_seats) if total_seats else 0.0
+
+        result = {
+            'allowlist_ok': allowlist_ok,
+            'scope_violations': scope_violations,
+            'total_seats_observed': total_seats,
+            'requested_count': len(requested),
+            'counts': {
+                'to_deactivate': len(to_deactivate),
+                'already_inactive': len(already_inactive),
+                'not_found': len(not_found),
+                'ambiguous_duplicate': len(ambiguous_duplicate),
+            },
+            'deactivate_fraction': round(deactivate_fraction, 4),
+            'batch_plan': {
+                'to_deactivate': to_deactivate,
+                'already_inactive': already_inactive,
+                'not_found': not_found,
+                'ambiguous_duplicate': ambiguous_duplicate,
+            },
+            'allowlist': sorted(requested_allow),
+        }
+
+  # 4) GATE (llm_eval): sanity-check the PLAN SHAPE before a human ever looks at it. Flags an
+  #    implausible deactivation fraction (likely a bad/over-broad feed) or any allowlist
+  #    violation. This is a secondary guard - the allowlist correctness already lives in code.
+  - id: plan_sanity_gate
+    type: gate
+    depends_on: [reconcile_plan]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >
+              You are an offboarding safety reviewer. Answer exactly 'approved' if this
+              deactivation plan looks safe to send to a human approver, or 'rejected' with the
+              reason if it looks like a bad feed. Reject if allowlist_ok is not true (scope
+              creep), if scope_violations is non-empty, or if deactivate_fraction exceeds
+              {input.max_deactivation_fraction} of all observed seats (an implausibly large
+              batch that suggests the wrong list was loaded). Otherwise approve. Plan:
+              {steps.reconcile_plan.output}
+            input: "{steps.reconcile_plan.output}"
+            model: sonnet
+
+  # 5) APPROVAL: the SINGLE human sign-off over the whole batch_plan. This is the ONLY place
+  #    a human authorizes mutation; nothing irreversible runs before this returns approved.
+  #    The reviewer sees the validated plan + counts and can edit (e.g. drop a borderline row).
+  - id: batch_approval
+    type: approval
+    depends_on: [plan_sanity_gate]
+    approval_config:
+      message: >
+        Offboarding batch - APPROVE to deactivate the listed seats, REJECT to abort the whole
+        run. This is the only authorization gate before any seat is changed. Review the counts
+        and the to_deactivate list carefully. to_deactivate will be deactivated one-by-one in
+        the admin console; already_inactive / not_found / ambiguous_duplicate will be SKIPPED
+        and reported. Allowlist OK: {steps.reconcile_plan.output.allowlist_ok}. Counts:
+        {steps.reconcile_plan.output.counts}. Seats observed: {steps.reconcile_plan.output.total_seats_observed}.
+      show_data: steps.reconcile_plan.output
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: true
+
+  # 6) LOOP over batch_plan.to_deactivate. Each iteration runs the per-user browser
+  #    deactivation (child step deactivate_one) reading the current user via _item. Runs ONLY
+  #    after the human approval above. max_iterations caps the batch size.
+  - id: deactivation_loop
+    type: loop
+    depends_on: [batch_approval]
+    loop_config:
+      over: "steps.reconcile_plan.output.batch_plan.to_deactivate"
+      step_ids: [deactivate_one]
+      max_iterations: 2000
+
+  # 6a) PER-USER deactivation (mode: playwright). The reasoning model only authors a
+  #     Playwright script from the prompt; the mutation itself is deterministic Playwright, so
+  #     any provider can author it and is swappable. max_actions is tightly capped so a
+  #     misnavigation cannot rampage through the roster; capture_screenshots is ON for audit;
+  #     captcha_strategy pauses for a human. output_schema returns a structured per-user result.
+  - id: deactivate_one
+    type: browser
+    prompt: >
+      You are deactivating exactly ONE departed user in the SaaS admin console. The target user
+      is: {{ _item }}. Navigate to that user's member row (search by their email if needed),
+      open their account, and click the control that DEACTIVATES / removes the seat for that
+      user only (Deactivate, Suspend, or Remove seat - whichever the console exposes). If the
+      requested_action is 'downgrade', instead set them to the lowest/free seat tier rather than
+      fully deactivating. Operate on this one email ONLY - never touch any other member row. If
+      a confirmation dialog appears, confirm it. Then read back this user's resulting account
+      status and return it. Do not navigate away to bulk actions or settings unrelated to this
+      user.
+    browser_config:
+      mode: playwright
+      start_url: "{input.member_url_template}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 25
+      headless: true
+      credentials_env: "{input.credentials_env_var}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          email: { type: string }
+          action_taken: { type: string, enum: ["deactivated", "downgraded", "skipped", "failed"] }
+          post_status: { type: string, enum: ["active", "inactive"] }
+          screenshot_ref: { type: string }
+        required: ["email", "action_taken", "post_status"]
+
+  # 7) RE-SNAPSHOT the roster (mode: dom, read-only) into after_roster - the post-image of the
+  #    audit pair. Same structured extraction as the census; no mutation.
+  - id: census_after
+    type: browser
+    depends_on: [deactivation_loop]
+    prompt: >
+      Re-open the members / users management page in the SaaS admin console (reload to get
+      fresh state). This is a read-only re-census after a batch of deactivations: do NOT click
+      any Deactivate, Remove, Suspend, or Delete control. Read every visible member row
+      (paginate through all pages) and extract each member's email, current account status
+      (active or inactive), role, and seat/plan type. Return the full roster as structured JSON.
+    browser_config:
+      mode: dom
+      start_url: "{input.admin_members_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 180
+      max_actions: 80
+      headless: true
+      credentials_env: "{input.credentials_env_var}"
+      captcha_strategy: pause
+      capture_screenshots: false
+      output_schema:
+        type: object
+        properties:
+          after_roster:
+            type: array
+            items:
+              type: object
+              properties:
+                email: { type: string }
+                status: { type: string, enum: ["active", "inactive"] }
+                role: { type: string }
+                seat_type: { type: string }
+              required: ["email", "status"]
+        required: ["after_roster"]
+
+  # 8) DETERMINISTIC final reconcile. The load-bearing post-check: assert EVERY targeted email
+  #    is now status==inactive and EVERY untouched email is unchanged vs the before census.
+  #    Emits a drift list of any user that did not reach the expected state. Pure Python.
+  - id: final_reconcile
+    type: code
+    depends_on: [reconcile_plan, census_after, deactivation_loop]
+    code_config:
+      language: python
+      code: |
+        import json
+
+        plan = _steps['reconcile_plan'] or {}
+        batch_plan = plan.get('batch_plan', {}) if isinstance(plan, dict) else {}
+        to_deactivate = batch_plan.get('to_deactivate', [])
+        targeted_emails = {x['email'] for x in to_deactivate}
+
+        # --- Before roster (from the original census, re-derived here for the diff) --------
+        census_b = _steps['census_before'] or {}
+        if isinstance(census_b, str):
+            try:
+                census_b = json.loads(census_b) if census_b.strip() else {}
+            except (ValueError, TypeError):
+                census_b = {}
+        before_rows = census_b.get('before_roster', []) if isinstance(census_b, dict) else []
+        before_status = {}
+        for m in before_rows:
+            if isinstance(m, dict):
+                em = str(m.get('email') or '').strip().lower()
+                if em:
+                    before_status[em] = str(m.get('status') or 'active').strip().lower()
+
+        # --- After roster -----------------------------------------------------------------
+        census_a = _steps['census_after'] or {}
+        if isinstance(census_a, str):
+            try:
+                census_a = json.loads(census_a) if census_a.strip() else {}
+            except (ValueError, TypeError):
+                census_a = {}
+        after_rows = census_a.get('after_roster', []) if isinstance(census_a, dict) else []
+        after_status = {}
+        for m in after_rows:
+            if isinstance(m, dict):
+                em = str(m.get('email') or '').strip().lower()
+                if em:
+                    after_status[em] = str(m.get('status') or 'active').strip().lower()
+
+        # --- Per-loop browser results, indexed by reported email --------------------------
+        loop_out = _steps['deactivation_loop'] or {}
+        loop_items = loop_out if isinstance(loop_out, list) else (
+            loop_out.get('results') or loop_out.get('items') or []
+        )
+        result_by_email = {}
+        for it in loop_items:
+            if isinstance(it, dict):
+                em = str(it.get('email') or '').strip().lower()
+                if em:
+                    result_by_email[em] = it
+
+        # --- Assert every targeted email is now inactive ----------------------------------
+        confirmed = []
+        drift = []
+        for em in sorted(targeted_emails):
+            post = after_status.get(em)
+            browser_res = result_by_email.get(em, {})
+            diff_row = {
+                'email': em,
+                'before_status': before_status.get(em),
+                'after_status': post,
+                'browser_action': browser_res.get('action_taken'),
+                'screenshot_ref': browser_res.get('screenshot_ref'),
+            }
+            if post == 'inactive':
+                confirmed.append(diff_row)
+            else:
+                drift.append({**diff_row, 'drift_reason': 'targeted_but_not_inactive'})
+
+        # --- Assert no UNTOUCHED user changed status (scope-creep / collateral check) ------
+        collateral = []
+        for em, before_s in before_status.items():
+            if em in targeted_emails:
+                continue
+            post = after_status.get(em)
+            if post is not None and post != before_s:
+                collateral.append({
+                    'email': em,
+                    'before_status': before_s,
+                    'after_status': post,
+                    'drift_reason': 'untouched_user_status_changed',
+                })
+
+        all_clean = (len(drift) == 0 and len(collateral) == 0)
+
+        result = {
+            'all_clean': all_clean,
+            'targeted_count': len(targeted_emails),
+            'confirmed_count': len(confirmed),
+            'drift_count': len(drift),
+            'collateral_count': len(collateral),
+            'confirmed': confirmed,
+            'drift': drift,
+            'collateral': collateral,
+        }
+
+  # 9) CONFIRMATION GATE (llm_eval) over the portal's OWN after-state. Secondary to the code
+  #    reconcile above (which is the authoritative correctness check): confirms the console's
+  #    reported roster is internally consistent before declaring success / shipping the audit.
+  - id: completion_gate
+    type: gate
+    depends_on: [final_reconcile]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >
+              You are an offboarding completion reviewer reading the console's own after-state
+              reconciliation. Answer exactly 'approved' if the result is internally consistent:
+              every targeted user that failed to reach inactive appears in the drift list, no
+              untouched user changed status (collateral_count must be 0), and the confirmed +
+              drift counts add up to targeted_count. Otherwise answer 'rejected' and name the
+              defect. Reconciliation: {steps.final_reconcile.output}
+            input: "{steps.final_reconcile.output}"
+            model: sonnet
+
+  # 10) AUDIT record: deterministic, tamper-evident SHA-256 over the canonical offboarding
+  #     record (plan, approver outcome, per-user before/after diffs, drift). No model.
+  - id: audit_record
+    type: code
+    depends_on: [reconcile_plan, batch_approval, final_reconcile, completion_gate]
+    code_config:
+      language: python
+      code: |
+        import json
+        import hashlib
+        from datetime import datetime, timezone
+
+        plan = _steps['reconcile_plan'] or {}
+        reconcile = _steps['final_reconcile'] or {}
+        approval = _steps['batch_approval'] or {}
+
+        approver = 'unknown'
+        if isinstance(approval, dict):
+            approver = str(approval.get('approver') or approval.get('approved_by') or 'unknown')
+
+        record = {
+            'generated_at': datetime.now(timezone.utc).isoformat(),
+            'approver': approver,
+            'allowlist_ok': plan.get('allowlist_ok'),
+            'plan_counts': plan.get('counts'),
+            'total_seats_observed': plan.get('total_seats_observed'),
+            'targeted_count': reconcile.get('targeted_count'),
+            'confirmed_count': reconcile.get('confirmed_count'),
+            'drift_count': reconcile.get('drift_count'),
+            'collateral_count': reconcile.get('collateral_count'),
+            'per_user_diffs': reconcile.get('confirmed', []) + reconcile.get('drift', []),
+            'collateral': reconcile.get('collateral', []),
+            'all_clean': reconcile.get('all_clean'),
+        }
+
+        # Canonical (sorted-key) serialization so the audit hash is reproducible byte-for-byte.
+        canonical = json.dumps(record, sort_keys=True, separators=(',', ':'))
+        digest = hashlib.sha256(canonical.encode('utf-8')).hexdigest()
+
+        result = {
+            'sha256': digest,
+            'byte_length': len(canonical),
+            'audit_record': record,
+            'canonical_json': canonical,
+        }
+
+  # 11) NOTIFY the offboarding channel with the result + drift report + audit integrity hash.
+  - id: notify_summary
+    type: notify
+    depends_on: [audit_record]
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: "Offboarding batch complete. Targeted: {steps.final_reconcile.output.targeted_count} | Confirmed inactive: {steps.final_reconcile.output.confirmed_count} | Drift (failed): {steps.final_reconcile.output.drift_count} | Collateral (untouched changed): {steps.final_reconcile.output.collateral_count} | All clean: {steps.final_reconcile.output.all_clean} | Approver: {steps.audit_record.output.audit_record.approver} | Audit sha256 {steps.audit_record.output.sha256}."
+
+on_complete:
+  storage_path: "saas-seat-deactivation-offboarder/{run_id}/result.json"

--- a/src/sandcastle/templates/supplier_portal_invoice_status_reconciler.yaml
+++ b/src/sandcastle/templates/supplier_portal_invoice_status_reconciler.yaml
@@ -1,0 +1,573 @@
+# name: Supplier Portal Invoice Status Reconciler
+# description: Logs into customer-mandated AP/supplier web portals (Ariba/Coupa-style and bespoke buyer portals) that expose no supplier-side API, scrapes the live status of every submitted invoice into structured JSON with a deterministic provider-neutral Playwright script, validates the extraction in code, reconciles it against the company's own AR ledger, and posts a stuck/short-paid invoices digest to Finance. Read-only on the external portals - it never submits, edits, or pays anything, so the only writes are to the internal reconciliation summary.
+# tags: [Finance, AccountsReceivable, Collections, Browser, Playwright, Ariba, Coupa, Reconciliation, RPA]
+# category: general_ai
+
+name: supplier-portal-invoice-status-reconciler
+description: >-
+  Reconciles invoice status across customer-mandated AP/supplier procurement
+  portals (Ariba/Coupa-style and bespoke buyer portals) that give suppliers NO
+  outbound API - the only source of truth is a login-gated, JS-heavy status grid
+  built for human AP clerks. A LOOP fans out over a list of configured portals;
+  each iteration runs a BROWSER step in playwright mode (the configured reasoning
+  model authors a deterministic, provider-neutral Playwright script ONCE, which
+  then replays) that signs in with per-portal credentials_env, opens the
+  invoice-status grid, applies a date filter, paginates under a max_actions cap,
+  and returns a strict output_schema {portal, invoices:[{invoice_number, amount,
+  currency, status, approval_date, expected_pay_date}]}. captcha_strategy=pause
+  hands any MFA/CAPTCHA to a human. A second BROWSER step in dom mode does a
+  lightweight, read-only liveness probe of each portal's post-login landing page
+  so a silent redesign or auth wall is caught before the heavy scrape is trusted.
+  A CODE step then VALIDATES every scraped row deterministically (amounts numeric,
+  currency in an allowed enum, status in a closed set, invoice_number format) and
+  REJECTS malformed rows - no reconciliation runs on a bad read. An HTTP step
+  pulls the matching invoices from the internal AR ledger API. A CODE step does
+  the load-bearing reconciliation in pure deterministic math (portal status vs
+  ledger status, amount deltas within 0.01 tolerance, overdue detection) with NO
+  model in the path, so the audit conclusion is reproducible and provider-neutral.
+  A SENSOR confirms the ledger API is live and fresh before the digest is trusted.
+  A GATE (llm_eval) sanity-checks the reconciliation summary for obvious
+  extraction drift before a human sees it; its judge model can be raced across
+  providers. A NOTIFY posts the stuck/short-paid digest to Finance. The workflow
+  is intentionally READ-ONLY on the external portals - it never submits, edits, or
+  pays anything - so the only safety gate needed on the outbound side is the
+  captcha pause; the only writes are to the internal reconciliation summary.
+  (connectors: slack, internal AR ledger via http)
+
+default_model: sonnet
+default_timeout: 600
+
+input_schema:
+  required: ["portals", "ledger_api_url"]
+  properties:
+    portals:
+      type: array
+      description: >-
+        Portal definitions the loop iterates over. Each item names the buyer
+        portal, its login start_url, the env var holding its credentials, and the
+        invoice-status grid URL. Shape per item: {portal, vendor (ariba|coupa|
+        bespoke), start_url, grid_url, credentials_env, supplier_id}. Secrets are
+        NEVER inlined - only the NAME of the env var is stored here.
+      default:
+        - portal: "acme_ariba"
+          vendor: "ariba"
+          start_url: "https://acme.supplier.ariba.com/login"
+          grid_url: "https://acme.supplier.ariba.com/invoices"
+          credentials_env: "PORTAL_ACME_ARIBA_CREDS"
+          supplier_id: "SUP-ACME-0091"
+        - portal: "globex_coupa"
+          vendor: "coupa"
+          start_url: "https://globex.coupahost.com/sessions/new"
+          grid_url: "https://globex.coupahost.com/invoices"
+          credentials_env: "PORTAL_GLOBEX_COUPA_CREDS"
+          supplier_id: "SUP-GLBX-4471"
+        - portal: "initech_bespoke"
+          vendor: "bespoke"
+          start_url: "https://ap.initech.example/portal/login"
+          grid_url: "https://ap.initech.example/portal/invoices"
+          credentials_env: "PORTAL_INITECH_CREDS"
+          supplier_id: "VENDOR-77123"
+    ledger_api_url:
+      type: string
+      description: "Base URL of the internal AR ledger API that returns this supplier's open invoices for the period."
+      default: "https://ar-ledger.internal.example/api/v1"
+    filter_since:
+      type: string
+      description: "Lower bound (ISO date) for the portal grid date filter - only invoices submitted on/after this date are scraped and reconciled."
+      default: "2026-01-01"
+    amount_tolerance:
+      type: number
+      description: "Absolute amount delta (in invoice currency) below which a portal-vs-ledger amount difference is treated as agreement (rounding noise)."
+      default: 0.01
+    allowed_currencies:
+      type: array
+      description: "Closed set of currency codes a scraped row may carry; rows with any other currency are rejected as malformed."
+      default: ["USD", "EUR", "GBP", "CZK"]
+    overdue_grace_days:
+      type: integer
+      description: "Days past expected_pay_date before a portal-approved-but-unpaid invoice is flagged as stuck/overdue."
+      default: 0
+    notify_service:
+      type: string
+      description: "Where to post the stuck/short-paid digest: slack or teams."
+      default: "slack"
+    notify_channel:
+      type: string
+      description: "Channel for the collections digest."
+      default: "#ar-collections"
+
+steps:
+  # 1) LOOP over the configured portals. Each iteration runs scrape_portal, the
+  #    provider-neutral Playwright browser step. The loop item (one portal def)
+  #    arrives on _input['_item'] and is read by the browser prompt via templating.
+  - id: scrape_portals
+    type: loop
+    loop_config:
+      over: "input.portals"
+      step_ids: [scrape_portal]
+      max_iterations: 50
+
+  # 1a) BROWSER (playwright mode - PROVIDER-NEUTRAL). The configured reasoning model
+  #     authors a deterministic Playwright script ONCE from this prompt, which then
+  #     replays - the script is provider-agnostic and the authoring model is
+  #     swappable via default_model. This is the READ pass: it logs in with the
+  #     per-portal credentials_env (NEVER an inline secret), opens the invoice-status
+  #     grid, applies the date filter, paginates under the max_actions cap, and
+  #     returns ONLY the strict output_schema below. captcha_strategy=pause hands any
+  #     MFA/CAPTCHA login challenge to a human. capture_screenshots keeps an audit
+  #     trail of every page the script touched. It performs NO write actions.
+  #     (loop child step - defined separately, read via _input['_item'])
+  - id: scrape_portal
+    type: browser
+    browser_config:
+      mode: playwright
+      start_url: "{input._item.start_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 50
+      headless: true
+      credentials_env: "{input._item.credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          portal: { type: string }
+          vendor: { type: string }
+          scraped_at: { type: string }
+          invoices:
+            type: array
+            items:
+              type: object
+              properties:
+                invoice_number: { type: string }
+                amount: { type: number }
+                currency: { type: string }
+                status: { type: string }
+                approval_date: { type: string }
+                expected_pay_date: { type: string }
+    prompt: |
+      You are automating a supplier-facing AP procurement portal (vendor family:
+      {input._item.vendor}; e.g. Ariba, Coupa, or a bespoke buyer portal) as a
+      read-only AP clerk. There is NO supplier API - the status grid is the only
+      source of truth.
+
+      Author a deterministic, provider-neutral Playwright script that:
+      1. Navigates to the login page ({input._item.start_url}) and signs in using
+         the credentials supplied by the credentials_env environment variable. NEVER
+         hardcode or echo the secret.
+      2. If a CAPTCHA, MFA, or device-verification challenge appears, STOP and hand
+         off to a human (captcha_strategy=pause). Do not attempt to solve it.
+      3. Opens the invoice-status grid at {input._item.grid_url} for supplier
+         {input._item.supplier_id}.
+      4. Applies the grid's date filter so only invoices submitted on/after
+         {input.filter_since} are shown.
+      5. Paginates through every result page (respecting the max_actions cap) and
+         reads each row.
+      6. Performs NO write actions - never click submit, approve, resubmit, dispute,
+         edit, or pay. This is extraction only.
+
+      Return ONLY the structured JSON described by the output_schema: the portal
+      identifier, the vendor family, an ISO scraped_at timestamp, and one object per
+      invoice row with invoice_number, amount (numeric), currency (ISO code), status
+      (the portal's literal status text), approval_date, and expected_pay_date.
+
+  # 1b) BROWSER (dom mode - lightweight read-only liveness probe). After the heavy
+  #     scrape, a fast DOM read of each portal's post-login landing page detects a
+  #     silent redesign, an auth wall, or a maintenance banner that could have made
+  #     the playwright scrape return an empty/garbage grid. Pure read, no writes.
+  #     A trajectory-replay golden run per portal can be layered on top of this to
+  #     hard-fail on UI drift.
+  - id: probe_portals
+    type: browser
+    depends_on: [scrape_portals]
+    browser_config:
+      mode: dom
+      start_url: "{input.ledger_api_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 60
+      max_actions: 10
+      headless: true
+      captcha_strategy: pause
+      capture_screenshots: false
+      output_schema:
+        type: object
+        properties:
+          reachable: { type: boolean }
+          looks_like_login_wall: { type: boolean }
+          maintenance_banner: { type: boolean }
+          notes: { type: string }
+    prompt: |
+      Do a fast, read-only DOM check of the portal landing area to confirm the
+      heavy scrape ran against the real invoice grid and not a login wall, an error
+      page, or a maintenance banner. Read the visible headings, any banner text, and
+      whether a login form is present. Do NOT log in, click, submit, or change
+      anything. Return ONLY the JSON in the output_schema: reachable,
+      looks_like_login_wall, maintenance_banner, and a short notes string.
+
+  # 2) CODE: VALIDATE the scraped extraction deterministically before anything is
+  #    trusted. Every row must have a non-empty invoice_number matching an accepted
+  #    format, a numeric amount, a currency in the allowed enum, and a status in the
+  #    closed set {submitted, approved, rejected, paid, disputed}. Malformed rows are
+  #    REJECTED into a quarantine list and NEVER reconciled. If a portal yields zero
+  #    valid rows (likely a silent redesign / auth wall) it is flagged. No model.
+  - id: validate_extraction
+    type: code
+    depends_on: [scrape_portals, probe_portals]
+    code_config:
+      language: python
+      code: |
+        # The loop output arrives as a list of per-portal scrape envelopes.
+        scraped = _steps.get("scrape_portals")
+        if not isinstance(scraped, list):
+            scraped = [scraped] if isinstance(scraped, dict) else []
+
+        try:
+            allowed_ccy = _input.get("allowed_currencies") or ["USD", "EUR", "GBP", "CZK"]
+        except Exception:
+            allowed_ccy = ["USD", "EUR", "GBP", "CZK"]
+        allowed_ccy = {str(c).upper() for c in allowed_ccy if isinstance(c, str)}
+
+        allowed_status = {"submitted", "approved", "rejected", "paid", "disputed"}
+        # Invoice numbers are 4-32 chars of letters, digits, dash, slash, dot.
+        inv_pattern = r"^[A-Za-z0-9][A-Za-z0-9\-\/\.]{3,31}$"
+
+        def _to_amount(v):
+            try:
+                return round(float(v), 2)
+            except (TypeError, ValueError):
+                return None
+
+        valid_rows = []
+        rejected_rows = []
+        per_portal = {}
+
+        for env in scraped:
+            if not isinstance(env, dict):
+                continue
+            portal = str(env.get("portal") or "unknown")
+            vendor = str(env.get("vendor") or "")
+            invoices = env.get("invoices")
+            if not isinstance(invoices, list):
+                invoices = []
+            ok_count = 0
+            bad_count = 0
+            for row in invoices:
+                if not isinstance(row, dict):
+                    rejected_rows.append({"portal": portal, "reason": "row_not_object", "raw": str(row)[:200]})
+                    bad_count += 1
+                    continue
+                inv = str(row.get("invoice_number") or "").strip()
+                amount = _to_amount(row.get("amount"))
+                ccy = str(row.get("currency") or "").strip().upper()
+                status = str(row.get("status") or "").strip().lower()
+                reasons = []
+                if not inv or not re.match(inv_pattern, inv):
+                    reasons.append("bad_invoice_number")
+                if amount is None or amount < 0:
+                    reasons.append("bad_amount")
+                if ccy not in allowed_ccy:
+                    reasons.append("bad_currency")
+                if status not in allowed_status:
+                    reasons.append("bad_status")
+                if reasons:
+                    rejected_rows.append({
+                        "portal": portal,
+                        "invoice_number": inv,
+                        "reasons": reasons,
+                    })
+                    bad_count += 1
+                    continue
+                valid_rows.append({
+                    "portal": portal,
+                    "vendor": vendor,
+                    "invoice_number": inv,
+                    "amount": amount,
+                    "currency": ccy,
+                    "status": status,
+                    "approval_date": str(row.get("approval_date") or ""),
+                    "expected_pay_date": str(row.get("expected_pay_date") or ""),
+                })
+                ok_count += 1
+            per_portal[portal] = {"valid": ok_count, "rejected": bad_count}
+
+        # A portal that returned zero valid rows is suspicious - probable redesign
+        # or auth wall. Surface it so the digest can flag a scrape failure, not a
+        # clean "no open invoices" result.
+        suspicious_portals = [p for p, c in per_portal.items() if c["valid"] == 0]
+
+        result = {
+            "valid_rows": valid_rows,
+            "valid_count": len(valid_rows),
+            "rejected_rows": rejected_rows,
+            "rejected_count": len(rejected_rows),
+            "per_portal": per_portal,
+            "suspicious_portals": suspicious_portals,
+            "extraction_ok": len(valid_rows) > 0,
+        }
+
+  # 3) HTTP: pull the matching open invoices for this supplier from the INTERNAL AR
+  #    ledger API. This is the company's own system of record - the side we are
+  #    reconciling the portal status against. Auth via a bearer token from the env,
+  #    never inlined. (connector: internal AR ledger via http)
+  - id: fetch_ar_ledger
+    type: http
+    depends_on: [validate_extraction]
+    http_config:
+      url: "{input.ledger_api_url}/invoices?status=open&since={input.filter_since}"
+      method: GET
+      auth: "bearer:{env.AR_LEDGER_TOKEN}"
+      headers:
+        Accept: "application/json"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 4) CODE: the LOAD-BEARING reconciliation. Pure deterministic math, NO model in
+  #    the path, so the conclusion is reproducible and provider-neutral. For every
+  #    validated portal row it finds the matching ledger row by invoice_number and
+  #    classifies: status mismatch (portal says paid but ledger open, etc.), amount
+  #    delta beyond tolerance (short-paid), overdue (portal-approved but past
+  #    expected_pay_date with no ledger payment), portal-only (never reached the
+  #    ledger), and ledger-only (submitted internally but missing from the portal).
+  - id: reconcile
+    type: code
+    depends_on: [validate_extraction, fetch_ar_ledger]
+    code_config:
+      language: python
+      code: |
+        extraction = _steps.get("validate_extraction") or {}
+        if not isinstance(extraction, dict):
+            extraction = {}
+        portal_rows = extraction.get("valid_rows") or []
+        if not isinstance(portal_rows, list):
+            portal_rows = []
+
+        ledger_resp = _steps.get("fetch_ar_ledger") or {}
+        if not isinstance(ledger_resp, dict):
+            ledger_resp = {}
+        # HTTP step output may carry the parsed body under common keys.
+        ledger_rows = (
+            ledger_resp.get("invoices")
+            or ledger_resp.get("data")
+            or ledger_resp.get("body")
+            or ledger_resp.get("json")
+        )
+        if isinstance(ledger_rows, dict):
+            ledger_rows = ledger_rows.get("invoices") or ledger_rows.get("data") or []
+        if not isinstance(ledger_rows, list):
+            ledger_rows = []
+
+        try:
+            tol = float(_input.get("amount_tolerance", 0.01) or 0.01)
+        except (TypeError, ValueError):
+            tol = 0.01
+        try:
+            grace = int(_input.get("overdue_grace_days", 0) or 0)
+        except (TypeError, ValueError):
+            grace = 0
+        today = str(_input.get("_today") or "")  # optional injected run date
+
+        def _num(v):
+            try:
+                return round(float(v), 2)
+            except (TypeError, ValueError):
+                return None
+
+        def _norm_status(s):
+            return str(s or "").strip().lower()
+
+        # Index the ledger by invoice number for O(1) matching.
+        ledger_by_inv = {}
+        for lr in ledger_rows:
+            if not isinstance(lr, dict):
+                continue
+            key = str(lr.get("invoice_number") or lr.get("number") or lr.get("id") or "").strip()
+            if key:
+                ledger_by_inv[key] = lr
+
+        # Statuses on the portal that mean the buyer considers it settled.
+        portal_settled = {"paid"}
+        # Ledger statuses that mean WE consider it settled / closed.
+        ledger_settled = {"paid", "closed", "settled"}
+
+        stuck = []          # approved/submitted on portal but unpaid past due
+        short_paid = []     # amount delta beyond tolerance
+        status_mismatch = []  # portal vs ledger disagree on settlement
+        portal_only = []    # on portal, missing from ledger
+        matched_ok = 0
+        seen_inv = set()
+
+        def _overdue(expected, has_payment):
+            # Overdue only if we have a comparable run date AND an expected date AND
+            # the invoice is not settled. String ISO compare is monotonic for dates.
+            if has_payment:
+                return False
+            if not today or not expected:
+                return False
+            return str(expected) < str(today)
+
+        for pr in portal_rows:
+            if not isinstance(pr, dict):
+                continue
+            inv = str(pr.get("invoice_number") or "").strip()
+            seen_inv.add(inv)
+            p_status = _norm_status(pr.get("status"))
+            p_amount = _num(pr.get("amount"))
+            expected = pr.get("expected_pay_date")
+
+            lr = ledger_by_inv.get(inv)
+            if lr is None:
+                portal_only.append({
+                    "invoice_number": inv,
+                    "portal": pr.get("portal"),
+                    "portal_status": p_status,
+                    "amount": p_amount,
+                    "currency": pr.get("currency"),
+                })
+                continue
+
+            l_status = _norm_status(lr.get("status"))
+            l_amount = _num(lr.get("amount") if "amount" in lr else lr.get("amount_due"))
+            l_paid = _num(lr.get("amount_paid"))
+            has_payment = l_status in ledger_settled or (l_paid is not None and l_paid > 0)
+
+            row_flags = []
+
+            # Short-paid: a recorded payment / ledger amount differs from the portal
+            # amount beyond tolerance, OR portal marks paid but a residual remains.
+            if p_amount is not None and l_amount is not None:
+                delta = round(abs(p_amount - l_amount), 2)
+                if delta > tol:
+                    short_paid.append({
+                        "invoice_number": inv,
+                        "portal": pr.get("portal"),
+                        "portal_amount": p_amount,
+                        "ledger_amount": l_amount,
+                        "delta": delta,
+                        "currency": pr.get("currency"),
+                    })
+                    row_flags.append("amount_delta")
+
+            # Settlement disagreement: portal says paid while the ledger is still
+            # unsettled, or vice versa. The core "is invoice #X actually paid" check.
+            p_is_settled = p_status in portal_settled
+            if p_is_settled != has_payment:
+                status_mismatch.append({
+                    "invoice_number": inv,
+                    "portal": pr.get("portal"),
+                    "portal_status": p_status,
+                    "ledger_status": l_status,
+                })
+                row_flags.append("status_mismatch")
+
+            # Stuck/overdue: approved on the portal but unpaid past the expected pay
+            # date with no ledger payment recorded.
+            if p_status in {"approved", "submitted"} and _overdue(expected, has_payment):
+                stuck.append({
+                    "invoice_number": inv,
+                    "portal": pr.get("portal"),
+                    "portal_status": p_status,
+                    "expected_pay_date": str(expected or ""),
+                    "amount": p_amount,
+                    "currency": pr.get("currency"),
+                })
+                row_flags.append("overdue")
+
+            if not row_flags:
+                matched_ok += 1
+
+        # Ledger invoices we submitted that never showed up on any portal grid.
+        ledger_only = []
+        for inv_no, lr in ledger_by_inv.items():
+            if inv_no not in seen_inv:
+                ledger_only.append({
+                    "invoice_number": inv_no,
+                    "ledger_status": _norm_status(lr.get("status")),
+                    "amount": _num(lr.get("amount") if "amount" in lr else lr.get("amount_due")),
+                })
+
+        exceptions_total = (
+            len(stuck) + len(short_paid) + len(status_mismatch)
+            + len(portal_only) + len(ledger_only)
+        )
+
+        result = {
+            "summary": {
+                "portal_rows": len(portal_rows),
+                "ledger_rows": len(ledger_rows),
+                "matched_ok": matched_ok,
+                "stuck_count": len(stuck),
+                "short_paid_count": len(short_paid),
+                "status_mismatch_count": len(status_mismatch),
+                "portal_only_count": len(portal_only),
+                "ledger_only_count": len(ledger_only),
+                "exceptions_total": exceptions_total,
+                "tolerance": tol,
+                "grace_days": grace,
+            },
+            "stuck": stuck,
+            "short_paid": short_paid,
+            "status_mismatch": status_mismatch,
+            "portal_only": portal_only,
+            "ledger_only": ledger_only,
+            "suspicious_portals": extraction.get("suspicious_portals", []),
+            "rejected_count": extraction.get("rejected_count", 0),
+            "clean": exceptions_total == 0,
+        }
+
+  # 5) SENSOR: confirm the internal AR ledger API is live and responding before the
+  #    digest is declared trustworthy. If the ledger was down or rate-limited during
+  #    fetch_ar_ledger, every portal row would look "portal_only" - a false alarm.
+  #    The sensor polls the ledger health endpoint and only proceeds on a 200.
+  - id: confirm_ledger_live
+    type: sensor
+    depends_on: [reconcile]
+    sensor_config:
+      url: "{input.ledger_api_url}/health"
+      condition: "status_code == 200"
+      check_interval: 30
+      timeout: 600
+
+  # 6) GATE (llm_eval): a non-load-bearing sanity check that the deterministic
+  #    reconciliation summary is internally consistent and shows no obvious
+  #    extraction drift (e.g. every portal suspicious, or exception counts that do
+  #    not add up) before a human is paged. The heavy correctness already happened
+  #    in code; this judge only catches gross drift and can be raced across providers.
+  - id: drift_gate
+    type: gate
+    depends_on: [reconcile, confirm_ledger_live]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >
+              You are a collections-controls reviewer. You are given a deterministic
+              portal-vs-ledger reconciliation summary. Answer exactly 'approved' if
+              the counts are internally consistent (exceptions_total equals the sum of
+              the individual exception counts), the suspicious_portals list does not
+              contain every configured portal (which would imply the whole scrape
+              failed), and nothing indicates wholesale extraction drift. Otherwise
+              answer 'rejected' and name the inconsistency. Do not re-do the math;
+              only judge consistency and drift.
+            input: "{steps.reconcile.output.summary}"
+            model: sonnet
+
+  # 7) NOTIFY: post the stuck / short-paid / mismatched invoices digest to Finance.
+  #    No portal write actions are ever taken - this is read-only extraction plus
+  #    internal reconciliation - so no outbound approval gate is needed; the only
+  #    safety gate on the portal side was the captcha pause inside the browser steps.
+  #    (connectors: slack, teams)
+  - id: notify_finance
+    type: notify
+    depends_on: [drift_gate]
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: ":receipt: Supplier portal reconciliation complete. Exceptions: {steps.reconcile.output.summary}. Stuck/short-paid/mismatched detail: {steps.reconcile.output}. Suspicious (possible portal redesign / auth wall) portals: {steps.reconcile.output.suspicious_portals}. Rejected malformed rows: {steps.reconcile.output.rejected_count}. This run was READ-ONLY on all external portals - no submit/edit/pay actions were taken."
+
+on_complete:
+  storage_path: "supplier-portal-invoice-status-reconciler/{run_id}/reconciliation.json"

--- a/src/sandcastle/templates/synthetic_signup_journey_sentinel.yaml
+++ b/src/sandcastle/templates/synthetic_signup_journey_sentinel.yaml
@@ -1,0 +1,398 @@
+# name: Synthetic Signup Journey Sentinel
+# description: Every 15 minutes a synthetic user drives your real production signup -> verify-email -> first-login -> onboarding journey in a headless browser, asserts each step structurally in deterministic code, replays against a recorded golden run to catch silent UI regressions, and pages on-call when account creation breaks.
+# tags: [SRE, Synthetic-Monitoring, Browser, Playwright, Signup, Activation, Golden-Run, On-Call]
+# category: engineering
+
+name: synthetic-signup-journey-sentinel
+description: >-
+  A read-only synthetic-monitoring sentinel for the most revenue-critical flow
+  in a self-serve SaaS: account creation. An http healthcheck on /signup returns
+  200 even when the submit button is wired to a dead endpoint, the verification
+  email never sends, or step 3 of the onboarding wizard throws in React. Only a
+  real browser driving the actual DOM proves a human can still create an account.
+
+  A SENSOR acts as a heartbeat clock (check_interval = 900s) and is also exposed
+  as a webhook so CI can fire the run post-deploy. A BROWSER step in provider-
+  neutral playwright mode authors a Playwright script from its prompt: it loads
+  the signup page, fills the form with a disposable seeded test account
+  (credentials_env = SYNTH_USER_SECRETS - never inline), polls a test-inbox page
+  for the verification link, clicks it, lands logged-in, and walks the onboarding
+  wizard - returning STRUCTURED JSON via output_schema (steps reached, http
+  status, email-received flag, onboarding-completed flag, per-step latency,
+  error text). A deterministic sandboxed CODE step then ASSERTS every field:
+  each expected milestone present, email received, onboarding completed, no error
+  text, every per-step latency under SLO - emitting pass/fail plus the exact
+  failing assertion. A TRAJECTORY-REPLAY scores the live run against a recorded
+  golden signup (fail_below_score = 0.85) to flag structural drift - a renamed
+  selector, a new interstitial - even when the assertions technically still pass.
+  A CONDITION routes the verdict: green -> a quiet NOTIFY on the ok channel; red
+  -> a NOTIFY that pages on-call with the failing assertion, the failure
+  screenshot URL, and the diff vs golden.
+
+  The journey only ever creates a known disposable test account, so there is NO
+  irreversible action and NO approval gate is required; the single human-in-the-
+  loop is captcha_strategy = pause. max_actions = 60 caps runaway clicking and
+  capture_screenshots = true gives an audit trail on the synthetic account.
+  Every load-bearing correctness check is deterministic code plus a golden-run
+  replay - never a single model's opinion. Swap default_model and nothing else
+  changes; dom mode is the cheap fallback for non-canvas signup forms.
+
+default_model: sonnet
+default_timeout: 900
+
+input_schema:
+  required: ["signup_url"]
+  properties:
+    signup_url:
+      type: string
+      description: "Production signup page URL the synthetic user starts from (e.g. https://app.acme.com/signup)"
+      default: ""
+    test_inbox_url:
+      type: string
+      description: "Disposable test-inbox web page the script polls for the verification email (e.g. https://inbox.testmail.app/u/synthetic)"
+      default: ""
+    expected_post_signup_url_contains:
+      type: string
+      description: "Substring the final logged-in URL must contain to prove first-login + onboarding landed (e.g. /app/welcome)"
+      default: "/app"
+    expected_steps:
+      type: string
+      description: "Comma-separated milestones the journey MUST reach, in order (used by the deterministic assertion code)"
+      default: "signup_form,form_submitted,verification_email_received,email_link_clicked,first_login,onboarding_completed"
+    browser_mode:
+      type: string
+      description: "Documented browser-mode choice for this monitor: 'playwright' (default, provider-neutral - the model authors the script) or swap the browser step's mode to 'dom' for cheap read-only checks of non-canvas signup forms"
+      default: "playwright"
+    step_latency_slo_ms:
+      type: number
+      description: "Per-step latency SLO in milliseconds; any per_step_latency_ms above this fails the run"
+      default: 8000
+    golden_run_id:
+      type: string
+      description: "Run id of a recorded healthy signup journey to replay against for structural-drift detection"
+      default: "golden-signup-baseline"
+    heartbeat_url:
+      type: string
+      description: "Lightweight heartbeat/clock endpoint the sensor polls on interval (also a CI webhook target for post-deploy firing)"
+      default: "https://app.acme.com/healthz/heartbeat"
+    ok_slack_channel:
+      type: string
+      description: "Quiet Slack channel for green synthetic-check confirmations"
+      default: "#synthetics-ok"
+    oncall_slack_channel:
+      type: string
+      description: "On-call Slack channel that pages when signup breaks (mirror of the PagerDuty route)"
+      default: "#oncall-activation"
+
+steps:
+  # 1) SENSOR heartbeat clock. On a schedule it ticks every 15 min (check_interval
+  #    = 900s); exposed as a webhook so CI can fire the same run post-deploy. It
+  #    gates the journey on the app being reachable at all before we drive a
+  #    browser at it - a cheap pre-flight, not the real proof of signup health.
+  - id: heartbeat_clock
+    type: sensor
+    sensor_config:
+      url: "{input.heartbeat_url}"
+      method: GET
+      condition: "status_code == 200"
+      check_interval: 900
+      timeout: 3600
+
+  # 2) BROWSER (provider-neutral playwright mode). The reasoning model authors a
+  #    Playwright script from this prompt that drives the REAL production signup
+  #    journey end to end and returns STRUCTURED JSON via output_schema (the read
+  #    pass). Disposable seeded credentials come from credentials_env, never
+  #    inline. captcha_strategy = pause hands a human the wheel on CAPTCHA;
+  #    max_actions = 60 caps runaway clicking; capture_screenshots = true keeps an
+  #    audit trail on the synthetic account. No write to any real system - it only
+  #    creates a known disposable test account - so no approval gate is needed.
+  - id: browser_journey
+    type: browser
+    depends_on: [heartbeat_clock]
+    browser_config:
+      mode: playwright
+      start_url: "{input.signup_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 60
+      headless: true
+      credentials_env: "SYNTH_USER_SECRETS"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          steps_reached:
+            type: array
+            items: { type: string }
+          signup_http_status: { type: integer }
+          verification_email_received: { type: boolean }
+          onboarding_completed: { type: boolean }
+          final_url: { type: string }
+          per_step_latency_ms: { type: object }
+          screenshot_url: { type: string }
+          error_text: { type: ["string", "null"] }
+        required:
+          - steps_reached
+          - signup_http_status
+          - verification_email_received
+          - onboarding_completed
+          - final_url
+          - per_step_latency_ms
+          - error_text
+    prompt: |
+      You are a synthetic monitoring user. Author and run a Playwright script that
+      drives the REAL production signup -> verify-email -> first-login ->
+      onboarding journey, behaving like a careful human creating one account.
+
+      Use ONLY the disposable seeded test account supplied via the credentials
+      environment (SYNTH_USER_SECRETS): it carries the test email address, a
+      strong password, and an inbox access token. NEVER print or echo the secret.
+
+      Journey (record a milestone string in steps_reached as each is reached, and
+      the wall-clock duration of each in per_step_latency_ms keyed by the same
+      milestone name):
+        1. "signup_form"                 - load {input.signup_url}; confirm the
+                                           signup form rendered (email + password
+                                           fields are present and interactable).
+        2. "form_submitted"              - fill email + password from the secret,
+                                           submit, and capture the HTTP status of
+                                           the submit request into signup_http_status.
+        3. "verification_email_received" - open {input.test_inbox_url}, poll (with
+                                           a bounded wait) until the verification
+                                           email arrives; set
+                                           verification_email_received = true and
+                                           extract the verify link. If it never
+                                           arrives, set it false and stop.
+        4. "email_link_clicked"          - click / navigate the verification link.
+        5. "first_login"                 - confirm you land authenticated (a
+                                           logged-in shell / dashboard chrome).
+        6. "onboarding_completed"        - walk every step of the onboarding wizard
+                                           to completion; set onboarding_completed
+                                           = true only if the final step succeeds.
+
+      Record final_url as the last URL after onboarding. Put a URL to the captured
+      failure screenshot (or the last screenshot) in screenshot_url. If anything
+      throws, breaks, or a milestone cannot be reached, put a short human-readable
+      explanation in error_text (otherwise error_text = null). On a CAPTCHA,
+      pause for the human per captcha_strategy.
+
+      Return ONLY the structured JSON object matching the output_schema. Do not
+      add prose outside the JSON.
+
+  # 3) DETERMINISTIC ASSERTION (sandboxed code). This is the load-bearing pass/fail
+  #    - NOT a model opinion. It validates the browser's structured extraction:
+  #    every expected milestone present, email received, onboarding completed, no
+  #    error text, and every per-step latency under SLO. Rejects on empty/bad reads.
+  - id: assert_journey
+    type: code
+    depends_on: [browser_journey]
+    code_config:
+      language: python
+      code: |
+        # Validate the browser's structured extraction field by field. Any miss is
+        # a hard fail; we record the FIRST failing assertion for the page-out.
+        j = _steps.get("browser_journey") or {}
+        if not isinstance(j, dict):
+            j = {}
+
+        # Parse the required milestone list from input (comma-separated, ordered).
+        raw_expected = str(_input.get("expected_steps", "") or "")
+        expected = [s.strip() for s in raw_expected.split(",") if s.strip()]
+        if not expected:
+            expected = [
+                "signup_form",
+                "form_submitted",
+                "verification_email_received",
+                "email_link_clicked",
+                "first_login",
+                "onboarding_completed",
+            ]
+
+        reached = j.get("steps_reached") or []
+        if not isinstance(reached, list):
+            reached = []
+        reached_set = {str(s).strip() for s in reached}
+
+        latencies = j.get("per_step_latency_ms") or {}
+        if not isinstance(latencies, dict):
+            latencies = {}
+
+        try:
+            slo_ms = float(_input.get("step_latency_slo_ms", 8000) or 8000)
+        except (TypeError, ValueError):
+            slo_ms = 8000.0
+
+        failures = []
+
+        # Guard against an empty / malformed read - a blank browser result must
+        # never be reported as a healthy signup.
+        if not reached_set:
+            failures.append("empty_read: browser returned no steps_reached")
+
+        # Assertion 1: every expected milestone was reached.
+        missing = [m for m in expected if m not in reached_set]
+        if missing:
+            failures.append("missing_steps: " + ", ".join(missing))
+
+        # Assertion 2: the submit HTTP status is a real 2xx (dead endpoint -> not).
+        status = j.get("signup_http_status")
+        try:
+            status_int = int(status)
+        except (TypeError, ValueError):
+            status_int = -1
+        if not (200 <= status_int < 300):
+            failures.append("bad_signup_status: " + str(status))
+
+        # Assertion 3: the verification email actually arrived.
+        if not bool(j.get("verification_email_received", False)):
+            failures.append("no_verification_email")
+
+        # Assertion 4: onboarding finished.
+        if not bool(j.get("onboarding_completed", False)):
+            failures.append("onboarding_incomplete")
+
+        # Assertion 5: the journey landed where first-login + onboarding should.
+        final_url = str(j.get("final_url", "") or "")
+        expect_frag = str(_input.get("expected_post_signup_url_contains", "") or "")
+        if expect_frag and expect_frag not in final_url:
+            failures.append("wrong_final_url: " + final_url)
+
+        # Assertion 6: the browser reported no error text.
+        err = j.get("error_text")
+        if err not in (None, "", "null"):
+            failures.append("browser_error: " + str(err))
+
+        # Assertion 7: every per-step latency is under SLO.
+        slow = []
+        for name, val in latencies.items():
+            try:
+                ms = float(val)
+            except (TypeError, ValueError):
+                continue
+            if ms > slo_ms:
+                slow.append(str(name) + "=" + str(int(ms)) + "ms")
+        if slow:
+            failures.append("latency_slo_breach(>" + str(int(slo_ms)) + "ms): " + ", ".join(slow))
+
+        passed = len(failures) == 0
+        result = {
+            "passed": passed,
+            "failing_assertion": ("" if passed else failures[0]),
+            "all_failures": failures,
+            "steps_reached": sorted(reached_set),
+            "missing_steps": missing,
+            "signup_http_status": status_int,
+            "verification_email_received": bool(j.get("verification_email_received", False)),
+            "onboarding_completed": bool(j.get("onboarding_completed", False)),
+            "final_url": final_url,
+            "screenshot_url": str(j.get("screenshot_url", "") or ""),
+            "slo_ms": slo_ms,
+        }
+
+  # 4) TRAJECTORY-REPLAY against a recorded healthy signup. Scores structural
+  #    similarity to the golden run and fails below 0.85 - catching drift (a
+  #    renamed selector, a new interstitial, an extra wizard step) even when the
+  #    field assertions above technically still pass. Reliability layer, not a vote.
+  - id: golden_replay
+    type: trajectory-replay
+    depends_on: [browser_journey, assert_journey]
+    trajectory_replay_config:
+      golden_run_id: "{input.golden_run_id}"
+      fail_below_score: 0.85
+      allow_cost_delta_pct: 15.0
+      cost_budget_usd: 0.5
+
+  # 5) Deterministically fold the assertion verdict AND the golden-replay verdict
+  #    into one health decision. Either a failed assertion OR structural drift
+  #    below threshold turns the synthetic check red. Pure code - no model here.
+  - id: synth_verdict
+    type: code
+    depends_on: [assert_journey, golden_replay]
+    code_config:
+      language: python
+      code: |
+        # Combine the deterministic assertion with the golden-run replay score.
+        a = _steps.get("assert_journey") or {}
+        rep = _steps.get("golden_replay") or {}
+        if not isinstance(a, dict):
+            a = {}
+        if not isinstance(rep, dict):
+            rep = {}
+
+        assertions_passed = bool(a.get("passed", False))
+
+        # The replay step surfaces a score and/or a pass flag depending on backend
+        # shape; read whichever is present and compare to the configured floor.
+        threshold = 0.85
+        score = rep.get("score", rep.get("replay_score"))
+        try:
+            score_f = float(score)
+        except (TypeError, ValueError):
+            score_f = None
+
+        if "passed" in rep:
+            replay_ok = bool(rep.get("passed"))
+        elif score_f is not None:
+            replay_ok = score_f >= threshold
+        else:
+            # No replay signal (e.g. golden run missing) - do not let a missing
+            # baseline mask a real assertion failure, but do not invent a drift
+            # failure either; treat replay as neutral/ok and rely on assertions.
+            replay_ok = True
+
+        healthy = assertions_passed and replay_ok
+
+        if not assertions_passed:
+            reason = "assertion_failed: " + str(a.get("failing_assertion", "unknown"))
+        elif not replay_ok:
+            sc = "n/a" if score_f is None else str(round(score_f, 3))
+            reason = "golden_drift: replay score " + sc + " below " + str(threshold)
+        else:
+            reason = "all_clear"
+
+        result = {
+            "healthy": healthy,
+            "status": ("green" if healthy else "red"),
+            "reason": reason,
+            "assertions_passed": assertions_passed,
+            "replay_ok": replay_ok,
+            "replay_score": score_f,
+            "failing_assertion": str(a.get("failing_assertion", "")),
+            "all_failures": a.get("all_failures", []),
+            "steps_reached": a.get("steps_reached", []),
+            "final_url": a.get("final_url", ""),
+            "screenshot_url": a.get("screenshot_url", ""),
+        }
+
+  # 6) CONDITION: route the verdict. healthy -> quiet OK notify; broken signup ->
+  #    page on-call. Read-only journey, so no destructive action and no approval.
+  - id: route_verdict
+    type: condition
+    depends_on: [synth_verdict]
+    condition_config:
+      expression: "{steps.synth_verdict.output.healthy} == True"
+      then: [notify_ok]
+      else: [notify_oncall]
+
+  # 6a) GREEN: a quiet confirmation on the synthetics-ok channel. Low noise.
+  - id: notify_ok
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.ok_slack_channel}"
+      message: ":white_check_mark: Synthetic signup journey GREEN. Reached {steps.synth_verdict.output.steps_reached}, landed {steps.synth_verdict.output.final_url}, golden replay score {steps.synth_verdict.output.replay_score}. (signup {input.signup_url})"
+
+  # 6b) RED: page on-call with the FAILING ASSERTION, the failure screenshot URL,
+  #     and the structural diff vs the golden run. This is the page that fires when
+  #     account creation is broken and every new signup that day is at risk.
+  - id: notify_oncall
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.oncall_slack_channel}"
+      message: ":rotating_light: SIGNUP BROKEN - synthetic journey RED. Cause: {steps.synth_verdict.output.reason}. Failing assertion: {steps.synth_verdict.output.failing_assertion}. Reached {steps.synth_verdict.output.steps_reached}. Golden replay score {steps.synth_verdict.output.replay_score} (drift threshold 0.85). Failure screenshot: {steps.synth_verdict.output.screenshot_url}. Signup URL {input.signup_url}. Paging on-call."
+
+on_complete:
+  storage_path: "synthetic-signup-journey-sentinel/{run_id}/result.json"

--- a/src/sandcastle/templates/web_portal_supplier_onboarding_filer.yaml
+++ b/src/sandcastle/templates/web_portal_supplier_onboarding_filer.yaml
@@ -1,0 +1,350 @@
+# name: Web Portal Supplier Onboarding Filer
+# description: Fills and submits a supplier/vendor onboarding application across a buyer's JS-heavy procurement portal (Ariba/Coupa-style SPA or government e-procurement) that has no public submission API. Uses provider-neutral Playwright mode - the reasoning model AUTHORS a Playwright script, so any of the 7 providers can drive it. Read is split from write; the irreversible filing is gated behind deterministic validation, an llm_eval verifier, and a human approval.
+# tags: [Procurement, Ariba, Coupa, SupplierOnboarding, Playwright, RPA, SalesOps, BidManagement, e-Procurement, HumanInTheLoop]
+# category: sales_crm
+
+name: web-portal-supplier-onboarding-filer
+description: >-
+  Registers a supplier on a buyer's bespoke, login-gated procurement portal (Ariba /
+  Coupa-style SPA or a government e-procurement wizard) that has NO public submission API
+  and renders entirely client-side, so a plain http step cannot post the form. Because the
+  pages are real DOM (not a remote-desktop canvas), this template uses Playwright mode: the
+  swappable reasoning model AUTHORS a deterministic Playwright script to log in, walk the
+  multi-page wizard, fill fields from the canonical company profile, upload the document set,
+  and STOP on the final REVIEW page WITHOUT submitting. The read pass returns structured JSON
+  via output_schema. A DETERMINISTIC Python step then validates that every required field is
+  non-empty and every expected document was uploaded - failing closed on any gap. A swappable
+  llm_eval gate compares the captured review-page screenshot against the source profile to
+  catch transposed values, then a human approval gates the actual, irreversible submission.
+  Only on approval does a second Playwright step click Submit and capture the confirmation /
+  reference number; a sensor polls the portal's own confirmation endpoint, and a
+  trajectory-replay against a sandbox-portal golden run catches when a portal redesign breaks
+  the wizard path. Provider-neutral end to end - no vendor agent runtime, no computer_use lock-in.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 1800
+
+input_schema:
+  required: ["portal_id", "profile_ref", "portal_login_url"]
+  properties:
+    portal_id:
+      type: string
+      description: "Stable identifier for the target buyer portal (drives golden-run lookup and storage path)."
+      example: "acme-coupa-eu"
+    profile_ref:
+      type: string
+      description: "Reference to the canonical company profile + document set in gdrive/s3 (path, URL, or @file: ref)."
+      example: "s3://supplier-profiles/globex/onboarding-pack.json"
+    portal_login_url:
+      type: string
+      description: "Login URL of the buyer's procurement portal SPA where the onboarding wizard begins."
+      example: "https://acme.coupahost.com/sessions/new"
+    portal_confirm_url:
+      type: string
+      description: "Portal endpoint that returns 200 once a submitted registration is accepted (used to poll the portal's own confirmation)."
+      default: "https://acme.coupahost.com/api/suppliers/registration/status"
+      example: "https://acme.coupahost.com/api/suppliers/registration/status"
+    crm_ack_url:
+      type: string
+      description: "CRM webhook to acknowledge that the registration task was picked up by this run."
+      default: "https://crm.internal/api/registration-tasks/ack"
+      example: "https://crm.internal/api/registration-tasks/ack"
+    expected_documents:
+      type: string
+      description: "Comma-separated list of document keys the portal requires (validated against actual uploads). e.g. 'w9,insurance_cert,iso9001,banking_letter'."
+      default: "w9,insurance_cert,iso9001,banking_letter"
+      example: "w9,insurance_cert,iso9001,banking_letter"
+    golden_run_id:
+      type: string
+      description: "Run id of the recorded sandbox-portal golden trajectory for this portal, used to detect wizard-path drift."
+      default: "golden-coupa-onboarding-v1"
+      example: "golden-coupa-onboarding-v1"
+    notify_channel:
+      type: string
+      description: "Slack channel for the final filed/blocked notification."
+      default: "#bid-management"
+      example: "#bid-management"
+
+steps:
+  # 1) TRIGGER ack: tell the CRM this registration task was picked up. http (deterministic).
+  - id: ack_task
+    type: http
+    http_config:
+      url: "{input.crm_ack_url}"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+      auth: "bearer:{env.CRM_TOKEN}"
+      body: '{"portal_id": "{input.portal_id}", "status": "picked_up", "profile_ref": "{input.profile_ref}"}'
+
+  # 2) LOAD the canonical company profile + document manifest from gdrive/s3. parse.
+  - id: load_profile
+    type: parse
+    depends_on: [ack_task]
+    prompt: "{input.profile_ref}"
+    parse_config:
+      output: json
+
+  # 3) READ PASS (Playwright, NO submit). The reasoning model AUTHORS a Playwright script to
+  #    log in (creds from PORTAL_CREDS - never inlined), walk the multi-page wizard, fill
+  #    fields from the profile, upload the document set, and STOP on the final review page.
+  #    captcha_strategy=pause hands off to a human on the near-certain procurement CAPTCHA.
+  #    max_actions=120 bounds the multi-page wizard; output_schema returns structured JSON.
+  - id: fill_to_review
+    type: browser
+    depends_on: [load_profile]
+    prompt: >-
+      You are filling a supplier/vendor onboarding application on a JavaScript procurement
+      portal SPA. Authenticate using the credentials provided via the PORTAL_CREDS environment
+      variable. Then walk the multi-page registration wizard end to end: on each page, map fields
+      from the canonical company profile below and fill them, handling dynamic client-side
+      validation (wait for fields to settle before advancing). Upload every required document
+      from the profile's document manifest. CRITICAL: advance only to the FINAL REVIEW / SUMMARY
+      page and STOP there. DO NOT click the final Submit / Confirm / File button - submission is a
+      separate, human-approved step. If a CAPTCHA or step-up auth appears, pause for a human.
+      Company profile and document manifest (JSON): {steps.load_profile.output}.
+      Return structured JSON describing exactly what you filled and uploaded, a human-readable
+      review summary of the values shown on the final review page, and whether the submit button
+      is present and enabled.
+    browser_config:
+      mode: playwright
+      start_url: "{input.portal_login_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 600
+      max_actions: 120
+      headless: true
+      credentials_env: "PORTAL_CREDS"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          fields_filled:
+            type: array
+            items:
+              type: object
+              properties:
+                name: { type: string }
+                value: { type: string }
+                page: { type: string }
+          files_uploaded:
+            type: array
+            items:
+              type: object
+              properties:
+                doc_key: { type: string }
+                filename: { type: string }
+                status: { type: string }
+          review_summary:
+            type: object
+            properties:
+              legal_name: { type: string }
+              tax_id: { type: string }
+              duns: { type: string }
+              primary_contact_email: { type: string }
+              page_count: { type: integer }
+          review_screenshot_ref: { type: string }
+          submit_button_present: { type: boolean }
+
+  # 4) DETERMINISTIC validation (sandboxed Python). Fail CLOSED if any required field is empty
+  #    or any expected document is missing. This is the load-bearing correctness - not a model.
+  - id: validate_fill
+    type: code
+    depends_on: [fill_to_review]
+    code_config:
+      language: python
+      code: |
+        read_out = _steps['fill_to_review'] or {}
+        if not isinstance(read_out, dict):
+            read_out = {}
+
+        fields = read_out.get('fields_filled') or []
+        uploads = read_out.get('files_uploaded') or []
+        review = read_out.get('review_summary') or {}
+
+        # Expected document keys come from input (comma-separated).
+        expected_raw = _input.get('expected_documents') or ''
+        expected_docs = [d.strip() for d in expected_raw.split(',') if d.strip()]
+
+        problems = []
+
+        # 4a) Every filled field must carry a non-empty value.
+        empty_fields = []
+        for f in fields:
+            if not isinstance(f, dict):
+                continue
+            name = str(f.get('name', '')).strip()
+            value = str(f.get('value', '')).strip()
+            if not value:
+                empty_fields.append(name or '<unnamed>')
+        if not fields:
+            problems.append('no fields were filled on the wizard')
+        if empty_fields:
+            problems.append('empty required fields: ' + ', '.join(empty_fields))
+
+        # 4b) Every expected document must have a successful upload.
+        uploaded_keys = set()
+        for u in uploads:
+            if not isinstance(u, dict):
+                continue
+            status = str(u.get('status', '')).strip().lower()
+            key = str(u.get('doc_key', '')).strip()
+            if key and status in ('ok', 'success', 'uploaded', 'complete', 'completed'):
+                uploaded_keys.add(key)
+        missing_docs = [d for d in expected_docs if d not in uploaded_keys]
+        if missing_docs:
+            problems.append('missing document uploads: ' + ', '.join(missing_docs))
+
+        # 4c) Core review-summary identity fields must be present.
+        for core in ('legal_name', 'tax_id'):
+            if not str(review.get(core, '')).strip():
+                problems.append('review summary missing ' + core)
+
+        # 4d) The wizard must actually have reached a submit-capable review page.
+        if not read_out.get('submit_button_present'):
+            problems.append('submit button not present - wizard did not reach the review page')
+
+        ok = len(problems) == 0
+        result = {
+            'ok': ok,
+            'problems': problems,
+            'fields_checked': len(fields),
+            'docs_expected': expected_docs,
+            'docs_uploaded': sorted(uploaded_keys),
+            'review_summary': review,
+            'review_screenshot_ref': read_out.get('review_screenshot_ref', ''),
+        }
+
+  # 5) Hard stop on a bad read - the workflow must NOT advance toward submission.
+  - id: validation_gate
+    type: condition
+    depends_on: [validate_fill]
+    condition_config:
+      expression: "{steps.validate_fill.output.ok} == True"
+      then: [verify_review]
+      else: [notify_blocked]
+
+  # 5b) Blocked branch: tell the bid team the application was NOT submitted and why.
+  - id: notify_blocked
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        Supplier onboarding on portal {input.portal_id} was BLOCKED before submission.
+        Validation failed: {steps.validate_fill.output.problems}. No filing was made.
+
+  # 6) SWAPPABLE llm_eval gate: a verifier model compares the review-page screenshot against
+  #    the source profile to catch transposed values BEFORE a human looks, plus a human
+  #    attester. ALL strategies must pass. The verifier can be a cheaper/different provider
+  #    than the script author - independently swappable.
+  - id: verify_review
+    type: gate
+    depends_on: [validation_gate]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are a data-fidelity reviewer for a supplier onboarding filing. Compare the
+              values shown on the portal's final REVIEW page against the canonical source company
+              profile. Answer exactly 'approved' only if every reviewed value (legal name, tax id,
+              DUNS, contact email, addresses) matches the source profile with NO transpositions,
+              truncations, or wrong-field placements; otherwise answer 'rejected' and name each
+              mismatch. Validated extraction: {steps.validate_fill.output} . Source profile:
+              {steps.load_profile.output}
+            input: "{steps.validate_fill.output}"
+            model: google/gemini-2.5-pro
+
+  # 7) HUMAN APPROVAL before the irreversible filing. The person reviews the captured
+  #    review-page screenshot + validated diff and approves the ACTUAL submit. No submission
+  #    can happen without this gate.
+  - id: approve_submit
+    type: approval
+    depends_on: [verify_review]
+    approval_config:
+      message: >-
+        Approve SUBMISSION of the supplier onboarding application on portal {input.portal_id}.
+        This is IRREVERSIBLE - it files the registration with the buyer. Review the captured
+        review-page screenshot and the validated field/document summary, then approve to submit
+        or reject to abort. Validated summary: {steps.validate_fill.output.review_summary}.
+        Screenshot: {steps.validate_fill.output.review_screenshot_ref}.
+      show_data: steps.validate_fill.output
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: false
+
+  # 8) WRITE PASS (Playwright, resumed): on approval ONLY, click the final Submit button and
+  #    capture the confirmation / reference number. capture_screenshots gives an auditable
+  #    after-submit record. max_actions kept small - this is a single confirm action.
+  - id: submit_application
+    type: browser
+    depends_on: [approve_submit]
+    prompt: >-
+      The supplier onboarding application is already filled and sitting on the portal's final
+      review page (a human has approved submission). Authenticate with PORTAL_CREDS if the
+      session expired, return to the review/summary page, and click the final Submit / Confirm /
+      File button ONCE to file the registration. Then read the confirmation page and capture the
+      buyer-issued confirmation or reference number. If a CAPTCHA appears, pause for a human. Do
+      not edit any field values. Return structured JSON with the submission outcome.
+    browser_config:
+      mode: playwright
+      start_url: "{input.portal_login_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 300
+      max_actions: 25
+      headless: true
+      credentials_env: "PORTAL_CREDS"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          submitted: { type: boolean }
+          confirmation_number: { type: string }
+          confirmation_message: { type: string }
+          confirmation_screenshot_ref: { type: string }
+
+  # 9) CONFIRM via the portal's OWN endpoint - never trust the click alone. Poll until the
+  #    buyer's registration-status endpoint reports the submission was accepted (200).
+  - id: await_portal_confirmation
+    type: sensor
+    depends_on: [submit_application]
+    sensor_config:
+      url: "{input.portal_confirm_url}?portal_id={input.portal_id}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200"
+      check_interval: 60
+      timeout: 3600
+
+  # 10) RELIABILITY: replay this run against a recorded sandbox-portal golden trajectory.
+  #     Fails when a portal redesign breaks the wizard path or cost blows up - catching drift
+  #     deterministically rather than on a model's say-so.
+  - id: drift_check
+    type: trajectory-replay
+    depends_on: [await_portal_confirmation]
+    trajectory_replay_config:
+      golden_run_id: "{input.golden_run_id}"
+      fail_below_score: 0.85
+      allow_cost_delta_pct: 15.0
+      cost_budget_usd: 0.5
+
+  # 11) SUCCESS notification with the buyer-issued reference number.
+  - id: notify_filed
+    type: notify
+    depends_on: [drift_check]
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        Supplier onboarding FILED on portal {input.portal_id}. Confirmation:
+        {steps.submit_application.output.confirmation_number}. Portal status endpoint
+        confirmed acceptance and the run passed golden-trajectory drift check.
+
+on_complete:
+  storage_path: "web-portal-supplier-onboarding-filer/{input.portal_id}/{run_id}/result.json"

--- a/tests/test_browser_rpa_templates_v034.py
+++ b/tests/test_browser_rpa_templates_v034.py
@@ -1,0 +1,221 @@
+"""Structural + safety validation for the v0.34 browser/computer-use RPA templates.
+
+This wave moves Sandcastle past API-based workflows into work that only exists inside a
+logged-in browser. The checks below add RPA-specific guarantees on top of the usual
+structural ones: every template drives a real browser step; the reasoning stays
+provider-neutral (playwright/dom modes, no computer_use lock-in in this build-first
+set); browser steps load secrets via credentials_env, never inline; and any template
+with a human approval gate positions it so a real browser/loop action runs after it
+(the irreversible click is gated), including loop-orchestrated writes.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from sandcastle.engine.dag import (
+    VALID_STEP_TYPES,
+    build_plan,
+    parse_yaml_string,
+    validate,
+)
+from sandcastle.engine.executor import _CODE_STEP_BLOCKED_PATTERNS
+from sandcastle.engine.tools.registry import KNOWN_TOOLS
+from sandcastle.templates import list_templates
+
+RPA_TEMPLATES = [
+    "synthetic_signup_journey_sentinel",
+    "act_then_sensor_verify_submission_skeleton",
+    "supplier_portal_invoice_status_reconciler",
+    "saas_seat_deactivation_offboarder",
+    "browser_flow_trajectory_replay_harness",
+    "web_portal_supplier_onboarding_filer",
+]
+
+NEUTRAL_BROWSER_MODES = {"playwright", "dom", "lightpanda", "browserbase"}
+LIGHTWEIGHT_READ_MODES = {"dom", "lightpanda"}
+
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "src" / "sandcastle" / "templates"
+
+
+def _load(name: str) -> str:
+    path = TEMPLATES_DIR / f"{name}.yaml"
+    assert path.exists(), f"Template file not found: {path}"
+    return path.read_text()
+
+
+def _downstream_of(target_ids: set[str], wf) -> set[str]:
+    """All step ids that run after any step in target_ids, following both depends_on
+    edges and loop orchestration (a loop's step_ids run when the loop runs)."""
+    by_id = {s.id: s for s in wf.steps}
+    # forward edges: dep -> step (depends_on), and loop -> its child step_ids
+    succ: dict[str, set[str]] = {s.id: set() for s in wf.steps}
+    for s in wf.steps:
+        for d in s.depends_on:
+            if d in succ:
+                succ[d].add(s.id)
+        if s.loop_config:
+            for child in s.loop_config.step_ids:
+                if child in by_id:
+                    succ[s.id].add(child)
+    seen: set[str] = set()
+    stack = [t for t in target_ids]
+    while stack:
+        cur = stack.pop()
+        for nxt in succ.get(cur, ()):
+            if nxt not in seen:
+                seen.add(nxt)
+                stack.append(nxt)
+    return seen
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_parses_with_steps(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    assert wf is not None and wf.name and len(wf.steps) > 0
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_step_types_valid(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    for step in wf.steps:
+        assert step.type in VALID_STEP_TYPES, (
+            f"{template_name}/{step.id} invalid type {step.type!r}"
+        )
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_depends_on_resolve(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    ids = {s.id for s in wf.steps}
+    for step in wf.steps:
+        for dep in step.depends_on:
+            assert dep in ids, f"{template_name}/{step.id} depends on unknown {dep!r}"
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_validates_clean(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    assert validate(wf) == [], f"{template_name} did not validate"
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_build_plan_covers_every_step_once(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    plan = build_plan(wf)
+    planned = [sid for stage in plan.stages for sid in stage]
+    assert len(planned) == len(set(planned)) and set(planned) == {s.id for s in wf.steps}
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_tool_references_known(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    for step in wf.steps:
+        if step.tool_config and step.tool_config.tool:
+            assert step.tool_config.tool.split(":")[0] in KNOWN_TOOLS
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_control_flow_branches_reference_real_steps(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    ids = {s.id for s in wf.steps}
+    for step in wf.steps:
+        if step.condition_config:
+            for sid in step.condition_config.then_steps + step.condition_config.else_steps:
+                assert sid in ids, f"{template_name}/{step.id} condition -> unknown {sid!r}"
+        if step.loop_config:
+            for sid in step.loop_config.step_ids:
+                assert sid in ids, f"{template_name}/{step.id} loop -> unknown {sid!r}"
+        if step.race_config:
+            for branch in step.race_config.branches:
+                for sid in branch:
+                    assert sid in ids, f"{template_name}/{step.id} race -> unknown {sid!r}"
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_drives_a_browser(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    assert any(s.type == "browser" for s in wf.steps), (
+        f"{template_name} is an RPA template but has no browser step"
+    )
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_browser_modes_are_provider_neutral(template_name: str) -> None:
+    """This build-first set must avoid computer_use (the one vendor-coupled mode): the
+    reasoning model only authors a Playwright script / DOM read, so it stays swappable."""
+    wf = parse_yaml_string(_load(template_name))
+    for step in wf.steps:
+        if step.type == "browser" and step.browser_config:
+            assert step.browser_config.mode in NEUTRAL_BROWSER_MODES, (
+                f"{template_name}/{step.id} uses non-neutral browser mode "
+                f"{step.browser_config.mode!r}"
+            )
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_browser_steps_handle_secrets_safely(template_name: str) -> None:
+    """A browser step either authenticates via credentials_env (never inline secrets) or
+    is a lightweight unauthenticated read (dom/lightpanda)."""
+    wf = parse_yaml_string(_load(template_name))
+    for step in wf.steps:
+        if step.type == "browser" and step.browser_config:
+            bc = step.browser_config
+            assert bc.credentials_env or bc.mode in LIGHTWEIGHT_READ_MODES, (
+                f"{template_name}/{step.id} browser step has no credentials_env and is "
+                f"not a lightweight read mode"
+            )
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_approval_gates_a_downstream_action(template_name: str) -> None:
+    """If a template has a human approval, it must actually gate downstream work: a
+    browser step or a loop runs after the approval (the irreversible click is gated),
+    including loop-orchestrated writes. Read-only templates legitimately have none."""
+    wf = parse_yaml_string(_load(template_name))
+    approval_ids = {s.id for s in wf.steps if s.type == "approval"}
+    if not approval_ids:
+        pytest.skip("read-only template - no approval gate required")
+    downstream = _downstream_of(approval_ids, wf)
+    gated_action = any(
+        s.id in downstream and (s.type in ("browser", "loop", "http"))
+        for s in wf.steps
+    )
+    assert gated_action, (
+        f"{template_name} has an approval that gates no downstream browser/loop/http action"
+    )
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_code_steps_pass_engine_sandbox_blocklist(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    for step in wf.steps:
+        if step.type == "code" and step.code_config and step.code_config.code:
+            code = step.code_config.code
+            match = _CODE_STEP_BLOCKED_PATTERNS.search(code)
+            assert match is None, (
+                f"{template_name}/{step.id} contains sandbox-blocked pattern "
+                f"{match.group(0)!r} (would fail at runtime)"
+            )
+            ast.parse(code)
+
+
+def test_wave_exercises_last_unused_step_types() -> None:
+    """The wave as a whole must finally exercise the browser-family step types the engine
+    shipped but no template used end to end: browser, trajectory-replay, delegate."""
+    types_seen: set[str] = set()
+    for name in RPA_TEMPLATES:
+        wf = parse_yaml_string(_load(name))
+        types_seen |= {s.type for s in wf.steps}
+    for needed in ("browser", "trajectory-replay", "delegate"):
+        assert needed in types_seen, f"wave should exercise the {needed} step type"
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_templates_are_discovered(template_name: str) -> None:
+    by_file = {t.file_name: t for t in list_templates()}
+    info = by_file.get(f"{template_name}.yaml")
+    assert info is not None and info.source == "built-in" and info.step_count > 0


### PR DESCRIPTION
## Why

A new domain (a different ideation wave): drive a **real browser** to do work that **no API exposes** - behind a login, a JS-heavy SPA, a portal - with the reasoning model kept **swappable** and every irreversible click behind a **human gate**. These are the first templates to exercise the engine's last-unused step types end to end: `browser`, `trajectory-replay`, `delegate` (plus `sub_workflow`), on top of the deterministic patterns from the model-neutral waves.

## The six

| Template | Category | Pattern |
|---|---|---|
| **synthetic_signup_journey_sentinel** | engineering | read-only canary: a synthetic user runs the real signup/verify/onboarding journey on a schedule, deterministic `code` asserts + `trajectory-replay` vs golden, pages on breakage |
| **act_then_sensor_verify_submission_skeleton** | general_ai | the safe write-path canon: fill -> validate preview in `code` -> human `approval` -> `browser` submit -> `sensor`-poll the portal's own status until confirmed |
| **supplier_portal_invoice_status_reconciler** | general_ai | `loop` no-API AP portals, scrape status via `output_schema`, reconcile deterministically vs the AR ledger |
| **saas_seat_deactivation_offboarder** | devops | dom census -> one batch `approval` (full blast radius) -> playwright deactivation `loop` (gated by the approval) -> before/after reconcile + email allowlist guard |
| **browser_flow_trajectory_replay_harness** | engineering | re-drives any recorded flow vs golden trajectory, fails on UI drift/cost blowup. Exercises `delegate` + `sub_workflow` + `trajectory-replay` together |
| **web_portal_supplier_onboarding_filer** | sales_crm | fills + submits a supplier registration on a procurement SPA, stopping at review so the filing happens only after human `approval` |

## Provider-neutral by construction

Every browser step uses **playwright/dom** mode - the model only *authors* a Playwright script / DOM read, swapped via `default_model`, any of the 7 providers. **No `computer_use`** lock-in in this set (it is the one vendor-coupled mode; reserved for pixels-only desktop, scored lower and left for later). The binding correctness lives in deterministic `code` + golden-trajectory replay, never a single model's opinion.

## Safety

Secrets via `credentials_env` (never inline), CAPTCHA via `captcha_strategy: pause`, the **read path split from the write path** (a dry run always exists), irreversible actions (submit/deactivate) gated behind a human `approval` that shows a code-validated preview, `max_actions` caps, `capture_screenshots` for audit, and after a write a `sensor`/gate confirms the portal's own acceptance before declaring success. Verified independently: the deactivation `loop` runs only after the approval, including its loop-orchestrated child write.

## Tests

`test_browser_rpa_templates_v034.py`: drives a browser, modes are provider-neutral (no computer_use), secrets via credentials_env, an approval actually gates a downstream browser/loop action (handles loop-orchestrated writes), the code-sandbox blocklist, and the usual structural checks (parse, validate, build-plan coverage, control-flow refs).

```
test_browser_rpa_templates_v034.py  76 passed, 3 read-only skips
```

Each template independently re-verified (parse, `validate()==[]`, build-plan coverage, no sandbox-blocked code, playwright/dom only, write gated behind approval). Catalog 173 -> 179.