### PR TITLE
feat(templates): 28 more provider-neutral browser RPA workflows (batch 2)

### DIFF
--- a/src/sandcastle/templates/ats_job_application_autosubmit.yaml
+++ b/src/sandcastle/templates/ats_job_application_autosubmit.yaml
@@ -1,0 +1,845 @@
+# name: ATS Job Application Autosubmit
+# description: Files a placed candidate's tailored application into a Workday / Greenhouse / Lever / iCIMS / Taleo-style ATS apply flow on behalf of an outplacement or high-volume recruiting agency's back-office application ops. Public ATS apply flows expose no candidate-facing write API: the apply form is a login-gated, multi-page JS SPA with dynamic per-job EEO / screening questions, resume-parse autofill that must be corrected, and file uploads - none reachable by http - and each posting renders a different field map that must be discovered at runtime in the live DOM. It deterministically validates the candidate payload and normalizes a flat field-intent map, reads the live apply-wizard structure READ-ONLY in dom mode (login via ATS_CREDS, CAPTCHA pauses to a human), classifies each discovered field to a candidate-data key, gates the whole mapping behind an llm_eval anti-fabrication check plus a human reviewer, fills every field and uploads the resume in a provider-neutral playwright pass that STOPS on the review page (never clicks Submit), holds for a human approval of the irreversible submit, clicks Submit and captures the confirmation number, asserts the confirmation deterministically, then sensor-polls the application's own status page until the ATS confirms receipt before writing the confirmation back. Read is split from write, the flow fails closed, and the irreversible submit can never fire on a single model's opinion alone.
+# tags: [ATS, JobApplication, Workday, Greenhouse, Lever, iCIMS, Taleo, RPA, Playwright, DOM, HumanInTheLoop, Sensor, ProviderNeutral, NoAPI, Outplacement, Recruiting]
+# category: sales_crm
+
+name: ats-job-application-autosubmit
+description: >-
+  Takes a single candidate-queue row - {job_url, candidate_profile, tailored_answers, resume_file} -
+  that an outplacement / career-services firm or a high-volume recruiting agency has queued for a placed
+  candidate, and FILES the application into a Workday / Greenhouse / Lever / iCIMS / Taleo-style ATS apply
+  flow on the candidate's behalf (back-office application ops). Public ATS apply flows expose NO
+  candidate-facing write API: the apply form is a login-gated, multi-page JS single-page app with
+  dynamic per-job EEO / voluntary-disclosure / screening questions, resume-parse autofill that must be
+  corrected, and file uploads - none of which http can reach. Because each posting renders a different
+  field map, the form structure must be discovered at RUNTIME in the live DOM. The flow is split
+  read-from-write and fails closed. A DETERMINISTIC code step validates the candidate payload (required
+  profile fields present, resume path resolvable, tailored answers non-empty) and normalizes a flat
+  field-intent map keyed by normalized label. A provider-neutral dom-mode browser step logs in via
+  ATS_CREDS (CAPTCHA / step-up hands off to a human through captcha_strategy=pause), walks the apply
+  wizard, and EXTRACTS its structure READ-ONLY via output_schema - every page, every field with its
+  label / type / required flag / options, plus a detected_captcha flag - writing nothing. A
+  provider-agnostic classify routes on how rich the per-job custom screening surface is, then a
+  deterministic code step matches each discovered field to a candidate-data key and produces a
+  {field_label -> value, unmapped_fields[]} fill plan, rejecting on any required field with no source
+  value. A gate (llm_eval anti-fabrication completeness check + a human reviewer of unmapped / sensitive
+  answers) must pass before anything is typed. Only then does a playwright-mode browser step re-open the
+  wizard, fill all fields per the approved plan, upload the resume, and STOP on the REVIEW page - it does
+  NOT click Submit - returning whether the fill landed, a review-page screenshot, and the entered values.
+  A deterministic code step validates that filled state, then a mandatory human approval gates the
+  IRREVERSIBLE submit: the reviewer sees the screenshot and entered values and authorizes it. A second
+  playwright step clicks Submit ONCE and captures {confirmation_id, confirmation_text, timestamp}; a
+  deterministic code step asserts a confirmation_id is present and well-formed - the load-bearing success
+  gate, so a silently-failed submit can never be recorded as a filed application. An engine-native sensor
+  then polls the application's own status page until the ATS confirms receipt (a second, portal-sourced
+  proof), and finally a notify + transform write the confirmation back to the candidate row. Every
+  browser step rides default_model and stays swappable; the anti-fabrication llm_eval and the classify
+  run provider-agnostically with failover; the code validators and the sensor are pure engine logic - so
+  swapping the reasoning provider never changes filing behavior or weakens safety.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 1800
+
+input_schema:
+  required: ["job_url", "candidate_profile", "tailored_answers", "resume_file", "status_url"]
+  properties:
+    job_url:
+      type: string
+      description: "Start URL of the ATS apply flow for this posting (a login-gated multi-page SPA with no candidate-facing write API). Templated into both browser steps' start_url."
+      example: "https://boards.greenhouse.io/acme/jobs/5512334/apply"
+    candidate_profile:
+      type: string
+      description: "Structured profile for the placed candidate, as a JSON string. Drives field mapping. Each key is a normalized candidate-data key (first_name, last_name, email, phone, work_authorization, etc.). PII values are NOT logged raw - only presence flags are emitted."
+      example: '{"first_name":"Dana","last_name":"Okoye","email":"dana.okoye@example.com","phone":"+1-415-555-0199","city":"San Francisco","work_authorization":"US Citizen","requires_sponsorship":false,"linkedin":"https://linkedin.com/in/danaokoye","veteran_status":"I am not a protected veteran","disability_status":"I do not wish to answer","gender":"Decline to self-identify","ethnicity":"Decline to self-identify"}'
+    tailored_answers:
+      type: string
+      description: "Per-job tailored free-text answers to custom screening / EEO / cover-letter style questions, as a JSON string keyed by normalized question label. Used to map the dynamic per-posting questions discovered at runtime. Must be non-empty for required custom questions."
+      example: '{"why_do_you_want_to_work_here":"I admire the work on developer tooling","years_of_python_experience":"6","are_you_willing_to_relocate":"Yes","cover_letter":"Dear Hiring Team, ..."}'
+    resume_file:
+      type: string
+      description: "Reference to the candidate's resume file to upload (e.g. an s3:// or file path). Existence/resolvability is validated before any filing; the upload happens in the playwright fill pass."
+      example: "s3://candidates/dana-okoye/resume.pdf"
+    status_url:
+      type: string
+      description: "URL of the application's own status / confirmation page for THIS submission; the post-submit sensor re-reads it to confirm the ATS recorded receipt (a second, portal-sourced proof beyond the on-screen confirmation)."
+      example: "https://boards.greenhouse.io/acme/applications/INV-OKOYE-5512334/status"
+    required_profile_fields:
+      type: array
+      description: "Profile keys that MUST be present and non-empty for the application to proceed. The validate step fails closed if any is missing."
+      default: ["first_name", "last_name", "email", "phone", "work_authorization"]
+    confirmation_id_pattern:
+      type: string
+      description: "Regex the ATS-issued confirmation_id must match (deterministic success gate). Defaults to a generic confirmation-id shape; override per ATS."
+      default: "^[A-Za-z0-9][A-Za-z0-9_-]{4,}$"
+      example: "^GH-[0-9]{6,}$"
+    candidate_row_id:
+      type: string
+      description: "Identifier of the candidate-queue row this run was triggered from (Postgres id / Sheet row key). Used to write the confirmation back to the right row and to label notifications."
+      default: ""
+      example: "queue-row-8841"
+    crm_writeback_url:
+      type: string
+      description: "Optional HTTP endpoint of the candidate queue / CRM to which the transform writes the confirmation back (the transform emits the payload; the engine's writeback target consumes it)."
+      default: ""
+      example: "https://ops.agency.example/api/candidate-queue/8841/applied"
+    sensor_poll_interval_seconds:
+      type: integer
+      description: "Seconds between status-page polls while waiting for the ATS to confirm receipt of the application."
+      default: 60
+      example: "60"
+    sensor_timeout_seconds:
+      type: integer
+      description: "Hard ceiling in seconds the receipt sensor waits for ATS confirmation before giving up; a timeout is NOT treated as success (the run is left needing attention)."
+      default: 3600
+      example: "3600"
+    approval_timeout_hours:
+      type: integer
+      description: "Hours the human submit-approval waits before its timeout fires (on_timeout: abort - never auto-submits)."
+      default: 24
+      example: "24"
+    notify_channel:
+      type: string
+      description: "Slack channel for the application-ops team's filed / blocked / needs-attention notifications."
+      default: "#application-ops"
+      example: "#application-ops"
+
+steps:
+  # 1) DETERMINISTIC intake validation + field-intent normalization (sandboxed Python, no model).
+  #    Confirm every required profile field is present and non-empty, the resume reference resolves,
+  #    and the tailored answers are non-empty, then NORMALIZE the candidate profile + tailored answers
+  #    into a single flat field-intent map keyed by normalized label (lowercased, spaces -> underscores)
+  #    so the discovered DOM fields can be matched against it deterministically. Raw PII is REDACTED
+  #    from emitted log fields (only presence flags). Fails CLOSED - nothing touches an ATS on a bad
+  #    payload. This is the load-bearing pre-flight check, not a model's opinion.
+  - id: validate_candidate
+    type: code
+    code_config:
+      language: python
+      code: |
+        import json
+        # --- Parse the structured candidate-queue row handed in by the trigger. ---
+        def _load(raw, default):
+            if isinstance(raw, (dict, list)):
+                return raw
+            try:
+                return json.loads(raw)
+            except (TypeError, ValueError):
+                return default
+
+        profile = _load(_input.get('candidate_profile') or '', {})
+        if not isinstance(profile, dict):
+            profile = {}
+        answers = _load(_input.get('tailored_answers') or '', {})
+        if not isinstance(answers, dict):
+            answers = {}
+        resume_ref = str(_input.get('resume_file', '') or '').strip()
+
+        problems = []
+
+        # --- Required profile fields must be present and non-empty. ---
+        required_fields = _input.get('required_profile_fields') or [
+            'first_name', 'last_name', 'email', 'phone', 'work_authorization',
+        ]
+        for k in required_fields:
+            if not str(profile.get(k, '') or '').strip():
+                problems.append('missing required profile field: ' + str(k))
+
+        # --- Resume reference must resolve to something (path / s3 ref present). ---
+        if not resume_ref:
+            problems.append('resume_file reference is empty (no resume to upload)')
+
+        # --- Tailored answers must be non-empty (at least one tailored answer present). ---
+        non_empty_answers = {k: v for k, v in answers.items() if str(v or '').strip()}
+        if len(non_empty_answers) == 0:
+            problems.append('tailored_answers is empty (no per-job answers to map)')
+
+        # --- Normalize a FLAT field-intent map keyed by normalized label. ---
+        # Profile keys and tailored-answer keys both become candidate-data keys the DOM
+        # fields can map against; answers win on a key clash (they are job-specific).
+        def _norm(label):
+            return str(label or '').strip().lower().replace(' ', '_')
+
+        field_intent = {}
+        for k, v in profile.items():
+            val = v
+            if isinstance(v, bool):
+                val = 'Yes' if v else 'No'
+            field_intent[_norm(k)] = val
+        for k, v in non_empty_answers.items():
+            field_intent[_norm(k)] = v
+
+        # --- PII REDACTION for logs: keep structure + presence flags, drop raw identity values. ---
+        redacted_profile = {
+            'has_first_name': bool(str(profile.get('first_name', '') or '').strip()),
+            'has_last_name': bool(str(profile.get('last_name', '') or '').strip()),
+            'has_email': bool(str(profile.get('email', '') or '').strip()),
+            'has_phone': bool(str(profile.get('phone', '') or '').strip()),
+            'work_authorization': str(profile.get('work_authorization', '') or ''),
+            'requires_sponsorship': bool(profile.get('requires_sponsorship', False)),
+            'answer_count': len(non_empty_answers),
+            'resume_present': bool(resume_ref),
+        }
+
+        ok = len(problems) == 0
+        result = {
+            'ok': ok,
+            'problems': problems,
+            # Redacted, log-safe view (no raw PII).
+            'redacted_profile': redacted_profile,
+            # Flat intent map the field-mapping step uses; carried forward, not a logged field.
+            'field_intent': field_intent,
+            'field_intent_keys': sorted(field_intent.keys()),
+            'resume_ref': resume_ref,
+            'answer_count': len(non_empty_answers),
+        }
+
+  # 1b) Hard stop on a bad payload - never touch an ATS apply flow with an incomplete candidate row.
+  - id: payload_gate
+    type: condition
+    depends_on: [validate_candidate]
+    condition_config:
+      expression: "{steps.validate_candidate.output.ok} == True"
+      then: [read_wizard]
+      else: [notify_blocked]
+
+  # 1c) Blocked branch: tell application-ops the row was NOT filed and why. Nothing was submitted.
+  - id: notify_blocked
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        ATS application for candidate row {input.candidate_row_id} was BLOCKED before any apply-flow
+        entry. Payload validation failed: {steps.validate_candidate.output.problems}. No application
+        was filed and no PII was transmitted. Fix the candidate row and re-run.
+
+  # 2) READ PASS (dom mode, READ-ONLY, provider-neutral). The reasoning model logs in via ATS_CREDS
+  #    (never inlined) - CAPTCHA / step-up auth hands off to a human through captcha_strategy=pause -
+  #    walks the multi-page apply wizard, and EXTRACTS its structure WITHOUT entering anything: each
+  #    page, and for each page every field's label / type / required flag / options, plus a
+  #    detected_captcha flag. Because each posting renders a different field map, this discovers the
+  #    live structure at runtime. max_actions caps clicking; output_schema returns structured JSON to
+  #    map against. No write happens.
+  - id: read_wizard
+    type: browser
+    depends_on: [payload_gate]
+    prompt: >-
+      You are doing a READ-ONLY reconnaissance of a multi-page ATS job-application wizard (Workday /
+      Greenhouse / Lever / iCIMS / Taleo style). Log in using the credentials provided via the ATS_CREDS
+      environment variable. If a CAPTCHA, bot-check, or step-up / device-verification prompt appears,
+      STOP and hand off to a human (captcha_strategy=pause) - do not attempt to solve it, and set
+      detected_captcha=true. Open the apply flow for this posting. DO NOT type into, select, upload to,
+      or submit any field - this is a structure read only; resume-parse autofill may pre-populate some
+      fields but do not correct or change anything. Walk every page of the wizard and report its
+      structure: the ordered list of pages, and for each page its page_name and its fields - for each
+      field the visible label, the input type (text / email / tel / select / radio / checkbox / file /
+      textarea), whether it is required, and the allowed options if it is a dropdown / radio. Capture the
+      dynamic per-job EEO / voluntary-disclosure / custom screening questions too. Return ONLY the
+      structured object described by the output schema.
+    browser_config:
+      mode: dom
+      start_url: "{input.job_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 300
+      max_actions: 60
+      headless: true
+      credentials_env: "ATS_CREDS"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          pages:
+            type: array
+            items:
+              type: object
+              properties:
+                page_name: { type: string }
+                fields:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      label: { type: string }
+                      type: { type: string }
+                      required: { type: boolean }
+                      options:
+                        type: array
+                        items: { type: string }
+          detected_captcha: { type: boolean }
+
+  # 3) CLASSIFY (provider-agnostic with failover) - route on how rich this posting's custom screening
+  #    surface is so the human reviewer knows what to expect, given the validated intent map and the
+  #    discovered wizard. Routing only - the load-bearing field mapping is built deterministically in
+  #    the next code step; every branch converges on build_fill_plan.
+  - id: classify_screening
+    type: classify
+    depends_on: [read_wizard]
+    model: haiku
+    classify_config:
+      model: haiku
+      input: >-
+        Decide how rich this ATS posting's custom screening surface is, given the discovered wizard
+        structure and the validated candidate intent map. Choose 'heavy_screening' when the wizard has
+        several custom free-text / screening questions beyond standard contact + EEO fields;
+        'eeo_heavy' when the bulk of the extra fields are voluntary EEO / disclosure questions;
+        'standard_apply' when it is mostly the standard contact + resume + a few questions; 'minimal'
+        when it is a short one-page apply. Validated candidate intent keys:
+        {steps.validate_candidate.output.field_intent_keys} . Discovered wizard structure:
+        {steps.read_wizard.output} .
+      categories:
+        - heavy_screening
+        - eeo_heavy
+        - standard_apply
+        - minimal
+      branches:
+        heavy_screening: [build_fill_plan]
+        eeo_heavy: [build_fill_plan]
+        standard_apply: [build_fill_plan]
+        minimal: [build_fill_plan]
+
+  # 4) DETERMINISTIC field-mapping FILL PLAN (sandboxed Python, no model). Matches each discovered DOM
+  #    field to a candidate-data key from the validated flat intent map (by normalized label), producing
+  #    a {field_label -> value} plan plus an explicit unmapped_fields[] list. REJECTS when any REQUIRED
+  #    discovered field has no source value, and surfaces every unmapped field (required or not) for the
+  #    human reviewer. This is the load-bearing correctness layer before the gate - nothing is typed on
+  #    a bad plan.
+  - id: build_fill_plan
+    type: code
+    depends_on: [classify_screening]
+    code_config:
+      language: python
+      code: |
+        validated = _steps.get('validate_candidate') or {}
+        if not isinstance(validated, dict):
+            validated = {}
+        wizard = _steps.get('read_wizard') or {}
+        if not isinstance(wizard, dict):
+            wizard = {}
+        # Browser payloads may nest under output/data/result.
+        for key in ('output', 'data', 'result'):
+            inner = wizard.get(key)
+            if isinstance(inner, dict) and ('pages' in inner or 'detected_captcha' in inner):
+                wizard = inner
+                break
+
+        intent = validated.get('field_intent') if isinstance(validated.get('field_intent'), dict) else {}
+        pages = wizard.get('pages') if isinstance(wizard.get('pages'), list) else []
+
+        problems = []
+
+        def _norm(label):
+            return str(label or '').strip().lower().replace(' ', '_')
+
+        # --- Field mapping: every REQUIRED discovered field must trace to a source value. ---
+        fill_plan = []          # [{label, value, source_key, type, required}]
+        unmapped_fields = []    # discovered fields with no source value (required or optional)
+        required_unmapped = []  # required discovered fields with no source value -> rejection
+        field_total = 0
+        for page in pages:
+            if not isinstance(page, dict):
+                continue
+            page_name = str(page.get('page_name', '') or '')
+            for f in (page.get('fields') or []):
+                if not isinstance(f, dict):
+                    continue
+                label = str(f.get('label', '') or '').strip()
+                if not label:
+                    continue
+                field_total += 1
+                required = bool(f.get('required'))
+                norm = _norm(label)
+                src_val = intent.get(norm)
+                # Light fuzzy fallback: try matching on a normalized-key containment when no exact hit.
+                if src_val in (None, '', [], {}):
+                    for ik, iv in intent.items():
+                        if ik and (ik in norm or norm in ik):
+                            src_val = iv
+                            norm = ik
+                            break
+                has_src = src_val not in (None, '', [], {})
+                if has_src:
+                    fill_plan.append({
+                        'page': page_name,
+                        'label': label,
+                        'value': src_val,
+                        'source_key': norm,
+                        'type': str(f.get('type', '') or ''),
+                        'required': required,
+                    })
+                else:
+                    unmapped_fields.append({'page': page_name, 'label': label, 'required': required})
+                    if required:
+                        required_unmapped.append(page_name + '.' + label)
+
+        if required_unmapped:
+            problems.append('required wizard fields with no source value: ' + ', '.join(required_unmapped))
+        if field_total == 0:
+            problems.append('no fields discovered in the apply wizard (empty read)')
+
+        # A captcha detected during the read means the flow cannot proceed unattended.
+        if bool(wizard.get('detected_captcha')):
+            problems.append('a CAPTCHA / bot-check was detected during the read pass')
+
+        ok = (len(problems) == 0) and (len(fill_plan) > 0)
+        result = {
+            'ok': ok,
+            'problems': problems,
+            'fill_plan': fill_plan,
+            'mapped_count': len(fill_plan),
+            'field_total': field_total,
+            'unmapped_fields': unmapped_fields,
+            'unmapped_count': len(unmapped_fields),
+            'required_unmapped': required_unmapped,
+            'resume_ref': validated.get('resume_ref', ''),
+        }
+
+  # 4b) Hard stop on a bad mapping - do NOT proceed to the gate / data entry on an incomplete plan.
+  - id: plan_gate
+    type: condition
+    depends_on: [build_fill_plan]
+    condition_config:
+      expression: "{steps.build_fill_plan.output.ok} == True"
+      then: [entry_gate]
+      else: [notify_plan_failed]
+
+  - id: notify_plan_failed
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        ATS application for candidate row {input.candidate_row_id} could NOT be mapped to the apply
+        wizard before any data entry: {steps.build_fill_plan.output.problems}. Required unmapped fields:
+        {steps.build_fill_plan.output.required_unmapped}. Nothing was entered. Resolve and re-run.
+
+  # 5) PRE-ENTRY GATE - ALL strategies must pass before anything is typed/uploaded into the apply flow.
+  #    (a) llm_eval ANTI-FABRICATION + completeness: confirms every required field is mapped AND that no
+  #        planned value looks fabricated / invented relative to the candidate profile and tailored
+  #        answers (provider-swappable, runs with failover).
+  #    (b) human: a reviewer signs off on the unmapped / sensitive answers (EEO, sponsorship, custom
+  #    screening) before entry. This is the last stop before the (still reversible) data entry; the
+  #    irreversible submit is gated separately downstream.
+  - id: entry_gate
+    type: gate
+    depends_on: [plan_gate]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are an ATS application mapping reviewer guarding against fabricated answers. Verify the
+              proposed field-mapping fill plan is COMPLETE and that NO value is fabricated BEFORE anything
+              is entered into the apply flow. Reply with exactly 'approved' only if: every required
+              wizard field has a traceable source value (no required field unmapped); and every planned
+              value is grounded in the candidate's validated profile or their tailored answers - no
+              invented employment dates, credentials, work-authorization, or EEO answers that the
+              candidate did not provide. Otherwise reply 'rejected' and name each unmapped required field
+              or each value that looks fabricated. Validated candidate (redacted flags):
+              {steps.validate_candidate.output.redacted_profile} . Fill plan:
+              {steps.build_fill_plan.output.fill_plan} . Unmapped fields:
+              {steps.build_fill_plan.output.unmapped_fields} .
+            input: "{steps.build_fill_plan.output}"
+            model: google/gemini-2.5-pro
+        - type: human
+          config:
+            message: >-
+              ATS pre-entry review for candidate row {input.candidate_row_id}. Confirm the field-mapping
+              fill plan is correct and approve entry into the apply flow. Mapped fields:
+              {steps.build_fill_plan.output.mapped_count} of {steps.build_fill_plan.output.field_total}.
+              Review the UNMAPPED / sensitive answers before approving (EEO, sponsorship, custom
+              screening): {steps.build_fill_plan.output.unmapped_fields}. Reject if any required field is
+              unmapped or any answer is wrong. Full plan: {steps.build_fill_plan.output.fill_plan}
+            timeout_hours: 24
+            on_timeout: abort
+
+  # 6) FILL PASS (playwright mode, provider-neutral). The reasoning model AUTHORS a Playwright script
+  #    that re-logs-in via ATS_CREDS (CAPTCHA pauses to a human), re-opens the apply wizard, corrects
+  #    any wrong resume-parse autofill, fills EVERY field from the approved plan across all pages,
+  #    uploads the resume to the file slot, advances to the FINAL REVIEW page, and STOPS. It does NOT
+  #    click Submit. capture_screenshots gives an auditable review snapshot; output_schema returns the
+  #    entered values and whether the submit control is present for the reviewer. max_actions bounds the
+  #    wizard.
+  - id: fill_to_review
+    type: browser
+    depends_on: [entry_gate]
+    prompt: >-
+      You are completing a multi-page ATS job-application wizard on behalf of a placed candidate.
+      Authenticate using the ATS_CREDS environment variable - if a CAPTCHA, bot-check, or step-up auth
+      appears, PAUSE for a human (do not attempt to solve it). Open the apply flow and walk it end to end.
+      Using the APPROVED fill plan, set every field to its planned value across every page, correcting any
+      wrong resume-parse autofill so the visible value matches the plan, and waiting for client-side
+      validation to settle before advancing each page. Upload the candidate's resume from the resume
+      reference to the file-upload slot. CRITICAL: advance only to the FINAL REVIEW / summary page and
+      STOP there - DO NOT click the final Submit / Apply / Send Application button. Submission is a
+      separate, human-approved step. Approved fill plan: {steps.build_fill_plan.output.fill_plan} . Resume
+      reference to upload: {steps.build_fill_plan.output.resume_ref} . Return ONLY the structured object:
+      whether the fill landed (filled), a reference to the captured review-page screenshot, a summary of
+      the entered values as shown on the review page, the count of fields actually filled, whether the
+      resume upload was accepted, and whether the final Submit button is present and enabled on the review
+      page.
+    browser_config:
+      mode: playwright
+      start_url: "{input.job_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 600
+      max_actions: 150
+      headless: true
+      credentials_env: "ATS_CREDS"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          filled: { type: boolean }
+          review_page_screenshot: { type: string }
+          summary_of_entered_values:
+            type: object
+            properties:
+              first_name: { type: string }
+              last_name: { type: string }
+              email: { type: string }
+              fields_filled: { type: integer }
+          filled_field_count: { type: integer }
+          resume_uploaded: { type: boolean }
+          submit_button_present: { type: boolean }
+
+  # 6b) DETERMINISTIC validation of the FILLED review state (no model). The load-bearing pre-submit
+  #     check: the fill must report success, the filled field count must cover the planned mapped fields,
+  #     the resume must be uploaded, the submit button must be present (wizard actually reached review),
+  #     and a review screenshot must exist for the human. Fails closed.
+  - id: validate_review
+    type: code
+    depends_on: [fill_to_review]
+    code_config:
+      language: python
+      code: |
+        read_out = _steps.get('fill_to_review') or {}
+        if not isinstance(read_out, dict):
+            read_out = {}
+        for key in ('output', 'data', 'result'):
+            inner = read_out.get(key)
+            if isinstance(inner, dict) and ('filled' in inner or 'summary_of_entered_values' in inner):
+                read_out = inner
+                break
+
+        plan = _steps.get('build_fill_plan') or {}
+        if not isinstance(plan, dict):
+            plan = {}
+
+        problems = []
+
+        def _int(v):
+            try:
+                return int(v)
+            except (TypeError, ValueError):
+                return 0
+
+        # The fill step must report it actually filled the form.
+        if not read_out.get('filled'):
+            problems.append('fill step did not report filled=true (form not safely filled)')
+
+        # Filled field count must cover the planned mapped fields (no silently dropped fields).
+        planned_mapped = _int(plan.get('mapped_count'))
+        filled_count = _int(read_out.get('filled_field_count'))
+        if filled_count < planned_mapped:
+            problems.append('filled field count ' + str(filled_count) + ' < planned mapped '
+                            + str(planned_mapped))
+
+        # The resume must have uploaded.
+        if not read_out.get('resume_uploaded'):
+            problems.append('resume was not reported as uploaded')
+
+        # The wizard must have reached a review screen with a submit control.
+        if not read_out.get('submit_button_present'):
+            problems.append('submit button not present - wizard did not reach the review page')
+
+        # A review screenshot must exist for the human approver to inspect.
+        review_shot = str(read_out.get('review_page_screenshot', '') or '').strip()
+        if not review_shot:
+            problems.append('no review-page screenshot captured for the human approver')
+
+        entered = read_out.get('summary_of_entered_values')
+        if not isinstance(entered, dict):
+            entered = {}
+
+        ok = len(problems) == 0
+        result = {
+            'ok': ok,
+            'problems': problems,
+            'review_page_screenshot': review_shot,
+            'summary_of_entered_values': entered,
+            'filled_field_count': filled_count,
+            'planned_mapped_count': planned_mapped,
+            'resume_uploaded': bool(read_out.get('resume_uploaded')),
+        }
+
+  # 6c) Hard stop on a bad fill - do NOT advance to the submit approval on a bad review read.
+  - id: review_gate
+    type: condition
+    depends_on: [validate_review]
+    condition_config:
+      expression: "{steps.validate_review.output.ok} == True"
+      then: [approve_submit]
+      else: [notify_review_failed]
+
+  - id: notify_review_failed
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        ATS application for candidate row {input.candidate_row_id} reached the apply REVIEW page but the
+        deterministic review check FAILED before submission:
+        {steps.validate_review.output.problems}. Nothing was submitted. Re-check the wizard fill and
+        resume upload, then re-run.
+
+  # 7) MANDATORY HUMAN APPROVAL before the IRREVERSIBLE submit. The reviewer sees the validated entered
+  #    values and the captured review-page screenshot and authorizes the submit. No submission can occur
+  #    without this gate; on_timeout: abort never auto-submits - this is the human authority over filing
+  #    an application on the candidate's behalf.
+  - id: approve_submit
+    type: approval
+    approval_config:
+      message: >-
+        AUTHORIZE the IRREVERSIBLE application SUBMIT for candidate row {input.candidate_row_id}. The
+        application is filled and sitting on the apply REVIEW page with
+        {steps.validate_review.output.filled_field_count} fields filled (planned
+        {steps.validate_review.output.planned_mapped_count}) and the resume uploaded
+        ({steps.validate_review.output.resume_uploaded}). Review the captured review-page screenshot and
+        the entered values - this is the EXACT state you are submitting on the candidate's behalf. Approve
+        to click Submit; reject to abort with nothing submitted.
+      show_data: steps.validate_review.output
+      show_images: ["steps.validate_review.output.review_page_screenshot"]
+      timeout_hours: 24
+      on_timeout: abort
+      allow_edit: false
+
+  # 8) SUBMIT PASS (playwright mode, WRITE). Only reached AFTER the human approves. Re-opens the filled
+  #    review page, confirms the values still match, clicks the SINGLE final Submit button ONCE, then
+  #    reads the ATS confirmation and captures {confirmation_id, confirmation_text, timestamp}.
+  #    capture_screenshots gives an after-submit audit record; max_actions tightly capped (one confirm
+  #    action); CAPTCHA / step-up pause to a human.
+  - id: submit_application
+    type: browser
+    depends_on: [approve_submit]
+    prompt: >-
+      A human has authorized this IRREVERSIBLE application submission for candidate row
+      {input.candidate_row_id}. Authenticate with ATS_CREDS if the session expired (CAPTCHA / step-up
+      pause to a human), return to the filled apply REVIEW page, confirm the entered values still match
+      the approved review, then click the SINGLE final Submit / Apply / Send Application button ONCE to
+      file the application. Do NOT edit any field, do NOT re-upload the resume, and do NOT click submit
+      more than once. If a CAPTCHA or bot-check appears at this final wall, PAUSE for a human - do not
+      attempt to solve it. Then read the ATS confirmation page and capture the CONFIRMATION NUMBER / id,
+      the on-screen confirmation text, and the timestamp. Return ONLY the structured object described by
+      the output schema.
+    browser_config:
+      mode: playwright
+      start_url: "{input.job_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 300
+      max_actions: 20
+      headless: true
+      credentials_env: "ATS_CREDS"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          confirmation_id: { type: string }
+          confirmation_text: { type: string }
+          timestamp: { type: string }
+          confirmation_screenshot: { type: string }
+
+  # 9) DETERMINISTIC SUCCESS GATE (no model). Assert the ATS-issued confirmation_id is present and
+  #    matches the expected pattern. A missing/malformed confirmation_id means the submit did NOT
+  #    provably land - so a silently-failed submit can NEVER be recorded as a filed application.
+  - id: assert_confirmation
+    type: code
+    depends_on: [submit_application]
+    code_config:
+      language: python
+      code: |
+        import re
+        sub = _steps.get('submit_application') or {}
+        if not isinstance(sub, dict):
+            sub = {}
+        for key in ('output', 'data', 'result'):
+            inner = sub.get(key)
+            if isinstance(inner, dict) and ('confirmation_id' in inner):
+                sub = inner
+                break
+
+        confirmation_id = str(sub.get('confirmation_id', '') or '').strip()
+        confirmation_text = str(sub.get('confirmation_text', '') or '').strip()
+        timestamp = str(sub.get('timestamp', '') or '').strip()
+
+        pattern = str(_input.get('confirmation_id_pattern', '') or '').strip()
+        if not pattern:
+            pattern = '^[A-Za-z0-9][A-Za-z0-9_-]{4,}$'
+
+        problems = []
+        matched = False
+        if not confirmation_id:
+            problems.append('ATS returned no confirmation_id - submission not provably accepted')
+        else:
+            try:
+                matched = bool(re.search(pattern, confirmation_id))
+            except (TypeError, ValueError):
+                matched = False
+            if not matched:
+                problems.append('confirmation_id "' + confirmation_id + '" does not match pattern ' + pattern)
+        if not timestamp:
+            problems.append('no confirmation timestamp returned')
+
+        filed = bool(confirmation_id) and matched and (len(problems) == 0)
+        result = {
+            'filed': filed,
+            'problems': problems,
+            'confirmation_id': confirmation_id,
+            'confirmation_text': confirmation_text,
+            'timestamp': timestamp,
+            'pattern': pattern,
+        }
+
+  # 9b) Branch on the deterministic success gate. Only a provably-confirmed submit proceeds to the
+  #     portal-sourced receipt sensor + writeback. An unconfirmed submit is paged and left needing
+  #     attention - a false success is NEVER recorded as a filed application.
+  - id: filed_gate
+    type: condition
+    depends_on: [assert_confirmation]
+    condition_config:
+      expression: "{steps.assert_confirmation.output.filed} == True"
+      then: [verify_receipt]
+      else: [notify_submit_unconfirmed]
+
+  # 9c) UNCONFIRMED PATH - submit happened but the confirmation_id did not validate. Page the team and
+  #     leave the run needing attention.
+  - id: notify_submit_unconfirmed
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        NEEDS ATTENTION: ATS submit for candidate row {input.candidate_row_id} did NOT return a valid
+        confirmation_id ({steps.assert_confirmation.output.problems}). Do NOT assume the application was
+        filed - manually check the ATS. The run is left in a needs-attention state.
+
+  # 10) RECEIPT SENSOR (engine-native, model-independent) - the act-then-VERIFY core. Poll the
+  #     application's OWN status page until the ATS provably recorded receipt: the status reads
+  #     submitted / received / under-review OR a confirmation/reference id is present. This is a second,
+  #     PORTAL-SOURCED proof beyond the on-screen confirmation. A provider-agnostic boolean over the
+  #     polled JSON - pure control flow, no model. Hard timeout so we never wait forever; a timeout is
+  #     NOT treated as success.
+  - id: verify_receipt
+    type: sensor
+    depends_on: [filed_gate]
+    sensor_config:
+      url: "{input.status_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and (str(response.get('status', '')).strip().lower() in ('submitted', 'received', 'under_review', 'under review', 'in_review', 'application received') or bool(str(response.get('confirmation_id', '') or response.get('reference', '') or '').strip()))"
+      check_interval: 60
+      timeout: 3600
+
+  # 11) Deterministically decide receipt from the sensor's last polled status payload. No model. A
+  #     missing confirmation (sensor timed out) yields confirmed=False so a silent failure can NEVER be
+  #     reported as a win.
+  - id: evaluate_receipt
+    type: code
+    depends_on: [verify_receipt]
+    code_config:
+      language: python
+      code: |
+        watch = _steps.get('verify_receipt') or {}
+        if not isinstance(watch, dict):
+            watch = {'raw': watch}
+        resp = watch.get('response') if isinstance(watch.get('response'), dict) else watch
+        if not isinstance(resp, dict):
+            resp = {}
+
+        status = str(resp.get('status', '') or '').strip().lower()
+        reference = str(resp.get('confirmation_id', '') or resp.get('reference', '') or '').strip()
+
+        received_states = ('submitted', 'received', 'under_review', 'under review',
+                           'in_review', 'application received')
+        confirmed = (status in received_states) or bool(reference)
+
+        sensor_satisfied = bool(watch.get('satisfied', watch.get('met', confirmed)))
+        timed_out = bool(watch.get('timed_out', False)) or (not sensor_satisfied and not confirmed)
+
+        result = {
+            'confirmed': bool(confirmed and not timed_out),
+            'status': status,
+            'reference': reference,
+            'timed_out': timed_out,
+            # fail_count > 0 routes the run to the needs-attention path (never false success).
+            'fail_count': 0 if (confirmed and not timed_out) else 1,
+        }
+
+  # 12) CONDITION - write the confirmation back on confirmed receipt, OR page the team and leave the run
+  #     needing attention on timeout / no-confirmation. We NEVER report a false win.
+  - id: receipt_outcome
+    type: condition
+    depends_on: [evaluate_receipt]
+    condition_config:
+      expression: "{steps.evaluate_receipt.output.fail_count} > 0"
+      then: [notify_needs_attention]
+      else: [notify_filed]
+
+  # 12a) NEEDS-ATTENTION PATH - the ATS never confirmed receipt (timeout or non-received status). Page
+  #      the team; the run stays unresolved. A silently-failed submit is surfaced, never mistaken for
+  #      success.
+  - id: notify_needs_attention
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        NEEDS ATTENTION: ATS application for candidate row {input.candidate_row_id} was SUBMITTED
+        (confirmation {steps.assert_confirmation.output.confirmation_id}) but the ATS status page has NOT
+        confirmed receipt within the timeout (last status '{steps.evaluate_receipt.output.status}',
+        reference '{steps.evaluate_receipt.output.reference}',
+        timed_out={steps.evaluate_receipt.output.timed_out}). Do NOT assume success - manually check the
+        ATS. The run is left in a needs-attention state.
+
+  # 12b) SUCCESS PATH - the ATS itself confirmed receipt. Notify the team the application was filed.
+  - id: notify_filed
+    type: notify
+    depends_on: [evaluate_receipt]
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        FILED: ATS application for candidate row {input.candidate_row_id} was submitted and the ATS
+        confirmed receipt. Confirmation id {steps.assert_confirmation.output.confirmation_id} at
+        {steps.assert_confirmation.output.timestamp} (status page status
+        '{steps.evaluate_receipt.output.status}').
+
+  # 13) WRITEBACK (transform) - emit the confirmation payload to write back to the candidate-queue row so
+  #     the queue reflects this application as FILED. The transform produces the structured writeback
+  #     record; the engine's writeback target (crm_writeback_url) consumes it. Only reached on confirmed
+  #     receipt, so the row is only marked applied when the ATS itself confirmed.
+  - id: write_back_confirmation
+    type: transform
+    depends_on: [notify_filed]
+    transform_config:
+      template: |
+        {
+          "candidate_row_id": "{input.candidate_row_id}",
+          "writeback_url": "{input.crm_writeback_url}",
+          "status": "applied",
+          "job_url": "{input.job_url}",
+          "confirmation_id": "{steps.assert_confirmation.output.confirmation_id}",
+          "confirmation_text": "{steps.assert_confirmation.output.confirmation_text}",
+          "submitted_at": "{steps.assert_confirmation.output.timestamp}",
+          "ats_status": "{steps.evaluate_receipt.output.status}"
+        }
+
+on_complete:
+  storage_path: "ats-job-application-autosubmit/{input.candidate_row_id}/{run_id}/confirmation.json"

--- a/src/sandcastle/templates/bank_statement_vault_reconciler.yaml
+++ b/src/sandcastle/templates/bank_statement_vault_reconciler.yaml
@@ -1,0 +1,653 @@
+# name: Bank Statement Vault Reconciler
+# description: On a monthly schedule, logs into each bank/card portal that exposes statements ONLY as PDFs behind an authenticated JS SPA (no API, no Plaid/Yodlee coverage), downloads the new statement, parses balances and transactions, reconciles deterministically against the GL/ledger, files the PDF + reconciliation report into a dated client/year/month vault, and notifies. Any unreconciled delta beyond tolerance is gated behind a human approval BEFORE the period is marked reconciled. The fragile login+download is wrapped by a per-portal trajectory-replay golden run that hard-fails on UI drift before any client books are touched.
+# tags: [Finance, Bookkeeping, Reconciliation, Browser, Playwright, RPA, BankStatements, GL, Vault, TrajectoryReplay]
+# category: general_ai
+
+name: bank-statement-vault-reconciler
+description: >-
+  Monthly statement-vault reconciler for an outsourced bookkeeping firm or
+  fractional controller running 20-80 SMB clients, each with multiple regional
+  bank and credit-card logins and NO aggregator coverage (the banks have no API
+  and forbid Plaid/Yodlee-style read tokens). A SENSOR gates the whole run on the
+  statement-close date so it only fires once the period has actually closed for
+  this account batch. A LOOP fans out over the configured portal accounts; per
+  account it runs a BROWSER step in playwright mode - the configured reasoning
+  model authors a deterministic, PROVIDER-NEUTRAL Playwright script ONCE that
+  signs in with a per-account credentials_env (secret NEVER inlined), clears any
+  MFA/CAPTCHA via captcha_strategy=pause, navigates the JS SPA to the Statements
+  page, selects the latest unfetched period, downloads the statement PDF, and
+  returns a strict output_schema manifest {account_label, statement_period,
+  statement_date, closing_balance, download_path, page_count}. This is a
+  READ-ONLY browse: the script never moves money - downloading is non-destructive
+  - and max_actions=60 caps runaway clicking while capture_screenshots keeps an
+  audit trail. A TRAJECTORY-REPLAY step (fail_below_score 0.85) immediately
+  replays each portal's golden recorded run and HARD-FAILS the workflow on UI
+  drift, preventing a wrong-statement file before client books are ever touched.
+  A PARSE step turns the downloaded PDF into text/tables. A deterministic CODE
+  step then VALIDATES the extraction: it asserts the parsed closing_balance ties
+  to the browser manifest closing_balance to the cent, asserts debits/credits tie
+  to the balance movement, and flags duplicate or missing periods - NO write runs
+  on a bad read. An HTTP step pulls the matching GL/ledger period balance and a
+  second deterministic CODE step computes the reconciliation delta (pure math, no
+  model in the path, so the conclusion is reproducible and provider-neutral). A
+  CONDITION routes on the delta: within tolerance AND validation clean -> file
+  and notify directly; otherwise -> a human APPROVAL that shows the validated
+  preview and the statement screenshot and BLOCKS before the period is marked
+  reconciled. After approval the filing CODE step writes the PDF + reconciliation
+  report into client/year/month/ (gdrive or s3 connector). A NOTIFY posts the
+  per-account summary, loudly flagging any unreconciled delta for human review.
+  The ONLY state-changing step (marking books reconciled / filing the close) sits
+  behind that approval gate; the only browser-side safety needed is the captcha
+  pause because the browsing itself is read-only. computer_use is offered only as
+  a fallback mode for the rare portal whose download control is a canvas/image map
+  needing pixel clicks. (connectors: gdrive, s3, slack, GL ledger via http)
+
+default_model: sonnet
+default_timeout: 900
+
+input_schema:
+  required: ["accounts", "ledger_api_url", "statement_close_url"]
+  properties:
+    accounts:
+      type: array
+      description: >-
+        The portal accounts the loop iterates over - one per bank/card login per
+        client. Shape per item: {account_label, client, bank_kind (bank|card),
+        start_url, statements_url, credentials_env, golden_run_id, gl_account_id,
+        download_mode (playwright|computer_use)}. Secrets are NEVER inlined - only
+        the NAME of the per-account env var is stored. credentials_env maps to one
+        env var per client account by loop index.
+      default:
+        - account_label: "acme_main_checking"
+          client: "acme-llc"
+          bank_kind: "bank"
+          start_url: "https://business.regionalbank.example/login"
+          statements_url: "https://business.regionalbank.example/accounts/statements"
+          credentials_env: "BANK_PORTAL_CREDS_ACME_CHECKING"
+          golden_run_id: "golden-acme-checking-statement-2026-05"
+          gl_account_id: "1010-acme-checking"
+          download_mode: "playwright"
+        - account_label: "acme_amex_card"
+          client: "acme-llc"
+          bank_kind: "card"
+          start_url: "https://card.regionalbank.example/signin"
+          statements_url: "https://card.regionalbank.example/statements"
+          credentials_env: "BANK_PORTAL_CREDS_ACME_AMEX"
+          golden_run_id: "golden-acme-amex-statement-2026-05"
+          gl_account_id: "2100-acme-amex"
+          download_mode: "playwright"
+        - account_label: "globex_ops_checking"
+          client: "globex-inc"
+          bank_kind: "bank"
+          start_url: "https://portal.communitybank.example/login"
+          statements_url: "https://portal.communitybank.example/edocuments"
+          credentials_env: "BANK_PORTAL_CREDS_GLOBEX_CHECKING"
+          golden_run_id: "golden-globex-checking-statement-2026-05"
+          gl_account_id: "1010-globex-checking"
+          download_mode: "computer_use"
+    ledger_api_url:
+      type: string
+      description: "Base URL of the GL/ledger API that returns a client account's closing balance and movement for the accounting period."
+      default: "https://gl-ledger.internal.example/api/v1"
+    statement_close_url:
+      type: string
+      description: >-
+        URL of the schedule marker / health endpoint the trigger sensor polls to
+        confirm the statement-close date has passed for this account batch (e.g.
+        first business day after the 5th of the month). Returns 200 with a
+        period_closed flag once the period is closeable.
+      default: "https://gl-ledger.internal.example/api/v1/period/close-status"
+    accounting_period:
+      type: string
+      description: "The accounting period being reconciled (YYYY-MM). Used to select the statement, the GL period, and the vault month folder."
+      default: "2026-05"
+    amount_tolerance:
+      type: number
+      description: "Absolute closing-balance delta (in account currency) below which a statement-vs-GL difference is treated as reconciled. Anything above routes to human approval."
+      default: 0.01
+    vault_backend:
+      type: string
+      description: "Where filed statements + reconciliation reports land: gdrive or s3."
+      default: "gdrive"
+    vault_root:
+      type: string
+      description: "Root prefix of the dated vault tree. Files land at {vault_root}/{client}/{year}/{month}/."
+      default: "statement-vault"
+    notify_service:
+      type: string
+      description: "Where the per-account reconciliation summary is posted: slack or teams."
+      default: "slack"
+    notify_channel:
+      type: string
+      description: "Channel for the reconciliation digest."
+      default: "#bookkeeping-recon"
+
+steps:
+  # ---------------------------------------------------------------------------
+  # 1) TRIGGER SENSOR - gate the entire run on the statement-close date. Polls a
+  #    schedule marker / GL period-close endpoint and only proceeds once the
+  #    accounting period has actually closed for this account batch (e.g. first
+  #    business day after the 5th). Hard timeout so a never-closing period does
+  #    not hang the run forever. Pure control flow, no model.
+  # ---------------------------------------------------------------------------
+  - id: await_statement_close
+    type: sensor
+    sensor_config:
+      url: "{input.statement_close_url}?period={input.accounting_period}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and bool(response.get('period_closed', False))"
+      check_interval: 3600
+      timeout: 86400
+
+  # ---------------------------------------------------------------------------
+  # 2) LOOP over the configured portal accounts. Each iteration drives ONE
+  #    bank/card login. The loop item (one account def) arrives on
+  #    _input['_item'] and is read by the child step prompts via templating.
+  # ---------------------------------------------------------------------------
+  - id: fetch_statements
+    type: loop
+    depends_on: [await_statement_close]
+    loop_config:
+      over: "input.accounts"
+      step_ids: [download_statement]
+      max_iterations: 80
+
+  # ---------------------------------------------------------------------------
+  # 2a) BROWSER (playwright mode - PROVIDER-NEUTRAL) - the READ pass. The
+  #     configured reasoning model authors a deterministic Playwright script ONCE
+  #     from this prompt, which then replays; the script is provider-agnostic and
+  #     the authoring model is swappable via default_model. It logs in with the
+  #     per-account credentials_env (NEVER an inline secret), pauses on any
+  #     CAPTCHA/MFA (captcha_strategy=pause), navigates the JS SPA to Statements,
+  #     selects the latest unfetched period, downloads the statement PDF, and
+  #     returns ONLY the strict output_schema manifest. READ-ONLY: it never moves
+  #     money - downloading is non-destructive - max_actions=60 caps runaway
+  #     clicking and capture_screenshots keeps an audit trail. computer_use is the
+  #     documented fallback for a portal whose download control is a canvas/image
+  #     map needing pixel clicks (set per-account download_mode).
+  #     (loop child step - defined separately, read via _input['_item'])
+  - id: download_statement
+    type: browser
+    browser_config:
+      mode: playwright
+      start_url: "{input._item.start_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 180
+      max_actions: 60
+      headless: true
+      credentials_env: "{input._item.credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          account_label: { type: string }
+          client: { type: string }
+          bank_kind: { type: string }
+          statement_period: { type: string }
+          statement_date: { type: string }
+          closing_balance: { type: number }
+          currency: { type: string }
+          download_path: { type: string }
+          page_count: { type: integer }
+          screenshot: { type: string }
+        required: ["account_label", "statement_period", "closing_balance", "download_path"]
+    prompt: |
+      You are automating a regional business bank / credit-card web portal as a
+      read-only bookkeeper for client {input._item.client}, account
+      {input._item.account_label} (kind: {input._item.bank_kind}). This portal has
+      NO API and forbids aggregators - the statement is exposed ONLY as a PDF
+      behind an authenticated JS single-page app, generated after login + MFA, so
+      a plain HTTP GET cannot reach it.
+
+      Author a deterministic, provider-neutral Playwright script that:
+      1. Navigates to the login page ({input._item.start_url}) and signs in using
+         the credentials supplied by the credentials_env environment variable.
+         NEVER hardcode, echo, or log the secret.
+      2. If a CAPTCHA, MFA one-time-code, or device-verification challenge appears,
+         STOP and hand off to a human (captcha_strategy=pause). Do not attempt to
+         solve or guess any challenge.
+      3. Navigates the SPA to the Statements / eDocuments page at
+         {input._item.statements_url}.
+      4. Selects the statement for accounting period {input.accounting_period} -
+         the latest period not yet fetched - and clicks its period-specific
+         download control to download the PDF.
+      5. Performs NO write actions of any kind: never transfer, pay, schedule,
+         enroll in paperless, change settings, or click anything that moves money
+         or mutates the account. This is download-only; downloading a statement is
+         non-destructive.
+      6. Respects the max_actions cap; if the Statements page is unreachable or the
+         period is missing, return an empty download_path rather than clicking
+         blindly.
+
+      Return ONLY the structured JSON described by the output_schema: account_label,
+      client, bank_kind, statement_period, statement_date, closing_balance (the
+      headline closing/ending balance numeric, no currency symbol), currency,
+      download_path (the saved PDF path), page_count, and the path to a screenshot
+      of the statement page for the audit trail.
+
+  # ---------------------------------------------------------------------------
+  # 3) TRAJECTORY-REPLAY - the load-bearing reliability check wrapping the fragile
+  #    login+download. Replays each portal's golden recorded run and FAILS the
+  #    workflow when the replay score drops below fail_below_score (UI drift) or
+  #    cost blows past the allowed delta / budget - BEFORE the downloaded
+  #    statement is ever trusted or filed. Deterministic scorer comparing
+  #    observable actions and extracted outputs, not a model's opinion. This is
+  #    what prevents filing the wrong statement when a portal silently redesigns.
+  # ---------------------------------------------------------------------------
+  - id: replay_login_download
+    type: trajectory-replay
+    depends_on: [fetch_statements]
+    trajectory_replay_config:
+      golden_run_id: "{input.accounts.0.golden_run_id}"
+      fail_below_score: 0.85
+      allow_cost_delta_pct: 10.0
+      cost_budget_usd: 0.5
+
+  # ---------------------------------------------------------------------------
+  # 4) PARSE - turn the downloaded statement PDF into text/tables so the
+  #    deterministic validator can read the printed closing balance and the
+  #    debit/credit lines. Provider-neutral document parse, no portal access.
+  # ---------------------------------------------------------------------------
+  - id: parse_statement
+    type: parse
+    depends_on: [replay_login_download]
+    prompt: "{steps.download_statement.output.download_path}"
+    parse_config:
+      output: markdown
+
+  # ---------------------------------------------------------------------------
+  # 5) CODE - VALIDATE the extraction deterministically BEFORE anything is
+  #    trusted or filed. Asserts the parsed printed closing_balance ties to the
+  #    browser manifest closing_balance to the cent, asserts sum(debits) -
+  #    sum(credits) ties to the balance movement within tolerance, and flags
+  #    duplicate or missing periods. On any mismatch or empty read, extraction_ok
+  #    is False and NO write path runs. Pure deterministic math, no model.
+  # ---------------------------------------------------------------------------
+  - id: validate_extraction
+    type: code
+    depends_on: [parse_statement, fetch_statements]
+    code_config:
+      language: python
+      code: |
+        # Browser manifest from the read pass (loop child output).
+        manifest = _steps.get("download_statement") or {}
+        if not isinstance(manifest, dict):
+            manifest = {}
+
+        # Parsed PDF text/tables.
+        parsed = _steps.get("parse_statement")
+        if isinstance(parsed, dict):
+            parsed_text = str(parsed.get("text") or parsed.get("markdown") or parsed.get("content") or "")
+        else:
+            parsed_text = str(parsed or "")
+
+        try:
+            tol = float(_input.get("amount_tolerance", 0.01) or 0.01)
+        except (TypeError, ValueError):
+            tol = 0.01
+
+        def _to_amount(v):
+            try:
+                return round(float(v), 2)
+            except (TypeError, ValueError):
+                return None
+
+        errors = []
+        flags = []
+
+        account_label = str(manifest.get("account_label") or "").strip()
+        statement_period = str(manifest.get("statement_period") or "").strip()
+        download_path = str(manifest.get("download_path") or "").strip()
+        manifest_balance = _to_amount(manifest.get("closing_balance"))
+
+        # A trustworthy read must have an account, a period, a downloaded file, and
+        # a numeric headline balance from the browser manifest.
+        if not account_label:
+            errors.append("missing_account_label")
+        if not statement_period:
+            errors.append("missing_statement_period")
+        if not download_path:
+            errors.append("empty_download_path")
+        if manifest_balance is None:
+            errors.append("non_numeric_manifest_balance")
+        if not parsed_text.strip():
+            errors.append("empty_parsed_pdf")
+
+        # Duplicate / missing period guard: the manifest period must match the
+        # period we asked to reconcile. A mismatch means the SPA handed back the
+        # wrong (often the most recent already-filed) statement.
+        target_period = str(_input.get("accounting_period") or "").strip()
+        if target_period and statement_period and target_period not in statement_period:
+            flags.append("period_mismatch")
+            errors.append("statement_period_does_not_match_target")
+
+        # Pull the printed closing/ending balance out of the parsed PDF text and
+        # assert it ties to the browser manifest balance to the cent. We search for
+        # a labelled balance line and read the trailing money figure.
+        printed_balance = None
+        label_match = re.search(
+            r"(?:closing|ending|new|statement)\s+balance[^0-9\-]*(-?[0-9][0-9,]*\.[0-9]{2})",
+            parsed_text,
+            flags=re.IGNORECASE,
+        )
+        if label_match:
+            printed_balance = _to_amount(label_match.group(1).replace(",", ""))
+        if printed_balance is None:
+            flags.append("no_printed_balance_found")
+
+        balance_ties = False
+        balance_delta = None
+        if manifest_balance is not None and printed_balance is not None:
+            balance_delta = round(abs(manifest_balance - printed_balance), 2)
+            balance_ties = balance_delta <= tol
+            if not balance_ties:
+                errors.append("manifest_vs_printed_balance_mismatch")
+
+        # Movement tie-out: sum debits and credits printed on the statement and
+        # confirm closing = opening + credits - debits within tolerance. We read an
+        # opening balance plus all signed money lines from the parsed text.
+        opening_balance = None
+        open_match = re.search(
+            r"(?:opening|beginning|previous|prior)\s+balance[^0-9\-]*(-?[0-9][0-9,]*\.[0-9]{2})",
+            parsed_text,
+            flags=re.IGNORECASE,
+        )
+        if open_match:
+            opening_balance = _to_amount(open_match.group(1).replace(",", ""))
+
+        credits_total = 0.0
+        debits_total = 0.0
+        # Credit lines: deposits / payments-in / credits.
+        for m in re.findall(
+            r"(?:deposit|credit|payment\s+received|interest)[^0-9\-]*(-?[0-9][0-9,]*\.[0-9]{2})",
+            parsed_text,
+            flags=re.IGNORECASE,
+        ):
+            amt = _to_amount(m.replace(",", ""))
+            if amt is not None:
+                credits_total = round(credits_total + abs(amt), 2)
+        # Debit lines: withdrawals / purchases / fees / debits.
+        for m in re.findall(
+            r"(?:withdrawal|purchase|debit|fee|charge|check)[^0-9\-]*(-?[0-9][0-9,]*\.[0-9]{2})",
+            parsed_text,
+            flags=re.IGNORECASE,
+        ):
+            amt = _to_amount(m.replace(",", ""))
+            if amt is not None:
+                debits_total = round(debits_total + abs(amt), 2)
+
+        movement_ties = None
+        movement_delta = None
+        if opening_balance is not None and manifest_balance is not None:
+            expected_close = round(opening_balance + credits_total - debits_total, 2)
+            movement_delta = round(abs(expected_close - manifest_balance), 2)
+            movement_ties = movement_delta <= tol
+            if not movement_ties:
+                flags.append("movement_does_not_tie")
+        else:
+            flags.append("movement_tieout_skipped_no_opening_balance")
+
+        extraction_ok = len(errors) == 0
+
+        result = {
+            "extraction_ok": extraction_ok,
+            "errors": errors,
+            "flags": flags,
+            "account_label": account_label,
+            "client": str(manifest.get("client") or ""),
+            "gl_account_id": "",
+            "statement_period": statement_period,
+            "statement_date": str(manifest.get("statement_date") or ""),
+            "download_path": download_path,
+            "currency": str(manifest.get("currency") or ""),
+            "page_count": manifest.get("page_count"),
+            "manifest_closing_balance": manifest_balance,
+            "printed_closing_balance": printed_balance,
+            "balance_ties": balance_ties,
+            "balance_delta": balance_delta,
+            "opening_balance": opening_balance,
+            "credits_total": credits_total,
+            "debits_total": debits_total,
+            "movement_ties": movement_ties,
+            "movement_delta": movement_delta,
+            "tolerance": tol,
+        }
+
+  # ---------------------------------------------------------------------------
+  # 6) HTTP - pull the matching GL/ledger period closing balance for this account.
+  #    This is the firm's own system of record - the side we reconcile the
+  #    statement against. Auth via a bearer token from the env, NEVER inlined.
+  #    (connector: GL ledger via http)
+  # ---------------------------------------------------------------------------
+  - id: fetch_gl_balance
+    type: http
+    depends_on: [validate_extraction]
+    http_config:
+      url: "{input.ledger_api_url}/accounts/{input.accounts.0.gl_account_id}/balance?period={input.accounting_period}"
+      method: GET
+      auth: "bearer:{env.GL_LEDGER_TOKEN}"
+      headers:
+        Accept: "application/json"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # ---------------------------------------------------------------------------
+  # 7) CODE - the LOAD-BEARING reconciliation. Pure deterministic math, NO model
+  #    in the path, so the conclusion is reproducible and provider-neutral. It
+  #    compares the validated statement closing_balance to the GL period closing
+  #    balance and computes the signed delta; the run is reconciled only if the
+  #    extraction was valid AND abs(delta) is within tolerance.
+  # ---------------------------------------------------------------------------
+  - id: reconcile
+    type: code
+    depends_on: [validate_extraction, fetch_gl_balance]
+    code_config:
+      language: python
+      code: |
+        extraction = _steps.get("validate_extraction") or {}
+        if not isinstance(extraction, dict):
+            extraction = {}
+
+        gl_resp = _steps.get("fetch_gl_balance") or {}
+        if not isinstance(gl_resp, dict):
+            gl_resp = {}
+        # HTTP step output may carry the parsed body under common keys.
+        gl_body = gl_resp.get("json") or gl_resp.get("data") or gl_resp.get("body") or gl_resp
+        if not isinstance(gl_body, dict):
+            gl_body = {}
+
+        def _num(v):
+            try:
+                return round(float(v), 2)
+            except (TypeError, ValueError):
+                return None
+
+        try:
+            tol = float(_input.get("amount_tolerance", 0.01) or 0.01)
+        except (TypeError, ValueError):
+            tol = 0.01
+
+        statement_balance = _num(extraction.get("manifest_closing_balance"))
+        gl_balance = _num(
+            gl_body.get("closing_balance")
+            if gl_body.get("closing_balance") is not None
+            else gl_body.get("balance")
+        )
+
+        extraction_ok = bool(extraction.get("extraction_ok", False))
+
+        delta = None
+        within_tolerance = False
+        if statement_balance is not None and gl_balance is not None:
+            delta = round(statement_balance - gl_balance, 2)
+            within_tolerance = abs(delta) <= tol
+
+        # A clean reconciliation requires BOTH a valid extraction AND a GL balance
+        # that ties within tolerance. A missing GL figure is never treated as a tie.
+        reconciled = extraction_ok and within_tolerance and (gl_balance is not None)
+        needs_review = not reconciled
+
+        result = {
+            "account_label": extraction.get("account_label"),
+            "client": extraction.get("client"),
+            "statement_period": extraction.get("statement_period"),
+            "statement_closing_balance": statement_balance,
+            "gl_closing_balance": gl_balance,
+            "delta": delta,
+            "abs_delta": (abs(delta) if delta is not None else None),
+            "tolerance": tol,
+            "within_tolerance": within_tolerance,
+            "extraction_ok": extraction_ok,
+            "extraction_errors": extraction.get("errors", []),
+            "extraction_flags": extraction.get("flags", []),
+            "reconciled": reconciled,
+            "needs_review": needs_review,
+        }
+
+  # ---------------------------------------------------------------------------
+  # 8) CONDITION - deterministic routing on the reconciliation result. Clean
+  #    (reconciled within tolerance, extraction valid) -> file + notify directly,
+  #    no human needed. Any delta beyond tolerance OR a failed validation -> the
+  #    human APPROVAL gate before the period is ever marked reconciled. No model.
+  # ---------------------------------------------------------------------------
+  - id: route_reconciliation
+    type: condition
+    depends_on: [reconcile]
+    condition_config:
+      expression: "{steps.reconcile.output.reconciled} == True"
+      then: [file_to_vault, notify_summary]
+      else: [approve_reconciliation]
+
+  # ---------------------------------------------------------------------------
+  # 8a) APPROVAL (REVIEW path) - the ONLY state-changing gate. Fires whenever the
+  #     deterministic reconciliation delta exceeds tolerance or validation failed.
+  #     Shows the validated preview (statement vs GL, the delta, the extraction
+  #     errors/flags) AND the statement screenshot, and BLOCKS until a person
+  #     authorizes marking the period reconciled. on_timeout: abort means a missed
+  #     approval NEVER auto-files an unreconciled period.
+  - id: approve_reconciliation
+    type: approval
+    depends_on: [route_reconciliation]
+    approval_config:
+      message: >-
+        UNRECONCILED DELTA - human review required before marking the period
+        reconciled. Account {steps.reconcile.output.account_label} (client
+        {steps.reconcile.output.client}), period
+        {steps.reconcile.output.statement_period}. Statement closing balance
+        {steps.reconcile.output.statement_closing_balance} vs GL closing balance
+        {steps.reconcile.output.gl_closing_balance}; delta
+        {steps.reconcile.output.delta} (tolerance
+        {steps.reconcile.output.tolerance}). Extraction valid:
+        {steps.reconcile.output.extraction_ok}; errors
+        {steps.reconcile.output.extraction_errors}; flags
+        {steps.reconcile.output.extraction_flags}. Review the attached statement
+        screenshot - this is the EXACT statement being filed. Approve to file the
+        statement and mark the period reconciled despite the delta; reject to
+        abort with nothing filed.
+      show_data: steps.reconcile.output
+      show_images: ["steps.download_statement.output.screenshot"]
+      timeout_hours: 24
+      on_timeout: abort
+      allow_edit: false
+
+  # ---------------------------------------------------------------------------
+  # 8b) FILE TO VAULT (WRITE path) - the irreversible filing. Reached either on a
+  #     clean condition (then-branch) OR after the human approval above. Files the
+  #     statement PDF + a deterministic reconciliation report into the dated vault
+  #     tree {vault_root}/{client}/{year}/{month}/ on the configured backend
+  #     (gdrive or s3). The destination paths are computed deterministically here;
+  #     no model. (connectors: gdrive, s3)
+  - id: file_to_vault
+    type: code
+    depends_on: [route_reconciliation, approve_reconciliation]
+    code_config:
+      language: python
+      code: |
+        recon = _steps.get("reconcile") or {}
+        if not isinstance(recon, dict):
+            recon = {}
+        extraction = _steps.get("validate_extraction") or {}
+        if not isinstance(extraction, dict):
+            extraction = {}
+
+        client = str(recon.get("client") or extraction.get("client") or "unknown-client")
+        period = str(recon.get("statement_period") or _input.get("accounting_period") or "")
+        # Derive year / month from the accounting period (YYYY-MM[...]).
+        ym = re.search(r"(\d{4})[-/](\d{2})", period)
+        if ym:
+            year = ym.group(1)
+            month = ym.group(2)
+        else:
+            year = "unknown-year"
+            month = "unknown-month"
+
+        vault_root = str(_input.get("vault_root") or "statement-vault").strip("/")
+        backend = str(_input.get("vault_backend") or "gdrive")
+        account_label = str(recon.get("account_label") or extraction.get("account_label") or "account")
+
+        folder = vault_root + "/" + client + "/" + year + "/" + month
+        pdf_dest = folder + "/" + account_label + "_statement_" + period + ".pdf"
+        report_dest = folder + "/" + account_label + "_reconciliation_" + period + ".json"
+
+        source_pdf = str(extraction.get("download_path") or "")
+
+        # Deterministic reconciliation report persisted alongside the PDF.
+        report = {
+            "client": client,
+            "account_label": account_label,
+            "statement_period": period,
+            "statement_closing_balance": recon.get("statement_closing_balance"),
+            "gl_closing_balance": recon.get("gl_closing_balance"),
+            "delta": recon.get("delta"),
+            "tolerance": recon.get("tolerance"),
+            "reconciled": recon.get("reconciled"),
+            "extraction_errors": recon.get("extraction_errors", []),
+            "extraction_flags": recon.get("extraction_flags", []),
+        }
+
+        # The connector layer reads these targets to upload the PDF + report to the
+        # gdrive/s3 vault. We emit the intent deterministically rather than letting
+        # a model choose where client books are filed.
+        result = {
+            "backend": backend,
+            "folder": folder,
+            "source_pdf": source_pdf,
+            "pdf_dest": pdf_dest,
+            "report_dest": report_dest,
+            "report": report,
+            "filed": bool(source_pdf),
+        }
+
+  # ---------------------------------------------------------------------------
+  # 9) NOTIFY - post the per-account reconciliation summary to the bookkeeping
+  #    channel, loudly flagging any unreconciled delta for human review. Reached
+  #    on the clean then-branch directly; on the review path the notify is implied
+  #    by the approval thread, so this fires for the auto-reconciled accounts.
+  #    (connectors: slack, teams)
+  - id: notify_summary
+    type: notify
+    depends_on: [file_to_vault]
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        :bank: Statement reconciled and filed. Account
+        {steps.reconcile.output.account_label} (client
+        {steps.reconcile.output.client}), period
+        {steps.reconcile.output.statement_period}. Statement
+        {steps.reconcile.output.statement_closing_balance} vs GL
+        {steps.reconcile.output.gl_closing_balance}, delta
+        {steps.reconcile.output.delta} (tolerance
+        {steps.reconcile.output.tolerance}). Reconciled:
+        {steps.reconcile.output.reconciled}. Filed to
+        {steps.file_to_vault.output.pdf_dest}. Any delta beyond tolerance was held
+        for human review before filing.
+
+on_complete:
+  storage_path: "bank-statement-vault-reconciler/{run_id}/reconciliation.json"

--- a/src/sandcastle/templates/consent_banner_cmp_compliance_auditor.yaml
+++ b/src/sandcastle/templates/consent_banner_cmp_compliance_auditor.yaml
@@ -1,0 +1,608 @@
+# name: Consent Banner CMP Compliance Auditor
+# description: Drives a real first-visit browser session per in-scope domain to PROVE the cookie/consent banner blocks non-essential trackers BEFORE any consent and honors a 'Reject All' click - the legally load-bearing client-side behavior no API can observe - then deterministically computes violations against a tracker denylist, gates severity (non-LLM threshold + swappable EU llm_eval), seals timestamped screenshots + a canonical network trace to an object-lock WORM S3 bucket, routes high-severity findings to privacy counsel behind a human approval, emits a per-domain PDF dossier, and trajectory-replays against a golden run so a CMP redesign that breaks the audit is caught as a regression, not a silent false-pass.
+# tags: [GDPR, ePrivacy, CNIL, ICO, ConsentBanner, CMP, PriorConsent, CookieAudit, Browser, Playwright, ObjectLock, WORM, TrajectoryReplay, DPO, PrivacyCounsel]
+# category: hr_legal
+
+name: consent-banner-cmp-compliance-auditor
+description: >-
+  A scheduled (weekly) or on-demand consent-banner compliance auditor for the DPO,
+  privacy counsel, or a GDPR/ePrivacy/CNIL audit firm at any EU/UK-facing company.
+  Consent legality lives ENTIRELY in client-side runtime behavior: which scripts and
+  cookies fire BEFORE any click, whether a CMP banner even appears, whether 'Reject
+  All' is as easy and prominent as 'Accept', and whether non-essential trackers still
+  fire AFTER rejection. There is no API for any of this - an http GET sees raw HTML
+  with none of the tag-manager / CMP SDK behavior. It only exists when a REAL browser
+  loads the page on a fresh profile, executes the JS / CMP SDK, and you observe the
+  network requests and document.cookie at each consent state.
+
+  Flow: a deterministic code step builds the per-URL audit list (each URL gets a fresh,
+  consent-free browser context so no prior consent leaks). A LOOP runs one first-visit
+  audit per domain. The browser step (mode: playwright, provider-neutral) only AUTHORS a
+  deterministic Playwright script: load with a clean context, snapshot document.cookie +
+  all network request hosts PRE-interaction, screenshot the banner, programmatically
+  click 'Reject All', then re-snapshot cookies + network hosts POST-reject. It returns a
+  STRUCTURED object via output_schema and NEVER performs any outbound or irreversible
+  action - it only reads and clicks the site's own Reject All. A DETERMINISTIC code step
+  loads an inline tracker-host denylist and computes violations (any non-essential host
+  firing pre-consent OR persisting post-reject) - this boolean math, not any model, is
+  the audit-load-bearing verdict. A GATE with TWO strategies (a non-LLM threshold on the
+  violation booleans, and a swappable EU/local llm_eval that only LABELS severity intent
+  and cannot overturn the deterministic count) must both pass. An http PUT seals the
+  screenshots + canonical JSON trace to an object-lock COMPLIANCE-mode S3 bucket (WORM
+  evidence; the only write, append-only). A CONDITION routes any high-severity violation
+  to a human APPROVAL so privacy counsel reviews BEFORE any complaint or disclosure is
+  filed - nothing leaves the org automatically. A REPORT emits a per-domain PDF dossier
+  with embedded screenshots. Finally a TRAJECTORY-REPLAY diffs this run against a golden
+  run so a CMP redesign that silently breaks the audit is caught as a regression.
+
+  PROVIDER NEUTRAL: the browser step runs in playwright mode - the reasoning model only
+  authors a deterministic Playwright script, so any provider's model can write it and the
+  resulting script is provider-agnostic. The pass/fail verdict is pure Python over a
+  tracker denylist, never the model. The single llm_eval in the gate is severity-labeling
+  only, pinned to a swappable EU/local model and unable to overturn the deterministic
+  violation count. SAFETY: no credentials needed (public first visit); captcha_strategy
+  pause halts for a human on any interstitial; max_actions ~25 caps the session; the
+  object-lock PUT is the only write and is append-only WORM; filing any complaint is gated
+  behind a human approval so nothing leaves the org automatically.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 1800
+
+# Default trigger: a weekly cron sweep of the in-scope domains. Fires 06:00 every Monday.
+# Override per audit calendar. A manual run (CMP / tag-manager config change) or a deploy
+# webhook wired to a sensor are the alternative event triggers.
+schedule: "0 6 * * 1"
+
+input_schema:
+  required: ["domains", "evidence_bucket_url"]
+  properties:
+    domains:
+      type: string
+      description: >-
+        JSON array of in-scope domains / start URLs to audit, each on a fresh consent-free
+        profile (e.g. '["https://www.acme-eu.com","https://shop.acme-eu.com"]'). The first
+        first-visit URL of each domain is where the per-domain browser audit starts.
+      default: '["https://www.example-eu.com"]'
+      example: '["https://www.acme-eu.com","https://shop.acme-eu.com","https://blog.acme-eu.com"]'
+    evidence_bucket_url:
+      type: string
+      description: >-
+        Base URL of the object-lock (WORM) S3 bucket the timestamped screenshots + canonical
+        JSON trace are sealed to via http PUT with x-amz-object-lock COMPLIANCE mode. This is
+        the ONLY write in the workflow and is append-only evidence.
+      default: "https://s3.eu-west-1.amazonaws.com/consent-evidence-worm"
+      example: "https://s3.eu-central-1.amazonaws.com/dpo-consent-evidence-lock"
+    evidence_token_env:
+      type: string
+      description: >-
+        Name of the environment variable holding the bearer token used to PUT evidence to the
+        object-lock bucket. The value is NEVER inlined into the workflow; the http step reads it
+        via the env reference. No site credentials are needed (public first visit).
+      default: "EVIDENCE_BUCKET_TOKEN"
+      example: "DPO_EVIDENCE_BUCKET_TOKEN"
+    object_lock_retain_until:
+      type: string
+      description: >-
+        ISO-8601 timestamp the object-lock retention is set to (x-amz-object-lock-retain-until-date).
+        Until this date the evidence cannot be deleted or overwritten - the WORM guarantee counsel
+        relies on to defend against a CNIL/ICO complaint.
+      default: "2031-06-01T00:00:00Z"
+      example: "2031-06-01T00:00:00Z"
+    tracker_denylist:
+      type: string
+      description: >-
+        Optional JSON array of EXTRA non-essential tracker host suffixes to treat as violations
+        if they fire pre-consent or persist post-reject, merged with the built-in denylist. Use to
+        add org-specific vendors. Essential first-party / CMP SDK hosts are excluded by the code.
+      default: '[]'
+      example: '["cdn.customtracker.io","pixel.partner-adtech.com"]'
+    high_severity_min_violations:
+      type: number
+      description: >-
+        Threshold: a domain is HIGH severity (routed to privacy counsel approval) if its
+        deterministic violation count is at least this many. The boolean math, not a model,
+        decides; this only sets where the high band begins.
+      default: 1
+      example: "1"
+    golden_run_id:
+      type: string
+      description: >-
+        ID of the known-good recorded audit run. The trajectory-replay step diffs THIS run against
+        it and fails below the score floor, so a CMP redesign that silently breaks the audit (e.g.
+        the Reject All selector moved) is caught as a regression rather than a silent false-pass.
+      default: "golden-consent-audit-2026-05-01"
+      example: "golden-consent-audit-2026-05-01"
+    report_author:
+      type: string
+      description: "Name shown as the author on the per-domain PDF compliance dossier (the DPO / privacy counsel)."
+      default: "Data Protection Office"
+      example: "Privacy Counsel - Acme EU"
+    counsel_channel:
+      type: string
+      description: "Slack channel privacy counsel watches for the completed audit summary and high-severity routing."
+      default: "#consent-compliance"
+      example: "#dpo-privacy-counsel"
+
+steps:
+  # ---------------------------------------------------------------------------
+  # 1) BUILD AUDIT LIST (deterministic, no model). Parses the in-scope domains
+  #    JSON, dedupes, and tags each with a fresh consent-free profile id so no
+  #    prior consent leaks between targets. Fails CLOSED (empty list) if the input
+  #    is malformed, so the loop never runs on garbage. Pure Python.
+  # ---------------------------------------------------------------------------
+  - id: build_audit_list
+    type: code
+    code_config:
+      language: python
+      code: |
+        import json
+
+        raw = _input.get('domains') or '[]'
+        if isinstance(raw, list):
+            domains = raw
+        else:
+            try:
+                domains = json.loads(str(raw))
+            except (ValueError, TypeError):
+                domains = []
+        if not isinstance(domains, list):
+            domains = []
+
+        seen = set()
+        audit_list = []
+        for idx, d in enumerate(domains):
+            url = str(d or '').strip()
+            if not url:
+                continue
+            if not (url.startswith('http://') or url.startswith('https://')):
+                url = 'https://' + url
+            key = url.lower().rstrip('/')
+            if key in seen:
+                continue
+            seen.add(key)
+            # Fresh, consent-free browser profile per target: first-visit semantics so
+            # no previously-accepted consent state can leak in and mask a violation.
+            audit_list.append({
+                'start_url': url,
+                'profile_id': 'fresh-consent-free-' + str(idx),
+                'fresh_context': True,
+            })
+
+        result = {
+            'audit_list': audit_list,
+            'count': len(audit_list),
+            'ok': len(audit_list) > 0,
+        }
+
+  # ---------------------------------------------------------------------------
+  # 2) LOOP over each in-scope domain. Each iteration runs the per-domain
+  #    first-visit browser audit (child audit_one_domain) reading the current
+  #    target via _item. max_iterations caps the sweep so a huge list cannot run
+  #    unbounded. Downstream steps depend on the loop.
+  # ---------------------------------------------------------------------------
+  - id: audit_loop
+    type: loop
+    depends_on: [build_audit_list]
+    loop_config:
+      over: "steps.build_audit_list.output.audit_list"
+      step_ids: [audit_one_domain]
+      max_iterations: 200
+
+  # 2a) PER-DOMAIN FIRST-VISIT AUDIT (mode: playwright, the READ pass). The
+  #     reasoning model only AUTHORS a deterministic Playwright script from the
+  #     prompt; the script + output_schema make this provider-neutral and a pure
+  #     READ (load, snapshot, click the site's own Reject All, re-snapshot). It
+  #     mutates NOTHING outbound. capture_screenshots ON for the WORM evidence /
+  #     audit trail; captcha_strategy pause hands any interstitial to a human;
+  #     max_actions ~25 caps the session so it cannot click forever. Operates on
+  #     ONE domain (_item) only.
+  - id: audit_one_domain
+    type: browser
+    prompt: >-
+      You are auditing a single website's cookie/consent banner for ePrivacy / GDPR
+      prior-consent compliance on a FIRST VISIT with NO prior consent. The target is:
+      {{ _item }}. Author and run a deterministic Playwright script that does EXACTLY
+      this and nothing else:
+      (1) Open a CLEAN browser context with NO stored cookies or localStorage so this is
+      a true first visit, and navigate to the target start_url.
+      (2) BEFORE clicking anything, snapshot the current state: list every distinct
+      network request HOST observed so far (cookies_pre = the names+domains in
+      document.cookie; pre_consent_hosts = the set of hosts the page has already
+      contacted), and record whether a consent/cookie banner is visible (banner_present),
+      whether a clearly labelled 'Reject All' / 'Refuse All' / 'Decline' control exists
+      (reject_all_present), and whether that Reject control is as visually prominent and
+      reachable as the Accept control (reject_equal_prominence - same layer, no extra
+      clicks, comparable size/contrast).
+      (3) Take a screenshot of the banner for the evidence record (add its reference to
+      screenshot_refs).
+      (4) Programmatically CLICK the 'Reject All' control. Do NOT accept, do NOT click any
+      other site control, do NOT submit any form, do NOT navigate off-site.
+      (5) AFTER the reject click settles, re-snapshot: cookies_post (document.cookie names
+      +domains now) and post_reject_hosts (the set of hosts contacted at any point, so
+      trackers that fired after rejection are captured). Take a post-reject screenshot.
+      Return ONLY the structured object described by the output schema. List raw observed
+      hosts verbatim - do NOT judge which are trackers; the deterministic step does that.
+      If a CAPTCHA, age gate, or any interstitial appears, PAUSE for a human rather than
+      guessing. This is strictly READ + the site's own Reject All; perform no other action.
+    browser_config:
+      mode: playwright
+      start_url: "{{ _item.start_url }}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 25
+      headless: true
+      credentials_env: "NONE_PUBLIC_FIRST_VISIT"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          start_url:
+            type: string
+            description: "The audited start URL (echo of the target, for reconciliation)."
+          banner_present:
+            type: boolean
+            description: "Did a consent/cookie banner appear on first visit?"
+          reject_all_present:
+            type: boolean
+            description: "Is a clearly labelled Reject All / Refuse All / Decline control present?"
+          reject_equal_prominence:
+            type: boolean
+            description: "Is Reject All as easy / prominent as Accept (same layer, comparable size, no extra clicks)?"
+          pre_consent_nonessential_hosts:
+            type: array
+            description: "Every distinct network request host observed BEFORE any interaction (raw, unjudged)."
+            items: { type: string }
+          post_reject_nonessential_hosts:
+            type: array
+            description: "Every distinct network request host observed AFTER clicking Reject All (raw, unjudged)."
+            items: { type: string }
+          cookies_pre:
+            type: array
+            description: "Cookies present BEFORE interaction (name and/or domain strings from document.cookie)."
+            items: { type: string }
+          cookies_post:
+            type: array
+            description: "Cookies present AFTER clicking Reject All."
+            items: { type: string }
+          screenshot_refs:
+            type: array
+            description: "References to the banner + pre/post screenshots captured for the evidence record."
+            items: { type: string }
+        required:
+          - start_url
+          - banner_present
+          - reject_all_present
+          - pre_consent_nonessential_hosts
+          - post_reject_nonessential_hosts
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: abort
+
+  # ---------------------------------------------------------------------------
+  # 3) DETERMINISTIC VERDICT (no model) - the audit-load-bearing core. Loads an
+  #    inline tracker-host denylist (merged with any caller-supplied extras),
+  #    VALIDATES the browser extraction shape (reject empty/malformed reads so a
+  #    blank scrape never passes), then computes violations with pure boolean
+  #    math: any denylisted non-essential host firing PRE-consent, or persisting
+  #    POST-reject, is a violation; a missing banner or missing Reject All is a
+  #    violation. The violation COUNT here, not any model, decides pass/fail.
+  # ---------------------------------------------------------------------------
+  - id: compute_verdict
+    type: code
+    depends_on: [audit_loop]
+    code_config:
+      language: python
+      code: |
+        import json
+
+        # --- Built-in non-essential tracker host suffixes (denylist). First-party / CMP
+        #     SDK / essential infra hosts are NOT here, so they never count as violations.
+        builtin_denylist = [
+            'google-analytics.com', 'googletagmanager.com', 'doubleclick.net',
+            'googlesyndication.com', 'googleadservices.com', 'g.doubleclick.net',
+            'facebook.com', 'facebook.net', 'connect.facebook.net', 'fbcdn.net',
+            'hotjar.com', 'hotjar.io', 'mixpanel.com', 'segment.com', 'segment.io',
+            'fullstory.com', 'mouseflow.com', 'clarity.ms', 'amplitude.com',
+            'criteo.com', 'criteo.net', 'taboola.com', 'outbrain.com', 'adnxs.com',
+            'adsrvr.org', 'rubiconproject.com', 'pubmatic.com', 'casalemedia.com',
+            'scorecardresearch.com', 'quantserve.com', 'bing.com', 'bat.bing.com',
+            'linkedin.com', 'licdn.com', 'twitter.com', 't.co', 'tiktok.com',
+            'snap.com', 'pinterest.com', 'yandex.ru', 'mc.yandex.ru', 'matomo.cloud',
+            'cdn.heapanalytics.com', 'heap.io', 'sentry.io', 'newrelic.com', 'nr-data.net',
+        ]
+
+        extra_raw = _input.get('tracker_denylist') or '[]'
+        if isinstance(extra_raw, list):
+            extra = extra_raw
+        else:
+            try:
+                extra = json.loads(str(extra_raw))
+            except (ValueError, TypeError):
+                extra = []
+        if not isinstance(extra, list):
+            extra = []
+        denylist = [str(h).strip().lower() for h in (builtin_denylist + extra) if str(h).strip()]
+
+        def _is_tracker(host):
+            h = str(host or '').strip().lower()
+            if not h:
+                return False
+            # Suffix match so sub.google-analytics.com is caught as well.
+            for suffix in denylist:
+                if h == suffix or h.endswith('.' + suffix):
+                    return True
+            return False
+
+        # --- Gather per-domain browser results from the loop output -----------------------
+        loop_out = _steps.get('audit_loop') or {}
+        if isinstance(loop_out, list):
+            items = loop_out
+        elif isinstance(loop_out, dict):
+            items = loop_out.get('results') or loop_out.get('items') or []
+        else:
+            items = []
+        if not isinstance(items, list):
+            items = []
+
+        per_domain = []
+        invalid_reads = []
+        for raw in items:
+            rec = raw
+            if isinstance(rec, str):
+                try:
+                    rec = json.loads(rec) if rec.strip() else {}
+                except (ValueError, TypeError):
+                    rec = {}
+            if not isinstance(rec, dict):
+                rec = {}
+            # Unwrap a nested output/data/result envelope if the runtime wrapped it.
+            for key in ('output', 'data', 'result'):
+                inner = rec.get(key)
+                if isinstance(inner, dict) and 'start_url' in inner:
+                    rec = inner
+                    break
+
+            start_url = str(rec.get('start_url') or '').strip()
+            banner_present = bool(rec.get('banner_present'))
+            reject_present = bool(rec.get('reject_all_present'))
+            reject_prominent = bool(rec.get('reject_equal_prominence'))
+            pre_hosts = rec.get('pre_consent_nonessential_hosts')
+            post_hosts = rec.get('post_reject_nonessential_hosts')
+            if not isinstance(pre_hosts, list):
+                pre_hosts = []
+            if not isinstance(post_hosts, list):
+                post_hosts = []
+            screenshots = rec.get('screenshot_refs')
+            if not isinstance(screenshots, list):
+                screenshots = []
+
+            # --- VALIDATE the read: a trustworthy audit must at least have a start_url and
+            #     must have observed SOME network hosts (a page that contacted zero hosts
+            #     means the load failed, not that it is clean). Reject before scoring.
+            read_errors = []
+            if not start_url.startswith('http'):
+                read_errors.append('missing/invalid start_url')
+            if len(pre_hosts) == 0 and len(post_hosts) == 0:
+                read_errors.append('zero network hosts observed (load likely failed)')
+            if read_errors:
+                invalid_reads.append({'start_url': start_url or 'unknown', 'errors': read_errors})
+                # Treat an invalid read as a hard FAIL for that domain, not a silent pass.
+
+            # --- DETERMINISTIC violation math (the load-bearing part, NOT a model) ---------
+            pre_trackers = sorted({str(h).strip().lower() for h in pre_hosts if _is_tracker(h)})
+            post_trackers = sorted({str(h).strip().lower() for h in post_hosts if _is_tracker(h)})
+
+            violations = []
+            if not banner_present:
+                violations.append('no_consent_banner_on_first_visit')
+            if not reject_present:
+                violations.append('no_reject_all_control')
+            if banner_present and reject_present and not reject_prominent:
+                violations.append('reject_not_equal_prominence')
+            if pre_trackers:
+                violations.append('nonessential_trackers_fired_pre_consent')
+            if post_trackers:
+                violations.append('nonessential_trackers_persisted_post_reject')
+            if read_errors:
+                violations.append('invalid_or_failed_browser_read')
+
+            per_domain.append({
+                'start_url': start_url,
+                'banner_present': banner_present,
+                'reject_all_present': reject_present,
+                'reject_equal_prominence': reject_prominent,
+                'pre_consent_trackers': pre_trackers,
+                'post_reject_trackers': post_trackers,
+                'pre_consent_tracker_count': len(pre_trackers),
+                'post_reject_tracker_count': len(post_trackers),
+                'violations': violations,
+                'violation_count': len(violations),
+                'compliant': len(violations) == 0,
+                'screenshot_refs': screenshots,
+                'read_errors': read_errors,
+            })
+
+        total_domains = len(per_domain)
+        total_violations = sum(d['violation_count'] for d in per_domain)
+        noncompliant = [d for d in per_domain if not d['compliant']]
+        max_domain_violations = max((d['violation_count'] for d in per_domain), default=0)
+
+        result = {
+            'per_domain': per_domain,
+            'total_domains': total_domains,
+            'noncompliant_count': len(noncompliant),
+            'total_violations': total_violations,
+            'max_domain_violations': max_domain_violations,
+            'invalid_read_count': len(invalid_reads),
+            'invalid_reads': invalid_reads,
+            'all_compliant': total_violations == 0 and total_domains > 0,
+            'denylist_size': len(denylist),
+        }
+
+  # ---------------------------------------------------------------------------
+  # 4) GATE - TWO strategies, BOTH must pass, before evidence is sealed:
+  #    (a) a NON-LLM threshold strategy that asserts the deterministic verdict is
+  #        internally consistent (counts add up, no invalid reads silently passed);
+  #    (b) a SWAPPABLE EU/local llm_eval that LABELS whether the banner meets the
+  #        ePrivacy prior-consent INTENT. The llm_eval is severity-labeling only -
+  #        it CANNOT overturn the deterministic violation count (the code output
+  #        above is the source of truth). Pinned to a swappable model alias.
+  # ---------------------------------------------------------------------------
+  - id: severity_gate
+    type: gate
+    depends_on: [compute_verdict]
+    gate_config:
+      strategies:
+        # (a) NON-LLM threshold: pure structural consistency of the deterministic verdict.
+        - type: threshold
+          config:
+            input: "{steps.compute_verdict.output}"
+            expression: "noncompliant_count <= total_domains and total_domains > 0 and (invalid_read_count == 0 or noncompliant_count >= invalid_read_count)"
+            description: >-
+              Non-LLM consistency check on the deterministic verdict: the noncompliant set
+              cannot exceed the audited set, at least one domain was audited, and any invalid
+              read was counted as noncompliant (never silently passed). This strategy reads the
+              boolean math only - it does not re-judge compliance.
+        # (b) SWAPPABLE EU/local llm_eval: labels prior-consent INTENT, cannot overturn the count.
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are an EU ePrivacy / GDPR prior-consent reviewer. You are given the
+              DETERMINISTIC audit verdict for a set of domains. Do NOT recompute or overturn
+              the violation counts - they are authoritative. Reply with exactly one word:
+              'approved' if the verdict record is internally consistent and safe to seal as
+              evidence (per-domain violation lists match their counts, noncompliant domains
+              are the ones with violations, no invalid read was marked compliant), otherwise
+              'rejected' and name the inconsistency. This is severity-intent labeling only.
+              Verdict: {steps.compute_verdict.output}
+            input: "{steps.compute_verdict.output}"
+            model: mistral/large
+
+  # ---------------------------------------------------------------------------
+  # 5) SEAL EVIDENCE (the ONLY write) - http PUT the screenshots + canonical JSON
+  #    trace to the object-lock S3 bucket in COMPLIANCE mode (WORM). x-amz-object-
+  #    lock-mode COMPLIANCE + retain-until make this append-only, undeletable
+  #    evidence counsel can rely on. Bearer token via env (never inlined). Runs
+  #    only AFTER the two-strategy gate passes. This step performs no destructive
+  #    action - it appends an immutable evidence object.
+  # ---------------------------------------------------------------------------
+  - id: seal_evidence_worm
+    type: http
+    depends_on: [severity_gate]
+    http_config:
+      url: "{input.evidence_bucket_url}/{run_id}/consent-audit-trace.json"
+      method: PUT
+      headers:
+        Content-Type: "application/json"
+        x-amz-object-lock-mode: "COMPLIANCE"
+        x-amz-object-lock-retain-until-date: "{input.object_lock_retain_until}"
+      auth: "bearer:{env.EVIDENCE_BUCKET_TOKEN}"
+      body: '{"run_id": "{run_id}", "sealed_at": "{input.object_lock_retain_until}", "total_domains": "{steps.compute_verdict.output.total_domains}", "noncompliant_count": "{steps.compute_verdict.output.noncompliant_count}", "total_violations": "{steps.compute_verdict.output.total_violations}", "max_domain_violations": "{steps.compute_verdict.output.max_domain_violations}", "invalid_read_count": "{steps.compute_verdict.output.invalid_read_count}", "per_domain": "{steps.compute_verdict.output.per_domain}"}'
+
+  # ---------------------------------------------------------------------------
+  # 6) CONDITION - route on the DETERMINISTIC severity. If any domain reaches the
+  #    high-severity violation floor, send it to a human APPROVAL (privacy counsel
+  #    reviews BEFORE any complaint / disclosure is filed). Otherwise skip straight
+  #    to the dossier. The boolean math decides which branch runs.
+  # ---------------------------------------------------------------------------
+  - id: route_severity
+    type: condition
+    depends_on: [seal_evidence_worm]
+    condition_config:
+      expression: "{steps.compute_verdict.output.max_domain_violations} >= {input.high_severity_min_violations}"
+      then: [counsel_approval, build_dossier]
+      else: [build_dossier]
+
+  # 6a) HIGH-SEVERITY PATH - the SINGLE human gate before anything leaves the org.
+  #     Privacy counsel reviews the sealed evidence and the per-domain violations and
+  #     authorizes (or rejects) filing a CNIL/ICO complaint or a disclosure. NOTHING
+  #     is filed automatically. on_timeout abort means a missed review never auto-files;
+  #     allow_edit lets counsel trim the domain set before filing.
+  - id: counsel_approval
+    type: approval
+    depends_on: [route_severity]
+    approval_config:
+      message: >-
+        PRIVACY COUNSEL REVIEW REQUIRED - one or more domains breached prior-consent at
+        HIGH severity. Evidence has been sealed to the object-lock WORM bucket. APPROVE to
+        authorize filing/escalation (e.g. a CNIL/ICO complaint or an internal disclosure),
+        REJECT to hold. Noncompliant domains:
+        {steps.compute_verdict.output.noncompliant_count} of
+        {steps.compute_verdict.output.total_domains}; total violations:
+        {steps.compute_verdict.output.total_violations}; worst domain violation count:
+        {steps.compute_verdict.output.max_domain_violations}. Nothing is filed or disclosed
+        until you approve.
+      show_data: steps.compute_verdict.output
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: true
+
+  # ---------------------------------------------------------------------------
+  # 7) REPORT - per-domain PDF compliance dossier with embedded screenshots. Built
+  #    from the deterministic verdict + sealed-evidence references so the document
+  #    a DPO defends with is reproducible. Runs on both branches.
+  # ---------------------------------------------------------------------------
+  - id: build_dossier
+    type: report
+    depends_on: [route_severity]
+    report_config:
+      template: research-report
+      format: pdf
+      theme: professional
+      title: "Consent Banner / CMP Prior-Consent Compliance Dossier - {run_id}"
+      author: "{input.report_author}"
+    prompt: |
+      Produce a per-domain ePrivacy / GDPR prior-consent compliance dossier (PDF) for the DPO
+      / privacy counsel from the deterministic audit payload below. Structure it as:
+      1. Executive summary: total domains audited
+      ({steps.compute_verdict.output.total_domains}), noncompliant
+      ({steps.compute_verdict.output.noncompliant_count}), total violations
+      ({steps.compute_verdict.output.total_violations}), worst domain violation count
+      ({steps.compute_verdict.output.max_domain_violations}).
+      2. A per-domain table: for each domain show banner_present, reject_all_present,
+      reject_equal_prominence, the pre-consent tracker hosts that fired before any click,
+      the trackers that persisted after Reject All, the explicit violation list, and the
+      compliant verdict.
+      3. For each noncompliant domain, embed the captured banner / pre / post screenshots
+      (screenshot_refs) as the evidence of the runtime behavior - the legally load-bearing
+      proof that no API can produce.
+      4. An evidence-integrity note: state that the canonical trace + screenshots were sealed
+      to an object-lock (WORM, COMPLIANCE-mode) bucket so the record is tamper-evident and
+      defensible against a regulator complaint.
+      Do NOT invent domains or trackers - use only the payload.
+      Verdict payload: {steps.compute_verdict.output}
+
+  # ---------------------------------------------------------------------------
+  # 8) TRAJECTORY-REPLAY - the reliability layer. Diffs THIS audit run against a
+  #    golden_run_id and FAILS below fail_below_score (UI drift, e.g. a CMP redesign
+  #    that moved or renamed the Reject All selector and broke the audit) or on a
+  #    cost blowup. Deterministic scorer, not a model's opinion: it compares the
+  #    observable browser actions + extracted outputs. Catches a silently-broken
+  #    audit (a false PASS) as a regression before it is trusted.
+  # ---------------------------------------------------------------------------
+  - id: replay_vs_golden
+    type: trajectory-replay
+    depends_on: [build_dossier]
+    trajectory_replay_config:
+      golden_run_id: "{input.golden_run_id}"
+      fail_below_score: 0.85
+      allow_cost_delta_pct: 15.0
+      cost_budget_usd: 0.5
+
+  # ---------------------------------------------------------------------------
+  # 9) NOTIFY privacy counsel with the audit result + evidence + replay verdict.
+  # ---------------------------------------------------------------------------
+  - id: notify_counsel
+    type: notify
+    depends_on: [replay_vs_golden, compute_verdict]
+    notify_config:
+      service: slack
+      channel: "{input.counsel_channel}"
+      message: "Consent banner / CMP audit complete. Domains: {steps.compute_verdict.output.total_domains} | Noncompliant: {steps.compute_verdict.output.noncompliant_count} | Total violations: {steps.compute_verdict.output.total_violations} | Worst domain: {steps.compute_verdict.output.max_domain_violations} | Invalid reads: {steps.compute_verdict.output.invalid_read_count} | Evidence sealed to object-lock WORM bucket for run {run_id} | Per-domain PDF dossier generated. High-severity findings (if any) were routed to privacy counsel approval before any complaint/disclosure."
+
+on_complete:
+  storage_path: "consent-banner-cmp-compliance-auditor/{run_id}/result.json"

--- a/src/sandcastle/templates/golden_journey_regression_gate.yaml
+++ b/src/sandcastle/templates/golden_journey_regression_gate.yaml
@@ -1,0 +1,543 @@
+# name: Golden Journey Regression Gate
+# description: A pre-release CI gate that, on every staging deploy, re-drives the recorded critical user journeys (signup, paid checkout, onboarding) against the new build in a real browser, scores each against its golden trajectory, and BLOCKS promotion to production unless every journey still passes - making fragile funnel flows a hard release-blocking test instead of a Datadog alert after rollout.
+# tags: [ci, release-gate, browser, playwright, trajectory-replay, regression, golden-run, devops, staging, funnel]
+# category: engineering
+
+name: golden-journey-regression-gate
+description: >-
+  A release gate for the human-visible funnel. Unit and API tests pass while the
+  Pay button silently detaches or step 4 of onboarding white-screens, because the
+  multi-step signup / paid-checkout / onboarding-wizard journeys only exist as
+  rendered browser interactions across SPA routes, iframes, and redirects - there
+  is no API contract test that proves them. This workflow is fired by a staging-
+  deploy webhook (and is re-runnable on demand before a manual promote): it reads
+  the deploy metadata (build id, staging URL, the list of critical journeys to
+  gate), LOOPS over each journey driving the REAL staging build in provider-neutral
+  playwright mode, and for each one runs a TRAJECTORY-REPLAY against that journey's
+  recorded golden run. The replay score (not a model's opinion) is the binding
+  pass/fail: any journey below fail_below_score is a regression.
+
+  The load-bearing decision is mechanical. A deterministic, sandboxed CODE step
+  aggregates the per-journey replay scores and completion booleans into a single
+  release verdict (all-green required) and attaches the failure screenshots. The
+  only irreversible action in the pipeline - promoting the build to production - is
+  held behind a GATE whose human strategy a release owner must explicitly satisfy:
+  a green run lets the advisory llm_eval summarize WHAT changed and the human
+  approve, while ANY regressed journey blocks the gate and forces an explicit human
+  override. A NOTIFY then posts the blocking journey, its replay-score delta, and
+  the failure screenshot to CI/Slack so the release owner sees exactly which flow
+  broke. A DELEGATE can fan the payment leg of a journey to an existing synthetic
+  checkout workflow for a deeper revenue-canary check.
+
+  SAFETY: this gate runs ONLY against STAGING via the http-supplied staging URL,
+  with credentials_env=CI_SYNTH_CREDS (disposable synthetic accounts, never inline
+  secrets). captcha_strategy is fail on purpose - CI must never block on a human, so
+  a CAPTCHA on a journey is reported as a finding, not a pause. max_actions=70 per
+  journey caps runaway scripts and capture_screenshots=true gives an audit trail.
+  Provider neutrality: each journey is reduced to a numeric replay score plus
+  deterministic code aggregation, the playwright authoring rides default_model
+  (swappable), and the gate's llm_eval is advisory-only - no vendor's agent is
+  load-bearing. Swap default_model to dom for cheap non-canvas journeys.
+
+default_model: sonnet
+default_timeout: 1800
+
+input_schema:
+  required: ["deploy_metadata_url", "build_id"]
+  properties:
+    deploy_metadata_url:
+      type: string
+      description: >-
+        CI/deploy API endpoint that returns this staging deploy's metadata: the
+        resolved staging base URL and the list of critical journeys to gate (each
+        with its entry path and golden_run_id). Read by the first http step.
+      default: "https://ci.internal.example.com/api/deploys/{build_id}/gate-manifest"
+    build_id:
+      type: string
+      description: "The staging build / deploy id under test. Echoed into every notify so the release owner knows exactly which build was gated."
+      default: "staging-build-unknown"
+    staging_base_url:
+      type: string
+      description: >-
+        Fallback staging base URL if the deploy-metadata response omits one. The
+        gate ONLY ever drives this staging origin - never production.
+      default: "https://staging.app.example.com"
+    critical_journeys_json:
+      type: string
+      description: >-
+        Fallback JSON array of journeys to gate when the metadata endpoint returns
+        none. Each item: {journey, entry_path, golden_run_id, is_payment_leg}. Used
+        verbatim by the loop; NEVER put secrets here (creds come from credentials_env).
+      default: >-
+        [{"journey":"signup","entry_path":"/signup","golden_run_id":"golden-signup-staging","is_payment_leg":false},{"journey":"paid_checkout","entry_path":"/checkout","golden_run_id":"golden-checkout-staging","is_payment_leg":true},{"journey":"onboarding","entry_path":"/onboarding","golden_run_id":"golden-onboarding-staging","is_payment_leg":false}]
+    fail_below_score:
+      type: number
+      description: "Trajectory-replay similarity floor (0..1). A journey scoring below this is a regression and blocks promotion."
+      default: 0.85
+    browser_mode:
+      type: string
+      description: >-
+        Documented browser-mode choice: 'playwright' (default, provider-neutral -
+        the model authors the script) or 'dom' for cheap read-only checks of non-
+        canvas journeys. Swap the browser step's mode without touching the gate.
+      default: "playwright"
+    checkout_canary_workflow:
+      type: string
+      description: "Existing workflow to delegate the payment leg to for a deeper synthetic revenue-canary check."
+      default: "synthetic_signup_journey_sentinel"
+    ci_slack_channel:
+      type: string
+      description: "CI/Slack channel that receives the gate verdict, the blocking journey, its replay-score delta, and the failure screenshot."
+      default: "#release-gate"
+
+steps:
+  # ---------------------------------------------------------------------------
+  # 1) HTTP - read this staging deploy's gate manifest: the resolved staging base
+  #    URL and the list of critical journeys to gate (each with entry path +
+  #    golden_run_id). This is what binds the run to ONE specific staging build and
+  #    keeps the journey list data-driven, not hardcoded.
+  # ---------------------------------------------------------------------------
+  - id: read_deploy_metadata
+    type: http
+    http_config:
+      url: "{input.deploy_metadata_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.CI_API_TOKEN}"
+      value_map:
+        manifest_staging_base_url: "staging_base_url"
+        manifest_journeys: "journeys"
+
+  # ---------------------------------------------------------------------------
+  # 2) CODE (deterministic) - normalize the manifest into a clean journey list the
+  #    loop iterates over. Prefers the manifest's journeys/staging URL, falls back
+  #    to the input JSON, and absolutizes each entry URL against the staging origin
+  #    so the browser only ever drives staging. No model here - pure shaping.
+  # ---------------------------------------------------------------------------
+  - id: build_journey_plan
+    type: code
+    depends_on: [read_deploy_metadata]
+    code_config:
+      language: python
+      code: |
+        import json
+        meta = _steps.get("read_deploy_metadata")
+        if not isinstance(meta, dict):
+            meta = {}
+
+        # Resolve the staging origin: manifest first, then input fallback.
+        base = str(meta.get("manifest_staging_base_url") or "").strip()
+        if not base:
+            base = str(_input.get("staging_base_url") or "").strip()
+        base = base.rstrip("/")
+
+        # Resolve the journey list: manifest journeys first, else parse the input
+        # JSON fallback. Defend against every malformed shape.
+        journeys = meta.get("manifest_journeys")
+        if not isinstance(journeys, list) or not journeys:
+            raw = str(_input.get("critical_journeys_json") or "").strip()
+            try:
+                parsed = json.loads(raw) if raw else []
+            except (ValueError, TypeError):
+                parsed = []
+            journeys = parsed if isinstance(parsed, list) else []
+
+        plan = []
+        for j in journeys:
+            if not isinstance(j, dict):
+                continue
+            name = str(j.get("journey") or "").strip()
+            entry = str(j.get("entry_path") or j.get("entry_url") or "").strip()
+            golden = str(j.get("golden_run_id") or "").strip()
+            if not name or not golden:
+                # A journey with no name or no golden run cannot be gated.
+                continue
+            # Absolutize the entry URL against the staging origin. If entry is
+            # already absolute (starts with http) keep it but force staging origin
+            # is NOT done here - we trust the manifest's own absolute staging URLs.
+            if entry.startswith("http"):
+                entry_url = entry
+            elif entry.startswith("/"):
+                entry_url = base + entry
+            elif entry:
+                entry_url = base + "/" + entry
+            else:
+                entry_url = base
+            plan.append({
+                "journey": name,
+                "entry_url": entry_url,
+                "golden_run_id": golden,
+                "is_payment_leg": bool(j.get("is_payment_leg", False)),
+            })
+
+        # Guard: a gate with zero journeys is itself a finding - it must NOT silently
+        # pass. We surface this so the verdict step can block on it.
+        result = {
+            "staging_base_url": base,
+            "journeys": plan,
+            "journey_count": len(plan),
+            "no_journeys": len(plan) == 0,
+            "is_staging_origin": base.startswith("http") and ("staging" in base or "localhost" in base),
+        }
+
+  # ---------------------------------------------------------------------------
+  # 3) LOOP over each critical journey. The child browser step (defined separately)
+  #    re-drives that journey against the staging build; downstream depends on the
+  #    loop. max_iterations caps the journey count.
+  # ---------------------------------------------------------------------------
+  - id: drive_journeys
+    type: loop
+    depends_on: [build_journey_plan]
+    loop_config:
+      over: "steps.build_journey_plan.output.journeys"
+      step_ids: [drive_one_journey]
+      max_iterations: 25
+
+  # 3a) BROWSER (READ pass, PROVIDER-NEUTRAL playwright). The model AUTHORS a
+  #     Playwright script from this prompt that drives ONE recorded journey against
+  #     the staging build and returns STRUCTURED JSON via output_schema - the read
+  #     pass the replay scores. Disposable synthetic creds come from credentials_env
+  #     (CI_SYNTH_CREDS), NEVER inline. captcha_strategy=fail: CI must not hang on a
+  #     human, so a CAPTCHA blocking the journey is reported as a finding, not a
+  #     pause. max_actions=70 caps runaway scripts; capture_screenshots=true gives
+  #     the audit trail and the failure screenshot the notify surfaces. The journey
+  #     drives staging only and performs no real-money / irreversible action - the
+  #     ONE irreversible action (promote to prod) lives behind the human gate below.
+  #     (loop child - read item via _input['_item'])
+  - id: drive_one_journey
+    type: browser
+    prompt: >-
+      You are a CI release-gate synthetic user. Author and run a Playwright script
+      that re-drives the "{input._item.journey}" critical user journey against the
+      NEW STAGING BUILD and emits a structured trajectory. This is a pre-release
+      regression check: drive the real rendered flow exactly as the recorded golden
+      run did so the trajectory can be scored against it.
+
+      Start at {input._item.entry_url} (this is the staging origin - you must NEVER
+      navigate to a production host). Authenticate when needed using ONLY the
+      disposable synthetic account supplied via the CI_SYNTH_CREDS environment
+      variable - NEVER hardcode, print, or log the secret.
+
+      Walk every stage of the journey in order, recording each stage name into
+      stages_passed AS you reach it (e.g. for signup: form_loaded, form_filled,
+      submitted, verification, first_login; for paid_checkout: cart, address,
+      payment_form, review, order_placed; for onboarding: welcome, profile, connect,
+      finish). Drive across SPA route changes, into any iframes (e.g. the payment
+      iframe), and through redirects. If the journey is a paid_checkout leg, use the
+      synthetic/test payment instrument from the credentials env against the STAGING
+      payment sandbox - never a real card.
+
+      Set completed=true ONLY if the final stage of the journey succeeds end to end.
+      If anything throws, white-screens, the action button silently detaches, or a
+      stage cannot be reached, set completed=false and put a short human-readable
+      explanation in error_text (otherwise error_text=null). If a CAPTCHA blocks the
+      journey, do NOT try to solve or wait - per captcha_strategy=fail, stop and
+      report it in error_text as a finding ("captcha_blocked: <where>"). Put the
+      object-storage keys of the captured screenshots (especially the failure frame)
+      into screenshot_keys.
+
+      Return ONLY the structured JSON object matching output_schema. No prose.
+    browser_config:
+      mode: playwright
+      start_url: "{input._item.entry_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 70
+      headless: true
+      credentials_env: "CI_SYNTH_CREDS"
+      captcha_strategy: fail
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          journey:
+            type: string
+            description: "The journey name this run drove (echo of the item's journey)."
+          stages_passed:
+            type: array
+            description: "Ordered stage names reached, for the trajectory diff."
+            items: { type: string }
+          completed:
+            type: boolean
+            description: "True only if the journey's final stage succeeded end to end on staging."
+          error_text:
+            type: ["string", "null"]
+            description: "Short explanation of the first failure / captcha finding, or null when clean."
+          screenshot_keys:
+            type: array
+            description: "Object-storage keys of captured screenshots (incl. the failure frame) for audit + notify."
+            items: { type: string }
+        required: ["journey", "stages_passed", "completed", "error_text", "screenshot_keys"]
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: abort
+
+  # ---------------------------------------------------------------------------
+  # 4) TRAJECTORY-REPLAY - the core regression detector. Loads the golden run for
+  #    EACH journey and scores the candidate trajectory against it, failing below
+  #    fail_below_score (UI drift) or on cost blowup. Deterministic scorer, not a
+  #    model's opinion; provider-neutral (compares observable stages + outputs).
+  #    Note: golden_run_id is supplied per-journey in the manifest; the candidate
+  #    set is the loop's structured output, replayed as a batch against goldens.
+  # ---------------------------------------------------------------------------
+  - id: replay_journeys
+    type: trajectory-replay
+    depends_on: [drive_journeys]
+    trajectory_replay_config:
+      golden_run_id: "{steps.build_journey_plan.output.journeys}"
+      fail_below_score: 0.85
+      allow_cost_delta_pct: 20.0
+      cost_budget_usd: 0.03
+
+  # ---------------------------------------------------------------------------
+  # 5) CODE (deterministic, LOAD-BEARING) - the release verdict. Aggregates per-
+  #    journey replay scores AND the browser completion booleans into ONE all-green
+  #    decision, attaches the failure screenshots, and computes each blocking
+  #    journey's score delta vs the floor. NO model decides release here - this is
+  #    the mechanical pass/fail. Empty/zero-journey gates are forced to BLOCK.
+  # ---------------------------------------------------------------------------
+  - id: compute_release_verdict
+    type: code
+    depends_on: [drive_journeys, replay_journeys]
+    code_config:
+      language: python
+      code: |
+        plan = _steps.get("build_journey_plan") or {}
+        if not isinstance(plan, dict):
+            plan = {}
+        candidates = _steps.get("drive_journeys")
+        if isinstance(candidates, dict):
+            candidates = [candidates]
+        if not isinstance(candidates, list):
+            candidates = []
+        replay = _steps.get("replay_journeys")
+        if not isinstance(replay, dict):
+            replay = {}
+
+        # Configured floor.
+        try:
+            floor = float(_input.get("fail_below_score", 0.85))
+        except (TypeError, ValueError):
+            floor = 0.85
+
+        # Index the per-journey replay scores the replay step surfaced. The backend
+        # may return a list of {journey, score, passed} or a dict keyed by journey;
+        # normalize both, and tolerate a single overall score as a fallback.
+        per_journey = replay.get("per_journey")
+        if per_journey is None:
+            per_journey = replay.get("journeys") or replay.get("results")
+        score_by_journey = {}
+        passed_by_journey = {}
+        if isinstance(per_journey, dict):
+            per_journey = list(per_journey.values())
+        if isinstance(per_journey, list):
+            for r in per_journey:
+                if not isinstance(r, dict):
+                    continue
+                nm = str(r.get("journey") or r.get("name") or "").strip()
+                if not nm:
+                    continue
+                sc = r.get("score", r.get("replay_score"))
+                try:
+                    score_by_journey[nm] = float(sc)
+                except (TypeError, ValueError):
+                    score_by_journey[nm] = 0.0
+                if "passed" in r:
+                    passed_by_journey[nm] = bool(r.get("passed"))
+
+        # A single overall score fallback (used only when no per-journey breakdown).
+        overall_score = replay.get("score", replay.get("replay_score"))
+        try:
+            overall_score = float(overall_score)
+        except (TypeError, ValueError):
+            overall_score = None
+
+        # Index browser completion + screenshots by journey name.
+        cand_by_journey = {}
+        for c in candidates:
+            if not isinstance(c, dict):
+                continue
+            nm = str(c.get("journey") or "").strip()
+            if nm:
+                cand_by_journey[nm] = c
+
+        results = []
+        blocking = []
+        for j in (plan.get("journeys") or []):
+            if not isinstance(j, dict):
+                continue
+            nm = str(j.get("journey") or "").strip()
+            cand = cand_by_journey.get(nm) or {}
+            completed = bool(cand.get("completed", False))
+            err = cand.get("error_text")
+            shots = cand.get("screenshot_keys") or []
+            if not isinstance(shots, list):
+                shots = []
+
+            if nm in score_by_journey:
+                score = score_by_journey[nm]
+            elif overall_score is not None:
+                score = overall_score
+            else:
+                score = 0.0
+
+            if nm in passed_by_journey:
+                replay_ok = passed_by_journey[nm]
+            else:
+                replay_ok = score >= floor
+
+            # A journey passes ONLY if the browser completed it AND the replay score
+            # holds AND no error/captcha finding was reported. All deterministic.
+            has_error = err not in (None, "", "null")
+            journey_ok = completed and replay_ok and (not has_error)
+            delta = round(score - floor, 4)
+
+            entry = {
+                "journey": nm,
+                "completed": completed,
+                "replay_score": round(score, 4),
+                "score_delta_vs_floor": delta,
+                "replay_ok": replay_ok,
+                "error_text": (None if not has_error else str(err)),
+                "screenshot_keys": shots,
+                "passed": journey_ok,
+            }
+            results.append(entry)
+            if not journey_ok:
+                if completed and not replay_ok:
+                    why = "regression: replay score " + str(round(score, 4)) + " below floor " + str(floor)
+                elif has_error:
+                    why = "journey error: " + str(err)
+                else:
+                    why = "journey did not complete on staging"
+                blocking.append({
+                    "journey": nm,
+                    "why": why,
+                    "replay_score": round(score, 4),
+                    "score_delta_vs_floor": delta,
+                    "screenshot_keys": shots,
+                })
+
+        no_journeys = bool(plan.get("no_journeys", False)) or len(results) == 0
+        is_staging = bool(plan.get("is_staging_origin", False))
+
+        # All-green required. A zero-journey gate, a non-staging origin, or any
+        # blocking journey turns the verdict red (release blocked).
+        all_green = (not no_journeys) and is_staging and (len(blocking) == 0)
+
+        # Worst journey for the headline.
+        worst = None
+        if blocking:
+            worst = sorted(blocking, key=lambda b: b.get("score_delta_vs_floor", 0.0))[0]
+
+        verdict = "PASS" if all_green else "BLOCK"
+        result = {
+            "verdict": verdict,
+            "all_green": all_green,
+            "release_blocked": not all_green,
+            "no_journeys": no_journeys,
+            "is_staging_origin": is_staging,
+            "floor": floor,
+            "journey_count": len(results),
+            "results": results,
+            "blocking_journeys": blocking,
+            "blocking_count": len(blocking),
+            "worst_journey": worst,
+            "failure_screenshot_keys": (worst.get("screenshot_keys") if worst else []),
+            "summary": (
+                "All " + str(len(results)) + " journeys green - release may promote."
+                if all_green else
+                "RELEASE BLOCKED: " + str(len(blocking)) + " of " + str(len(results)) +
+                " journeys regressed (or no staging journeys to gate)."
+            ),
+        }
+
+  # ---------------------------------------------------------------------------
+  # 6) DELEGATE - fan the payment leg out to an existing synthetic checkout /
+  #    revenue-canary workflow for a deeper check of the money path. Advisory side
+  #    channel: the binding pass/fail stays the replay scores above. Read-only
+  #    against staging; performs no real charge.
+  # ---------------------------------------------------------------------------
+  - id: deep_checkout_canary
+    type: delegate
+    depends_on: [compute_release_verdict]
+    delegate_config:
+      workflow: "{input.checkout_canary_workflow}"
+      task_description: >-
+        Deep-check the PAID CHECKOUT leg of staging build {input.build_id} as a
+        synthetic revenue canary. Drive the checkout journey end to end against the
+        staging payment sandbox using the disposable CI_SYNTH_CREDS test instrument
+        only - NEVER a real card and NEVER a production host. Return whether the
+        money path completed and any stage where it broke. This is advisory context
+        for the release owner; the binding gate is the trajectory-replay verdict
+        ({steps.compute_release_verdict.output.verdict}).
+      timeout: 900
+
+  # ---------------------------------------------------------------------------
+  # 7) GATE - the promotion control. Strategy 1 (llm_eval) is ADVISORY ONLY: it
+  #    summarizes WHAT changed across the journeys for the human, it does not decide
+  #    release. Strategy 2 (human) is the binding control on the ONE irreversible
+  #    action - promoting to production. ALL strategies must pass. A green verdict
+  #    lets the human approve cleanly; ANY blocking journey forces the human to
+  #    EXPLICITLY override before promotion can proceed. CI never auto-promotes a
+  #    regressed funnel.
+  # ---------------------------------------------------------------------------
+  - id: promotion_gate
+    type: gate
+    depends_on: [compute_release_verdict, deep_checkout_canary]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are an ADVISORY release-diff summarizer - you do NOT decide the
+              release; the deterministic verdict already did. Read the verdict record
+              and reply with exactly one word: "approved" if the record is internally
+              consistent (release_blocked is the logical negation of all_green, and
+              every entry in blocking_journeys has a regression reason), otherwise
+              "rejected" and name the inconsistency. Then, in one extra sentence,
+              summarize WHICH journeys changed and by how much for the human reviewer.
+              Verdict record: {steps.compute_release_verdict.output}
+            input: "{steps.compute_release_verdict.output}"
+            model: sonnet
+        - type: human
+          config:
+            message: >-
+              Release owner: this is the production-promotion gate for build
+              {input.build_id}. The deterministic journey verdict is
+              {steps.compute_release_verdict.output.verdict} (blocking journeys:
+              {steps.compute_release_verdict.output.blocking_count}). APPROVE to
+              promote to production. If any journey regressed, promotion is blocked
+              unless you explicitly override after reviewing the failure screenshots.
+            timeout_hours: 24
+            on_timeout: abort
+
+  # ---------------------------------------------------------------------------
+  # 8) NOTIFY - post the gate result to CI/Slack so the release owner sees exactly
+  #    which flow regressed: the blocking journey, its replay-score delta vs the
+  #    floor, and the failure screenshot. Fires after the gate so the message
+  #    reflects the human's promote/override decision context.
+  # ---------------------------------------------------------------------------
+  - id: notify_release_owner
+    type: notify
+    depends_on: [promotion_gate]
+    notify_config:
+      service: slack
+      channel: "{input.ci_slack_channel}"
+      message: >-
+        Golden Journey Regression Gate for build {input.build_id}:
+        verdict {steps.compute_release_verdict.output.verdict}
+        ({steps.compute_release_verdict.output.summary}).
+        Blocking journeys: {steps.compute_release_verdict.output.blocking_count} of
+        {steps.compute_release_verdict.output.journey_count}. Worst:
+        {steps.compute_release_verdict.output.worst_journey}. Floor
+        {steps.compute_release_verdict.output.floor}. Failure screenshots:
+        {steps.compute_release_verdict.output.failure_screenshot_keys}. A blocked
+        verdict means a critical funnel flow regressed on staging and must NOT be
+        promoted to production without an explicit human override.
+
+on_complete:
+  storage_path: "golden-journey-regression-gate/{run_id}/verdict.json"

--- a/src/sandcastle/templates/gov_portal_filing_status_puller.yaml
+++ b/src/sandcastle/templates/gov_portal_filing_status_puller.yaml
@@ -1,0 +1,607 @@
+# name: Gov Portal Filing Status Puller
+# description: Logs into government / utility / insurance portals that publish case and filing status ONLY behind a per-account login web UI (no API), reads the live status and any newly issued documents for a tracked list of cases, validates every extraction deterministically, replay-tests the fragile portal read against a golden trajectory so a redesign fails loudly, classifies what changed, and ships a daily status digest. Strictly READ-ONLY against external portals - no submit / pay / delete anywhere.
+# tags: [compliance, paralegal, government, permits, insurance, browser, dom, lightpanda, trajectory-replay, rpa, read-only]
+# category: general_ai
+
+name: gov-portal-filing-status-puller
+description: >-
+  Tracks the live status of dozens of cases / filings across government, court,
+  permit, tax-authority, utility, and insurance-carrier portals that expose NO
+  API - status and newly-issued documents live ONLY behind a per-account login on
+  a server-rendered (often ancient, sometimes JS-gated) web UI. An HTTP step loads
+  the tracked {portal, case_id} list from the firm's OWN database. A LOOP fans out
+  over that list; each iteration runs a BROWSER step in dom mode (plain
+  server-rendered portals) - lightpanda is the cheap headless-DOM alternative for
+  JS-gated ones - that signs in with the per-portal credentials_env (NEVER an
+  inline secret), opens the case-lookup page, and returns ONLY a strict
+  output_schema {case_id, status, status_date, next_action_due, new_documents[],
+  amount_due}. It is PURELY a read: no form submission, no write, anywhere.
+  captcha_strategy=pause hands the near-certain portal CAPTCHA / MFA to a human;
+  max_actions=25 caps each per-case session; capture_screenshots keeps an audit
+  trail. A TRAJECTORY-REPLAY step then diffs this fragile portal read against a
+  recorded golden_run_id with fail_below_score=0.85 and a cost budget, so a portal
+  redesign or layout drift FAILS the run loudly instead of returning
+  silently-wrong legal/financial status. A deterministic CODE step VALIDATES every
+  extraction (status in an allowed enum, dates parse, case_id echoes back) and
+  QUARANTINES any row that fails - nothing bad is ever written to the database. A
+  CLASSIFY step flags cases whose status changed, that have a new document, or that
+  have an approaching deadline. A CONDITION routes: if any case became
+  'action_required' or 'denied', a NOTIFY pages the responsible owner; otherwise it
+  just records the clean sweep. A REPORT renders the daily status digest. The
+  reliability is load-bearing in deterministic code + trajectory-replay, never a
+  single model's opinion, and the dom/lightpanda reasoning model is swappable via
+  default_model for provider failover. NO write step exists by design - this
+  template is strictly read-only against external systems, which sidesteps the
+  biggest RPA legality / ToS hazard.
+  (connectors: firm case DB via http, slack)
+
+default_model: sonnet
+default_timeout: 900
+
+input_schema:
+  required: ["case_list_api_url"]
+  properties:
+    case_list_api_url:
+      type: string
+      description: >-
+        Base URL of the firm's OWN database/API that returns the tracked list of
+        cases to check. Each returned row carries {portal, case_id, lookup_url,
+        credentials_env, owner, last_status, last_status_date}. Secrets are NEVER
+        inlined - only the NAME of the per-portal credentials env var is stored.
+      default: "https://cases.internal.example/api/v1"
+    allowed_statuses:
+      type: array
+      description: >-
+        Closed enum a scraped status must fall into after normalization. A row
+        whose status is outside this set is quarantined as a bad/drifted read and
+        never trusted.
+      default:
+        - "received"
+        - "in_review"
+        - "pending_info"
+        - "action_required"
+        - "approved"
+        - "denied"
+        - "closed"
+    golden_run_id:
+      type: string
+      description: >-
+        ID of the known-good recorded portal-read trajectory the replay step diffs
+        the live read against. A portal redesign / layout drift drops the replay
+        score below the floor and fails the run loudly.
+      default: "golden-gov-portal-case-lookup-2026-05-01"
+    deadline_warn_days:
+      type: integer
+      description: >-
+        A case whose next_action_due falls within this many days of the run date is
+        flagged as an approaching deadline by the change classifier.
+      default: 7
+    run_date:
+      type: string
+      description: >-
+        ISO run date (YYYY-MM-DD) used for deterministic deadline math. ISO date
+        string compare is monotonic, so no date library is needed in the sandbox.
+      default: "2026-06-02"
+    notify_service:
+      type: string
+      description: "Where to page the responsible owner on action_required / denied: slack or teams."
+      default: "slack"
+    notify_channel:
+      type: string
+      description: "Channel for the action-required alert."
+      default: "#filings-watch"
+    report_author:
+      type: string
+      description: "Author line on the daily status digest PDF."
+      default: "Compliance Operations"
+
+steps:
+  # ---------------------------------------------------------------------------
+  # 1) HTTP - load the tracked {portal, case_id} list from the firm's OWN case
+  #    database. This is the internal system of record that drives the sweep; it
+  #    is NOT an external portal. Auth via a bearer token from the env, never
+  #    inlined. (connector: firm case DB via http)
+  # ---------------------------------------------------------------------------
+  - id: load_case_list
+    type: http
+    http_config:
+      url: "{input.case_list_api_url}/cases?tracked=true"
+      method: GET
+      auth: "bearer:{env.CASE_DB_TOKEN}"
+      headers:
+        Accept: "application/json"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # ---------------------------------------------------------------------------
+  # 2) CODE - normalize the case DB response into a clean list the loop can fan
+  #    out over. Pure deterministic shaping (defends against the body arriving
+  #    under data/cases/rows), no model. Rows missing a portal, case_id, or
+  #    lookup_url are dropped here so the browser never runs on a junk row.
+  # ---------------------------------------------------------------------------
+  - id: build_case_queue
+    type: code
+    depends_on: [load_case_list]
+    code_config:
+      language: python
+      code: |
+        resp = _steps.get("load_case_list") or {}
+        if not isinstance(resp, dict):
+            resp = {}
+        rows = (
+            resp.get("cases")
+            or resp.get("data")
+            or resp.get("rows")
+            or resp.get("body")
+            or resp.get("json")
+        )
+        if isinstance(rows, dict):
+            rows = rows.get("cases") or rows.get("data") or rows.get("rows") or []
+        if not isinstance(rows, list):
+            rows = []
+
+        queue = []
+        dropped = []
+        for r in rows:
+            if not isinstance(r, dict):
+                dropped.append({"reason": "row_not_object", "raw": str(r)[:160]})
+                continue
+            portal = str(r.get("portal") or "").strip()
+            case_id = str(r.get("case_id") or r.get("id") or "").strip()
+            lookup_url = str(r.get("lookup_url") or "").strip()
+            creds_env = str(r.get("credentials_env") or "").strip()
+            if not portal or not case_id or not lookup_url:
+                dropped.append({
+                    "reason": "missing_required_field",
+                    "portal": portal,
+                    "case_id": case_id,
+                })
+                continue
+            queue.append({
+                "portal": portal,
+                "case_id": case_id,
+                "lookup_url": lookup_url,
+                "credentials_env": creds_env or "PORTAL_CREDS",
+                "owner": str(r.get("owner") or "").strip(),
+                "last_status": str(r.get("last_status") or "").strip().lower(),
+                "last_status_date": str(r.get("last_status_date") or "").strip(),
+            })
+
+        result = {
+            "queue": queue,
+            "queue_size": len(queue),
+            "dropped": dropped,
+            "dropped_count": len(dropped),
+        }
+
+  # ---------------------------------------------------------------------------
+  # 3) LOOP - fan out over the tracked cases. Each iteration runs read_case, the
+  #    provider-neutral dom-mode browser read. The loop item (one case row) is
+  #    delivered on _input['_item'] and read by the browser prompt via templating.
+  # ---------------------------------------------------------------------------
+  - id: read_cases
+    type: loop
+    depends_on: [build_case_queue]
+    loop_config:
+      over: "steps.build_case_queue.output.queue"
+      step_ids: [read_case]
+      max_iterations: 50
+
+  # 3a) BROWSER (dom mode - PROVIDER-NEUTRAL). The configured reasoning model
+  #     authors the login + navigation + extraction from this prompt; dom mode is a
+  #     lightweight server-rendered read (lightpanda is the cheap headless-DOM
+  #     alternative for JS-gated portals) and the authoring model is swappable via
+  #     default_model. This is PURELY the READ pass: it signs in with the per-case
+  #     credentials_env (NEVER an inline secret), opens the case-lookup page, and
+  #     returns ONLY the strict output_schema below. It performs NO form submission
+  #     and NO write of any kind. captcha_strategy=pause hands the near-certain
+  #     portal CAPTCHA / MFA login challenge to a human. max_actions=25 caps each
+  #     per-case session. capture_screenshots keeps an audit trail of every page.
+  #     (loop child step - defined separately, read via _input['_item'])
+  - id: read_case
+    type: browser
+    browser_config:
+      mode: dom
+      start_url: "{input._item.lookup_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 25
+      headless: true
+      credentials_env: "{input._item.credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          case_id: { type: string }
+          portal: { type: string }
+          status: { type: string }
+          status_date: { type: string }
+          next_action_due: { type: string }
+          amount_due: { type: number }
+          new_documents:
+            type: array
+            items:
+              type: object
+              properties:
+                title: { type: string }
+                doc_id: { type: string }
+                issued_date: { type: string }
+                url: { type: string }
+        required: ["case_id", "status"]
+    prompt: |
+      You are automating a government / court / permit / tax-authority / utility /
+      insurance-carrier portal (portal: {input._item.portal}) as a READ-ONLY
+      compliance clerk checking case {input._item.case_id}. There is NO API - this
+      login-gated, often server-rendered (sometimes JS-gated) status page is the
+      ONLY source of truth.
+
+      Navigate the portal deterministically:
+      1. Open the case-lookup page ({input._item.lookup_url}) and sign in using ONLY
+         the credentials supplied by the credentials_env environment variable. NEVER
+         hardcode, echo, or log the secret.
+      2. If a CAPTCHA, MFA, or device-verification challenge appears, STOP and hand
+         off to a human (captcha_strategy=pause). Do not attempt to solve it.
+      3. Look up case {input._item.case_id} and open its status detail page.
+      4. Read the live status, the date that status was set, any stated next-action
+         or response deadline, any amount due, and the list of NEW documents the
+         portal has issued (title, document id, issued date, link).
+      5. Perform NO write actions whatsoever - never submit, file, respond, pay,
+         upload, withdraw, e-sign, or change anything. This is extraction ONLY.
+
+      Return ONLY the structured JSON described by the output_schema: the case_id
+      (echoed back exactly), the portal, the literal status text, status_date,
+      next_action_due, amount_due (numeric, 0 if none), and a new_documents array.
+
+  # ---------------------------------------------------------------------------
+  # 4) TRAJECTORY-REPLAY - the load-bearing reliability check for the fragile
+  #    portal read. Loads the recorded golden trajectory by golden_run_id, diffs
+  #    the live read against it, and FAILS the run when the replay score drops
+  #    below fail_below_score (UI / layout drift from a portal redesign) OR cost
+  #    exceeds the allowed delta / budget. Deterministic scorer, not a model's
+  #    opinion, comparing observable actions + extracted outputs only - so a portal
+  #    redesign fails LOUDLY instead of returning silently-wrong legal status.
+  # ---------------------------------------------------------------------------
+  - id: replay_vs_golden
+    type: trajectory-replay
+    depends_on: [read_cases]
+    trajectory_replay_config:
+      golden_run_id: "{input.golden_run_id}"
+      fail_below_score: 0.85
+      allow_cost_delta_pct: 10.0
+      cost_budget_usd: 0.5
+
+  # ---------------------------------------------------------------------------
+  # 5) CODE - VALIDATE every extraction deterministically before anything is
+  #    trusted. Each row must echo a non-empty case_id, carry a status that
+  #    normalizes into the allowed enum, and have parseable ISO-ish dates. Rows
+  #    that fail are QUARANTINED (never trusted, never written). A portal that
+  #    yielded zero valid rows is surfaced as a likely redesign / auth wall. No
+  #    model in this gate - this is the load-bearing correctness, paired with the
+  #    trajectory-replay above.
+  # ---------------------------------------------------------------------------
+  - id: validate_extractions
+    type: code
+    depends_on: [read_cases, replay_vs_golden]
+    code_config:
+      language: python
+      code: |
+        reads = _steps.get("read_cases")
+        if isinstance(reads, dict):
+            reads = [reads]
+        if not isinstance(reads, list):
+            reads = []
+
+        allowed = _input.get("allowed_statuses") or [
+            "received", "in_review", "pending_info",
+            "action_required", "approved", "denied", "closed",
+        ]
+        allowed_set = {str(s).strip().lower() for s in allowed if isinstance(s, str)}
+
+        # Build the case-row context (last_status, owner, due) keyed by case_id from
+        # the normalized queue, so the change classifier downstream has prior state.
+        queue_ctx = {}
+        bq = _steps.get("build_case_queue") or {}
+        if isinstance(bq, dict):
+            for row in bq.get("queue") or []:
+                if isinstance(row, dict):
+                    queue_ctx[str(row.get("case_id") or "").strip()] = row
+
+        # A loose ISO date guard: YYYY-MM-DD, optionally with a time suffix. Empty
+        # strings are allowed (a case may legitimately have no deadline / doc date).
+        date_pattern = r"^\d{4}-\d{2}-\d{2}([ T].*)?$"
+
+        def _date_ok(v):
+            s = str(v or "").strip()
+            if s == "":
+                return True
+            return bool(re.match(date_pattern, s))
+
+        def _to_amount(v):
+            if v is None or v == "":
+                return 0.0
+            try:
+                return round(float(v), 2)
+            except (TypeError, ValueError):
+                return None
+
+        valid = []
+        quarantined = []
+        seen_case_ids = set()
+
+        for env in reads:
+            if not isinstance(env, dict):
+                quarantined.append({"reason": "read_not_object", "raw": str(env)[:160]})
+                continue
+            case_id = str(env.get("case_id") or "").strip()
+            portal = str(env.get("portal") or "").strip()
+            status_raw = str(env.get("status") or "").strip()
+            status = re.sub(r"[\s\-]+", "_", status_raw.lower())
+            status_date = env.get("status_date")
+            next_due = env.get("next_action_due")
+            amount = _to_amount(env.get("amount_due"))
+            docs = env.get("new_documents")
+            if not isinstance(docs, list):
+                docs = []
+
+            ctx = queue_ctx.get(case_id) or {}
+            reasons = []
+            # case_id must be present and must echo a tracked case from our DB.
+            if not case_id:
+                reasons.append("missing_case_id")
+            elif queue_ctx and case_id not in queue_ctx:
+                reasons.append("unknown_case_id")
+            if status not in allowed_set:
+                reasons.append("status_not_in_enum")
+            if not _date_ok(status_date):
+                reasons.append("bad_status_date")
+            if not _date_ok(next_due):
+                reasons.append("bad_next_action_due")
+            if amount is None:
+                reasons.append("bad_amount_due")
+
+            if reasons:
+                quarantined.append({
+                    "case_id": case_id,
+                    "portal": portal,
+                    "raw_status": status_raw,
+                    "reasons": reasons,
+                })
+                continue
+
+            seen_case_ids.add(case_id)
+            valid.append({
+                "case_id": case_id,
+                "portal": portal,
+                "owner": str(ctx.get("owner") or ""),
+                "status": status,
+                "status_date": str(status_date or ""),
+                "next_action_due": str(next_due or ""),
+                "amount_due": amount,
+                "new_documents": docs,
+                "new_document_count": len(docs),
+                "prior_status": str(ctx.get("last_status") or ""),
+                "prior_status_date": str(ctx.get("last_status_date") or ""),
+            })
+
+        # Cases we were tracking but got no valid read for - probable scrape failure
+        # (login wall / redesign), surfaced rather than silently treated as no-change.
+        missing_reads = []
+        if queue_ctx:
+            for cid in queue_ctx:
+                if cid not in seen_case_ids:
+                    missing_reads.append(cid)
+
+        result = {
+            "valid": valid,
+            "valid_count": len(valid),
+            "quarantined": quarantined,
+            "quarantined_count": len(quarantined),
+            "missing_reads": missing_reads,
+            "missing_read_count": len(missing_reads),
+            "extraction_ok": len(valid) > 0,
+        }
+
+  # ---------------------------------------------------------------------------
+  # 6) CODE - deterministic CHANGE DETECTION over the validated rows. Compares the
+  #    fresh status against the prior status from the DB, detects new documents,
+  #    and computes approaching-deadline using monotonic ISO-date string compare
+  #    against the run_date + deadline_warn_days window. Pure math, no model; this
+  #    produces the change facts the classifier then labels.
+  # ---------------------------------------------------------------------------
+  - id: detect_changes
+    type: code
+    depends_on: [validate_extractions]
+    code_config:
+      language: python
+      code: |
+        extraction = _steps.get("validate_extractions") or {}
+        if not isinstance(extraction, dict):
+            extraction = {}
+        rows = extraction.get("valid") or []
+        if not isinstance(rows, list):
+            rows = []
+
+        run_date = str(_input.get("run_date") or "").strip()
+        try:
+            warn_days = int(_input.get("deadline_warn_days", 7) or 7)
+        except (TypeError, ValueError):
+            warn_days = 7
+
+        # Deterministic warn-window upper bound as an ISO date string. Avoids any
+        # date library: add warn_days to the day component with simple carry-free
+        # month rollover handled by string compare being inclusive on the same month
+        # where possible; if it would overflow the month we widen to month-end+window
+        # by comparing on the YYYY-MM prefix as a fallback.
+        warn_window_end = ""
+        m = re.match(r"^(\d{4})-(\d{2})-(\d{2})", run_date)
+        if m:
+            yr = int(m.group(1))
+            mo = int(m.group(2))
+            day = int(m.group(3))
+            new_day = day + warn_days
+            if new_day <= 28:
+                warn_window_end = "%04d-%02d-%02d" % (yr, mo, new_day)
+            else:
+                # Be conservative: widen the window to the end of next month so we
+                # never MISS a near deadline due to month rollover. False positives
+                # here are acceptable (a human reviews); false negatives are not.
+                nmo = mo + 1
+                nyr = yr
+                if nmo > 12:
+                    nmo = 1
+                    nyr = yr + 1
+                warn_window_end = "%04d-%02d-28" % (nyr, nmo)
+
+        changed = []
+        new_docs = []
+        approaching = []
+        unchanged = []
+
+        for r in rows:
+            if not isinstance(r, dict):
+                continue
+            case_id = str(r.get("case_id") or "")
+            status = str(r.get("status") or "")
+            prior = str(r.get("prior_status") or "")
+            doc_count = int(r.get("new_document_count") or 0)
+            next_due = str(r.get("next_action_due") or "")
+
+            status_changed = bool(prior) and status != prior
+            has_new_doc = doc_count > 0
+            # Approaching deadline: a non-empty due date that falls on/before the
+            # warn-window end and is not already in the past relative to run_date.
+            is_approaching = False
+            if next_due and run_date and warn_window_end:
+                is_approaching = (next_due >= run_date) and (next_due <= warn_window_end)
+
+            flags = []
+            if status_changed:
+                flags.append("status_changed")
+                changed.append({
+                    "case_id": case_id, "owner": r.get("owner"),
+                    "from": prior, "to": status, "portal": r.get("portal"),
+                })
+            if has_new_doc:
+                flags.append("new_document")
+                new_docs.append({
+                    "case_id": case_id, "owner": r.get("owner"),
+                    "count": doc_count, "documents": r.get("new_documents"),
+                })
+            if is_approaching:
+                flags.append("approaching_deadline")
+                approaching.append({
+                    "case_id": case_id, "owner": r.get("owner"),
+                    "next_action_due": next_due, "status": status,
+                })
+            if not flags:
+                unchanged.append({"case_id": case_id, "status": status})
+
+            r["change_flags"] = flags
+
+        # The portal's own status text drives the escalation set: anything the
+        # firm must act on or that was denied.
+        escalation = [
+            r for r in rows
+            if str(r.get("status") or "") in ("action_required", "denied")
+        ]
+
+        result = {
+            "rows": rows,
+            "changed": changed,
+            "changed_count": len(changed),
+            "new_docs": new_docs,
+            "new_doc_count": len(new_docs),
+            "approaching": approaching,
+            "approaching_count": len(approaching),
+            "unchanged_count": len(unchanged),
+            "escalation": escalation,
+            "escalation_count": len(escalation),
+            "warn_window_end": warn_window_end,
+            "any_change": (len(changed) + len(new_docs) + len(approaching)) > 0,
+            "needs_owner": len(escalation) > 0,
+        }
+
+  # ---------------------------------------------------------------------------
+  # 7) CLASSIFY - label the overall sweep so the digest leads with the right
+  #    headline. Non-load-bearing (the deterministic change facts already exist in
+  #    detect_changes); this is a haiku triage label and is provider-swappable. All
+  #    branches converge on the same routing decision so no information is lost.
+  # ---------------------------------------------------------------------------
+  - id: classify_sweep
+    type: classify
+    depends_on: [detect_changes]
+    classify_config:
+      model: haiku
+      input: "Classify the urgency of this government/insurance portal filing sweep. Use: critical = any case is 'denied' or 'action_required', or a hard deadline is approaching; attention = a status changed or a new document was issued but nothing is action_required/denied; routine = no changes, no new docs, no approaching deadlines. Change facts: {steps.detect_changes.output}"
+      categories:
+        - routine
+        - attention
+        - critical
+      branches:
+        routine: [route_outcome]
+        attention: [route_outcome]
+        critical: [route_outcome]
+
+  # ---------------------------------------------------------------------------
+  # 8) CONDITION - deterministic routing on the change facts (NOT the model label).
+  #    If any case became action_required / denied, page the responsible owner AND
+  #    build the digest. Otherwise just build the digest for the clean sweep. The
+  #    expression reads the deterministic detect_changes.needs_owner flag.
+  # ---------------------------------------------------------------------------
+  - id: route_outcome
+    type: condition
+    depends_on: [detect_changes, classify_sweep]
+    condition_config:
+      expression: "{steps.detect_changes.output.needs_owner} == True"
+      then: [notify_owner, build_digest]
+      else: [build_digest]
+
+  # 8a) NOTIFY (escalation branch) - page the responsible owner with the
+  #     action-required / denied cases so a legal/financial deadline is never
+  #     silently missed. Read-only: this only alerts; it never touches a portal.
+  - id: notify_owner
+    type: notify
+    depends_on: [route_outcome]
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: ":rotating_light: Filing watch: action required. Escalation cases (action_required / denied): {steps.detect_changes.output.escalation}. Status changes: {steps.detect_changes.output.changed}. New documents: {steps.detect_changes.output.new_docs}. Approaching deadlines: {steps.detect_changes.output.approaching}. Quarantined (bad/drifted reads): {steps.validate_extractions.output.quarantined_count}. Missing reads (possible portal redesign / login wall): {steps.validate_extractions.output.missing_reads}. This run was READ-ONLY on all external portals - no submit/file/pay/withdraw actions were taken."
+
+  # ---------------------------------------------------------------------------
+  # 9) REPORT (both branches converge here) - render the daily filing status
+  #    digest PDF: the full status table, what changed, new documents, approaching
+  #    deadlines, the sweep urgency label, plus the reliability footer (replay
+  #    verdict, quarantined rows, missing reads). This is the deliverable.
+  # ---------------------------------------------------------------------------
+  - id: build_digest
+    type: report
+    depends_on: [route_outcome]
+    report_config:
+      template: research-report
+      format: pdf
+      theme: professional
+      title: "Daily Filing Status Digest - {input.run_date}"
+      author: "{input.report_author}"
+    prompt: |
+      Produce a daily filing-status digest PDF for a compliance / paralegal team
+      from the payload below. Lead with the sweep urgency label
+      ({steps.classify_sweep.output}). Then a status table of every tracked case
+      with its current status, status date, next action due, amount due, and new
+      document count. Add sections for: status changes (from -> to), newly issued
+      documents (with titles and links), and approaching deadlines (with owners).
+      End with a RELIABILITY footer: how many extractions were quarantined as
+      bad/drifted reads, which tracked cases got NO valid read (possible portal
+      redesign or login wall), and that the fragile portal read was diffed against
+      a recorded golden trajectory (a redesign would have failed the run). State
+      explicitly that this run was strictly READ-ONLY against all external portals:
+      no submit, file, pay, withdraw, e-sign, or delete actions were taken.
+      Validated status rows: {steps.detect_changes.output.rows}
+      Change facts: {steps.detect_changes.output}
+      Extraction QA: {steps.validate_extractions.output}
+
+on_complete:
+  storage_path: "gov-portal-filing-status-puller/{run_id}/filing-status-digest.json"

--- a/src/sandcastle/templates/government_procurement_bid_submitter.yaml
+++ b/src/sandcastle/templates/government_procurement_bid_submitter.yaml
@@ -1,0 +1,713 @@
+# name: Government Procurement Bid Submitter
+# description: Assembles and files a tender response in a public e-procurement portal (SAM.gov, TED/eSourcing, a state vendor portal) that has NO bid-submission API - fetches the approved bid package (pricing PDF, technical proposal, compliance attestations) from a gdrive/s3 vault via a presigned URL, deterministically verifies the document checklist is complete and the deadline has not passed (fails closed), then drives a provider-neutral playwright browser step that logs in (credentials via PROCURE_PORTAL_CREDS, captcha_strategy=pause), uploads every required document, fills the structured bid form (price, lead time, certifications), advances to the REVIEW screen and STOPS - returning a structured preview via output_schema. A deterministic code step asserts the uploaded-doc set matches the required checklist and the portal-computed total_bid_price equals the approved pricing figure (anti-fat-finger guard). Only then does an llm_eval + human gate plus a mandatory approval show the exact price + docs + review screenshot and require explicit sign-off, because a submitted public bid is legally binding. A second playwright step clicks Submit ONCE and captures the confirmation/receipt number + timestamp screenshot; a sensor re-reads the portal's own submission-status page until it confirms received before the receipt is archived (presigned s3 PUT) and the team is notified. The brittle write is isolated behind the human gate; the load-bearing correctness is deterministic code + an engine-native sensor, never a single model's opinion.
+# tags: [Procurement, Tender, RFP, SAMgov, TED, eProcurement, RPA, Playwright, HumanInTheLoop, ProviderNeutral, DeadlineGuard, Sensor]
+# category: sales_crm
+
+name: government-procurement-bid-submitter
+description: >-
+  Files a complete tender response into a public e-procurement portal - SAM.gov, the EU's TED /
+  eSourcing, or a state/municipal vendor portal - on behalf of a bid/proposal manager at a government
+  contractor or SME. These portals are login-gated, JavaScript-heavy single-page apps with multi-step
+  upload wizards, document-checklist validation, and NO bid-submission API: attaching files and clicking
+  'Submit Bid' literally only exists in the browser UI, so teams re-key pricing and re-upload documents
+  by hand and lose deals to missed deadlines or transcription errors. This template is triggered when an
+  approved bid package in a watched gdrive/s3 folder reaches status=ready_to_submit and the deadline is
+  inside the configured window. It splits read-prep from the legally binding write and fails closed.
+  First an http step downloads the approved bid-package manifest from the vault via a presigned URL
+  (gdrive/s3 connector; no inline secrets). A DETERMINISTIC code step then verifies the document
+  checklist is complete (every required filename present, page counts greater than zero) and that the
+  submission deadline has NOT passed - rejecting on any gap so nothing is ever filed late or short a
+  document. A provider-neutral playwright browser step logs in via PROCURE_PORTAL_CREDS
+  (captcha_strategy=pause), opens the solicitation, uploads each document, fills the structured bid form
+  (total price, lead time, certifications), advances to the REVIEW screen and STOPS - returning
+  {solicitation_id, uploaded_docs[], total_bid_price, attestations_checked, review_page_summary,
+  review_screenshot} via output_schema. A second DETERMINISTIC code step asserts the uploaded-doc set
+  matches the required checklist exactly and the portal-computed total_bid_price equals the approved
+  pricing figure within tolerance - the anti-fat-finger guard, with no model deciding correctness. An
+  llm_eval + human gate then verifies internal consistency and requires an explicit human, followed by a
+  mandatory approval that shows the exact price, the document list, and the review screenshot and BLOCKS
+  until a person authorizes, because a submitted public bid is legally binding. Only on sign-off does a
+  second playwright step click Submit ONCE and capture the portal's confirmation/submission receipt
+  number and a timestamp screenshot. An engine-native sensor re-reads the portal's own submission-status
+  page until it confirms the bid was received before success is declared; a deterministic decision routes
+  a timeout to a needs-attention page, never a false win. Finally the receipt is archived to the vault via
+  a presigned s3 PUT (audit chain) and the team is notified. Both browser steps ride default_model and
+  stay swappable across providers; the consistency llm_eval, the human gate, and the approval are
+  model-independent and engine-native, so swapping the reasoning provider never weakens the safety or
+  changes filing behavior.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 1800
+
+input_schema:
+  required: ["solicitation_url", "submission_status_url", "bid_package_url", "required_documents", "approved_total_price", "bid_deadline_iso"]
+  properties:
+    solicitation_url:
+      type: string
+      description: "URL of the solicitation / tender response wizard in the e-procurement portal (login-gated SPA, no submission API). Templated into both browser steps' start_url."
+      example: "https://sam.gov/opp/abc123def456/responses/new"
+    submission_status_url:
+      type: string
+      description: "URL of the portal's OWN submission-status page for THIS response; the verify sensor re-reads it until the portal confirms the bid was received."
+      example: "https://sam.gov/opp/abc123def456/responses/mine/status"
+    bid_package_url:
+      type: string
+      description: "Presigned gdrive/s3 download URL for the approved bid-package manifest JSON (lists pricing PDF, technical proposal, compliance attestations and their page counts). NEVER inline secrets - this is a short-lived presigned URL."
+      example: "https://storage.googleapis.com/bid-vault/SOL-2026-0098/manifest.json?X-Goog-Signature=..."
+    required_documents:
+      type: string
+      description: "Comma-separated list of required document filenames the solicitation demands (the checklist). Every one must be present in the package and uploaded to the portal before submission is allowed."
+      example: "pricing.pdf,technical_proposal.pdf,sf1449.pdf,reps_and_certs.pdf,past_performance.pdf"
+    approved_total_price:
+      type: number
+      description: "The approved total bid price (the figure sign-off was given for). The deterministic guard rejects if the portal-computed total_bid_price differs from this beyond tolerance - prevents a fat-finger price error on a binding bid."
+      example: "487350.00"
+    bid_deadline_iso:
+      type: string
+      description: "The solicitation's hard submission deadline as an ISO-8601 timestamp. The deterministic deadline check fails closed if now is at or past this - never files late."
+      example: "2026-06-15T17:00:00+00:00"
+    now_iso:
+      type: string
+      description: "Current time as an ISO-8601 timestamp, injected by the trigger so the deadline check is deterministic and testable (no clock calls in the sandbox). Defaults empty; supply at run time."
+      default: ""
+      example: "2026-06-10T09:30:00+00:00"
+    lead_time_days:
+      type: integer
+      description: "Promised delivery lead time in days, entered into the structured bid form alongside price and certifications."
+      default: 30
+      example: "45"
+    certifications:
+      type: string
+      description: "Comma-separated certification / attestation codes to assert on the bid form (e.g. small-business, ISO9001, ITAR). Used to fill the certifications section and checked by the deterministic guard."
+      default: ""
+      example: "small-business,ISO9001,ITAR-registered"
+    price_tolerance:
+      type: number
+      description: "Absolute currency tolerance allowed when reconciling the portal-computed total_bid_price against approved_total_price (covers portal rounding/fees). A larger delta is rejected."
+      default: 0.01
+      example: "0.01"
+    deadline_window_hours:
+      type: integer
+      description: "How many hours BEFORE the deadline the deadline check still considers it safe to submit. If now is within this window of the deadline it warns but allows; past the deadline it always fails closed."
+      default: 1
+      example: "2"
+    receipt_archive_url:
+      type: string
+      description: "Presigned gdrive/s3 PUT URL the captured submission receipt is archived to for the audit chain after the portal confirms receipt."
+      default: ""
+      example: "https://bid-vault.s3.amazonaws.com/SOL-2026-0098/receipt.json?X-Amz-Signature=..."
+    portal_credentials_env:
+      type: string
+      description: "Name of the environment variable holding the e-procurement portal login credentials (NEVER inline secrets). Passed to both browser steps' credentials_env."
+      default: "PROCURE_PORTAL_CREDS"
+      example: "PROCURE_PORTAL_CREDS"
+    approval_timeout_hours:
+      type: integer
+      description: "Hours the human submit-approval and the human gate wait before timing out. on_timeout: abort means a missed approval NEVER auto-submits a binding public bid."
+      default: 12
+      example: "12"
+    sensor_poll_interval_seconds:
+      type: integer
+      description: "Seconds between submission-status-page polls while waiting for the portal to confirm the bid was received."
+      default: 60
+      example: "60"
+    sensor_timeout_seconds:
+      type: integer
+      description: "Hard ceiling in seconds the verify sensor waits for the portal to confirm receipt before the run is routed to needs-attention (never reported as a successful submission)."
+      default: 3600
+      example: "3600"
+    notify_channel:
+      type: string
+      description: "Slack channel for the bid desk's filed / blocked / needs-attention notifications."
+      default: "#bid-desk"
+      example: "#bid-desk"
+    solicitation_label:
+      type: string
+      description: "Human-readable label for this solicitation used in the approval message and notifications (e.g. solicitation number and agency)."
+      default: "tender response"
+      example: "SOL-2026-0098 - GSA IT Services BPA"
+
+steps:
+  # 1) FETCH the approved bid-package manifest from the gdrive/s3 vault via a presigned URL (http,
+  #    deterministic; no inline secrets - the presigned URL is short-lived and supplied at run time).
+  #    The manifest lists each required document and its page count so the checklist can be verified
+  #    BEFORE any portal entry. value_map lifts the fields the validator needs.
+  - id: fetch_bid_package
+    type: http
+    http_config:
+      url: "{input.bid_package_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      value_map:
+        documents: "documents"
+        package_status: "status"
+        package_solicitation_id: "solicitation_id"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 2) DETERMINISTIC checklist + deadline gate (sandboxed Python, no model). The load-bearing pre-portal
+  #    check: every required filename must be present in the fetched package with a page count greater
+  #    than zero, the package must be ready_to_submit, and the deadline must NOT have passed. Fails
+  #    CLOSED - nothing touches the portal on an incomplete package or a missed deadline.
+  - id: verify_checklist_and_deadline
+    type: code
+    depends_on: [fetch_bid_package]
+    code_config:
+      language: python
+      code: |
+        import json
+        import datetime
+
+        # --- Pull the document manifest from the http fetch (value_map lifted fields, with fallbacks). ---
+        fetched = _steps.get('fetch_bid_package') or {}
+        if not isinstance(fetched, dict):
+            fetched = {}
+        # http step may surface lifted fields at top level or nest the raw body under output/data/body.
+        body = fetched
+        for key in ('output', 'data', 'body', 'json', 'result'):
+            inner = fetched.get(key)
+            if isinstance(inner, dict) and ('documents' in inner or 'status' in inner):
+                body = inner
+                break
+
+        docs = body.get('documents')
+        if not isinstance(docs, list):
+            docs = []
+        package_status = str(body.get('package_status', body.get('status', '')) or '').strip().lower()
+        package_solicitation_id = str(
+            body.get('package_solicitation_id', body.get('solicitation_id', '')) or ''
+        ).strip()
+
+        problems = []
+
+        # --- Required-document checklist: each required filename present with page_count > 0. ---
+        required_raw = _input.get('required_documents') or ''
+        required = [r.strip() for r in str(required_raw).split(',') if r.strip()]
+        if not required:
+            problems.append('no required_documents checklist supplied (cannot verify completeness)')
+
+        # Map provided filename -> page count.
+        present = {}
+        for d in docs:
+            if not isinstance(d, dict):
+                continue
+            fname = str(d.get('filename', d.get('name', '')) or '').strip()
+            if not fname:
+                continue
+            pages_val = d.get('page_count', d.get('pages', 0))
+            try:
+                pages = int(pages_val)
+            except (TypeError, ValueError):
+                pages = 0
+            present[fname] = pages
+
+        missing_docs = [f for f in required if f not in present]
+        empty_docs = [f for f in required if f in present and present.get(f, 0) <= 0]
+        if missing_docs:
+            problems.append('missing required documents: ' + ', '.join(missing_docs))
+        if empty_docs:
+            problems.append('required documents have zero pages: ' + ', '.join(empty_docs))
+
+        uploaded_ok_set = sorted([f for f in required if f in present and present.get(f, 0) > 0])
+
+        # --- Package must be flagged ready_to_submit by the upstream approval. ---
+        if package_status and package_status != 'ready_to_submit':
+            problems.append("package status is '" + package_status + "', expected 'ready_to_submit'")
+
+        # --- Deadline check (deterministic, fails closed). Parse ISO timestamps without clock calls. ---
+        def _parse_iso(s):
+            s = str(s or '').strip()
+            if not s:
+                return None
+            # Normalise a trailing Z to +00:00 for fromisoformat.
+            if s.endswith('Z'):
+                s = s[:-1] + '+00:00'
+            try:
+                return datetime.datetime.fromisoformat(s)
+            except (TypeError, ValueError):
+                return None
+
+        deadline_dt = _parse_iso(_input.get('bid_deadline_iso'))
+        now_dt = _parse_iso(_input.get('now_iso'))
+
+        deadline_ok = False
+        within_window = False
+        if deadline_dt is None:
+            problems.append('bid_deadline_iso missing or unparseable (cannot verify deadline)')
+        elif now_dt is None:
+            problems.append('now_iso missing or unparseable (cannot deterministically check deadline)')
+        else:
+            # If either is naive, compare as naive to avoid mixed tz errors.
+            if (deadline_dt.tzinfo is None) != (now_dt.tzinfo is None):
+                deadline_dt = deadline_dt.replace(tzinfo=None)
+                now_dt = now_dt.replace(tzinfo=None)
+            remaining = (deadline_dt - now_dt).total_seconds()
+            deadline_ok = remaining > 0
+            try:
+                window_hours = int(_input.get('deadline_window_hours', 1) or 1)
+            except (TypeError, ValueError):
+                window_hours = 1
+            within_window = (0 < remaining <= window_hours * 3600)
+            if not deadline_ok:
+                problems.append('DEADLINE PASSED - now is at or past the submission deadline; refusing to file late')
+
+        ok = len(problems) == 0
+        result = {
+            'ok': ok,
+            'problems': problems,
+            'required_documents': required,
+            'present_documents': sorted(list(present.keys())),
+            'uploaded_ok_set': uploaded_ok_set,
+            'missing_documents': missing_docs,
+            'empty_documents': empty_docs,
+            'package_status': package_status,
+            'package_solicitation_id': package_solicitation_id,
+            'approved_total_price': float(_input.get('approved_total_price', 0) or 0),
+            'deadline_ok': deadline_ok,
+            'within_deadline_window': within_window,
+        }
+
+  # 2b) Hard stop on an incomplete package or a missed deadline - never touch the portal.
+  - id: checklist_gate
+    type: condition
+    depends_on: [verify_checklist_and_deadline]
+    condition_config:
+      expression: "{steps.verify_checklist_and_deadline.output.ok} == True"
+      then: [assemble_and_fill]
+      else: [notify_blocked]
+
+  # 2c) Blocked branch: tell the bid desk the response was NOT filed and exactly why. Nothing submitted.
+  - id: notify_blocked
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        BLOCKED before portal entry: {input.solicitation_label}. Pre-submission checks FAILED, so no
+        tender response was filed. Problem(s): {steps.verify_checklist_and_deadline.output.problems}.
+        Missing docs: {steps.verify_checklist_and_deadline.output.missing_documents}; deadline_ok:
+        {steps.verify_checklist_and_deadline.output.deadline_ok}. Fix the package or deadline and re-run.
+
+  # 3) ASSEMBLE + FILL (READ-PREP pass, playwright mode, provider-neutral). The reasoning model AUTHORS a
+  #    Playwright script that logs in via PROCURE_PORTAL_CREDS (never inlined), opens the solicitation,
+  #    UPLOADS every required document, fills the structured bid form (total price, lead time,
+  #    certifications), advances to the REVIEW screen and STOPS - it does NOT click Submit. CAPTCHA pauses
+  #    to a human; max_actions bounds the upload wizard; capture_screenshots gives an auditable review
+  #    screenshot; output_schema returns structured JSON to validate against. Read-prep only - reversible.
+  - id: assemble_and_fill
+    type: browser
+    depends_on: [checklist_gate]
+    prompt: >-
+      You are assembling a tender response in a public e-procurement portal (SAM.gov / TED / a state
+      vendor portal). Authenticate using the credentials provided via the PROCURE_PORTAL_CREDS
+      environment variable, then open the solicitation response wizard at the start URL. Walk the upload
+      wizard and UPLOAD every required document from this checklist to its correct slot:
+      {input.required_documents}. Then fill the structured bid form: enter the total bid price exactly as
+      the approved figure {input.approved_total_price}, set the delivery lead time to
+      {input.lead_time_days} days, and assert these certifications/attestations:
+      {input.certifications}. Let the portal compute and display its own total. CRITICAL: advance only to
+      the FINAL REVIEW / SUMMARY page and STOP there - DO NOT click Submit, Submit Bid, File Response, or
+      any final/confirm button. Submission is a separate, human-approved step. If a CAPTCHA or step-up
+      auth appears, PAUSE for a human - do not attempt to solve it. Solicitation: {input.solicitation_label}.
+      Read back the review screen and return ONLY the structured object described by the output schema: the
+      solicitation_id the portal shows, the list of uploaded document filenames, the portal-computed
+      total_bid_price, the list of attestations/certifications it shows as checked, a human-readable
+      review_page_summary, a reference to the captured review screenshot, and whether the final Submit
+      button is present and enabled.
+    browser_config:
+      mode: playwright
+      start_url: "{input.solicitation_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 600
+      max_actions: 120
+      headless: true
+      credentials_env: "{input.portal_credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          solicitation_id:
+            type: string
+            description: "The solicitation/opportunity id the portal shows for this response."
+          uploaded_docs:
+            type: array
+            items: { type: string }
+            description: "Filenames of every document the wizard shows as successfully uploaded."
+          total_bid_price:
+            type: number
+            description: "The total bid price the portal itself computed/displays on the review screen."
+          attestations_checked:
+            type: array
+            items: { type: string }
+            description: "Certification/attestation codes the form shows as checked."
+          review_page_summary:
+            type: string
+            description: "Human-readable summary of the bid as shown on the portal's review page."
+          review_screenshot:
+            type: string
+            description: "Reference to the captured review-page screenshot for the human approver."
+          submit_button_present:
+            type: boolean
+            description: "True if the final Submit button is present and enabled (wizard reached review)."
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: abort
+
+  # 4) DETERMINISTIC anti-fat-finger guard (sandboxed Python, no model). The load-bearing pre-submit
+  #    check: the uploaded-doc set must match the required checklist EXACTLY, the portal-computed
+  #    total_bid_price must equal the approved figure within tolerance, the attestations must cover the
+  #    requested certifications, the wizard must have reached a submit-capable review, and a review
+  #    screenshot must exist. ANY mismatch => ok=False with reasons; nothing is submitted on a bad fill.
+  - id: validate_filled_bid
+    type: code
+    depends_on: [assemble_and_fill]
+    code_config:
+      language: python
+      code: |
+        read_out = _steps.get('assemble_and_fill') or {}
+        if not isinstance(read_out, dict):
+            read_out = {}
+        # Browser payloads may nest the structured object under output/data/result.
+        for key in ('output', 'data', 'result'):
+            inner = read_out.get(key)
+            if isinstance(inner, dict) and ('total_bid_price' in inner or 'uploaded_docs' in inner):
+                read_out = inner
+                break
+
+        checklist = _steps.get('verify_checklist_and_deadline') or {}
+        if not isinstance(checklist, dict):
+            checklist = {}
+
+        problems = []
+
+        def _num(v, default=0.0):
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return default
+
+        # --- Uploaded documents must match the required checklist EXACTLY (set equality). ---
+        required = checklist.get('required_documents')
+        if not isinstance(required, list):
+            required = []
+        uploaded = read_out.get('uploaded_docs')
+        if not isinstance(uploaded, list):
+            uploaded = []
+        req_set = set(str(r).strip() for r in required if str(r).strip())
+        up_set = set(str(u).strip() for u in uploaded if str(u).strip())
+        missing_uploads = sorted(req_set - up_set)
+        extra_uploads = sorted(up_set - req_set)
+        docs_ok = (req_set == up_set) and len(req_set) > 0
+        if missing_uploads:
+            problems.append('documents not uploaded to portal: ' + ', '.join(missing_uploads))
+        if extra_uploads:
+            problems.append('unexpected extra documents uploaded: ' + ', '.join(extra_uploads))
+        if len(req_set) == 0:
+            problems.append('empty required-document checklist (cannot confirm uploads)')
+
+        # --- Anti-fat-finger price guard: portal total must equal the approved price within tolerance. ---
+        portal_price = _num(read_out.get('total_bid_price'), -1.0)
+        approved_price = _num(_input.get('approved_total_price'), 0.0)
+        tolerance = abs(_num(_input.get('price_tolerance'), 0.01))
+        price_ok = (portal_price >= 0) and (abs(portal_price - approved_price) <= tolerance)
+        if portal_price < 0:
+            problems.append('portal did not return a total_bid_price (empty read)')
+        elif not price_ok:
+            problems.append(
+                'PRICE MISMATCH: portal shows ' + str(round(portal_price, 2))
+                + ' but approved price is ' + str(round(approved_price, 2))
+            )
+
+        # --- Requested certifications must all appear among the portal-checked attestations. ---
+        cert_raw = _input.get('certifications') or ''
+        wanted_certs = [c.strip().lower() for c in str(cert_raw).split(',') if c.strip()]
+        checked = read_out.get('attestations_checked')
+        if not isinstance(checked, list):
+            checked = []
+        checked_set = set(str(c).strip().lower() for c in checked)
+        missing_certs = [c for c in wanted_certs if c not in checked_set]
+        certs_ok = len(missing_certs) == 0
+        if missing_certs:
+            problems.append('certifications not checked on the bid form: ' + ', '.join(missing_certs))
+
+        # --- The wizard must have reached a submit-capable review with a screenshot for the approver. ---
+        submit_present = bool(read_out.get('submit_button_present', False))
+        if not submit_present:
+            problems.append('Submit button not present - wizard did not reach the review screen')
+        review_screenshot = str(read_out.get('review_screenshot', '') or '').strip()
+        if not review_screenshot:
+            problems.append('no review screenshot captured for the human approver')
+
+        ok = bool(docs_ok and price_ok and certs_ok and submit_present and review_screenshot)
+        result = {
+            'ok': ok,
+            'problems': problems,
+            'docs_ok': docs_ok,
+            'price_ok': price_ok,
+            'certs_ok': certs_ok,
+            'solicitation_id': str(read_out.get('solicitation_id', '') or ''),
+            'uploaded_docs': sorted(list(up_set)),
+            'portal_total_bid_price': round(portal_price, 2) if portal_price >= 0 else None,
+            'approved_total_price': round(approved_price, 2),
+            'attestations_checked': sorted(list(checked_set)),
+            'review_page_summary': str(read_out.get('review_page_summary', '') or ''),
+            'review_screenshot': review_screenshot,
+            'reason_summary': '; '.join(problems) if problems else 'all pre-submit checks passed',
+        }
+
+  # 4b) Hard stop on a bad fill - do NOT advance to the human gate / approval / submit on a bad review read.
+  - id: filled_gate
+    type: condition
+    depends_on: [validate_filled_bid]
+    condition_config:
+      expression: "{steps.validate_filled_bid.output.ok} == True"
+      then: [presubmit_gate]
+      else: [notify_fill_failed]
+
+  - id: notify_fill_failed
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        {input.solicitation_label} reached the portal review page but the deterministic anti-fat-finger
+        check FAILED before submission: {steps.validate_filled_bid.output.problems}. Nothing was
+        submitted. Re-check uploads and price and re-run.
+
+  # 5) PRE-SUBMIT GATE - ALL strategies must pass before the binding submit is even offered for approval.
+  #    (a) llm_eval consistency: the review summary, price, docs and attestations are internally
+  #        consistent and traceable to the validated bid (provider-swappable verifier, pinned to a
+  #        cross-provider judge). (b) human: a second person confirms the bid before the legally binding
+  #        submit. This gate is engine-native and model-independent for the human leg.
+  - id: presubmit_gate
+    type: gate
+    depends_on: [filled_gate]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are a public-procurement bid-review checker. The bid is filled on the portal's review
+              screen and is about to be submitted as a LEGALLY BINDING public tender response. Reply with
+              exactly 'approved' only if ALL hold: the portal-computed total price equals the approved
+              price, every required document is uploaded, every requested certification is checked, and the
+              review_page_summary is internally consistent with those values with no invented data.
+              Otherwise reply 'rejected' and name each inconsistency. Validated bid:
+              {steps.validate_filled_bid.output} . Approved price: {input.approved_total_price}. Required
+              documents: {input.required_documents}. Certifications: {input.certifications}.
+            input: "{steps.validate_filled_bid.output}"
+            model: google/gemini-2.5-pro
+        - type: human
+          config:
+            message: >-
+              PRE-SUBMIT review for {input.solicitation_label}. Portal total
+              {steps.validate_filled_bid.output.portal_total_bid_price} (approved
+              {steps.validate_filled_bid.output.approved_total_price}); uploaded
+              {steps.validate_filled_bid.output.uploaded_docs}; attestations
+              {steps.validate_filled_bid.output.attestations_checked}. Confirm the bid is correct before the
+              binding submission. Reject to abort with nothing submitted.
+            timeout_hours: 12
+            on_timeout: abort
+
+  # 6) MANDATORY HUMAN APPROVAL before the irreversible Submit. Shows the EXACT validated price + document
+  #    list and the captured review screenshot, and BLOCKS until a person authorizes - a submitted public
+  #    bid is legally binding. on_timeout: abort means a missed approval NEVER auto-submits.
+  - id: approve_submit
+    type: approval
+    depends_on: [presubmit_gate]
+    approval_config:
+      message: >-
+        AUTHORIZE the legally binding SUBMISSION of {input.solicitation_label}. This is IRREVERSIBLE - it
+        files the tender response with the agency. The bid is filled and sitting on the portal's review
+        screen: total price {steps.validate_filled_bid.output.portal_total_bid_price} (approved
+        {steps.validate_filled_bid.output.approved_total_price}), documents uploaded
+        {steps.validate_filled_bid.output.uploaded_docs}, attestations checked
+        {steps.validate_filled_bid.output.attestations_checked}. Checks:
+        {steps.validate_filled_bid.output.reason_summary}. Review the attached review screenshot - this is
+        the EXACT state you are submitting. Approve to click Submit; reject to abort with nothing submitted.
+      show_data: steps.validate_filled_bid.output
+      show_images: ["steps.validate_filled_bid.output.review_screenshot"]
+      timeout_hours: 12
+      on_timeout: abort
+      allow_edit: false
+
+  # 7) SUBMIT (WRITE pass, playwright mode). Only reached AFTER human approval. Re-opens the filled review
+  #    screen and clicks the single final Submit/Submit-Bid button ONCE, then reads the portal's
+  #    confirmation page and captures the submission RECEIPT number, timestamp, and a confirmation
+  #    screenshot. capture_screenshots gives an after-submit audit record; max_actions tightly capped (one
+  #    confirm action, no runaway); CAPTCHA pauses to a human at the final wall.
+  - id: submit_bid
+    type: browser
+    depends_on: [approve_submit]
+    prompt: >-
+      A human has authorized this IRREVERSIBLE, legally binding tender submission:
+      {input.solicitation_label}. Authenticate with the PROCURE_PORTAL_CREDS environment credentials if the
+      session expired, return to the filled review screen, confirm the total price still reads
+      {steps.validate_filled_bid.output.portal_total_bid_price} and the same documents are attached, then
+      click the SINGLE final Submit / Submit Bid / File Response button ONCE to file the response. Do NOT
+      edit any field and do NOT click submit more than once. If a CAPTCHA or step-up auth appears at this
+      final wall, PAUSE for a human - do not attempt to solve it. Then read the portal's confirmation page
+      and capture the submission RECEIPT / confirmation number, the submitted timestamp the portal shows,
+      and a confirmation screenshot. Return ONLY the structured object described by the output schema.
+    browser_config:
+      mode: playwright
+      start_url: "{input.solicitation_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 300
+      max_actions: 20
+      headless: true
+      credentials_env: "{input.portal_credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          submitted:
+            type: boolean
+            description: "True if the UI accepted the final submit click without an error."
+          receipt_number:
+            type: string
+            description: "The portal-issued submission receipt / confirmation number."
+          submitted_at:
+            type: string
+            description: "The submitted timestamp the portal's confirmation page shows."
+          confirmation_screenshot:
+            type: string
+            description: "Reference to the captured post-submit confirmation screenshot for audit."
+    retry:
+      max_attempts: 1
+      backoff: fixed
+      on_failure: abort
+
+  # 8) VERIFY (engine-native SENSOR) - the act-then-VERIFY core. Poll the portal's OWN submission-status
+  #    page until it PROVABLY confirms the bid was received: status reads received/submitted/accepted OR a
+  #    receipt number is present. Pure control flow over the polled JSON, no model. Hard timeout so we
+  #    never wait forever; a timeout is NOT treated as success.
+  - id: verify_received
+    type: sensor
+    depends_on: [submit_bid]
+    sensor_config:
+      url: "{input.submission_status_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and (str(response.get('status', '')).strip().lower() in ('received', 'submitted', 'accepted', 'confirmed', 'under_review') or bool(str(response.get('receipt_number', '') or response.get('confirmation_number', '') or '').strip()))"
+      check_interval: 60
+      timeout: 3600
+
+  # 9) Deterministically decide acceptance from the sensor's last polled status payload AND the submit
+  #    step's captured receipt. No model. A missing confirmation (sensor timed out) yields confirmed=False
+  #    so a silently-failed submit can NEVER be reported as a filed bid.
+  - id: evaluate_receipt
+    type: code
+    depends_on: [verify_received]
+    code_config:
+      language: python
+      code: |
+        watch = _steps.get('verify_received') or {}
+        if not isinstance(watch, dict):
+            watch = {}
+        # The sensor surfaces the last polled `response` payload.
+        resp = watch.get('response') if isinstance(watch.get('response'), dict) else watch
+        if not isinstance(resp, dict):
+            resp = {}
+
+        # The submit browser step's captured receipt (preferred proof if present).
+        sub = _steps.get('submit_bid') or {}
+        if not isinstance(sub, dict):
+            sub = {}
+        for key in ('output', 'data', 'result'):
+            inner = sub.get(key)
+            if isinstance(inner, dict) and ('receipt_number' in inner):
+                sub = inner
+                break
+
+        status = str(resp.get('status', '') or '').strip().lower()
+        receipt = str(
+            sub.get('receipt_number', '')
+            or resp.get('receipt_number', '')
+            or resp.get('confirmation_number', '')
+            or ''
+        ).strip()
+        submitted_at = str(sub.get('submitted_at', '') or resp.get('submitted_at', '') or '').strip()
+
+        accepted_states = ('received', 'submitted', 'accepted', 'confirmed', 'under_review')
+        confirmed = (status in accepted_states) or bool(receipt)
+
+        sensor_satisfied = bool(watch.get('satisfied', watch.get('met', confirmed)))
+        timed_out = bool(watch.get('timed_out', False)) or (not sensor_satisfied and not confirmed)
+
+        landed = bool(confirmed and not timed_out and receipt)
+        result = {
+            'confirmed': landed,
+            'status': status,
+            'receipt_number': receipt,
+            'submitted_at': submitted_at,
+            'timed_out': timed_out,
+            # fail_count > 0 routes the run to the needs-attention path (never a false success).
+            'fail_count': 0 if landed else 1,
+            'solicitation_label': _input.get('solicitation_label', 'tender response'),
+        }
+
+  # 9b) Branch on the deterministic decision. Only a provably-received bid proceeds to archive + notify.
+  - id: receipt_gate
+    type: condition
+    depends_on: [evaluate_receipt]
+    condition_config:
+      expression: "{steps.evaluate_receipt.output.fail_count} > 0"
+      then: [notify_needs_attention]
+      else: [archive_receipt]
+
+  # 9c) NEEDS-ATTENTION PATH - the portal never confirmed receipt (timeout or non-received status). Page
+  #     the bid desk; the run stays unresolved. A silently-failed submit is surfaced, never a false win.
+  - id: notify_needs_attention
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        NEEDS ATTENTION: {input.solicitation_label} was SUBMITTED but the portal has NOT confirmed receipt
+        within the timeout (last status '{steps.evaluate_receipt.output.status}', receipt
+        '{steps.evaluate_receipt.output.receipt_number}',
+        timed_out={steps.evaluate_receipt.output.timed_out}). Do NOT assume the bid landed - manually check
+        the portal's submission-status page. The run is left in a needs-attention state.
+
+  # 10) ARCHIVE the submission receipt to the gdrive/s3 vault via a presigned PUT (audit chain, http,
+  #     deterministic; no inline secrets). Only reached once the portal provably confirmed receipt.
+  - id: archive_receipt
+    type: http
+    depends_on: [receipt_gate]
+    http_config:
+      url: "{input.receipt_archive_url}"
+      method: PUT
+      headers:
+        Content-Type: "application/json"
+      body: '{"event": "bid_submitted", "solicitation_label": "{input.solicitation_label}", "solicitation_id": "{steps.validate_filled_bid.output.solicitation_id}", "receipt_number": "{steps.evaluate_receipt.output.receipt_number}", "submitted_at": "{steps.evaluate_receipt.output.submitted_at}", "total_bid_price": "{steps.validate_filled_bid.output.portal_total_bid_price}", "uploaded_docs": "{steps.validate_filled_bid.output.uploaded_docs}", "status": "{steps.evaluate_receipt.output.status}"}'
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 11) NOTIFY the bid desk that the tender response was filed, with the portal-issued receipt number.
+  - id: notify_filed
+    type: notify
+    depends_on: [archive_receipt]
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        FILED: {input.solicitation_label} was submitted and the portal CONFIRMED receipt. Receipt number
+        {steps.evaluate_receipt.output.receipt_number}, submitted at
+        {steps.evaluate_receipt.output.submitted_at}, total bid price
+        {steps.validate_filled_bid.output.portal_total_bid_price}. Receipt archived to the vault for audit.
+
+on_complete:
+  storage_path: "government-procurement-bid-submitter/{input.solicitation_label}/{run_id}/result.json"

--- a/src/sandcastle/templates/insurance_claim_fnol_portal_filer.yaml
+++ b/src/sandcastle/templates/insurance_claim_fnol_portal_filer.yaml
@@ -1,0 +1,724 @@
+# name: Insurance Claim FNOL Portal Filer
+# description: Files a structured First-Notice-of-Loss packet onto a carrier or TPA web claims portal - a per-carrier, login-gated SPA with no agency-accessible claims-write API. Each portal has a different multi-step loss wizard, peril-specific dynamic fields, and photo/estimate upload widgets, so agencies re-key the same loss into dozens of portals by hand. This template reads the wizard structure read-only (dom mode), maps the loss with a deterministic validator plus a provider-agnostic peril classify, fills and uploads via a provider-neutral playwright script that STOPS at review, then holds for a human adjuster approval before the binding submit, and asserts the carrier's claim-number pattern deterministically so a false success can never be recorded.
+# tags: [Insurance, FNOL, ClaimsIntake, CarrierPortal, TPA, RPA, Playwright, DOM, HumanInTheLoop, ProviderNeutral]
+# category: general_ai
+
+name: insurance-claim-fnol-portal-filer
+description: >-
+  Takes a completed First-Notice-of-Loss (FNOL) packet - {carrier, policy_no, loss_facts, photos[],
+  estimate_pdf} that has reached status=ready_to_file - and files it on the right carrier or TPA web
+  claims portal on behalf of an insured. Carrier and TPA FNOL portals are per-carrier, login-gated
+  single-page apps with NO standardized or agency-accessible claims-write API: each has its own
+  multi-step loss wizard, peril-specific dynamic fields, and photo/estimate upload widgets, so
+  high-volume agencies, body shops, and property-restoration TPAs re-key the same loss into dozens of
+  portals by hand. This is the canonical no-API, login + JavaScript + file-upload RPA case. The flow is
+  split read-from-write and fails closed. First a DETERMINISTIC code step validates loss-facts
+  completeness for the peril, the policy-number format, and that every referenced media file exists. A
+  condition routes to the correct carrier portal start_url. A provider-neutral dom-mode browser step
+  logs in (credentials_env, captcha_strategy=pause) and EXTRACTS the wizard structure READ-ONLY via
+  output_schema - it writes nothing. A provider-agnostic classify maps loss_facts to the carrier's
+  fields and picks the peril branch, surfacing any unmapped fields. A gate (llm_eval consistency check
+  on dates/amounts/peril codes traceable to the intake, plus a human gate for any unmapped or
+  high-severity loss) must pass before entry. Only then does a playwright-mode browser step fill every
+  wizard step, attach photos to the loss-photo slot and the estimate PDF to the estimate slot, advance
+  to REVIEW and STOP - returning a review screenshot, the entered loss summary, and the attached-file
+  count. A mandatory human adjuster approval gates the binding submission. A second playwright step
+  clicks Submit and captures {claim_number, carrier_ref, submitted_at}; a deterministic code step then
+  asserts the claim_number matches the carrier's expected pattern - the load-bearing success gate, so a
+  silently-failed submit can never be recorded as a filed claim. Finally the insured is notified, the
+  claim number is written back to the claims system via transform, and a report logs the filing. Every
+  browser step rides default_model and stays swappable; the consistency llm_eval and peril classify run
+  provider-agnostically with failover; the condition router and code validators are pure engine logic,
+  so swapping the model never changes filing behavior.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 1800
+
+input_schema:
+  required: ["carrier", "policy_no", "loss_facts", "photos", "estimate_pdf"]
+  properties:
+    carrier:
+      type: string
+      description: "Carrier or TPA key that selects the target portal start_url and the expected claim-number pattern (e.g. statefarm, allstate, sedgwick-tpa)."
+      example: "statefarm"
+    policy_no:
+      type: string
+      description: "The insured's policy number being claimed against. Format-validated deterministically and entered into the FNOL wizard."
+      example: "SF-AUTO-0098127734"
+    loss_facts:
+      type: string
+      description: "Structured loss packet for this FNOL as a JSON string - peril type, date/time of loss, location, description, severity, amounts, parties. Drives field mapping and the consistency check."
+      example: '{"peril":"auto_collision","date_of_loss":"2026-05-28","loss_location":"I-95 mile 42, FL","description":"Rear-ended at a red light","estimated_amount":7350.00,"severity":"moderate","injuries":false,"deductible":500.00}'
+    photos:
+      type: string
+      description: "Comma-separated list of loss-photo file refs (s3/gdrive paths or @file: refs) to attach to the portal's loss-photo upload slot. Existence is validated before any filing."
+      example: "s3://fnol/claim-0098/photo1.jpg,s3://fnol/claim-0098/photo2.jpg,s3://fnol/claim-0098/photo3.jpg"
+    estimate_pdf:
+      type: string
+      description: "File ref to the repair/loss estimate PDF to attach to the portal's estimate upload slot. Existence is validated before any filing."
+      example: "s3://fnol/claim-0098/estimate.pdf"
+    carrier_portal_url:
+      type: string
+      description: "Fallback FNOL wizard start_url if the carrier is not in the built-in router map. The condition step prefers a known carrier route and falls back to this."
+      default: ""
+      example: "https://agents.examplecarrier.com/fnol/new"
+    claim_number_pattern:
+      type: string
+      description: "Regex the carrier's issued claim_number must match (deterministic success gate). Defaults to a generic carrier-claim shape; override per carrier."
+      default: "^[A-Z0-9]{2,6}-[A-Z0-9]{4,}$"
+      example: "^SF-[0-9]{2}-[0-9]{7,10}$"
+    insured_email:
+      type: string
+      description: "Email of the insured to notify with the filed claim number once the carrier confirms."
+      default: ""
+      example: "jane.doe@example.com"
+    claims_system_url:
+      type: string
+      description: "Webhook on the agency claims system that the filed claim_number + carrier_ref are written back to."
+      default: "https://claims.internal/api/fnol/filed"
+      example: "https://claims.internal/api/fnol/filed"
+    notify_channel:
+      type: string
+      description: "Slack channel for the back-office team's filed/blocked notification."
+      default: "#fnol-filing"
+      example: "#fnol-filing"
+    severity_human_threshold:
+      type: string
+      description: "Severity values that force the human gate strategy regardless of mapping (comma-separated). High-severity or injury losses always get a human before entry."
+      default: "high,total_loss,injury"
+      example: "high,total_loss,injury"
+
+steps:
+  # 1) DETERMINISTIC intake validation (sandboxed Python, no model). Confirm loss_facts are complete
+  #    for the given peril, the policy_no matches an acceptable format, and EVERY referenced media file
+  #    ref is present (photos + estimate). Fails CLOSED - nothing routes to a portal on a bad packet.
+  - id: validate_packet
+    type: code
+    code_config:
+      language: python
+      code: |
+        import json
+        # --- Parse the structured loss packet handed in by the intake / extraction upstream. ---
+        raw = _input.get('loss_facts') or ''
+        loss = {}
+        if isinstance(raw, dict):
+            loss = raw
+        else:
+            try:
+                loss = json.loads(raw)
+            except (TypeError, ValueError):
+                loss = {}
+        if not isinstance(loss, dict):
+            loss = {}
+
+        problems = []
+
+        # --- Required core loss fields for ANY peril. ---
+        base_required = ['peril', 'date_of_loss', 'loss_location', 'description', 'severity']
+        for k in base_required:
+            if not str(loss.get(k, '') or '').strip():
+                problems.append('missing loss fact: ' + k)
+
+        peril = str(loss.get('peril', '') or '').strip().lower()
+
+        # --- Peril-specific completeness (dynamic, like the carrier wizards). ---
+        peril_required = {
+            'auto_collision': ['estimated_amount', 'deductible'],
+            'auto_glass': ['estimated_amount'],
+            'property_water': ['estimated_amount', 'loss_location'],
+            'property_fire': ['estimated_amount'],
+            'theft': ['estimated_amount'],
+            'liability': ['parties'],
+        }
+        for k in peril_required.get(peril, ['estimated_amount']):
+            if not str(loss.get(k, '') or '').strip():
+                problems.append('peril ' + (peril or '<none>') + ' requires loss fact: ' + k)
+
+        if not peril:
+            problems.append('peril type is required to choose the wizard branch')
+
+        # --- Policy number format: non-empty, mostly alnum/dash, sane length. ---
+        policy_no = str(_input.get('policy_no', '') or '').strip()
+        policy_ok = False
+        if policy_no:
+            cleaned = policy_no.replace('-', '').replace('_', '')
+            policy_ok = cleaned.isalnum() and (6 <= len(policy_no) <= 40)
+        if not policy_ok:
+            problems.append('policy_no format invalid (expect 6-40 alphanumeric/dash chars)')
+
+        # --- Every referenced media file ref must be present (non-empty). ---
+        photos_raw = _input.get('photos') or ''
+        photo_refs = [p.strip() for p in str(photos_raw).split(',') if p.strip()]
+        if not photo_refs:
+            problems.append('no photo file refs provided')
+        estimate_ref = str(_input.get('estimate_pdf', '') or '').strip()
+        if not estimate_ref:
+            problems.append('estimate_pdf file ref missing')
+
+        # --- Numeric sanity on the amount, used later by the consistency check. ---
+        def _num(v):
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return 0.0
+        estimated_amount = _num(loss.get('estimated_amount'))
+        if estimated_amount < 0:
+            problems.append('estimated_amount is negative')
+
+        severity = str(loss.get('severity', '') or '').strip().lower()
+        injuries = bool(loss.get('injuries', False))
+        ok = len(problems) == 0
+
+        result = {
+            'ok': ok,
+            'problems': problems,
+            'peril': peril,
+            'severity': severity,
+            'injuries': injuries,
+            'policy_no': policy_no,
+            'estimated_amount': round(estimated_amount, 2),
+            'date_of_loss': str(loss.get('date_of_loss', '') or ''),
+            'loss_location': str(loss.get('loss_location', '') or ''),
+            'photo_refs': photo_refs,
+            'photo_count': len(photo_refs),
+            'estimate_ref': estimate_ref,
+            'loss_facts': loss,
+        }
+
+  # 1b) Hard stop on a bad packet - never touch a carrier portal with an incomplete loss.
+  - id: packet_gate
+    type: condition
+    depends_on: [validate_packet]
+    condition_config:
+      expression: "{steps.validate_packet.output.ok} == True"
+      then: [route_carrier]
+      else: [notify_blocked]
+
+  # 1c) Blocked branch: tell the back-office the FNOL was NOT filed and why. Nothing was submitted.
+  - id: notify_blocked
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        FNOL for policy {input.policy_no} on carrier {input.carrier} was BLOCKED before any portal
+        entry. Packet validation failed: {steps.validate_packet.output.problems}. No claim was filed.
+
+  # 2) ROUTE to the correct carrier/TPA portal start_url by {carrier} (pure engine logic, no model).
+  #    A known-carrier map; unknown carriers fall back to the supplied carrier_portal_url.
+  - id: route_carrier
+    type: code
+    depends_on: [packet_gate]
+    code_config:
+      language: python
+      code: |
+        carrier = str(_input.get('carrier', '') or '').strip().lower()
+
+        # Per-carrier FNOL wizard start URLs (login-gated SPAs, no claims-write API).
+        routes = {
+            'statefarm':   'https://b2b.statefarm.com/fnol/new',
+            'allstate':    'https://agents.allstate.com/claims/fnol/start',
+            'progressive': 'https://foragentsonly.progressive.com/fnol',
+            'geico':       'https://partners.geico.com/claims/new',
+            'libertymutual': 'https://agent.libertymutual.com/fnol/intake',
+            'sedgwick-tpa': 'https://intake.sedgwick.com/fnol/new',
+            'crawford-tpa': 'https://portal.crawco.com/claims/fnol',
+        }
+
+        fallback = str(_input.get('carrier_portal_url', '') or '').strip()
+        start_url = routes.get(carrier, fallback)
+        known = carrier in routes
+
+        routed = bool(start_url)
+        result = {
+            'carrier': carrier,
+            'start_url': start_url,
+            'known_carrier': known,
+            'routed': routed,
+            'note': ('matched built-in route' if known else
+                     ('using supplied fallback url' if start_url else 'NO route - missing start_url')),
+        }
+
+  # 2b) If no portal URL could be resolved, stop before any browser step.
+  - id: route_gate
+    type: condition
+    depends_on: [route_carrier]
+    condition_config:
+      expression: "{steps.route_carrier.output.routed} == True"
+      then: [read_wizard]
+      else: [notify_no_route]
+
+  - id: notify_no_route
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        FNOL for policy {input.policy_no} could NOT be filed: no portal start_url for carrier
+        {input.carrier} (not in the built-in route map and no carrier_portal_url supplied). No claim filed.
+
+  # 3) READ PASS (dom mode, READ-ONLY). Provider-neutral lightweight DOM read: the reasoning model
+  #    logs in via CARRIER_PORTAL_CREDS (never inlined), opens the FNOL wizard, and EXTRACTS the
+  #    wizard's structure - the ordered steps, each step's fields and any conditional_on logic, and
+  #    the upload slots - WITHOUT entering anything. captcha_strategy=pause hands a portal CAPTCHA to
+  #    a human; max_actions caps clicking; output_schema returns structured JSON to map against.
+  - id: read_wizard
+    type: browser
+    depends_on: [route_gate]
+    prompt: >-
+      You are doing a READ-ONLY reconnaissance of a carrier/TPA First-Notice-of-Loss web wizard. Log
+      in using the credentials provided via the CARRIER_PORTAL_CREDS environment variable, then open
+      the FNOL / new-claim wizard for this loss. DO NOT type into, select, upload to, or submit any
+      field - this is a structure read only. Walk the wizard pages and report its structure: the
+      ordered list of steps, and for each step its fields (name, label, input type, whether required,
+      allowed options if a dropdown, and any conditional_on logic that shows/hides the field based on
+      a prior answer such as the peril type), plus the file UPLOAD slots (which slot takes loss photos
+      and which takes the repair/loss estimate PDF). If a CAPTCHA or step-up auth appears, PAUSE for a
+      human. Context: carrier {input.carrier}, policy {input.policy_no}, peril
+      {steps.validate_packet.output.peril}. Return ONLY the structured object described by the output schema.
+    browser_config:
+      mode: dom
+      start_url: "{steps.route_carrier.output.start_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 300
+      max_actions: 60
+      headless: true
+      credentials_env: "CARRIER_PORTAL_CREDS"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          steps:
+            type: array
+            items:
+              type: object
+              properties:
+                name: { type: string }
+                fields:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name: { type: string }
+                      label: { type: string }
+                      input_type: { type: string }
+                      required: { type: boolean }
+                      options:
+                        type: array
+                        items: { type: string }
+                conditional_on: { type: string }
+          upload_slots:
+            type: array
+            items:
+              type: object
+              properties:
+                slot_name: { type: string }
+                accepts: { type: string }
+                purpose: { type: string }
+
+  # 4) MAP loss_facts -> the carrier's fields and choose the peril branch (provider-agnostic classify
+  #    with failover). It emits the field-fill PLAN and the list of any fields it could NOT confidently
+  #    map (unmapped[]). The branch result also tells the gate whether a human is required.
+  - id: map_fields
+    type: classify
+    depends_on: [read_wizard]
+    model: haiku
+    classify_config:
+      model: haiku
+      input: >-
+        Map a validated First-Notice-of-Loss packet onto a specific carrier FNOL wizard's fields and
+        choose the correct peril branch. Produce a fill PLAN: for each wizard field, the loss-fact (or
+        derived/peril-code value) that should go in it, attaching photos to the loss-photo upload slot
+        and the estimate PDF to the estimate upload slot; and an unmapped[] list of any required field
+        you cannot confidently fill from the packet. Then classify the OVERALL mapping outcome into one
+        category. Use 'clean_auto' when the loss is an auto peril and every required field maps with no
+        unmapped fields; 'clean_property' when it is a property peril and every required field maps with
+        no unmapped fields; 'needs_human' when ANY required field is unmapped OR the severity/injury
+        indicates a high-severity loss that an agent must review before entry; 'unsupported' when the
+        peril does not correspond to any branch the wizard offers. Validated packet:
+        {steps.validate_packet.output} . Wizard structure: {steps.read_wizard.output} .
+        Human-review severities: {input.severity_human_threshold}.
+      categories:
+        - clean_auto
+        - clean_property
+        - needs_human
+        - unsupported
+      branches:
+        clean_auto: [consistency_gate]
+        clean_property: [consistency_gate]
+        needs_human: [consistency_gate]
+        unsupported: [consistency_gate]
+
+  # 5) PRE-ENTRY GATE - ALL strategies must pass before anything is typed into the portal.
+  #    (a) llm_eval consistency: dates/amounts/peril codes internally consistent and traceable to the
+  #        intake (provider-swappable verifier). (b) human: an agent signs off on any unmapped field or
+  #        high-severity loss. This gate is the last stop before the (still reversible) data entry.
+  - id: consistency_gate
+    type: gate
+    depends_on: [map_fields]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are a claims-intake consistency reviewer. Verify the proposed FNOL field mapping is
+              internally consistent and traceable to the source intake BEFORE any data is entered into
+              the carrier portal. Reply with exactly 'approved' only if: the date_of_loss is a real,
+              non-future date; every monetary amount (estimated_amount, deductible) is non-negative and
+              consistent with the packet; the chosen peril branch and any peril codes match the packet's
+              peril; and every planned field value is traceable to a fact in the validated packet with no
+              invented data. Otherwise reply 'rejected' and name each inconsistency. Validated packet:
+              {steps.validate_packet.output} . Mapping/plan + branch: {steps.map_fields.output}
+            input: "{steps.validate_packet.output}"
+            model: google/gemini-2.5-pro
+        - type: human
+          config:
+            message: >-
+              FNOL pre-entry review for policy {input.policy_no} on {input.carrier} (peril
+              {steps.validate_packet.output.peril}, severity {steps.validate_packet.output.severity},
+              amount {steps.validate_packet.output.estimated_amount}). Confirm the field mapping is
+              correct and approve entry into the carrier portal. Reject if any unmapped field or
+              high-severity/injury loss needs handling first. Mapping: {steps.map_fields.output}
+            timeout_hours: 24
+            on_timeout: abort
+
+  # 6) FILL PASS (playwright mode, provider-neutral). The reasoning model AUTHORS a Playwright script
+  #    that re-logs-in via CARRIER_PORTAL_CREDS, fills EVERY wizard step from the approved plan,
+  #    attaches the loss photos to the loss-photo slot and the estimate PDF to the estimate slot,
+  #    advances to the REVIEW/SUMMARY page, and STOPS - it does NOT click Submit. capture_screenshots
+  #    gives an auditable review screenshot; output_schema returns the entered loss summary + attached
+  #    file count for the adjuster to approve. CAPTCHA pauses to a human; max_actions bounds the wizard.
+  - id: fill_to_review
+    type: browser
+    depends_on: [consistency_gate]
+    prompt: >-
+      You are filing a First-Notice-of-Loss on a carrier/TPA web claims wizard. Authenticate using the
+      CARRIER_PORTAL_CREDS environment variable, open the FNOL wizard, and walk it end to end. Using the
+      APPROVED field-fill plan, fill every required field on every wizard step from the validated loss
+      packet, handling peril-specific dynamic fields and waiting for client-side validation to settle
+      before advancing. Attach EVERY loss photo from the packet's photo list to the loss-photo upload
+      slot, and attach the estimate PDF to the estimate upload slot. CRITICAL: advance only to the FINAL
+      REVIEW / SUMMARY page and STOP there - DO NOT click the final Submit / File / Report-Claim button.
+      Submission is a separate, human-approved step. If a CAPTCHA or step-up auth appears, pause for a
+      human. Validated packet: {steps.validate_packet.output} . Approved plan: {steps.map_fields.output} .
+      Policy {input.policy_no}, peril {steps.validate_packet.output.peril}. Return ONLY the structured
+      object: a reference to the captured review screenshot, a human-readable summary of the loss values
+      shown on the review page, the count of files actually attached, and whether the submit button is
+      present and enabled.
+    browser_config:
+      mode: playwright
+      start_url: "{steps.route_carrier.output.start_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 600
+      max_actions: 120
+      headless: true
+      credentials_env: "CARRIER_PORTAL_CREDS"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          review_screenshot: { type: string }
+          entered_loss_summary:
+            type: object
+            properties:
+              policy_no: { type: string }
+              peril: { type: string }
+              date_of_loss: { type: string }
+              loss_location: { type: string }
+              estimated_amount: { type: number }
+              steps_completed: { type: integer }
+          attached_file_count: { type: integer }
+          submit_button_present: { type: boolean }
+
+  # 6b) DETERMINISTIC validation of the FILLED review state (no model). The load-bearing pre-submit
+  #     check: the review must echo the right policy/peril, the attached-file count must equal photos+1
+  #     (estimate), and the submit button must be present (wizard actually reached review). Fails closed.
+  - id: validate_review
+    type: code
+    depends_on: [fill_to_review]
+    code_config:
+      language: python
+      code: |
+        read_out = _steps.get('fill_to_review') or {}
+        if not isinstance(read_out, dict):
+            read_out = {}
+        # Browser payloads may nest under output/data/result.
+        for key in ('output', 'data', 'result'):
+            inner = read_out.get(key)
+            if isinstance(inner, dict) and ('entered_loss_summary' in inner or 'attached_file_count' in inner):
+                read_out = inner
+                break
+
+        packet = _steps.get('validate_packet') or {}
+        if not isinstance(packet, dict):
+            packet = {}
+
+        summary = read_out.get('entered_loss_summary') or {}
+        if not isinstance(summary, dict):
+            summary = {}
+
+        problems = []
+
+        # Review must echo the policy number we intended to file under.
+        want_policy = str(packet.get('policy_no', '') or '').strip()
+        got_policy = str(summary.get('policy_no', '') or '').strip()
+        if want_policy and got_policy and want_policy != got_policy:
+            problems.append('review policy_no ' + got_policy + ' does not match intake ' + want_policy)
+        if not got_policy:
+            problems.append('review page shows no policy_no')
+
+        # Peril on the review page must match the validated peril.
+        want_peril = str(packet.get('peril', '') or '').strip().lower()
+        got_peril = str(summary.get('peril', '') or '').strip().lower()
+        if want_peril and got_peril and want_peril != got_peril:
+            problems.append('review peril ' + got_peril + ' does not match intake ' + want_peril)
+
+        # Attached files must equal the photos plus the single estimate PDF.
+        photo_count = int(packet.get('photo_count', 0) or 0)
+        expected_files = photo_count + 1
+        def _int(v):
+            try:
+                return int(v)
+            except (TypeError, ValueError):
+                return 0
+        attached = _int(read_out.get('attached_file_count'))
+        if attached != expected_files:
+            problems.append('attached file count ' + str(attached) + ' != expected ' + str(expected_files)
+                            + ' (' + str(photo_count) + ' photos + 1 estimate)')
+
+        # The wizard must actually have reached a submit-capable review page.
+        if not read_out.get('submit_button_present'):
+            problems.append('submit button not present - wizard did not reach review')
+
+        # A review screenshot must exist for the adjuster to inspect.
+        review_screenshot = str(read_out.get('review_screenshot', '') or '').strip()
+        if not review_screenshot:
+            problems.append('no review screenshot captured for the adjuster')
+
+        ok = len(problems) == 0
+        result = {
+            'ok': ok,
+            'problems': problems,
+            'policy_no': got_policy or want_policy,
+            'peril': got_peril or want_peril,
+            'attached_file_count': attached,
+            'expected_file_count': expected_files,
+            'review_screenshot': review_screenshot,
+            'entered_loss_summary': summary,
+        }
+
+  # 6c) Hard stop on a bad fill - do NOT advance to the adjuster approval / submit on a bad review read.
+  - id: review_gate
+    type: condition
+    depends_on: [validate_review]
+    condition_config:
+      expression: "{steps.validate_review.output.ok} == True"
+      then: [approve_submit]
+      else: [notify_review_failed]
+
+  - id: notify_review_failed
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        FNOL for policy {input.policy_no} on {input.carrier} reached the portal review page but the
+        deterministic review check FAILED before submission: {steps.validate_review.output.problems}.
+        Nothing was submitted. Re-check the wizard fill and re-run.
+
+  # 7) HUMAN ADJUSTER APPROVAL before the binding submission. The adjuster/agent sees the validated
+  #    review summary and the captured review screenshot and authorizes the IRREVERSIBLE submit. No
+  #    submission can occur without this gate; on_timeout: abort never auto-submits.
+  - id: approve_submit
+    type: approval
+    approval_config:
+      message: >-
+        AUTHORIZE the binding FNOL SUBMISSION for policy {input.policy_no} on {input.carrier}. This is
+        IRREVERSIBLE - it files the claim with the carrier and opens a claim number. The loss is filled
+        and sitting on the portal's review page: peril {steps.validate_review.output.peril},
+        {steps.validate_review.output.attached_file_count} files attached
+        (expected {steps.validate_review.output.expected_file_count}). Review the captured review
+        screenshot - this is the EXACT state you are filing. Approve to submit, reject to abort with
+        nothing filed.
+      show_data: steps.validate_review.output
+      show_images: ["steps.validate_review.output.review_screenshot"]
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: false
+
+  # 8) SUBMIT PASS (playwright mode, WRITE). Only reached AFTER the adjuster approves. Re-opens the
+  #    filled review page and clicks the single final Submit/File button ONCE, then reads the carrier's
+  #    confirmation page and captures {claim_number, carrier_ref, submitted_at}. capture_screenshots
+  #    gives an after-submit audit record; max_actions tightly capped (one confirm action); CAPTCHA pauses.
+  - id: submit_claim
+    type: browser
+    depends_on: [approve_submit]
+    prompt: >-
+      A human adjuster has authorized this IRREVERSIBLE FNOL submission for policy {input.policy_no} on
+      {input.carrier}. Authenticate with CARRIER_PORTAL_CREDS if the session expired, return to the
+      filled FNOL review page, confirm the values still match the approved review, then click the SINGLE
+      final Submit / File / Report-Claim button ONCE to file the claim. Do NOT edit any field and do NOT
+      click submit more than once. If a CAPTCHA or step-up auth appears at this final wall, PAUSE for a
+      human - do not attempt to solve it. Then read the carrier's confirmation page and capture the
+      carrier-issued CLAIM NUMBER, any carrier reference id, and the submitted timestamp. Return ONLY the
+      structured object described by the output schema.
+    browser_config:
+      mode: playwright
+      start_url: "{steps.route_carrier.output.start_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 300
+      max_actions: 20
+      headless: true
+      credentials_env: "CARRIER_PORTAL_CREDS"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          claim_number: { type: string }
+          carrier_ref: { type: string }
+          submitted_at: { type: string }
+          confirmation_screenshot: { type: string }
+
+  # 9) DETERMINISTIC SUCCESS GATE (no model). Assert the carrier-issued claim_number matches the
+  #    carrier's expected pattern. A missing/malformed claim_number means the submit did NOT provably
+  #    land - so a silently-failed submit can NEVER be recorded as a filed claim.
+  - id: assert_claim_number
+    type: code
+    depends_on: [submit_claim]
+    code_config:
+      language: python
+      code: |
+        import re
+        sub = _steps.get('submit_claim') or {}
+        if not isinstance(sub, dict):
+            sub = {}
+        for key in ('output', 'data', 'result'):
+            inner = sub.get(key)
+            if isinstance(inner, dict) and ('claim_number' in inner):
+                sub = inner
+                break
+
+        claim_number = str(sub.get('claim_number', '') or '').strip()
+        carrier_ref = str(sub.get('carrier_ref', '') or '').strip()
+        submitted_at = str(sub.get('submitted_at', '') or '').strip()
+
+        pattern = str(_input.get('claim_number_pattern', '') or '').strip()
+        if not pattern:
+            pattern = '^[A-Z0-9]{2,6}-[A-Z0-9]{4,}$'
+
+        problems = []
+        matched = False
+        if not claim_number:
+            problems.append('carrier returned no claim_number - submission not provably accepted')
+        else:
+            try:
+                matched = bool(re.search(pattern, claim_number))
+            except (TypeError, ValueError):
+                matched = False
+            if not matched:
+                problems.append('claim_number "' + claim_number + '" does not match carrier pattern ' + pattern)
+
+        if not submitted_at:
+            problems.append('no submitted_at timestamp returned')
+
+        filed = bool(claim_number) and matched and (len(problems) == 0)
+
+        result = {
+            'filed': filed,
+            'problems': problems,
+            'claim_number': claim_number,
+            'carrier_ref': carrier_ref,
+            'submitted_at': submitted_at,
+            'pattern': pattern,
+            'policy_no': str(_input.get('policy_no', '') or ''),
+            'carrier': str(_input.get('carrier', '') or ''),
+        }
+
+  # 9b) Branch on the deterministic success gate. Only a provably-filed claim proceeds to recording.
+  - id: filed_gate
+    type: condition
+    depends_on: [assert_claim_number]
+    condition_config:
+      expression: "{steps.assert_claim_number.output.filed} == True"
+      then: [record_claim]
+      else: [notify_submit_unconfirmed]
+
+  # 9c) UNCONFIRMED PATH - submit happened but the claim_number did not validate. Page the team and
+  #     leave the run needing attention. A false success is NEVER recorded.
+  - id: notify_submit_unconfirmed
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        NEEDS ATTENTION: FNOL submit for policy {input.policy_no} on {input.carrier} did NOT return a
+        valid claim_number ({steps.assert_claim_number.output.problems}). Do NOT assume the claim was
+        filed - manually check the carrier portal. The run is left in a needs-attention state.
+
+  # 10a) RECORD - write the validated claim_number + carrier_ref back to the agency claims system.
+  - id: record_claim
+    type: transform
+    depends_on: [filed_gate]
+    transform_config:
+      template: |
+        {
+          "event": "fnol_filed",
+          "carrier": "{steps.assert_claim_number.output.carrier}",
+          "policy_no": "{steps.assert_claim_number.output.policy_no}",
+          "claim_number": "{steps.assert_claim_number.output.claim_number}",
+          "carrier_ref": "{steps.assert_claim_number.output.carrier_ref}",
+          "submitted_at": "{steps.assert_claim_number.output.submitted_at}"
+        }
+
+  # 10b) WRITE-BACK to the claims system webhook (deterministic http POST).
+  - id: writeback_claim
+    type: http
+    depends_on: [record_claim]
+    http_config:
+      url: "{input.claims_system_url}"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+      auth: "bearer:{env.CLAIMS_SYSTEM_TOKEN}"
+      body: '{"carrier": "{steps.assert_claim_number.output.carrier}", "policy_no": "{steps.assert_claim_number.output.policy_no}", "claim_number": "{steps.assert_claim_number.output.claim_number}", "carrier_ref": "{steps.assert_claim_number.output.carrier_ref}", "submitted_at": "{steps.assert_claim_number.output.submitted_at}"}'
+
+  # 10c) NOTIFY the insured that the claim was filed, with the carrier-issued claim number.
+  - id: notify_insured
+    type: notify
+    depends_on: [writeback_claim]
+    notify_config:
+      service: gmail
+      channel: "{input.insured_email}"
+      message: >-
+        Your insurance claim has been filed with {steps.assert_claim_number.output.carrier} under policy
+        {input.policy_no}. Your claim number is {steps.assert_claim_number.output.claim_number}
+        (carrier reference {steps.assert_claim_number.output.carrier_ref}), filed at
+        {steps.assert_claim_number.output.submitted_at}. Keep this claim number for any follow-up.
+
+  # 10d) REPORT - log the filing as a branded PDF record for the agency's claim-intake audit trail.
+  - id: filing_report
+    type: report
+    depends_on: [notify_insured]
+    report_config:
+      template: "research-report"
+      format: pdf
+      theme: professional
+      title: "FNOL Filing Record - {steps.assert_claim_number.output.claim_number}"
+      author: "Claims Intake Desk"
+    prompt: >-
+      Produce a formal FNOL filing record PDF from the payload below. Include the carrier, policy number,
+      peril, the carrier-issued claim number and reference, the submitted timestamp, the count of files
+      attached, and a note that the loss packet was deterministically validated, a dual consistency check
+      (llm_eval + human pre-entry gate) passed, a human adjuster approved the binding submission, and the
+      claim number was asserted against the carrier's expected pattern before recording. Filing payload:
+      {steps.assert_claim_number.output} . Review summary: {steps.validate_review.output.entered_loss_summary}
+
+on_complete:
+  storage_path: "insurance-claim-fnol-portal-filer/{input.carrier}/{input.policy_no}/{run_id}/result.json"

--- a/src/sandcastle/templates/kyc_onboarding_portal_filer.yaml
+++ b/src/sandcastle/templates/kyc_onboarding_portal_filer.yaml
@@ -1,0 +1,864 @@
+# name: KYC Onboarding Portal Filer
+# description: Drives a bank/broker/exchange KYC onboarding portal that exposes no batch write API to the onboarding party - a login-gated SPA with live document upload, OTP/2FA, and conditional PEP / beneficial-owner / source-of-funds sections that only render after earlier answers. It deterministically validates the entity record and document set, reads the onboarding wizard structure read-only (dom mode), builds a deterministic field+document mapping plan with a provider-agnostic conditional-section classify, gates data entry behind a compliance llm_eval plus a human analyst, fills every section and uploads each document via a provider-neutral playwright script that STOPS at the attestation/review screen, holds for a compliance officer's legally-binding approval, then checks the attestation box and Submits, asserts the case-reference pattern deterministically, regression-guards the fragile portal flow with a trajectory-replay against a golden run, and archives an immutable audit packet (screenshots, doc hashes, confirmation) for the AML file. Read is split from write and the flow fails closed - raw PII is redacted from logs, document hashes are logged, and the irreversible submit can never fire on a model's opinion alone.
+# tags: [KYC, AML, Onboarding, Compliance, BankPortal, BrokerPortal, CryptoExchange, RPA, Playwright, DOM, HumanInTheLoop, TrajectoryReplay, ProviderNeutral, NoAPI]
+# category: hr_legal
+
+name: kyc-onboarding-portal-filer
+description: >-
+  Takes an approved onboarding case that has reached status=ready_to_file - {entity_record, ubo_list,
+  document_set} - and files it onto a bank, broker, or crypto-exchange KYC onboarding portal on behalf
+  of a fintech / neobank / crypto-exchange compliance ops team onboarding a business or high-net-worth
+  customer. Correspondent-bank partner portals, regional regulator e-KYC sites, and broker sub-account
+  portals are per-provider, login-gated single-page apps with NO batch write API on the customer's plan:
+  data is keyed by hand today, with live document upload, OTP/2FA, and dynamic conditional sections
+  (PEP, beneficial-owner, source-of-funds) that only render after earlier answers. http cannot satisfy
+  session, file upload, or conditional rendering, so a real authenticated browser is the only path. The
+  flow is split read-from-write and fails closed. A DETERMINISTIC code step validates the entity record
+  against the required KYC field set, verifies every document file exists and matches an allowed
+  type/size, and redacts raw PII from logs while logging document hashes. A provider-neutral dom-mode
+  browser step logs in via KYC_PORTAL_CREDS (OTP/2FA handled by captcha_strategy=pause) and EXTRACTS the
+  onboarding wizard structure READ-ONLY via output_schema - sections, their visible_when conditions, and
+  the document upload slots - writing nothing. A provider-agnostic classify flags which conditional
+  sections (PEP / UBO / source-of-funds) must be filled, and a deterministic code step builds the exact
+  field+document mapping plan, rejecting on any value mismatch versus the source record. A gate
+  (llm_eval mapping-completeness + no-mismatch check, plus a human compliance analyst) must pass before
+  any data entry. Only then does a playwright-mode browser step fill all sections, upload each document
+  to its matched slot, advance to the attestation/REVIEW screen and STOP - returning a review snapshot,
+  the entered values, and the uploaded document hashes. A mandatory human compliance-officer approval
+  gates the legally-binding attestation: the officer reviews the entered values and doc hashes and
+  authorizes the irreversible submit. A second playwright step checks the attestation box and Submits,
+  capturing {case_reference, submitted_at, status}; a deterministic code step asserts the case_reference
+  matches the expected pattern - the load-bearing success gate, so a silently-failed submit can never be
+  recorded as a filed case. A trajectory-replay then regression-guards the fragile portal flow against a
+  known-good golden onboarding run (fail_below_score=0.9) so a portal redesign or a misclick is caught
+  instead of silently submitting garbage. Finally a report logs the filing as an immutable audit packet
+  PDF, and a reusable summarizer sub-workflow archives it for the AML file. Every browser step rides
+  default_model and stays swappable; the mapping-completeness llm_eval and the conditional-section
+  classify run provider-agnostically with failover; trajectory-replay compares structural trajectories,
+  not model-specific tokens, and the code validators are pure engine logic - so swapping the reasoning
+  provider never changes filing behavior or weakens safety.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 1800
+
+input_schema:
+  required: ["portal_url", "entity_record", "ubo_list", "document_set", "golden_run_id"]
+  properties:
+    portal_url:
+      type: string
+      description: "Start URL of the KYC onboarding wizard (a login-gated SPA with no batch write API). Templated into both browser steps' start_url."
+      example: "https://onboarding.partner-bank.example/kyc/new"
+    entity_record:
+      type: string
+      description: "Structured customer identity + entity data for this onboarding case, as a JSON string. Drives field mapping and the consistency check. Raw PII values are redacted from logs by the validate step."
+      example: '{"legal_name":"Acme Holdings Ltd","entity_type":"private_limited","registration_number":"HRB-558210","country":"DE","incorporation_date":"2019-03-14","registered_address":"Hauptstr 1, 10115 Berlin","is_pep":true,"source_of_funds":"operating_revenue","tax_id":"DE284912"}'
+    ubo_list:
+      type: string
+      description: "List of ultimate beneficial owners (>=25% or controlling) as a JSON string array. Each UBO drives the beneficial-owner conditional section. PII redacted from logs."
+      example: '[{"name":"Jane Roe","ownership_pct":40.0,"nationality":"DE","is_pep":true},{"name":"John Doe","ownership_pct":35.0,"nationality":"GB","is_pep":false}]'
+    document_set:
+      type: string
+      description: "List of identity / proof-of-address / incorporation documents to upload, as a JSON string array. Each item: {label, file_ref, type, size_bytes, sha256}. Existence, type, and size are validated before any filing; hashes are logged (never the raw bytes/PII)."
+      example: '[{"label":"certificate_of_incorporation","file_ref":"s3://kyc/acme/coi.pdf","type":"application/pdf","size_bytes":482113,"sha256":"a1b2c3"},{"label":"proof_of_address","file_ref":"s3://kyc/acme/poa.pdf","type":"application/pdf","size_bytes":201554,"sha256":"d4e5f6"},{"label":"ubo_passport_jane","file_ref":"s3://kyc/acme/jane.jpg","type":"image/jpeg","size_bytes":903221,"sha256":"99aa88"}]'
+    golden_run_id:
+      type: string
+      description: "Recorded run id of a known-good KYC onboarding flow for this portal. trajectory-replay diffs the live run against it and fails below fail_below_score so a portal redesign or misclick is caught (regression guard)."
+      example: "golden-partner-bank-kyc-2026-05-01"
+    required_kyc_fields:
+      type: array
+      description: "The required KYC field set the entity_record must satisfy for this jurisdiction/portal. The validate step fails closed if any is missing."
+      default: ["legal_name", "entity_type", "registration_number", "country", "incorporation_date", "registered_address", "source_of_funds"]
+    allowed_doc_types:
+      type: array
+      description: "Closed set of MIME types a document may carry; any other type fails validation (no filing on a disallowed document)."
+      default: ["application/pdf", "image/jpeg", "image/png"]
+    max_doc_size_bytes:
+      type: integer
+      description: "Maximum allowed size per document in bytes; an oversized file fails validation before any upload."
+      default: 10485760
+    case_reference_pattern:
+      type: string
+      description: "Regex the portal-issued case_reference must match (deterministic success gate). Defaults to a generic case-id shape; override per portal."
+      default: "^[A-Z]{2,6}-[0-9]{6,}$"
+      example: "^KYC-[0-9]{8,}$"
+    drift_fail_below_score:
+      type: number
+      description: "trajectory-replay score floor: if the live onboarding trajectory diverges from the golden run below this, the run is flagged as drifted (portal-redesign / misclick guard). Default 0.9 for a fragile legally-binding flow."
+      default: 0.9
+    compliance_officer_email:
+      type: string
+      description: "Email of the compliance officer who performs the legally-binding attestation approval before the irreversible submit."
+      default: ""
+      example: "compliance.officer@neobank.example"
+    notify_channel:
+      type: string
+      description: "Slack channel for the compliance ops team's filed / blocked / needs-attention notifications."
+      default: "#kyc-onboarding"
+      example: "#kyc-onboarding"
+
+steps:
+  # 1) DETERMINISTIC intake validation (sandboxed Python, no model). Confirm the entity_record satisfies
+  #    the required KYC field set, every referenced document exists with an allowed type and within the
+  #    size cap, and the UBO list is well-formed. Raw PII is REDACTED from the emitted log fields while
+  #    document HASHES are retained for the audit trail. Fails CLOSED - nothing touches a portal on a bad
+  #    packet. This is the load-bearing pre-flight check, not a model's opinion.
+  - id: validate_case
+    type: code
+    code_config:
+      language: python
+      code: |
+        import json
+        # --- Parse the structured onboarding case handed in by the CRM / case system. ---
+        def _load(raw, default):
+            if isinstance(raw, (dict, list)):
+                return raw
+            try:
+                return json.loads(raw)
+            except (TypeError, ValueError):
+                return default
+
+        entity = _load(_input.get('entity_record') or '', {})
+        if not isinstance(entity, dict):
+            entity = {}
+        ubos = _load(_input.get('ubo_list') or '', [])
+        if not isinstance(ubos, list):
+            ubos = []
+        docs = _load(_input.get('document_set') or '', [])
+        if not isinstance(docs, list):
+            docs = []
+
+        problems = []
+
+        # --- Required KYC field set for the entity record. ---
+        required_fields = _input.get('required_kyc_fields') or [
+            'legal_name', 'entity_type', 'registration_number', 'country',
+            'incorporation_date', 'registered_address', 'source_of_funds',
+        ]
+        for k in required_fields:
+            if not str(entity.get(k, '') or '').strip():
+                problems.append('missing required KYC field: ' + str(k))
+
+        # --- UBO list sanity: at least one UBO, each with a name and a numeric ownership pct. ---
+        if len(ubos) == 0:
+            problems.append('ubo_list is empty (at least one beneficial owner required)')
+        clean_ubos = []
+        for i, u in enumerate(ubos):
+            if not isinstance(u, dict):
+                problems.append('ubo #' + str(i) + ' is malformed')
+                continue
+            name = str(u.get('name', '') or '').strip()
+            if not name:
+                problems.append('ubo #' + str(i) + ' missing name')
+            try:
+                pct = float(u.get('ownership_pct'))
+            except (TypeError, ValueError):
+                pct = None
+                problems.append('ubo #' + str(i) + ' ownership_pct not numeric')
+            clean_ubos.append({
+                'index': i,
+                'has_name': bool(name),
+                'ownership_pct': pct,
+                'is_pep': bool(u.get('is_pep', False)),
+            })
+
+        # --- Document set: each must exist, carry an allowed type, and be within the size cap. ---
+        allowed_types = {str(t).lower() for t in (_input.get('allowed_doc_types') or
+                         ['application/pdf', 'image/jpeg', 'image/png'])}
+        try:
+            max_size = int(_input.get('max_doc_size_bytes', 10485760) or 10485760)
+        except (TypeError, ValueError):
+            max_size = 10485760
+
+        doc_manifest = []
+        if len(docs) == 0:
+            problems.append('document_set is empty (no documents to upload)')
+        for i, d in enumerate(docs):
+            if not isinstance(d, dict):
+                problems.append('document #' + str(i) + ' is malformed')
+                continue
+            label = str(d.get('label', '') or '').strip()
+            file_ref = str(d.get('file_ref', '') or '').strip()
+            dtype = str(d.get('type', '') or '').strip().lower()
+            sha = str(d.get('sha256', '') or '').strip()
+            try:
+                size = int(d.get('size_bytes', 0) or 0)
+            except (TypeError, ValueError):
+                size = 0
+            if not label:
+                problems.append('document #' + str(i) + ' missing label')
+            if not file_ref:
+                problems.append('document #' + str(i) + ' (' + (label or '?') + ') missing file_ref')
+            if dtype not in allowed_types:
+                problems.append('document ' + (label or '#' + str(i)) + ' has disallowed type ' + (dtype or '<none>'))
+            if size <= 0:
+                problems.append('document ' + (label or '#' + str(i)) + ' has non-positive size')
+            elif size > max_size:
+                problems.append('document ' + (label or '#' + str(i)) + ' exceeds max size ' + str(max_size))
+            if not sha:
+                problems.append('document ' + (label or '#' + str(i)) + ' missing sha256 hash (needed for audit)')
+            # Manifest carries the HASH, never raw bytes/PII.
+            doc_manifest.append({
+                'label': label,
+                'type': dtype,
+                'size_bytes': size,
+                'sha256': sha,
+                'present': bool(file_ref),
+            })
+
+        # --- PII REDACTION for logs: keep structure + flags, drop raw identity values. ---
+        is_pep = bool(entity.get('is_pep', False)) or any(u.get('is_pep') for u in clean_ubos)
+        source_of_funds = str(entity.get('source_of_funds', '') or '').strip()
+        redacted_entity = {
+            'entity_type': str(entity.get('entity_type', '') or ''),
+            'country': str(entity.get('country', '') or ''),
+            'legal_name_present': bool(str(entity.get('legal_name', '') or '').strip()),
+            'registration_number_present': bool(str(entity.get('registration_number', '') or '').strip()),
+            'registered_address_present': bool(str(entity.get('registered_address', '') or '').strip()),
+            'is_pep': is_pep,
+            'source_of_funds': source_of_funds,
+            'ubo_count': len(clean_ubos),
+        }
+
+        ok = len(problems) == 0
+        result = {
+            'ok': ok,
+            'problems': problems,
+            # Redacted, log-safe view (no raw PII).
+            'redacted_entity': redacted_entity,
+            'doc_manifest': doc_manifest,
+            'doc_count': len(doc_manifest),
+            'doc_hashes': [d['sha256'] for d in doc_manifest if d['sha256']],
+            'ubos': clean_ubos,
+            'ubo_count': len(clean_ubos),
+            # Flags that decide which conditional sections MUST be filled.
+            'is_pep': is_pep,
+            'has_ubos': len(clean_ubos) > 0,
+            'source_of_funds_present': bool(source_of_funds),
+            # Full entity is passed forward for the fill/mapping steps but is NOT a logged field.
+            'entity': entity,
+        }
+
+  # 1b) Hard stop on a bad packet - never touch a KYC portal with an incomplete case or bad document.
+  - id: case_gate
+    type: condition
+    depends_on: [validate_case]
+    condition_config:
+      expression: "{steps.validate_case.output.ok} == True"
+      then: [read_wizard]
+      else: [notify_blocked]
+
+  # 1c) Blocked branch: tell compliance ops the case was NOT filed and why. Nothing was submitted.
+  - id: notify_blocked
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        KYC onboarding case was BLOCKED before any portal entry. Packet validation failed:
+        {steps.validate_case.output.problems}. No case was filed and no PII was transmitted. Fix the
+        entity record / document set and re-run.
+
+  # 2) READ PASS (dom mode, READ-ONLY, provider-neutral). The reasoning model logs in via
+  #    KYC_PORTAL_CREDS (never inlined) - OTP/2FA and CAPTCHA both hand off to a human through
+  #    captcha_strategy=pause - opens the onboarding wizard, and EXTRACTS its structure WITHOUT entering
+  #    anything: the ordered sections, each section's visible_when condition (so PEP / UBO /
+  #    source-of-funds conditional rendering is captured), the fields, and the document UPLOAD slots.
+  #    max_actions caps clicking; output_schema returns structured JSON to map against. No write happens.
+  - id: read_wizard
+    type: browser
+    depends_on: [case_gate]
+    prompt: >-
+      You are doing a READ-ONLY reconnaissance of a bank/broker/exchange KYC onboarding web wizard. Log
+      in using the credentials provided via the KYC_PORTAL_CREDS environment variable. If an OTP / 2FA
+      prompt, a device-verification step, or a CAPTCHA appears, STOP and hand off to a human
+      (captcha_strategy=pause) - do not attempt to solve it. Open the onboarding / new-customer wizard.
+      DO NOT type into, select, upload to, or submit any field - this is a structure read only. Walk the
+      wizard and report its structure: the ordered list of sections, and for each section its name, its
+      visible_when condition (the prior answer that makes it render, e.g. a PEP, beneficial-owner, or
+      source-of-funds section that only appears after earlier answers), and its fields (name, label,
+      input type, whether required, allowed options if a dropdown). Also report the document UPLOAD slots
+      (which slot accepts which document label / accepted types). Return ONLY the structured object
+      described by the output schema.
+    browser_config:
+      mode: dom
+      start_url: "{input.portal_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 300
+      max_actions: 60
+      headless: true
+      credentials_env: "KYC_PORTAL_CREDS"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          sections:
+            type: array
+            items:
+              type: object
+              properties:
+                name: { type: string }
+                visible_when: { type: string }
+                fields:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name: { type: string }
+                      label: { type: string }
+                      input_type: { type: string }
+                      required: { type: boolean }
+                      options:
+                        type: array
+                        items: { type: string }
+          upload_slots:
+            type: array
+            items:
+              type: object
+              properties:
+                label: { type: string }
+                accepted_types:
+                  type: array
+                  items: { type: string }
+
+  # 3) CLASSIFY (provider-agnostic with failover) - flag WHICH conditional sections must be filled for
+  #    this case (PEP / beneficial-owner / source-of-funds) given the validated flags and the wizard's
+  #    visible_when conditions. Routing only - the load-bearing mapping is built deterministically in the
+  #    next code step; every branch converges on build_mapping_plan.
+  - id: flag_conditional_sections
+    type: classify
+    depends_on: [read_wizard]
+    model: haiku
+    classify_config:
+      model: haiku
+      input: >-
+        Decide which conditional onboarding sections this KYC case must complete, given the wizard's
+        sections and their visible_when conditions and the validated case flags. Choose 'pep_and_ubo'
+        when the case is a PEP AND has beneficial owners (both the PEP and beneficial-owner sections must
+        be filled); 'ubo_only' when there are beneficial owners but no PEP exposure; 'source_of_funds'
+        when neither PEP nor extra UBO sections apply but a source-of-funds section is required; 'base'
+        when only the standard identity sections apply. Validated case flags (PEP / UBO / source-of-funds
+        presence): {steps.validate_case.output} . Wizard structure with visible_when conditions:
+        {steps.read_wizard.output} .
+      categories:
+        - pep_and_ubo
+        - ubo_only
+        - source_of_funds
+        - base
+      branches:
+        pep_and_ubo: [build_mapping_plan]
+        ubo_only: [build_mapping_plan]
+        source_of_funds: [build_mapping_plan]
+        base: [build_mapping_plan]
+
+  # 4) DETERMINISTIC field+document MAPPING PLAN (sandboxed Python, no model). Builds the exact plan:
+  #    each entity_record value -> the wizard field that should hold it, each document -> its matched
+  #    upload slot, and the list of conditional sections that MUST be filled (PEP / UBO / source-of-funds
+  #    flagged from the validated record). REJECTS on any value mismatch vs the source record or any
+  #    required field with no source value, and flags any document with no matching slot. This is the
+  #    load-bearing correctness layer before the gate - nothing is entered on a bad plan.
+  - id: build_mapping_plan
+    type: code
+    depends_on: [flag_conditional_sections]
+    code_config:
+      language: python
+      code: |
+        validated = _steps.get('validate_case') or {}
+        if not isinstance(validated, dict):
+            validated = {}
+        wizard = _steps.get('read_wizard') or {}
+        if not isinstance(wizard, dict):
+            wizard = {}
+        # Browser payloads may nest under output/data/result.
+        for key in ('output', 'data', 'result'):
+            inner = wizard.get(key)
+            if isinstance(inner, dict) and ('sections' in inner or 'upload_slots' in inner):
+                wizard = inner
+                break
+
+        entity = validated.get('entity') if isinstance(validated.get('entity'), dict) else {}
+        doc_manifest = validated.get('doc_manifest') if isinstance(validated.get('doc_manifest'), list) else []
+        sections = wizard.get('sections') if isinstance(wizard.get('sections'), list) else []
+        upload_slots = wizard.get('upload_slots') if isinstance(wizard.get('upload_slots'), list) else []
+
+        problems = []
+
+        # --- Field mapping: every REQUIRED wizard field must trace to a source value. ---
+        field_plan = []
+        # Build a lower-cased lookup of source values so portal field names map by normalized key.
+        src_lookup = {}
+        for k, v in entity.items():
+            src_lookup[str(k).strip().lower().replace(' ', '_')] = v
+        required_unmapped = []
+        for sec in sections:
+            if not isinstance(sec, dict):
+                continue
+            sec_name = str(sec.get('name', '') or '')
+            for f in (sec.get('fields') or []):
+                if not isinstance(f, dict):
+                    continue
+                fname = str(f.get('name', '') or '').strip()
+                if not fname:
+                    continue
+                norm = fname.lower().replace(' ', '_')
+                src_val = src_lookup.get(norm)
+                has_src = src_val not in (None, '', [], {})
+                if bool(f.get('required')) and not has_src:
+                    required_unmapped.append(sec_name + '.' + fname)
+                field_plan.append({
+                    'section': sec_name,
+                    'field': fname,
+                    'source_key': norm if has_src else '',
+                    'has_source': bool(has_src),
+                    'required': bool(f.get('required')),
+                })
+        if required_unmapped:
+            problems.append('required wizard fields with no source value: ' + ', '.join(required_unmapped))
+
+        # --- Document -> upload slot matching (by normalized label, then by accepted type). ---
+        slot_by_label = {}
+        for s in upload_slots:
+            if isinstance(s, dict):
+                slot_by_label[str(s.get('label', '') or '').strip().lower()] = s
+        doc_plan = []
+        unmatched_docs = []
+        for d in doc_manifest:
+            if not isinstance(d, dict):
+                continue
+            label = str(d.get('label', '') or '').strip()
+            slot = slot_by_label.get(label.lower())
+            matched = bool(slot)
+            if not matched:
+                unmatched_docs.append(label or '<unlabeled>')
+            doc_plan.append({
+                'label': label,
+                'sha256': str(d.get('sha256', '') or ''),
+                'type': str(d.get('type', '') or ''),
+                'matched_slot': str(slot.get('label', '')) if isinstance(slot, dict) else '',
+                'matched': matched,
+            })
+        if unmatched_docs:
+            problems.append('documents with no matching upload slot: ' + ', '.join(unmatched_docs))
+
+        # --- Conditional sections that MUST be filled, from the validated flags. ---
+        must_fill = []
+        if validated.get('is_pep'):
+            must_fill.append('pep')
+        if validated.get('has_ubos'):
+            must_fill.append('beneficial_owner')
+        if validated.get('source_of_funds_present'):
+            must_fill.append('source_of_funds')
+
+        # The plan is only safe when every required field maps and every doc has a slot.
+        ok = (len(problems) == 0) and (len(field_plan) > 0) and (len(doc_plan) > 0)
+        result = {
+            'ok': ok,
+            'problems': problems,
+            'field_plan': field_plan,
+            'field_count': len(field_plan),
+            'required_unmapped': required_unmapped,
+            'doc_plan': doc_plan,
+            'doc_count': len(doc_plan),
+            'unmatched_docs': unmatched_docs,
+            'must_fill_conditional': must_fill,
+            'doc_hashes': validated.get('doc_hashes', []),
+        }
+
+  # 4b) Hard stop on a bad mapping - do NOT proceed to the gate / data entry on an incomplete plan.
+  - id: plan_gate
+    type: condition
+    depends_on: [build_mapping_plan]
+    condition_config:
+      expression: "{steps.build_mapping_plan.output.ok} == True"
+      then: [entry_gate]
+      else: [notify_plan_failed]
+
+  - id: notify_plan_failed
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        KYC onboarding case could NOT be mapped to the portal wizard before any data entry:
+        {steps.build_mapping_plan.output.problems}. Unmatched documents:
+        {steps.build_mapping_plan.output.unmatched_docs}; unmapped required fields:
+        {steps.build_mapping_plan.output.required_unmapped}. Nothing was entered. Resolve and re-run.
+
+  # 5) PRE-ENTRY GATE - ALL strategies must pass before anything is typed/uploaded into the portal.
+  #    (a) llm_eval: verifies the mapping is COMPLETE (all required conditional sections covered) and has
+  #        NO value mismatch versus the source record (provider-swappable, runs with failover).
+  #    (b) human: a compliance analyst signs off on the mapping before entry. This gate is the last stop
+  #    before the (still reversible) data entry; the irreversible submit is gated separately downstream.
+  - id: entry_gate
+    type: gate
+    depends_on: [plan_gate]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are a KYC mapping-completeness reviewer. Verify the proposed field+document mapping plan
+              is COMPLETE and CONSISTENT with the validated source record BEFORE any data is entered into
+              the onboarding portal. Reply with exactly 'approved' only if: every required wizard field
+              has a traceable source value (no required field unmapped); every required conditional
+              section flagged in must_fill_conditional (PEP / beneficial-owner / source-of-funds) is
+              covered by the field plan; every document is matched to an upload slot; and no planned value
+              contradicts the source record (no invented data). Otherwise reply 'rejected' and name each
+              gap or mismatch. Validated case (redacted flags + hashes): {steps.validate_case.output} .
+              Mapping plan: {steps.build_mapping_plan.output} .
+            input: "{steps.build_mapping_plan.output}"
+            model: google/gemini-2.5-pro
+        - type: human
+          config:
+            message: >-
+              KYC pre-entry review. Confirm the field+document mapping plan is correct and approve entry
+              into the onboarding portal. Conditional sections that must be filled:
+              {steps.build_mapping_plan.output.must_fill_conditional}. Documents:
+              {steps.build_mapping_plan.output.doc_count} matched. Reject if any required field is
+              unmapped or any document is unmatched. Mapping: {steps.build_mapping_plan.output}
+            timeout_hours: 24
+            on_timeout: abort
+
+  # 6) FILL PASS (playwright mode, provider-neutral). The reasoning model AUTHORS a Playwright script
+  #    that re-logs-in via KYC_PORTAL_CREDS (OTP/2FA/CAPTCHA pause to a human), fills EVERY section from
+  #    the approved plan - including the conditional PEP / beneficial-owner / source-of-funds sections
+  #    that only render after earlier answers - uploads EACH document to its matched slot, advances to
+  #    the ATTESTATION / REVIEW screen, and STOPS. It does NOT check the attestation box or click Submit.
+  #    capture_screenshots gives an auditable review snapshot; output_schema returns the entered values
+  #    and the uploaded document hashes for the compliance officer. max_actions bounds the wizard.
+  - id: fill_to_attestation
+    type: browser
+    depends_on: [entry_gate]
+    prompt: >-
+      You are completing a KYC onboarding wizard on a bank/broker/exchange portal. Authenticate using the
+      KYC_PORTAL_CREDS environment variable - if an OTP / 2FA prompt or CAPTCHA appears, PAUSE for a human
+      (do not attempt to solve it). Open the onboarding wizard and walk it end to end. Using the APPROVED
+      mapping plan, fill every required field in every section from the source record, including the
+      conditional sections that only render after earlier answers (PEP, beneficial-owner, and
+      source-of-funds), waiting for client-side validation to settle before advancing. Upload EACH
+      document from the plan to its matched upload slot. CRITICAL: advance only to the FINAL ATTESTATION /
+      REVIEW screen and STOP there - DO NOT check the attestation / declaration checkbox and DO NOT click
+      the final Submit / File button. Attestation and submission are a separate, human-approved step.
+      Approved mapping plan: {steps.build_mapping_plan.output} . Conditional sections to complete:
+      {steps.build_mapping_plan.output.must_fill_conditional}. Return ONLY the structured object: a
+      reference to the captured review snapshot, the entered values as shown on the review screen, the
+      list of uploaded document hashes (sha256), the count of documents actually attached, and whether
+      the attestation checkbox + submit button are present and enabled.
+    browser_config:
+      mode: playwright
+      start_url: "{input.portal_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 600
+      max_actions: 150
+      headless: true
+      credentials_env: "KYC_PORTAL_CREDS"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          review_snapshot: { type: string }
+          entered_values:
+            type: object
+            properties:
+              legal_name: { type: string }
+              entity_type: { type: string }
+              country: { type: string }
+              registration_number: { type: string }
+              is_pep: { type: boolean }
+              sections_completed: { type: integer }
+          uploaded_doc_hashes:
+            type: array
+            items: { type: string }
+          attached_doc_count: { type: integer }
+          attestation_checkbox_present: { type: boolean }
+          submit_button_present: { type: boolean }
+
+  # 6b) DETERMINISTIC validation of the FILLED attestation state (no model). The load-bearing pre-submit
+  #     check: the uploaded document hashes must equal the validated set (no missing/extra/wrong doc),
+  #     the attached count must match the plan, and the attestation checkbox + submit button must be
+  #     present (wizard actually reached attestation). A review snapshot must exist. Fails closed.
+  - id: validate_attestation
+    type: code
+    depends_on: [fill_to_attestation]
+    code_config:
+      language: python
+      code: |
+        read_out = _steps.get('fill_to_attestation') or {}
+        if not isinstance(read_out, dict):
+            read_out = {}
+        for key in ('output', 'data', 'result'):
+            inner = read_out.get(key)
+            if isinstance(inner, dict) and ('uploaded_doc_hashes' in inner or 'entered_values' in inner):
+                read_out = inner
+                break
+
+        plan = _steps.get('build_mapping_plan') or {}
+        if not isinstance(plan, dict):
+            plan = {}
+        validated = _steps.get('validate_case') or {}
+        if not isinstance(validated, dict):
+            validated = {}
+
+        problems = []
+
+        # Uploaded doc hashes must equal the validated document hash set (no missing/extra/wrong doc).
+        expected_hashes = [str(h) for h in (validated.get('doc_hashes') or []) if str(h)]
+        got_hashes = read_out.get('uploaded_doc_hashes')
+        if not isinstance(got_hashes, list):
+            got_hashes = []
+        got_hashes = [str(h) for h in got_hashes if str(h)]
+        if set(got_hashes) != set(expected_hashes):
+            missing = [h for h in expected_hashes if h not in got_hashes]
+            extra = [h for h in got_hashes if h not in expected_hashes]
+            problems.append('uploaded doc hashes do not match the validated set (missing '
+                            + str(len(missing)) + ', unexpected ' + str(len(extra)) + ')')
+
+        # Attached document count must equal the planned document count.
+        def _int(v):
+            try:
+                return int(v)
+            except (TypeError, ValueError):
+                return 0
+        expected_docs = _int(plan.get('doc_count'))
+        attached = _int(read_out.get('attached_doc_count'))
+        if attached != expected_docs:
+            problems.append('attached doc count ' + str(attached) + ' != planned ' + str(expected_docs))
+
+        # The wizard must have reached an attestation-capable review screen.
+        if not read_out.get('attestation_checkbox_present'):
+            problems.append('attestation checkbox not present - wizard did not reach attestation')
+        if not read_out.get('submit_button_present'):
+            problems.append('submit button not present - wizard did not reach review')
+
+        # A review snapshot must exist for the compliance officer to inspect.
+        review_snapshot = str(read_out.get('review_snapshot', '') or '').strip()
+        if not review_snapshot:
+            problems.append('no review snapshot captured for the compliance officer')
+
+        entered = read_out.get('entered_values') if isinstance(read_out.get('entered_values'), dict) else {}
+
+        ok = len(problems) == 0
+        result = {
+            'ok': ok,
+            'problems': problems,
+            'review_snapshot': review_snapshot,
+            'entered_values': entered,
+            'uploaded_doc_hashes': got_hashes,
+            'expected_doc_hashes': expected_hashes,
+            'attached_doc_count': attached,
+            'expected_doc_count': expected_docs,
+        }
+
+  # 6c) Hard stop on a bad fill - do NOT advance to the officer approval / submit on a bad attestation read.
+  - id: attestation_gate
+    type: condition
+    depends_on: [validate_attestation]
+    condition_config:
+      expression: "{steps.validate_attestation.output.ok} == True"
+      then: [approve_attestation]
+      else: [notify_attestation_failed]
+
+  - id: notify_attestation_failed
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        KYC onboarding reached the portal attestation screen but the deterministic review check FAILED
+        before submission: {steps.validate_attestation.output.problems}. Nothing was submitted. Re-check
+        the wizard fill and document uploads, then re-run.
+
+  # 7) HUMAN COMPLIANCE-OFFICER APPROVAL before the legally-binding attestation/submit. The officer sees
+  #    the validated entered values, the uploaded document hashes, and the captured review snapshot and
+  #    authorizes the IRREVERSIBLE submit. No submission can occur without this gate; on_timeout: abort
+  #    never auto-submits - this is the human authority over a legally-binding KYC filing.
+  - id: approve_attestation
+    type: approval
+    approval_config:
+      message: >-
+        AUTHORIZE the legally-binding KYC ATTESTATION + SUBMISSION. This is IRREVERSIBLE - it attests to
+        and files the customer's KYC onboarding case. The case is filled and sitting on the portal's
+        attestation screen with {steps.validate_attestation.output.attached_doc_count} documents attached
+        (expected {steps.validate_attestation.output.expected_doc_count}). Uploaded document hashes:
+        {steps.validate_attestation.output.uploaded_doc_hashes}. Review the captured review snapshot and
+        the entered values - this is the EXACT state you are attesting to and filing. Approve to check the
+        attestation box and submit; reject to abort with nothing filed.
+      show_data: steps.validate_attestation.output
+      show_images: ["steps.validate_attestation.output.review_snapshot"]
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: false
+
+  # 8) SUBMIT PASS (playwright mode, WRITE). Only reached AFTER the compliance officer approves. Re-opens
+  #    the filled attestation screen, checks the attestation/declaration box, clicks the single final
+  #    Submit button ONCE, then reads the portal's confirmation and captures {case_reference,
+  #    submitted_at, status}. capture_screenshots gives an after-submit audit record; max_actions tightly
+  #    capped (check box + one confirm action); OTP/2FA/CAPTCHA pause to a human.
+  - id: submit_case
+    type: browser
+    depends_on: [approve_attestation]
+    prompt: >-
+      A compliance officer has authorized this IRREVERSIBLE, legally-binding KYC submission. Authenticate
+      with KYC_PORTAL_CREDS if the session expired (OTP/2FA/CAPTCHA pause to a human), return to the
+      filled attestation / review screen, confirm the values still match the approved review, then check
+      the attestation / declaration checkbox and click the SINGLE final Submit / File button ONCE to file
+      the case. Do NOT edit any field, do NOT re-upload any document, and do NOT click submit more than
+      once. If a CAPTCHA or step-up auth appears at this final wall, PAUSE for a human - do not attempt to
+      solve it. Then read the portal's confirmation page and capture the portal-issued CASE REFERENCE, the
+      submitted timestamp, and the case status. Return ONLY the structured object described by the output
+      schema.
+    browser_config:
+      mode: playwright
+      start_url: "{input.portal_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 300
+      max_actions: 20
+      headless: true
+      credentials_env: "KYC_PORTAL_CREDS"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          case_reference: { type: string }
+          submitted_at: { type: string }
+          status: { type: string }
+          confirmation_screenshot: { type: string }
+
+  # 9) DETERMINISTIC SUCCESS GATE (no model). Assert the portal-issued case_reference is present and
+  #    matches the expected pattern. A missing/malformed case_reference means the submit did NOT provably
+  #    land - so a silently-failed submit can NEVER be recorded as a filed case.
+  - id: assert_case_reference
+    type: code
+    depends_on: [submit_case]
+    code_config:
+      language: python
+      code: |
+        import re
+        sub = _steps.get('submit_case') or {}
+        if not isinstance(sub, dict):
+            sub = {}
+        for key in ('output', 'data', 'result'):
+            inner = sub.get(key)
+            if isinstance(inner, dict) and ('case_reference' in inner):
+                sub = inner
+                break
+
+        case_reference = str(sub.get('case_reference', '') or '').strip()
+        submitted_at = str(sub.get('submitted_at', '') or '').strip()
+        status = str(sub.get('status', '') or '').strip()
+
+        pattern = str(_input.get('case_reference_pattern', '') or '').strip()
+        if not pattern:
+            pattern = '^[A-Z]{2,6}-[0-9]{6,}$'
+
+        problems = []
+        matched = False
+        if not case_reference:
+            problems.append('portal returned no case_reference - submission not provably accepted')
+        else:
+            try:
+                matched = bool(re.search(pattern, case_reference))
+            except (TypeError, ValueError):
+                matched = False
+            if not matched:
+                problems.append('case_reference "' + case_reference + '" does not match pattern ' + pattern)
+        if not submitted_at:
+            problems.append('no submitted_at timestamp returned')
+
+        filed = bool(case_reference) and matched and (len(problems) == 0)
+        result = {
+            'filed': filed,
+            'problems': problems,
+            'case_reference': case_reference,
+            'submitted_at': submitted_at,
+            'status': status,
+            'pattern': pattern,
+        }
+
+  # 9b) Branch on the deterministic success gate. Only a provably-filed case proceeds to the regression
+  #     guard + archive. An unconfirmed submit is paged to the team and left needing attention.
+  - id: filed_gate
+    type: condition
+    depends_on: [assert_case_reference]
+    condition_config:
+      expression: "{steps.assert_case_reference.output.filed} == True"
+      then: [regression_guard]
+      else: [notify_submit_unconfirmed]
+
+  # 9c) UNCONFIRMED PATH - submit happened but the case_reference did not validate. Page the team and
+  #     leave the run needing attention. A false success is NEVER recorded as a filed case.
+  - id: notify_submit_unconfirmed
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        NEEDS ATTENTION: KYC submit did NOT return a valid case_reference
+        ({steps.assert_case_reference.output.problems}). Do NOT assume the case was filed - manually
+        check the onboarding portal. The run is left in a needs-attention state.
+
+  # 10) TRAJECTORY-REPLAY (reliability gate, engine-native, model-independent). Re-drive the recorded
+  #     onboarding flow and diff its structural trajectory against the known-good golden run. If a portal
+  #     redesign moved a section or the submit control, or a misclick diverged the path - which could
+  #     otherwise silently submit garbage - the replay score drops below drift_fail_below_score (0.9 for
+  #     this fragile legally-binding flow) and the run is flagged as drifted. Cost blowup vs golden is
+  #     rejected too. trajectory-replay compares structural trajectories, not model-specific tokens, so
+  #     reliability does not depend on any one provider.
+  - id: regression_guard
+    type: trajectory-replay
+    depends_on: [filed_gate]
+    trajectory_replay_config:
+      golden_run_id: "{input.golden_run_id}"
+      fail_below_score: 0.9
+      allow_cost_delta_pct: 10.0
+      cost_budget_usd: 0.50
+
+  # 11) REPORT - log the filing as an immutable audit packet PDF for the AML file: the redacted case
+  #     summary, the portal case reference, the submitted timestamp, the uploaded document hashes, and a
+  #     note that the case was deterministically validated, a dual pre-entry gate (llm_eval mapping
+  #     completeness + human analyst) passed, a compliance officer approved the legally-binding
+  #     attestation, the case reference was asserted against the expected pattern, and a trajectory-replay
+  #     regression-guarded the portal flow. Screenshots from the browser steps are part of the audit trail.
+  - id: audit_packet_report
+    type: report
+    depends_on: [regression_guard]
+    report_config:
+      template: "research-report"
+      format: pdf
+      theme: professional
+      title: "KYC Onboarding Filing Record - {steps.assert_case_reference.output.case_reference}"
+      author: "Compliance Onboarding Desk"
+    prompt: >-
+      Produce a formal, immutable KYC onboarding audit packet PDF for the AML file from the payload below.
+      Include: the portal case reference, the submitted timestamp and status, the count of documents
+      attached and the full list of uploaded document hashes (sha256), the redacted entity/case summary
+      (entity type, country, PEP flag, UBO count, source of funds - NO raw PII), and an attestation trail
+      noting that the case packet was deterministically validated, a dual pre-entry gate (llm_eval mapping
+      completeness + a human compliance analyst) passed, a human compliance officer approved the
+      legally-binding attestation and submission, the case reference was asserted against the portal's
+      expected pattern before recording, and a trajectory-replay regression-guarded the fragile portal
+      flow against a golden run (score floor {input.drift_fail_below_score}). Filing payload:
+      {steps.assert_case_reference.output} . Validated case (redacted): {steps.validate_case.output.redacted_entity} .
+      Uploaded document hashes: {steps.validate_attestation.output.uploaded_doc_hashes} .
+
+  # 12) ARCHIVE (sub-workflow) - hand the audit packet to a reusable summarizer workflow so every filing
+  #     leaves an auditable, structured record for the AML file. Read-only handoff, provider-neutral
+  #     downstream workflow (not a vendor agent runtime). The packet bytes land via on_complete.storage_path.
+  - id: archive_audit_packet
+    type: sub_workflow
+    depends_on: [audit_packet_report]
+    sub_workflow:
+      workflow: "summarize"
+      input_mapping:
+        text: "{steps.assert_case_reference.output}"
+        format: "bullet-points"
+      max_concurrent: 1
+
+on_complete:
+  storage_path: "kyc-onboarding-portal-filer/{steps.assert_case_reference.output.case_reference}/{run_id}/audit-packet.json"

--- a/src/sandcastle/templates/legacy_admin_report_export_to_warehouse.yaml
+++ b/src/sandcastle/templates/legacy_admin_report_export_to_warehouse.yaml
@@ -1,0 +1,568 @@
+# name: Legacy Admin Report Export To Warehouse
+# description: Scheduled RPA bridge that logs into an internal/legacy admin tool with NO export API, runs the canonical report for yesterday, scrapes the rendered result grid (or the JS 'Download CSV'), deterministically validates row count / column arity / numeric parse / a daily-total anomaly band, then UPSERTs clean structured rows into the data warehouse - escalating an anomalous total to a human approval before the load so a layout change or a wrong filter can never silently poison the warehouse. The browser drive is provider-neutral playwright mode (the reasoning model authors the filter-set/run/extract script, fully swappable); trajectory-replay against a golden run, the row/total validation, and the warehouse upsert are deterministic and model-independent, so swapping the reasoning model never changes the data contract.
+# tags: [rpa, browser, playwright, legacy-admin, no-api, data-warehouse, etl, trajectory-replay, anomaly-guard, scheduled, provider-neutral]
+# category: data
+
+name: legacy-admin-report-export-to-warehouse
+description: >-
+  A scheduled (daily 06:00, before the morning dashboards refresh) provider-neutral RPA bridge
+  for a data/analytics engineer or RevOps analyst whose critical metric is trapped inside a
+  legacy admin panel, a vendor dashboard, or an internal tool with NO export API and NO
+  server-side scheduled export. http cannot authenticate the proprietary session or click the
+  JS-driven 'Download CSV', and there is no endpoint to GET - the only path to the numbers is to
+  drive the browser. Step 1 (transform) computes the 'yesterday' date-range parameters that feed
+  the report filters deterministically. Step 2 (browser, PLAYWRIGHT mode) is the core: it logs in
+  via credentials_env=ADMIN_TOOL_CREDS (never inline secrets), sets the date filters, runs the
+  canonical report, and reads the rendered result grid (or triggers and parses the session-
+  authenticated CSV download), returning a STRUCTURED export via output_schema
+  (report_date, columns[], rows[[...]], row_count, grid_reported_total, totals) - capture_screenshots
+  on so each load has an audit trail of exactly which filters produced it, captcha_strategy=pause
+  for admin-login challenges, max_actions caps the session. Step 3 (trajectory-replay) wraps the
+  drive against a golden_run_id with fail_below_score=0.9 / allow_cost_delta_pct=15 so a layout
+  change in the admin tool or a wrong filter selection FAILS the load instead of poisoning the
+  warehouse. Step 4 (deterministic sandboxed Python) is the load-bearing correctness gate: it
+  rejects on empty/short reads, checks the scraped row_count matches the grid's own reported total,
+  enforces that every row has the expected column arity, parses the numeric columns, and compares
+  the daily total against the prior load within an anomaly band. Step 5 (condition) routes: a clean,
+  in-band load goes straight to the warehouse UPSERT; a tripped anomaly guard (e.g. the total
+  dropped 80%) escalates to a human approval ('Report total looks anomalous, load anyway?') showing
+  the validated summary, and only on sign-off does it UPSERT - otherwise nothing is written. After
+  the UPSERT, an llm_eval+human gate / the warehouse's own row-count echo confirms the landing
+  before success, and step 6 (notify, slack) reports row_count + totals so the analyst sees the
+  daily landing succeeded. The flow is strictly read-then-load: it NEVER mutates the source admin
+  tool; the only destructive risk is a bad load, which trajectory-replay + the deterministic guard +
+  the human anomaly approval gate. Both reasoning passes ride default_model and stay swappable across
+  providers; the replay scorer, the validation, the warehouse contract, and the approval are
+  engine-native and model-independent.
+
+default_model: sonnet
+default_timeout: 1200
+
+input_schema:
+  required: ["admin_report_url", "warehouse_endpoint", "target_table"]
+  properties:
+    admin_report_url:
+      type: string
+      description: >-
+        URL of the legacy admin tool's report page to drive (logged-in UI, no export API).
+        Templated into the browser step's start_url. The model sets the date filters here and
+        runs the canonical report.
+      example: "https://admin.internal.example/reports/daily-revenue"
+    warehouse_endpoint:
+      type: string
+      description: >-
+        Base URL of the warehouse write API (PostgREST over Postgres / Snowflake SQL API /
+        internal loader). The UPSERT POSTs the validated rows here. Auth via WAREHOUSE_API_TOKEN
+        env, never inline.
+      example: "https://warehouse.internal.example/rest/v1"
+    target_table:
+      type: string
+      description: "Fully-qualified warehouse table the validated rows are UPSERTed into."
+      example: "analytics.daily_revenue"
+    upsert_conflict_key:
+      type: string
+      description: >-
+        Column(s) the warehouse UPSERT uses as the conflict/merge key so a re-run for the same day
+        is idempotent (no duplicate rows). Sent as the PostgREST on_conflict / merge key.
+      default: "report_date,dimension_key"
+      example: "report_date,dimension_key"
+    expected_column_count:
+      type: integer
+      description: >-
+        The exact number of columns every scraped row MUST have. The deterministic guard rejects
+        the load if any row's arity differs (a layout change adds/drops a column).
+      default: 0
+      example: "5"
+    numeric_columns:
+      type: string
+      description: >-
+        Comma-separated 0-based column indexes that MUST parse as numbers (e.g. amount/count
+        columns). The guard rejects the load if any value in these columns fails to parse.
+      default: ""
+      example: "2,3,4"
+    total_column_index:
+      type: integer
+      description: >-
+        0-based index of the column whose daily sum is the canonical metric used for the anomaly
+        band check (and surfaced in the notification).
+      default: -1
+      example: "4"
+    prior_total:
+      type: number
+      description: >-
+        The canonical daily total from the PRIOR successful load. The guard compares today's total
+        against this; a swing beyond anomaly_band_pct trips the human approval before the load.
+        Pass 0 on the very first run to skip the band check (count/arity checks still apply).
+      default: 0
+      example: "184230.55"
+    anomaly_band_pct:
+      type: number
+      description: >-
+        Allowed percent swing of today's total vs prior_total before the load is treated as
+        anomalous and escalated to human approval (e.g. 50 = within +/-50%).
+      default: 50
+      example: "50"
+    min_rows:
+      type: integer
+      description: >-
+        Minimum number of rows a valid report must contain. A read returning fewer rows than this
+        (e.g. the grid failed to render) is rejected before any load.
+      default: 1
+      example: "1"
+    admin_credentials_env:
+      type: string
+      description: >-
+        Name of the environment variable holding the admin-tool login credentials (NEVER inline
+        secrets). Passed to the browser step's credentials_env.
+      default: "ADMIN_TOOL_CREDS"
+      example: "ADMIN_TOOL_CREDS"
+    golden_run_id:
+      type: string
+      description: >-
+        ID of the known-good recorded drive (correct filters, correct grid layout) the live
+        trajectory is diffed against. UI drift or a wrong filter selection drops the replay score
+        below fail_below_score and fails the load.
+      default: "golden-admin-daily-revenue-export-2026-05-01"
+      example: "golden-admin-daily-revenue-export-2026-05-01"
+    approval_timeout_hours:
+      type: integer
+      description: "Hours the anomalous-load approval waits before its timeout fires (on_timeout: abort - never auto-loads a suspect total)."
+      default: 12
+      example: "12"
+    slack_channel:
+      type: string
+      description: "Slack channel the daily landing summary (and any failure) is posted to."
+      default: "#data-loads"
+      example: "#data-loads"
+
+steps:
+  # ---------------------------------------------------------------------------
+  # 1) TRANSFORM - deterministically compute the 'yesterday' date-range params that
+  #    feed the report filters. No model: a pure template so the same calendar day
+  #    is always requested, making the scheduled run reproducible and golden-diffable.
+  # ---------------------------------------------------------------------------
+  - id: compute_date_range
+    type: transform
+    transform_config:
+      template: |
+        {
+          "report_label": "daily-export",
+          "range_hint": "yesterday",
+          "note": "Browser step resolves the concrete yesterday date from the admin tool's own clock/timezone and echoes it back as report_date; this range hint keeps the filter intent explicit and replayable."
+        }
+
+  # ---------------------------------------------------------------------------
+  # 2) BROWSER (READ pass) - the core. PLAYWRIGHT mode = provider-neutral: the model
+  #    AUTHORS the login + filter-set + run + extract Playwright script, fully
+  #    swappable across reasoning providers. Logs in via credentials_env (no inline
+  #    secrets), sets yesterday's date filters, runs the canonical report, and reads
+  #    the rendered result grid (or triggers and parses the session-authenticated
+  #    'Download CSV'). Returns a STRUCTURED export via output_schema so all downstream
+  #    correctness is on JSON, not screen-scraping. capture_screenshots gives an audit
+  #    trail of exactly which filters produced this load; captcha_strategy=pause hands
+  #    admin-login challenges to a human; max_actions caps the session. NO source
+  #    mutation - extract only.
+  # ---------------------------------------------------------------------------
+  - id: drive_admin_export
+    type: browser
+    depends_on: [compute_date_range]
+    prompt: >-
+      Log into the legacy admin tool at the start URL using the credentials provided via the
+      environment (do not echo them). This tool has no export API, so you must drive the UI. Using
+      the report's date filters, set the reporting range to YESTERDAY (the full prior calendar day
+      in the admin tool's own timezone) per this intent: {steps.compute_date_range.output}. Run the
+      canonical report. Then read the FULL rendered result grid: capture the ordered column headers,
+      every data row as an array of cell strings in column order, and - critically - the grid's OWN
+      reported total / row-count summary if it prints one (e.g. a 'N rows' footer or a totals row),
+      because the validator cross-checks the scraped count against it. If the report instead exposes
+      a 'Download CSV' / 'Export' button that triggers a session-authenticated, JS-driven download,
+      click it, parse the downloaded CSV, and return the same structure. Do NOT change any setting,
+      save, delete, or mutate anything in the admin tool - this is read-only. If a CAPTCHA or step-up
+      login wall appears, PAUSE for a human rather than guessing. Return ONLY the structured object
+      described by the output schema (report_date, columns, rows, row_count, grid_reported_total,
+      totals).
+    browser_config:
+      mode: playwright
+      start_url: "{input.admin_report_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 50
+      headless: true
+      credentials_env: "{input.admin_credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          report_date:
+            type: string
+            description: "The concrete date the report was run for (resolved 'yesterday'), ISO YYYY-MM-DD."
+          columns:
+            type: array
+            items:
+              type: string
+            description: "Ordered column headers of the result grid (defines column order for rows)."
+          rows:
+            type: array
+            description: "Every data row as an array of cell strings, in the same column order as `columns`."
+            items:
+              type: array
+              items:
+                type: string
+          row_count:
+            type: integer
+            description: "Number of data rows the scraper actually extracted (len(rows))."
+          grid_reported_total:
+            type: integer
+            description: "The row-count the grid itself prints in its footer/summary (e.g. 'Showing N rows'), if any; used to cross-check row_count."
+          totals:
+            type: object
+            description: "Any totals/subtotals row the grid renders, as a column-name -> value map (for cross-checking the computed daily total)."
+        required: ["report_date", "columns", "rows", "row_count"]
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: abort
+
+  # ---------------------------------------------------------------------------
+  # 3) TRAJECTORY-REPLAY - the reliability layer. Diffs THIS live drive against the
+  #    golden run (correct filters, correct grid layout). A layout change in the admin
+  #    tool or a wrong filter selection drops the replay score below fail_below_score
+  #    (0.9) or blows the cost delta (15%), FAILING the load instead of poisoning the
+  #    warehouse. Deterministic scorer over observable actions / extracted outputs -
+  #    provider-neutral, not a model's opinion.
+  # ---------------------------------------------------------------------------
+  - id: replay_vs_golden
+    type: trajectory-replay
+    depends_on: [drive_admin_export]
+    trajectory_replay_config:
+      golden_run_id: "{input.golden_run_id}"
+      fail_below_score: 0.9
+      allow_cost_delta_pct: 15.0
+      cost_budget_usd: 0.5
+
+  # ---------------------------------------------------------------------------
+  # 4) VALIDATE (deterministic, no model) - the load-bearing correctness gate over the
+  #    browser READ pass. Rejects empty/short reads, checks the scraped row_count
+  #    matches the grid's own reported total, enforces that EVERY row has the expected
+  #    column arity, parses the numeric columns, and compares today's daily total to
+  #    the prior load within the anomaly band. ANY hard failure => ok=False (abort the
+  #    load); an in-shape-but-out-of-band total => anomalous=True (escalate to human).
+  #    Nothing is ever written on a bad read.
+  # ---------------------------------------------------------------------------
+  - id: validate_export
+    type: code
+    depends_on: [replay_vs_golden]
+    code_config:
+      language: python
+      code: |
+        # Deterministic guard over the browser READ pass. No model decides correctness here.
+        export = _steps.get("drive_admin_export") or {}
+        if not isinstance(export, dict):
+            export = {"raw": export}
+        # The browser step may nest its structured payload under output/data/result.
+        for key in ("output", "data", "result"):
+            inner = export.get(key)
+            if isinstance(inner, dict) and ("rows" in inner or "columns" in inner):
+                export = inner
+                break
+
+        reasons = []
+
+        def _to_int(v, default=0):
+            try:
+                return int(v)
+            except (TypeError, ValueError):
+                return default
+
+        def _to_float(v, default=None):
+            try:
+                return float(str(v).replace(",", "").replace("$", "").strip())
+            except (TypeError, ValueError):
+                return default
+
+        columns = export.get("columns")
+        if not isinstance(columns, list):
+            columns = []
+        rows = export.get("rows")
+        if not isinstance(rows, list):
+            rows = []
+        report_date = str(export.get("report_date", "") or "").strip()
+
+        # --- Minimum-shape: a non-empty report with a real date and headers ---
+        min_rows = _to_int(_input.get("min_rows", 1), 1)
+        if not report_date:
+            reasons.append("read returned no report_date (grid likely failed to render)")
+        if len(columns) == 0:
+            reasons.append("read returned zero columns")
+        if len(rows) < max(1, min_rows):
+            reasons.append("read returned " + str(len(rows)) + " rows, below min_rows " + str(min_rows))
+
+        # --- row_count matches the grid's OWN reported total (no silent truncation) ---
+        scraped_count = len(rows)
+        stated_row_count = _to_int(export.get("row_count", scraped_count), scraped_count)
+        grid_total = export.get("grid_reported_total", None)
+        count_ok = (stated_row_count == scraped_count)
+        if not count_ok:
+            reasons.append("row_count " + str(stated_row_count) + " != actually scraped rows " + str(scraped_count))
+        if grid_total is not None:
+            grid_total_i = _to_int(grid_total, -1)
+            if grid_total_i >= 0 and grid_total_i != scraped_count:
+                reasons.append("grid reported " + str(grid_total_i) + " rows but " + str(scraped_count) + " were scraped (truncated/extra)")
+
+        # --- Column arity: every row matches the expected width (layout-change guard) ---
+        expected_cols = _to_int(_input.get("expected_column_count", 0), 0)
+        if expected_cols <= 0:
+            expected_cols = len(columns)
+        bad_arity = [i for i, r in enumerate(rows) if not isinstance(r, list) or len(r) != expected_cols]
+        arity_ok = (len(bad_arity) == 0) and (expected_cols > 0)
+        if expected_cols <= 0:
+            reasons.append("could not determine expected column count")
+        if bad_arity:
+            reasons.append(str(len(bad_arity)) + " row(s) have wrong column count (expected " + str(expected_cols) + "); first at index " + str(bad_arity[0]))
+
+        # --- Numeric columns parse cleanly ---
+        num_spec = str(_input.get("numeric_columns", "") or "").strip()
+        numeric_idxs = []
+        if num_spec:
+            for tok in num_spec.split(","):
+                tok = tok.strip()
+                if tok.lstrip("-").isdigit():
+                    numeric_idxs.append(int(tok))
+        unparseable = []
+        for idx in numeric_idxs:
+            for ri, r in enumerate(rows):
+                if isinstance(r, list) and 0 <= idx < len(r):
+                    if _to_float(r[idx], None) is None:
+                        unparseable.append((ri, idx))
+        numeric_ok = (len(unparseable) == 0)
+        if unparseable:
+            reasons.append(str(len(unparseable)) + " cell(s) in numeric columns failed to parse; first at row " + str(unparseable[0][0]) + " col " + str(unparseable[0][1]))
+
+        # --- Compute today's canonical daily total from the total column ---
+        total_idx = _to_int(_input.get("total_column_index", -1), -1)
+        today_total = 0.0
+        total_computed = False
+        if 0 <= total_idx:
+            total_computed = True
+            for r in rows:
+                if isinstance(r, list) and total_idx < len(r):
+                    v = _to_float(r[total_idx], 0.0)
+                    today_total += (v if v is not None else 0.0)
+
+        # --- Anomaly band: today's total vs the prior successful load ---
+        prior_total = _to_float(_input.get("prior_total", 0), 0.0) or 0.0
+        band_pct = _to_float(_input.get("anomaly_band_pct", 50), 50.0) or 50.0
+        anomalous = False
+        anomaly_detail = ""
+        if total_computed and prior_total > 0:
+            swing_pct = abs(today_total - prior_total) / prior_total * 100.0
+            if swing_pct > band_pct:
+                anomalous = True
+                anomaly_detail = ("today total " + str(round(today_total, 2)) + " swings "
+                                  + str(round(swing_pct, 1)) + "% vs prior " + str(round(prior_total, 2))
+                                  + " (band " + str(round(band_pct, 1)) + "%)")
+        elif total_computed and prior_total <= 0:
+            anomaly_detail = "no prior_total baseline (first run) - band check skipped"
+
+        # Hard-fail checks gate the load entirely; the anomaly band only escalates to a human.
+        ok = bool(
+            (not reasons)
+            and count_ok
+            and arity_ok
+            and numeric_ok
+            and report_date
+            and len(rows) >= max(1, min_rows)
+        )
+
+        result = {
+            "ok": ok,
+            "anomalous": bool(anomalous),
+            "report_date": report_date,
+            "row_count": scraped_count,
+            "expected_column_count": expected_cols,
+            "count_ok": count_ok,
+            "arity_ok": arity_ok,
+            "numeric_ok": numeric_ok,
+            "total_computed": total_computed,
+            "today_total": round(today_total, 2),
+            "prior_total": round(prior_total, 2),
+            "anomaly_detail": anomaly_detail,
+            "reasons": reasons,
+            "reason_summary": "; ".join(reasons) if reasons else "all hard checks passed",
+        }
+
+  # ---------------------------------------------------------------------------
+  # 5) CONDITION - deterministic routing on the guard result.
+  #    ok=False                -> abort path: notify the failure, write NOTHING.
+  #    ok=True  & anomalous    -> human approval BEFORE the irreversible UPSERT.
+  #    ok=True  & not anomalous-> straight to the warehouse UPSERT.
+  #    (handled as two cascading conditions so each branch target is reachable.)
+  # ---------------------------------------------------------------------------
+  - id: route_validity
+    type: condition
+    depends_on: [validate_export]
+    condition_config:
+      expression: "{steps.validate_export.output.ok} == True"
+      then: [route_anomaly]
+      else: [notify_bad_read]
+
+  # 5a) ABORT PATH - the deterministic guard rejected the read (drift, wrong arity,
+  #     unparseable numbers, truncation, empty grid). Page the channel with exactly
+  #     why and STOP. Nothing is written to the warehouse.
+  - id: notify_bad_read
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: >-
+        LOAD ABORTED for {input.target_table} ({steps.validate_export.output.report_date}): the
+        deterministic export guard FAILED, so nothing was loaded. Reason(s):
+        {steps.validate_export.output.reason_summary}. Scraped
+        {steps.validate_export.output.row_count} rows. Check the admin tool layout / filters and
+        re-run; screenshots of the drive are attached to this run for audit.
+
+  # 5b) Second condition - among VALID reads, split anomalous (human gate) vs clean.
+  - id: route_anomaly
+    type: condition
+    depends_on: [route_validity]
+    condition_config:
+      expression: "{steps.validate_export.output.anomalous} == True"
+      then: [approve_anomalous_load]
+      else: [upsert_clean]
+
+  # 5c) HUMAN APPROVAL - the validated rows are in-shape but the daily total swung
+  #     beyond the anomaly band (e.g. dropped 80%). Show the validated summary and
+  #     BLOCK until a person decides; on_timeout: abort means a suspect total is NEVER
+  #     auto-loaded. Only on approval do we proceed to the UPSERT.
+  - id: approve_anomalous_load
+    type: approval
+    approval_config:
+      message: >-
+        Report total looks anomalous, load anyway? Table {input.target_table} for
+        {steps.validate_export.output.report_date}: {steps.validate_export.output.row_count} rows
+        passed shape/arity/numeric checks, but {steps.validate_export.output.anomaly_detail}.
+        Today total {steps.validate_export.output.today_total} vs prior
+        {steps.validate_export.output.prior_total}. Review the attached drive screenshots (the exact
+        filters that produced this), then APPROVE to UPSERT these rows or REJECT to abort the load
+        with nothing written.
+      show_data: steps.validate_export.output
+      timeout_hours: 12
+      on_timeout: abort
+      allow_edit: false
+
+  # ---------------------------------------------------------------------------
+  # 6) UPSERT (WRITE pass) - the only irreversible action, reached EITHER from a clean
+  #    in-band load OR after explicit human approval of an anomalous one. POSTs the
+  #    validated rows to the warehouse write API with an on_conflict/merge key so a
+  #    re-run for the same day is idempotent (no duplicate rows). Auth via
+  #    WAREHOUSE_API_TOKEN env, never inline. Defined ONCE and reached by both upstream
+  #    branches via depends_on so there is a single warehouse contract.
+  # ---------------------------------------------------------------------------
+  - id: upsert_clean
+    type: http
+    depends_on: [route_anomaly]
+    http_config:
+      url: "{input.warehouse_endpoint}/{input.target_table}?on_conflict={input.upsert_conflict_key}"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+        Prefer: "resolution=merge-duplicates,return=representation,count=exact"
+      auth: "bearer:{env.WAREHOUSE_API_TOKEN}"
+      body: |
+        {
+          "report_date": "{steps.validate_export.output.report_date}",
+          "row_count": "{steps.validate_export.output.row_count}",
+          "daily_total": "{steps.validate_export.output.today_total}",
+          "source": "legacy-admin-export",
+          "rows": "{steps.drive_admin_export.output.rows}",
+          "columns": "{steps.drive_admin_export.output.columns}"
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  - id: upsert_approved
+    type: http
+    depends_on: [approve_anomalous_load]
+    http_config:
+      url: "{input.warehouse_endpoint}/{input.target_table}?on_conflict={input.upsert_conflict_key}"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+        Prefer: "resolution=merge-duplicates,return=representation,count=exact"
+      auth: "bearer:{env.WAREHOUSE_API_TOKEN}"
+      body: |
+        {
+          "report_date": "{steps.validate_export.output.report_date}",
+          "row_count": "{steps.validate_export.output.row_count}",
+          "daily_total": "{steps.validate_export.output.today_total}",
+          "source": "legacy-admin-export-human-approved",
+          "rows": "{steps.drive_admin_export.output.rows}",
+          "columns": "{steps.drive_admin_export.output.columns}"
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # ---------------------------------------------------------------------------
+  # 7) CONFIRM THE LANDING (engine-native gate, no single-model trust) - after the
+  #    write, an llm_eval gate inspects the warehouse's OWN response (it echoes the
+  #    affected-row representation under Prefer: count/return) and a human gate backstop
+  #    asserts the upserted row_count matches what the guard validated, BEFORE we declare
+  #    success. A clean depends_on on the two mutually-exclusive upsert branches: at
+  #    runtime exactly one fired, and the gate reads whichever landed. This prevents a
+  #    half-applied or rejected write from being reported as a win.
+  # ---------------------------------------------------------------------------
+  - id: confirm_landing
+    type: gate
+    depends_on: [upsert_clean, upsert_approved]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              The warehouse UPSERT response is shown. Confirm the load actually landed: the response
+              must indicate a successful write (HTTP 2xx style, a returned representation, or an
+              affected/count value greater than zero) for table {input.target_table} on
+              {steps.validate_export.output.report_date}, and the affected row count should be
+              consistent with the {steps.validate_export.output.row_count} validated rows. Answer
+              PASS only if the warehouse confirms the rows landed; FAIL on any error, empty
+              response, or zero rows affected.
+            input: "{steps.upsert_clean.output}{steps.upsert_approved.output}"
+            model: sonnet
+        - type: human
+          config:
+            message: >-
+              Confirm the warehouse landing for {input.target_table}
+              ({steps.validate_export.output.report_date}, {steps.validate_export.output.row_count}
+              rows, total {steps.validate_export.output.today_total}) before this run is marked
+              successful. Reject if the warehouse did not actually persist the rows.
+            timeout_hours: 6
+            on_timeout: abort
+
+  # ---------------------------------------------------------------------------
+  # 8) NOTIFY - the daily landing summary so the analyst sees fresh numbers before the
+  #    morning dashboards refresh: report date, row_count, and the canonical daily total.
+  #    Only reached after the confirm gate passes, so it can never announce a phantom load.
+  # ---------------------------------------------------------------------------
+  - id: notify_landed
+    type: notify
+    depends_on: [confirm_landing]
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: >-
+        Daily load LANDED: {input.target_table} for {steps.validate_export.output.report_date} -
+        {steps.validate_export.output.row_count} rows, daily total
+        {steps.validate_export.output.today_total} (prior {steps.validate_export.output.prior_total}).
+        Source: legacy admin export via browser RPA; warehouse confirmed the upsert. Fresh numbers
+        are ready for the morning dashboards.
+
+on_complete:
+  storage_path: "legacy-admin-report-export-to-warehouse/{run_id}/result.json"

--- a/src/sandcastle/templates/legacy_erp_order_status_sync.yaml
+++ b/src/sandcastle/templates/legacy_erp_order_status_sync.yaml
@@ -1,0 +1,551 @@
+# name: Legacy ERP Order Status Sync
+# description: Logs into a no-API legacy ERP / order portal (old SAP GUI-web, Epicor, or a homegrown 1990s order system exposed only as a session-cookie-authenticated server-rendered web UI), reads each open order's TRUE fulfillment status via a provider-neutral dom-mode browser extraction, deterministically diffs it in sandboxed Python against the desired status from the downstream WMS/CRM system of record, and pushes status updates back into the ERP ONLY after a human approves the per-order old->new diff. The irreversible write is a stateful CSRF-gated multi-field form fill driven in provider-neutral playwright mode, captured with screenshots for audit, then double-checked by an llm_eval gate against the ERP's own confirmation page before success is declared. Read is split from write; the load-bearing correctness (the diff and the extraction validation) is deterministic code, never a single model's opinion.
+# tags: [DevOps, ERP, LegacyIntegration, Browser, Playwright, DOM, RPA, OrderManagement, HumanApproval, NoAPI, ProviderNeutral]
+# category: devops
+
+name: legacy-erp-order-status-sync
+description: >-
+  Keeps a no-API legacy ERP / order portal in sync with the downstream system of
+  record for operations and supply-chain teams running an on-prem 1990s-era order
+  system (old SAP GUI-web, Epicor, or a homegrown portal) that exposes order status
+  ONLY through a session-cookie-authenticated, server-rendered web UI - no REST, no
+  SOAP, no export worth scripting, dynamic field names, and a CSRF token regenerated
+  per page render, so no http/API step can authenticate the proprietary session or
+  POST the form correctly. Triggered every 30 minutes during business hours, or by a
+  webhook from the downstream WMS/CRM when a shipment event needs reflecting back in
+  the ERP. Step 1 (HTTP) pulls the list of order IDs needing a status check from the
+  downstream system of record - that side DOES have an API - along with each order's
+  desired/true status. Step 2 is a LOOP over those order IDs; each iteration runs a
+  BROWSER step in dom mode (the configured reasoning model authors the DOM-extraction
+  logic from the prompt, so any of the providers can drive it and the model is
+  swappable via default_model) that signs in with ERP_PORTAL_CREDS, navigates to the
+  order-detail page, and returns a STRICT structured read {order_id, current_status,
+  last_updated, line_items[], blocked_reason} under a max_actions cap, with
+  captcha_strategy=pause handing any login challenge to a human. Step 3 is the
+  LOAD-BEARING deterministic code: it diffs the live ERP status against the desired
+  downstream status using re.search on normalized status codes, VALIDATES the
+  extraction (rejects on order_id mismatch or schema-empty as a HARD FAIL so nothing
+  is written on a bad read), and builds a normalized change set of only the orders
+  with a real delta. A CONDITION continues only when at least one genuine status delta
+  exists. A mandatory human APPROVAL then shows the per-order old->new change set
+  (allow_edit so the operator can trim or correct rows) and BLOCKS until sign-off -
+  this is the gate before the irreversible record mutation. Only on approval does the
+  WRITE run: a LOOP over the approved change set drives a BROWSER step in playwright
+  mode (the model authors the Playwright form-fill script, provider-neutral) that
+  re-opens each order, fills the stateful CSRF-gated multi-field status form, clicks
+  save once, captures a screenshot for a tamper-evident audit trail, and returns
+  {order_id, write_confirmed, confirmation_number}. A GATE (llm_eval) then reads the
+  post-write confirmation text / screenshot and confirms the ERP actually ACCEPTED the
+  change - on an llm_eval failure the run is NOT marked successful. Finally a NOTIFY
+  posts the per-order write confirmations plus audit references to operations. Secrets
+  live only in ERP_PORTAL_CREDS (never inline); both browser steps ride default_model
+  and stay swappable across providers; the approval and the diff are model-independent.
+
+default_model: sonnet
+default_timeout: 1200
+
+input_schema:
+  required: ["sor_api_url", "erp_order_detail_url", "erp_status_form_url"]
+  properties:
+    sor_api_url:
+      type: string
+      description: >-
+        Base URL of the downstream system-of-record (WMS/CRM) API that returns the
+        order IDs needing a status check and each order's desired/true fulfillment
+        status. This is the side that DOES have an API. Auth via a bearer token from
+        the env (SOR_API_TOKEN), never inlined.
+      example: "https://wms.internal.example/api/v1"
+    erp_order_detail_url:
+      type: string
+      description: >-
+        URL template for the legacy ERP order-detail page. The loop substitutes the
+        current order id; the read browser step opens this to scrape the live status.
+        Use {order_id} as the placeholder the dom prompt fills per iteration.
+      example: "https://erp.onprem.example/orders/detail?id={order_id}"
+    erp_status_form_url:
+      type: string
+      description: >-
+        URL template for the legacy ERP order STATUS edit form (the stateful,
+        CSRF-gated multi-field form). The write loop substitutes the order id; the
+        playwright write step opens this to push the approved status update.
+      example: "https://erp.onprem.example/orders/status/edit?id={order_id}"
+    erp_credentials_env:
+      type: string
+      description: >-
+        Name of the environment variable holding the legacy ERP login credentials.
+        NEVER an inline secret - only the env var NAME is stored. Passed to both
+        browser steps' credentials_env.
+      default: "ERP_PORTAL_CREDS"
+      example: "ERP_PORTAL_CREDS"
+    status_check_endpoint:
+      type: string
+      description: >-
+        Path on the SOR API that lists open orders needing a status check, each with
+        its desired status. Appended to sor_api_url.
+      default: "/orders/needs-status-check"
+      example: "/orders/needs-status-check"
+    allowed_statuses:
+      type: array
+      description: >-
+        Closed set of normalized fulfillment status codes a read or a target status
+        may carry. A scraped current_status or a desired status outside this set is
+        rejected as malformed - no write is built on an unknown status.
+      default: ["open", "picking", "packed", "shipped", "delivered", "backordered", "cancelled", "on_hold"]
+    max_orders:
+      type: integer
+      description: "Safety cap on how many orders a single run will read / write (bounds the loops)."
+      default: 50
+    approval_timeout_hours:
+      type: integer
+      description: "Hours the human write-approval waits before its timeout fires. on_timeout: abort means a missed approval NEVER auto-writes to the ERP."
+      default: 8
+    notify_service:
+      type: string
+      description: "Where to post the write-confirmation digest: slack or teams."
+      default: "slack"
+    notify_channel:
+      type: string
+      description: "Channel for the per-order write-confirmation digest."
+      default: "#erp-order-sync"
+
+steps:
+  # 1) HTTP - pull the list of order IDs needing a status check (and each order's
+  #    desired/true status) from the downstream WMS/CRM system of record. THIS side
+  #    has a real API; the ERP does not. Auth via a bearer token from the env, never
+  #    inlined. (connector: downstream WMS/CRM via http)
+  - id: fetch_orders_to_sync
+    type: http
+    http_config:
+      url: "{input.sor_api_url}{input.status_check_endpoint}?limit={input.max_orders}"
+      method: GET
+      auth: "bearer:{env.SOR_API_TOKEN}"
+      headers:
+        Accept: "application/json"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 1a) CODE - normalize the SOR response into a plain list of order targets the read
+  #     loop can iterate over: [{order_id, desired_status}]. Deterministic, no model.
+  #     Caps at max_orders so a runaway SOR response can never explode the loops.
+  - id: build_order_worklist
+    type: code
+    depends_on: [fetch_orders_to_sync]
+    code_config:
+      language: python
+      code: |
+        resp = _steps.get("fetch_orders_to_sync") or {}
+        if not isinstance(resp, dict):
+            resp = {}
+        # HTTP step output may carry the parsed body under common keys.
+        rows = (
+            resp.get("orders")
+            or resp.get("data")
+            or resp.get("body")
+            or resp.get("json")
+            or resp.get("items")
+        )
+        if isinstance(rows, dict):
+            rows = rows.get("orders") or rows.get("data") or rows.get("items") or []
+        if not isinstance(rows, list):
+            rows = []
+
+        try:
+            cap = int(_input.get("max_orders", 50) or 50)
+        except (TypeError, ValueError):
+            cap = 50
+
+        worklist = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            oid = str(
+                row.get("order_id")
+                or row.get("id")
+                or row.get("number")
+                or ""
+            ).strip()
+            if not oid:
+                continue
+            desired = str(
+                row.get("desired_status")
+                or row.get("true_status")
+                or row.get("status")
+                or ""
+            ).strip().lower()
+            worklist.append({"order_id": oid, "desired_status": desired})
+            if len(worklist) >= cap:
+                break
+
+        result = {
+            "worklist": worklist,
+            "count": len(worklist),
+            "has_work": len(worklist) > 0,
+        }
+
+  # 2) LOOP over the order worklist. Each iteration runs read_order_status, the
+  #    provider-neutral dom-mode browser read. The loop item ({order_id, desired_status})
+  #    arrives on _input['_item'] and is read by the browser prompt via templating.
+  - id: read_order_statuses
+    type: loop
+    depends_on: [build_order_worklist]
+    loop_config:
+      over: "steps.build_order_worklist.output.worklist"
+      step_ids: [read_order_status]
+      max_iterations: 50
+
+  # 2a) BROWSER (dom mode - PROVIDER-NEUTRAL READ pass). The configured reasoning model
+  #     authors the DOM-extraction logic from this prompt - any of the providers can do
+  #     this and the authoring model is swappable via default_model. It signs into the
+  #     legacy ERP with credentials_env (NEVER an inline secret), navigates to the
+  #     order-detail page for the current order id, and returns ONLY the strict
+  #     output_schema below. captcha_strategy=pause hands any login challenge to a human.
+  #     max_actions caps runaway clicking. This is READ ONLY - it never edits or saves.
+  #     (loop child step - defined separately, read via _input['_item'])
+  - id: read_order_status
+    type: browser
+    browser_config:
+      mode: dom
+      start_url: "{input.erp_order_detail_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 30
+      headless: true
+      credentials_env: "{input.erp_credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          order_id: { type: string }
+          current_status: { type: string }
+          last_updated: { type: string }
+          line_items:
+            type: array
+            items:
+              type: object
+              properties:
+                sku: { type: string }
+                description: { type: string }
+                quantity: { type: number }
+                line_status: { type: string }
+          blocked_reason: { type: string }
+    prompt: |
+      You are reading the live fulfillment status of a single order from a legacy,
+      no-API ERP / order portal (e.g. old SAP GUI-web, Epicor, or a homegrown 1990s
+      order system). The ERP exposes status ONLY through this session-cookie-
+      authenticated, server-rendered web UI - there is no REST/SOAP endpoint, so the
+      order-detail page is the only source of truth.
+
+      The current order to read is provided as a JSON object on the loop item:
+      {input._item}. Use its order_id to locate the order.
+
+      Author the DOM-extraction logic to:
+      1. Sign in to the ERP using the credentials supplied via the credentials_env
+         environment variable. NEVER hardcode or echo the secret.
+      2. If a CAPTCHA, MFA, or device-verification login challenge appears, STOP and
+         hand off to a human (captcha_strategy=pause). Do not attempt to solve it.
+      3. Navigate to the order-detail page for this order id (substitute the order id
+         into the order-detail URL).
+      4. Read, from the rendered order-detail DOM: the order_id shown on the page, the
+         current fulfillment status text, the last-updated timestamp, every line item
+         (sku, description, quantity, per-line status), and any blocked/hold reason.
+      5. Perform NO write actions - never click save, submit, update, edit, cancel, or
+         any button that mutates the record. This is extraction only.
+
+      Return ONLY the structured JSON described by the output_schema: order_id,
+      current_status (the portal's literal status text), last_updated, the line_items
+      array, and blocked_reason (empty string if none).
+
+  # 3) CODE - the LOAD-BEARING step: VALIDATE the extraction and DIFF against the
+  #    desired downstream status. Pure deterministic Python, NO model in the path, so
+  #    the change set is reproducible and provider-neutral. For every scraped read it
+  #    confirms the order_id matches the worklist entry (rejects on mismatch), rejects
+  #    schema-empty reads (no current_status), and rejects unknown statuses. It then
+  #    normalizes both sides with re.search on status codes and emits a change set of
+  #    only the orders with a REAL delta. A HARD FAIL (extraction_ok False) means no
+  #    write is ever built on a bad read.
+  - id: diff_and_validate
+    type: code
+    depends_on: [read_order_statuses, build_order_worklist]
+    code_config:
+      language: python
+      code: |
+        reads = _steps.get("read_order_statuses")
+        if not isinstance(reads, list):
+            reads = [reads] if isinstance(reads, dict) else []
+
+        wl = _steps.get("build_order_worklist") or {}
+        if not isinstance(wl, dict):
+            wl = {}
+        worklist = wl.get("worklist") or []
+        if not isinstance(worklist, list):
+            worklist = []
+
+        # Desired status by order id, from the system of record.
+        desired_by_id = {}
+        for w in worklist:
+            if isinstance(w, dict):
+                oid = str(w.get("order_id") or "").strip()
+                if oid:
+                    desired_by_id[oid] = str(w.get("desired_status") or "").strip().lower()
+
+        allowed = _input.get("allowed_statuses") or []
+        if not isinstance(allowed, list):
+            allowed = []
+        allowed_set = {str(s).strip().lower() for s in allowed if isinstance(s, str)}
+
+        # Normalize a raw status string to a known code using a direct pattern search.
+        # We look for any allowed code as a token inside the raw text (covers values
+        # like "SHIPPED - 2026/05/30" or "Status: On Hold").
+        def _normalize(raw):
+            txt = str(raw or "").strip().lower()
+            if not txt:
+                return ""
+            for code in sorted(allowed_set, key=len, reverse=True):
+                token = code.replace("_", "[ _-]?")
+                if re.search(token, txt):
+                    return code
+            return txt  # unknown - will be rejected downstream
+
+        def _unwrap(env):
+            # The browser step may nest its payload under output/data/result.
+            if not isinstance(env, dict):
+                return {}
+            for key in ("output", "data", "result"):
+                inner = env.get(key)
+                if isinstance(inner, dict) and ("current_status" in inner or "order_id" in inner):
+                    return inner
+            return env
+
+        change_set = []
+        rejected = []
+        in_sync = []
+        seen = 0
+
+        for env in reads:
+            rec = _unwrap(env)
+            seen += 1
+            scraped_id = str(rec.get("order_id") or "").strip()
+            raw_status = rec.get("current_status")
+            # HARD VALIDATION: empty read or unknown order id => reject, never write.
+            if not scraped_id:
+                rejected.append({"reason": "empty_order_id_in_read", "raw": str(rec)[:200]})
+                continue
+            if scraped_id not in desired_by_id:
+                rejected.append({"order_id": scraped_id, "reason": "order_id_not_in_worklist"})
+                continue
+            if raw_status is None or str(raw_status).strip() == "":
+                rejected.append({"order_id": scraped_id, "reason": "empty_current_status"})
+                continue
+
+            current = _normalize(raw_status)
+            desired = desired_by_id.get(scraped_id, "")
+
+            # Reject reads/targets whose normalized status is not in the allowed set.
+            if current not in allowed_set:
+                rejected.append({"order_id": scraped_id, "reason": "unknown_current_status", "value": str(raw_status)[:80]})
+                continue
+            if desired and desired not in allowed_set:
+                rejected.append({"order_id": scraped_id, "reason": "unknown_desired_status", "value": desired})
+                continue
+
+            if not desired or current == desired:
+                in_sync.append({"order_id": scraped_id, "status": current})
+                continue
+
+            change_set.append({
+                "order_id": scraped_id,
+                "old_status": current,
+                "new_status": desired,
+                "last_updated": str(rec.get("last_updated") or ""),
+                "blocked_reason": str(rec.get("blocked_reason") or ""),
+            })
+
+        # extraction_ok is False only when we read orders but EVERY read was rejected -
+        # a strong signal of a silent ERP redesign / auth wall. An empty worklist or a
+        # clean "all in sync" result is NOT a failure.
+        extraction_ok = not (seen > 0 and len(rejected) == seen)
+
+        result = {
+            "change_set": change_set,
+            "change_count": len(change_set),
+            "in_sync_count": len(in_sync),
+            "rejected": rejected,
+            "rejected_count": len(rejected),
+            "reads_seen": seen,
+            "extraction_ok": extraction_ok,
+            "has_delta": extraction_ok and len(change_set) > 0,
+        }
+
+  # 4) CONDITION - continue to the human approval ONLY when the extraction was sound
+  #    AND a real status delta exists. If the read was bad (extraction_ok False) or
+  #    there is nothing to change, skip straight to the no-op / failure notify - no
+  #    approval is offered and no write can possibly happen.
+  - id: delta_gate
+    type: condition
+    depends_on: [diff_and_validate]
+    condition_config:
+      expression: "{steps.diff_and_validate.output.has_delta} == True"
+      then: [approve_writes]
+      else: [notify_no_writes]
+
+  # 4a) NO-WRITE PATH - either nothing changed or the extraction failed. Report it and
+  #     STOP. Nothing is ever written to the ERP on this path.
+  - id: notify_no_writes
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        Legacy ERP order status sync: no writes performed. Reads seen
+        {steps.diff_and_validate.output.reads_seen}, in-sync
+        {steps.diff_and_validate.output.in_sync_count}, deltas
+        {steps.diff_and_validate.output.change_count}, rejected reads
+        {steps.diff_and_validate.output.rejected_count}, extraction_ok
+        {steps.diff_and_validate.output.extraction_ok}. If extraction_ok is false the
+        ERP UI may have changed (silent redesign / auth wall) - investigate before
+        trusting the next run.
+
+  # 5) MANDATORY HUMAN APPROVAL before the irreversible ERP record mutation. Shows the
+  #    deterministically-built per-order change set (old_status -> new_status) so the
+  #    operator can see exactly what will be written, with allow_edit so they can trim
+  #    or correct rows. BLOCKS until a person authorizes. on_timeout: abort means a
+  #    missed approval NEVER auto-writes to the ERP.
+  - id: approve_writes
+    type: approval
+    approval_config:
+      message: >-
+        Confirm ERP status writes. The following orders will have their fulfillment
+        status pushed into the legacy ERP (irreversible record mutation):
+        {steps.diff_and_validate.output.change_set}. That is
+        {steps.diff_and_validate.output.change_count} order(s); reads seen
+        {steps.diff_and_validate.output.reads_seen}, rejected
+        {steps.diff_and_validate.output.rejected_count}. Review each old->new row.
+        Approve to write to the ERP; edit to trim/correct the rows; reject to abort
+        with nothing written.
+      show_data: steps.diff_and_validate.output.change_set
+      timeout_hours: 8
+      on_timeout: abort
+      allow_edit: true
+
+  # 6) WRITE LOOP - only reached AFTER human approval. Iterates over the approved
+  #    change set; each iteration runs write_order_status, the provider-neutral
+  #    playwright write. The approved change row arrives on _input['_item'].
+  - id: write_order_statuses
+    type: loop
+    depends_on: [approve_writes]
+    loop_config:
+      over: "steps.diff_and_validate.output.change_set"
+      step_ids: [write_order_status]
+      max_iterations: 50
+
+  # 6a) BROWSER (playwright mode - PROVIDER-NEUTRAL WRITE pass). Only runs after the
+  #     human approval. The model authors a deterministic Playwright form-fill script
+  #     from this prompt (provider-neutral, swappable via default_model). It re-opens
+  #     the order's status-edit form (the stateful, CSRF-token-gated multi-field form),
+  #     sets the new status, and clicks save ONCE. capture_screenshots=true keeps a
+  #     tamper-evident audit trail of the write. captcha_strategy=pause hands any
+  #     challenge to a human. max_actions tightly caps the fill so there is no runaway.
+  #     Acceptance is NOT trusted from here - the gate below re-reads the ERP's own
+  #     confirmation. (loop child step - defined separately, read via _input['_item'])
+  - id: write_order_status
+    type: browser
+    browser_config:
+      mode: playwright
+      start_url: "{input.erp_status_form_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 30
+      headless: true
+      credentials_env: "{input.erp_credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          order_id: { type: string }
+          write_confirmed: { type: boolean }
+          confirmation_number: { type: string }
+          confirmation_text: { type: string }
+    prompt: |
+      A human has APPROVED writing a new fulfillment status into the legacy, no-API
+      ERP / order portal. The approved change for THIS order is provided as a JSON
+      object on the loop item: {input._item} - it contains order_id, old_status, and
+      new_status.
+
+      Author a deterministic, provider-neutral Playwright script that:
+      1. Signs in to the ERP using the credentials supplied via the credentials_env
+         environment variable. NEVER hardcode or echo the secret.
+      2. If a CAPTCHA, MFA, or device-verification challenge appears, STOP and hand
+         off to a human (captcha_strategy=pause). Do not attempt to solve it.
+      3. Opens the order STATUS edit form for this order id (substitute the order id
+         into the status-form URL). The form is stateful and CSRF-token-gated, with a
+         token regenerated per page render - read the live form, capture the current
+         CSRF token from the rendered page, and submit it with the form.
+      4. Verifies the form is bound to the SAME order_id as the approved item before
+         touching anything. If the order id on the form does not match, do NOT submit -
+         abort this iteration.
+      5. Sets the fulfillment status field to new_status from the approved item, leaving
+         all other fields intact, and clicks the single Save/Update button ONCE. Do not
+         click save more than once and do not edit unrelated fields.
+      6. Capture a screenshot of the post-save confirmation screen for the audit trail.
+
+      Return ONLY the structured JSON described by the output_schema: order_id,
+      write_confirmed (true only if the ERP UI accepted the save without an error),
+      confirmation_number (any reference the ERP printed, empty string if none), and
+      confirmation_text (the literal on-screen confirmation message the ERP rendered).
+
+  # 7) GATE (llm_eval) - reads the ERP's OWN post-write confirmation text/number from
+  #    every write and confirms the ERP actually ACCEPTED the change. This is the
+  #    act-then-verify check against the portal's own confirmation page; on an llm_eval
+  #    FAIL it does NOT mark the run successful. The judge only reads the confirmation
+  #    evidence (it does not re-do the diff, which already happened deterministically)
+  #    and its model can be raced across providers.
+  - id: confirm_writes_gate
+    type: gate
+    depends_on: [write_order_statuses]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >
+              You are an ERP write-verification reviewer. You are given the per-order
+              results of status writes into a legacy ERP, each carrying write_confirmed,
+              a confirmation_number, and the literal confirmation_text the ERP rendered
+              after save. Answer exactly 'approved' ONLY if EVERY order shows
+              write_confirmed=true AND its confirmation_text/confirmation_number is
+              consistent with the ERP genuinely accepting the status change (a real
+              success/confirmation message, not an error, validation failure, session
+              timeout, or CSRF rejection). If ANY order lacks a credible confirmation,
+              shows an error, or has write_confirmed=false, answer 'rejected' and name
+              the order_id(s) that were not confirmed. Do not re-do any diff - only
+              judge whether the ERP's own confirmation evidence proves acceptance.
+            input: "{steps.write_order_statuses.output}"
+            model: sonnet
+
+  # 8) NOTIFY - post the per-order write confirmations plus audit references (the
+  #    confirmation numbers; screenshots are captured on the write step for the audit
+  #    trail) to operations. Reached only after the llm_eval gate confirms the ERP
+  #    accepted every change, so this is a confirmed-success digest, never a false win.
+  #    (connectors: slack, teams)
+  - id: notify_confirmations
+    type: notify
+    depends_on: [confirm_writes_gate]
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        Legacy ERP order status sync complete and ERP-confirmed. Wrote
+        {steps.diff_and_validate.output.change_count} order status update(s).
+        Per-order write confirmations (order_id, write_confirmed, confirmation_number):
+        {steps.write_order_statuses.output}. Audit screenshots were captured on each
+        write step. In-sync (no change needed):
+        {steps.diff_and_validate.output.in_sync_count}; rejected reads:
+        {steps.diff_and_validate.output.rejected_count}.
+
+on_complete:
+  storage_path: "legacy-erp-order-status-sync/{run_id}/sync-result.json"

--- a/src/sandcastle/templates/onpage_claim_and_price_verifier_vs_source_of_truth.yaml
+++ b/src/sandcastle/templates/onpage_claim_and_price_verifier_vs_source_of_truth.yaml
@@ -1,0 +1,796 @@
+# name: Onpage Claim And Price Verifier Vs Source Of Truth
+# description: Logs into the live storefront as a real (often member-priced, geo-set) customer, reads what the shopper ACTUALLY sees - the JS-assembled rendered price, '50% off' / '#1 rated' / regulatory claim badges, and the displayed legal disclaimer - then DETERMINISTICALLY diffs each against an authoritative source of truth (price DB + approved-claims register) with screenshot proof of every mismatch for the legal / advertising-standards file. The browser runs in provider-neutral playwright mode (the model only authors the load/extract/screenshot script); the price-tolerance check and claim-vs-register matching are pure Python (re.search on an approved-phrasing whitelist), so the FTC/ASA/EU UCPD verdict never depends on one provider. The browser only READS - never adds to cart or checks out; the sole write is an append-only object-lock WORM evidence PUT, sensor-confirmed before success is declared; filing any takedown/correction ticket is gated behind a human approval.
+# tags: [PriceVerification, ClaimSubstantiation, FTC, ASA, UCPD, PriceParity, MSRP, Browser, Playwright, ObjectLock, WORM, SourceOfTruth, TrajectoryReplay, AdvertisingCompliance, RegulatoryAffairs]
+# category: general_ai
+
+name: onpage-claim-and-price-verifier-vs-source-of-truth
+description: >-
+  A scheduled (daily) or event-triggered on-site price-and-claim verifier for the legal /
+  regulatory-affairs or e-commerce compliance team that must PROVE the live storefront's
+  displayed prices and advertising claims match approved sources (FTC/ASA/EU UCPD
+  substantiation, MSRP / price-parity, MiFID / medical / 'organic' claim controls). The
+  legally relevant artifact is the rendered, personalized, JS-assembled page a customer
+  actually sees - prices injected by a pricing engine, A/B'd claim badges, geo/segment
+  banners, and disclaimers loaded late. NONE of that lives in the static HTML or any product
+  API; the price API may say one number while the rendered PDP shows a stale or wrong one. So
+  this workflow drives a REAL (often logged-in or geo-set) browser to capture the as-displayed
+  truth and screenshot it.
+
+  Flow: (1) an http GET loads the authoritative SOURCE OF TRUTH (price DB + approved-claims
+  register) so expected values are pulled fresh, not hardcoded. (2) a deterministic code step
+  builds the per-item audit list (one entry per SKU / claim location) from the watchlist and
+  the source-of-truth payload, failing CLOSED on malformed input so the loop never runs on
+  garbage. (3) a LOOP runs one audit per watchlist item. (3a) a browser step (mode: playwright,
+  provider-neutral) AUTHORS a deterministic Playwright script: load the live PDP / landing page,
+  set the geo / segment if needed, log in via credentials_env only if member pricing is gated,
+  wait for the price / claim / disclaimer elements to settle, extract the AS-DISPLAYED price,
+  currency, discount badge text, claim strings, and disclaimer text, and screenshot them. It
+  returns a STRUCTURED object via output_schema and performs NO outbound or irreversible action -
+  it only reads and screenshots; it never adds to cart, checks out, or submits anything.
+  captcha_strategy pause hands any bot-check to a human; max_actions caps the session. (4) a
+  DETERMINISTIC code step is the audit verdict, no model: it diffs displayed_price vs the
+  source price within tolerance, checks each claim string against the approved register using
+  re.search on a whitelist of sanctioned phrasings, and verifies a required disclaimer is
+  present for any regulated claim - emitting per-item {match, discrepancy_type, severity}. (5) a
+  GATE with TWO strategies (a non-LLM threshold on the discrepancy count / severity that must
+  pass, and a swappable advisory llm_eval that can only FLAG 'claim looks materially misleading
+  vs register' and CANNOT overturn the deterministic price/claim diff) must both pass. (6) an
+  http PUT seals the mismatches + screenshots + canonical diff JSON to an object-lock
+  COMPLIANCE-mode (WORM) S3 bucket as evidence - the only write, append-only. (7) a sensor
+  re-reads the sealed object until the bucket itself confirms the immutable evidence landed,
+  so a silently-failed seal is never mistaken for proof. (8) a condition routes any HIGH-severity
+  mismatch (wrong price live, unsubstantiated claim) to a human APPROVAL - the legal / pricing
+  owner must sign off before a takedown / correction ticket is filed, the only irreversible
+  outbound action. (9) on approval the correction ticket is filed; (10) the compliance channel
+  is notified and a PDF evidence dossier is emitted; (11) a trajectory-replay diffs this run
+  against a golden run so a storefront redesign that silently breaks the extractor is caught as
+  a regression rather than a false PASS.
+
+  PROVIDER NEUTRAL: the browser runs in playwright mode - the model only authors the
+  load/extract/screenshot script and is fully swappable; the price tolerance check and
+  claim-vs-register matching are deterministic Python (re.search on an approved-phrasing
+  whitelist), so the legal verdict never depends on a specific provider. The single optional
+  llm_eval is advisory-only and pinned to a swappable model. SAFETY: member-pricing / login
+  uses credentials_env only (no inline secrets); captcha_strategy pause hands off to a human on
+  any bot-check; max_actions caps the session and the browser only READS the page and
+  screenshots - it never adds to cart, checks out, or submits anything. The sole write is the
+  append-only object-lock S3 evidence PUT (sensor-confirmed); filing any correction / takedown
+  ticket is gated behind a human approval, so no outbound action happens automatically.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 1800
+
+# Default trigger: a daily cron sweep of the SKU / claim watchlist. Fires 05:00 every day.
+# Override per audit calendar. Alternative event triggers (wire externally): a sensor that
+# fires when the source-of-truth price DB / claims register changes, or a marketing-site
+# deploy webhook.
+schedule: "0 5 * * *"
+
+input_schema:
+  required: ["watchlist", "source_of_truth_url", "evidence_bucket_url"]
+  properties:
+    watchlist:
+      type: string
+      description: >-
+        JSON array of watchlist items to verify, each an object with the live page URL and the
+        SKU / claim-location id to look up in the source of truth, e.g.
+        '[{"sku":"ACME-123","url":"https://shop.acme.com/p/acme-123","geo":"DE","segment":"member"}]'.
+        One browser audit runs per item.
+      default: '[{"sku":"ACME-123","url":"https://shop.acme.com/p/acme-123","geo":"DE","segment":"guest"}]'
+      example: '[{"sku":"ACME-123","url":"https://shop.acme.com/p/acme-123","geo":"DE","segment":"member"},{"sku":"ACME-999","url":"https://shop.acme.com/p/acme-999","geo":"US","segment":"guest"}]'
+    source_of_truth_url:
+      type: string
+      description: >-
+        URL of the authoritative source of truth API (price DB + approved-claims register). The
+        http GET pulls expected prices, currency, the per-SKU approved-claim whitelist, and which
+        claims are regulated (require a disclaimer). NEVER hardcode prices in the workflow.
+      default: "https://pricing.internal.acme.com/api/source-of-truth"
+      example: "https://pricing.internal.acme.com/api/v2/source-of-truth"
+    source_of_truth_token_env:
+      type: string
+      description: >-
+        Name of the environment variable holding the bearer token for the source-of-truth API.
+        The value is NEVER inlined; the http step reads it via the env reference.
+      default: "SOURCE_OF_TRUTH_TOKEN"
+      example: "PRICE_DB_READ_TOKEN"
+    store_login_env:
+      type: string
+      description: >-
+        Name of the environment variable holding the storefront login credentials, used by the
+        browser ONLY when the page is behind login or member pricing. NEVER inline secrets. If the
+        page is fully public, the value is unused.
+      default: "STORE_LOGIN"
+      example: "ACME_MEMBER_LOGIN"
+    evidence_bucket_url:
+      type: string
+      description: >-
+        Base URL of the object-lock (WORM) S3 bucket the mismatch screenshots + canonical diff
+        JSON are sealed to via http PUT with x-amz-object-lock COMPLIANCE mode. This is the ONLY
+        write in the workflow and is append-only evidence for the advertising-standards file.
+      default: "https://s3.eu-west-1.amazonaws.com/price-claim-evidence-worm"
+      example: "https://s3.eu-central-1.amazonaws.com/legal-price-evidence-lock"
+    evidence_token_env:
+      type: string
+      description: >-
+        Name of the environment variable holding the bearer token used to PUT evidence to the
+        object-lock bucket, and to GET it back for the sensor confirmation. NEVER inlined.
+      default: "EVIDENCE_BUCKET_TOKEN"
+      example: "LEGAL_EVIDENCE_BUCKET_TOKEN"
+    object_lock_retain_until:
+      type: string
+      description: >-
+        ISO-8601 timestamp the object-lock retention is set to (x-amz-object-lock-retain-until-date).
+        Until this date the evidence cannot be deleted or overwritten - the WORM guarantee the
+        legal / advertising-standards file relies on.
+      default: "2031-06-01T00:00:00Z"
+      example: "2031-06-01T00:00:00Z"
+    price_tolerance:
+      type: number
+      description: >-
+        Absolute currency tolerance allowed when diffing the displayed price vs the source-of-truth
+        price (covers rounding / minor fees). A displayed price outside this band is a mismatch.
+      default: 0.01
+      example: "0.01"
+    high_severity_min:
+      type: number
+      description: >-
+        Threshold: the run is HIGH severity (routed to the legal / pricing owner approval before
+        any takedown / correction ticket is filed) if its high-severity discrepancy count is at
+        least this many. The deterministic diff, not a model, sets the count.
+      default: 1
+      example: "1"
+    ticketing_url:
+      type: string
+      description: >-
+        URL of the ticketing API a correction / takedown ticket is filed to ONLY after a human
+        approves. This is the single irreversible outbound action and never fires automatically.
+      default: "https://tickets.internal.acme.com/api/correction-tickets"
+      example: "https://jira.acme.com/rest/api/2/issue"
+    ticketing_token_env:
+      type: string
+      description: "Name of the environment variable holding the bearer token for the ticketing API. NEVER inlined."
+      default: "TICKETING_TOKEN"
+      example: "JIRA_API_TOKEN"
+    golden_run_id:
+      type: string
+      description: >-
+        ID of the known-good recorded run. The trajectory-replay step diffs THIS run against it and
+        fails below the score floor, so a storefront redesign that silently breaks the price / claim
+        extractor (e.g. the price selector moved) is caught as a regression, not a false PASS.
+      default: "golden-price-claim-audit-2026-05-01"
+      example: "golden-price-claim-audit-2026-05-01"
+    report_author:
+      type: string
+      description: "Name shown as the author on the per-run PDF evidence dossier (legal / regulatory affairs)."
+      default: "Regulatory Affairs"
+      example: "Advertising Standards Counsel - Acme"
+    compliance_channel:
+      type: string
+      description: "Slack channel the compliance team watches for the discrepancy summary and high-severity routing."
+      default: "#price-claim-compliance"
+      example: "#legal-advertising-standards"
+
+steps:
+  # ---------------------------------------------------------------------------
+  # 1) SOURCE OF TRUTH (http GET) - load authoritative expected prices, currency,
+  #    the per-SKU approved-claim whitelist, and which claims are regulated (need a
+  #    disclaimer). Prices are NEVER hardcoded - they come from the price DB / claims
+  #    register here so the diff is against the real approved values. Bearer token via
+  #    env (never inlined). Read-only.
+  # ---------------------------------------------------------------------------
+  - id: load_source_of_truth
+    type: http
+    http_config:
+      url: "{input.source_of_truth_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.SOURCE_OF_TRUTH_TOKEN}"
+
+  # ---------------------------------------------------------------------------
+  # 2) BUILD AUDIT LIST (deterministic, no model). Parses the watchlist JSON and the
+  #    source-of-truth payload, joins each watchlist item to its approved price /
+  #    claim whitelist by SKU, and tags each with the live URL + geo/segment. Fails
+  #    CLOSED (empty list) on malformed input so the loop never runs on garbage. Pure
+  #    Python, no model decides anything here.
+  # ---------------------------------------------------------------------------
+  - id: build_audit_list
+    type: code
+    depends_on: [load_source_of_truth]
+    code_config:
+      language: python
+      code: |
+        import json
+
+        raw_watch = _input.get('watchlist') or '[]'
+        if isinstance(raw_watch, list):
+            watch = raw_watch
+        else:
+            try:
+                watch = json.loads(str(raw_watch))
+            except (ValueError, TypeError):
+                watch = []
+        if not isinstance(watch, list):
+            watch = []
+
+        # Source-of-truth payload from the http GET. The runtime may nest the JSON body
+        # under output/data/body/response - unwrap defensively without a model.
+        sot = _steps.get('load_source_of_truth') or {}
+        if isinstance(sot, str):
+            try:
+                sot = json.loads(sot) if sot.strip() else {}
+            except (ValueError, TypeError):
+                sot = {}
+        if not isinstance(sot, dict):
+            sot = {}
+        for key in ('output', 'data', 'body', 'response', 'json'):
+            inner = sot.get(key)
+            if isinstance(inner, dict) and ('items' in inner or 'skus' in inner or 'prices' in inner):
+                sot = inner
+                break
+
+        # Build a SKU -> approved record index from the source of truth. Accept a few
+        # common shapes (a list under items/skus/prices, or a dict keyed by sku).
+        sot_index = {}
+        candidates = sot.get('items') or sot.get('skus') or sot.get('prices') or []
+        if isinstance(candidates, dict):
+            candidates = [dict(v or {}, sku=k) for k, v in candidates.items()]
+        if not isinstance(candidates, list):
+            candidates = []
+        for rec in candidates:
+            if not isinstance(rec, dict):
+                continue
+            sku = str(rec.get('sku') or rec.get('id') or '').strip()
+            if not sku:
+                continue
+            sot_index[sku] = rec
+
+        audit_list = []
+        skipped = []
+        seen = set()
+        for item in watch:
+            if not isinstance(item, dict):
+                skipped.append({'reason': 'watchlist item not an object', 'item': str(item)[:120]})
+                continue
+            sku = str(item.get('sku') or item.get('id') or '').strip()
+            url = str(item.get('url') or '').strip()
+            if not sku or not (url.startswith('http://') or url.startswith('https://')):
+                skipped.append({'reason': 'missing sku or invalid url', 'sku': sku, 'url': url})
+                continue
+            key = sku + '|' + url.lower().rstrip('/')
+            if key in seen:
+                continue
+            seen.add(key)
+            sot_rec = sot_index.get(sku) or {}
+            audit_list.append({
+                'sku': sku,
+                'url': url,
+                'geo': str(item.get('geo') or '').strip(),
+                'segment': str(item.get('segment') or 'guest').strip(),
+                # Approved expectations pulled from the source of truth (NOT hardcoded):
+                'expected_price': sot_rec.get('price'),
+                'expected_currency': str(sot_rec.get('currency') or '').strip(),
+                # Whitelist of sanctioned claim phrasings approved for this SKU.
+                'approved_claims': sot_rec.get('approved_claims') if isinstance(sot_rec.get('approved_claims'), list) else [],
+                # Claim phrasings that are regulated and REQUIRE a visible disclaimer.
+                'regulated_claims': sot_rec.get('regulated_claims') if isinstance(sot_rec.get('regulated_claims'), list) else [],
+                'sot_found': sku in sot_index,
+            })
+
+        result = {
+            'audit_list': audit_list,
+            'count': len(audit_list),
+            'skipped': skipped,
+            'source_of_truth_skus': len(sot_index),
+            'ok': len(audit_list) > 0,
+        }
+
+  # ---------------------------------------------------------------------------
+  # 3) LOOP over each watchlist item. Each iteration runs the per-item browser audit
+  #    (child audit_one_item) reading the current target via _item. max_iterations
+  #    caps the sweep so a huge watchlist cannot run unbounded. Downstream depends on
+  #    the loop.
+  # ---------------------------------------------------------------------------
+  - id: audit_loop
+    type: loop
+    depends_on: [build_audit_list]
+    loop_config:
+      over: "steps.build_audit_list.output.audit_list"
+      step_ids: [audit_one_item]
+      max_iterations: 500
+
+  # 3a) PER-ITEM ON-SITE AUDIT (mode: playwright, the READ pass). The reasoning model
+  #     only AUTHORS a deterministic Playwright script from the prompt; the script +
+  #     output_schema make this provider-neutral and a pure READ (load, set geo/segment,
+  #     wait for elements to settle, extract, screenshot). It mutates NOTHING outbound -
+  #     it NEVER adds to cart, checks out, or submits. capture_screenshots ON for the WORM
+  #     evidence; captcha_strategy pause hands any bot-check to a human; max_actions caps
+  #     the session. credentials_env is used ONLY if the page is behind login / member
+  #     pricing (secret never inlined). Operates on ONE item (_item) only.
+  - id: audit_one_item
+    type: browser
+    prompt: >-
+      You are verifying what a real customer ACTUALLY sees on a live storefront page so a legal
+      / advertising-standards diff can be run. The target watchlist item is: {{ _item }}.
+      Author and run a deterministic Playwright script that does EXACTLY this and nothing else:
+      (1) Open the page at {{ _item.url }}. If a geo is given ({{ _item.geo }}), set the store
+      region / locale to it (locale selector, geo cookie, or region switcher) so the personalized
+      price renders. If the segment is 'member' ({{ _item.segment }}) and the page is behind login
+      or member pricing, log in using ONLY the credentials provided via the STORE_LOGIN environment
+      variable - never type any inline secret. If the page is public, do not log in.
+      (2) WAIT for the price, discount badge, claim badges, and legal disclaimer elements to fully
+      settle (the price is injected late by the pricing engine; claim badges may be A/B'd; the
+      disclaimer often loads last). Do not read a half-rendered page.
+      (3) Extract the AS-DISPLAYED values verbatim: displayed_price (the numeric price the customer
+      sees), displayed_currency, discount_badge (the literal text of any '50% off' / sale badge),
+      claim_strings (every marketing / rating / regulatory claim string shown, e.g. '#1 rated',
+      'clinically proven', 'organic'), disclaimer_present (is a legal disclaimer visible), and
+      disclaimer_text (its literal text). List claim strings verbatim - do NOT judge which are
+      approved; the deterministic step does that.
+      (4) Take screenshots of the price area, any claim badges, and the disclaimer for the evidence
+      record (add their references to screenshot_refs).
+      CRITICAL: this is strictly READ + screenshot. Do NOT add to cart, do NOT begin checkout, do
+      NOT click buy/pay, do NOT submit any form or newsletter, do NOT navigate to purchase. If a
+      CAPTCHA or bot-check appears, PAUSE for a human rather than solving it. Return ONLY the
+      structured object described by the output schema.
+    browser_config:
+      mode: playwright
+      start_url: "{{ _item.url }}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 30
+      headless: true
+      credentials_env: "STORE_LOGIN"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          sku:
+            type: string
+            description: "Echo of the audited SKU (for reconciliation with the source of truth)."
+          url:
+            type: string
+            description: "Echo of the audited live page URL."
+          displayed_price:
+            type: number
+            description: "The numeric price as RENDERED to the customer (after the pricing engine injects it)."
+          displayed_currency:
+            type: string
+            description: "The currency code/symbol shown next to the displayed price."
+          discount_badge:
+            type: string
+            description: "Literal text of any discount / sale badge shown (e.g. '50% off'), empty if none."
+          claim_strings:
+            type: array
+            description: "Every marketing / rating / regulatory claim string displayed (raw, unjudged)."
+            items: { type: string }
+          disclaimer_present:
+            type: boolean
+            description: "Is a legal disclaimer visible on the page?"
+          disclaimer_text:
+            type: string
+            description: "Literal text of the displayed legal disclaimer, empty if none."
+          screenshot_refs:
+            type: array
+            description: "References to the price / claim / disclaimer screenshots captured for the evidence record."
+            items: { type: string }
+        required:
+          - sku
+          - url
+          - displayed_price
+          - claim_strings
+          - disclaimer_present
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: abort
+
+  # ---------------------------------------------------------------------------
+  # 4) DETERMINISTIC DIFF (no model) - the audit-load-bearing verdict. For each item:
+  #    VALIDATE the browser read (reject empty/malformed so a blank scrape never passes),
+  #    diff displayed_price vs the source-of-truth price within price_tolerance, check
+  #    each displayed claim string against the approved register using re.search on a
+  #    whitelist of sanctioned phrasings, and verify a required disclaimer is present for
+  #    any regulated claim. Emits per-item {match, discrepancy_type, severity}. This
+  #    boolean / regex math, NOT any model, is the legal verdict.
+  # ---------------------------------------------------------------------------
+  - id: compute_diff
+    type: code
+    depends_on: [audit_loop, build_audit_list]
+    code_config:
+      language: python
+      code: |
+        import json
+
+        try:
+            tolerance = abs(float(_input.get('price_tolerance', 0.01)))
+        except (TypeError, ValueError):
+            tolerance = 0.01
+
+        # Approved expectations per SKU from the deterministic audit list (sourced from the
+        # price DB / claims register, never a model).
+        audit_meta = _steps.get('build_audit_list') or {}
+        if not isinstance(audit_meta, dict):
+            audit_meta = {}
+        expected_by_sku = {}
+        for entry in (audit_meta.get('audit_list') or []):
+            if isinstance(entry, dict) and entry.get('sku'):
+                expected_by_sku[str(entry['sku'])] = entry
+
+        # Per-item browser results from the loop output.
+        loop_out = _steps.get('audit_loop') or {}
+        if isinstance(loop_out, list):
+            items = loop_out
+        elif isinstance(loop_out, dict):
+            items = loop_out.get('results') or loop_out.get('items') or []
+        else:
+            items = []
+        if not isinstance(items, list):
+            items = []
+
+        def _num(v):
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return None
+
+        def _claim_matches_register(displayed_claim, approved_list):
+            # Whitelist match: a displayed claim is APPROVED only if it matches one of the
+            # sanctioned phrasings via a word-boundary, case-insensitive re.search. The
+            # approved phrasing is the pattern; the displayed claim is the text.
+            disp = str(displayed_claim or '').strip()
+            if not disp:
+                return True  # empty string is not a claim
+            for phrase in approved_list:
+                pat = str(phrase or '').strip()
+                if not pat:
+                    continue
+                # Escape the approved phrase so it is treated literally, then bound it.
+                escaped = re.sub(r'([.^$*+?{}\[\]\\|()])', r'\\\1', pat)
+                if re.search(r'(?i)\b' + escaped + r'\b', disp):
+                    return True
+                # Also allow the displayed claim to be a sanctioned substring match the
+                # other way (register phrase fully contained in the displayed string).
+                if re.search(r'(?i)\b' + re.sub(r'([.^$*+?{}\[\]\\|()])', r'\\\1', disp) + r'\b', pat):
+                    return True
+            return False
+
+        per_item = []
+        for raw in items:
+            rec = raw
+            if isinstance(rec, str):
+                try:
+                    rec = json.loads(rec) if rec.strip() else {}
+                except (ValueError, TypeError):
+                    rec = {}
+            if not isinstance(rec, dict):
+                rec = {}
+            for key in ('output', 'data', 'result'):
+                inner = rec.get(key)
+                if isinstance(inner, dict) and 'sku' in inner:
+                    rec = inner
+                    break
+
+            sku = str(rec.get('sku') or '').strip()
+            url = str(rec.get('url') or '').strip()
+            displayed_price = _num(rec.get('displayed_price'))
+            displayed_currency = str(rec.get('displayed_currency') or '').strip()
+            discount_badge = str(rec.get('discount_badge') or '').strip()
+            claim_strings = rec.get('claim_strings')
+            if not isinstance(claim_strings, list):
+                claim_strings = []
+            disclaimer_present = bool(rec.get('disclaimer_present'))
+            disclaimer_text = str(rec.get('disclaimer_text') or '').strip()
+            screenshots = rec.get('screenshot_refs')
+            if not isinstance(screenshots, list):
+                screenshots = []
+
+            exp = expected_by_sku.get(sku) or {}
+            expected_price = _num(exp.get('expected_price'))
+            expected_currency = str(exp.get('expected_currency') or '').strip()
+            approved_claims = exp.get('approved_claims') if isinstance(exp.get('approved_claims'), list) else []
+            regulated_claims = exp.get('regulated_claims') if isinstance(exp.get('regulated_claims'), list) else []
+
+            discrepancies = []
+
+            # --- VALIDATE the read: a trustworthy audit needs a sku and a numeric price.
+            read_ok = True
+            if not sku.startswith(''):
+                pass
+            if not sku:
+                discrepancies.append({'type': 'invalid_read_no_sku', 'severity': 'high'})
+                read_ok = False
+            if displayed_price is None:
+                discrepancies.append({'type': 'invalid_read_no_price', 'severity': 'high'})
+                read_ok = False
+            if not exp.get('sot_found', False) and not expected_by_sku.get(sku):
+                discrepancies.append({'type': 'no_source_of_truth_record', 'severity': 'high'})
+
+            # --- PRICE diff within tolerance (deterministic math) ---------------------
+            if read_ok and expected_price is not None and displayed_price is not None:
+                delta = abs(displayed_price - expected_price)
+                if delta > tolerance:
+                    discrepancies.append({
+                        'type': 'price_mismatch',
+                        'severity': 'high',
+                        'displayed': round(displayed_price, 2),
+                        'expected': round(expected_price, 2),
+                        'delta': round(delta, 2),
+                    })
+            elif read_ok and expected_price is None:
+                discrepancies.append({'type': 'no_expected_price_in_source', 'severity': 'medium'})
+
+            # --- CURRENCY check -------------------------------------------------------
+            if expected_currency and displayed_currency and displayed_currency.upper() != expected_currency.upper():
+                discrepancies.append({
+                    'type': 'currency_mismatch', 'severity': 'medium',
+                    'displayed': displayed_currency, 'expected': expected_currency,
+                })
+
+            # --- CLAIM check vs approved register (re.search whitelist) ---------------
+            unapproved_claims = []
+            for claim in claim_strings:
+                if not _claim_matches_register(claim, approved_claims):
+                    unapproved_claims.append(str(claim).strip())
+            # The discount badge is itself an advertising claim - it must also be approved.
+            if discount_badge and not _claim_matches_register(discount_badge, approved_claims):
+                unapproved_claims.append(discount_badge)
+            if unapproved_claims:
+                discrepancies.append({
+                    'type': 'unsubstantiated_claim', 'severity': 'high',
+                    'claims': unapproved_claims,
+                })
+
+            # --- DISCLAIMER required for any displayed regulated claim ----------------
+            regulated_shown = []
+            for reg in regulated_claims:
+                # A regulated phrasing is "shown" if it appears in any displayed claim.
+                reg_pat = re.sub(r'([.^$*+?{}\[\]\\|()])', r'\\\1', str(reg or '').strip())
+                if not reg_pat:
+                    continue
+                for claim in (claim_strings + [discount_badge]):
+                    if claim and re.search(r'(?i)\b' + reg_pat + r'\b', str(claim)):
+                        regulated_shown.append(str(reg).strip())
+                        break
+            if regulated_shown and not disclaimer_present:
+                discrepancies.append({
+                    'type': 'missing_required_disclaimer', 'severity': 'high',
+                    'regulated_claims_shown': regulated_shown,
+                })
+
+            severities = [str(d.get('severity', 'low')) for d in discrepancies]
+            high_count = severities.count('high')
+            item_severity = 'high' if high_count else ('medium' if 'medium' in severities else ('low' if discrepancies else 'none'))
+
+            per_item.append({
+                'sku': sku,
+                'url': url,
+                'match': len(discrepancies) == 0,
+                'displayed_price': displayed_price,
+                'expected_price': expected_price,
+                'displayed_currency': displayed_currency,
+                'discount_badge': discount_badge,
+                'unapproved_claims': unapproved_claims,
+                'regulated_claims_shown': regulated_shown,
+                'disclaimer_present': disclaimer_present,
+                'discrepancies': discrepancies,
+                'discrepancy_count': len(discrepancies),
+                'high_severity_count': high_count,
+                'severity': item_severity,
+                'screenshot_refs': screenshots,
+            })
+
+        total_items = len(per_item)
+        mismatched = [d for d in per_item if not d['match']]
+        total_discrepancies = sum(d['discrepancy_count'] for d in per_item)
+        high_severity_count = sum(d['high_severity_count'] for d in per_item)
+        max_item_high = max((d['high_severity_count'] for d in per_item), default=0)
+
+        result = {
+            'per_item': per_item,
+            'total_items': total_items,
+            'mismatched_count': len(mismatched),
+            'total_discrepancies': total_discrepancies,
+            'high_severity_count': high_severity_count,
+            'max_item_high_severity': max_item_high,
+            'all_match': total_discrepancies == 0 and total_items > 0,
+            'price_tolerance': tolerance,
+        }
+
+  # ---------------------------------------------------------------------------
+  # 5) GATE - TWO strategies, BOTH must pass, before evidence is sealed:
+  #    (a) a NON-LLM threshold asserting the deterministic verdict is internally
+  #        consistent (the mismatch set cannot exceed the audited set, at least one
+  #        item was audited, high-severity count is non-negative);
+  #    (b) a SWAPPABLE advisory llm_eval that may only FLAG 'a claim looks materially
+  #        misleading vs the register'. It is advisory ONLY - it CANNOT overturn the
+  #        deterministic price/claim diff above (that code output is the source of
+  #        truth). Pinned to a swappable model alias.
+  # ---------------------------------------------------------------------------
+  - id: discrepancy_gate
+    type: gate
+    depends_on: [compute_diff]
+    gate_config:
+      strategies:
+        # (a) NON-LLM threshold: structural consistency of the deterministic verdict.
+        - type: threshold
+          config:
+            input: "{steps.compute_diff.output}"
+            expression: "mismatched_count <= total_items and total_items > 0 and high_severity_count >= 0"
+            description: >-
+              Non-LLM consistency check on the deterministic diff: the mismatched set cannot exceed
+              the audited set, at least one item was audited, and the high-severity count is valid.
+              This strategy reads the boolean math only - it does NOT re-judge prices or claims.
+        # (b) SWAPPABLE advisory llm_eval: flags materially-misleading intent, cannot overturn the diff.
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are an advertising-standards reviewer. You are given the DETERMINISTIC
+              price/claim audit verdict for a set of items. Do NOT recompute or overturn the
+              price diffs or claim matches - they are authoritative. Your ONLY job is an advisory
+              flag: reply 'approved' if the verdict record is internally consistent and safe to
+              seal as evidence (per-item discrepancy lists match their counts, mismatched items
+              are the ones with discrepancies). Reply 'approved' even if discrepancies exist - the
+              presence of violations does not block sealing the evidence; only an INCONSISTENT
+              record should be 'rejected' with the inconsistency named. This is advisory labeling
+              only and cannot change the deterministic count. Verdict: {steps.compute_diff.output}
+            input: "{steps.compute_diff.output}"
+            model: mistral/large
+
+  # ---------------------------------------------------------------------------
+  # 6) SEAL EVIDENCE (the ONLY write) - http PUT the mismatches + screenshots + canonical
+  #    diff JSON to the object-lock S3 bucket in COMPLIANCE mode (WORM). x-amz-object-lock
+  #    -mode COMPLIANCE + retain-until make this append-only, undeletable evidence for the
+  #    advertising-standards file. Bearer token via env (never inlined). Runs only AFTER the
+  #    two-strategy gate passes. Appends an immutable object - no destructive action.
+  # ---------------------------------------------------------------------------
+  - id: seal_evidence_worm
+    type: http
+    depends_on: [discrepancy_gate]
+    http_config:
+      url: "{input.evidence_bucket_url}/{run_id}/price-claim-diff.json"
+      method: PUT
+      headers:
+        Content-Type: "application/json"
+        x-amz-object-lock-mode: "COMPLIANCE"
+        x-amz-object-lock-retain-until-date: "{input.object_lock_retain_until}"
+      auth: "bearer:{env.EVIDENCE_BUCKET_TOKEN}"
+      body: '{"run_id": "{run_id}", "sealed_at": "{input.object_lock_retain_until}", "total_items": "{steps.compute_diff.output.total_items}", "mismatched_count": "{steps.compute_diff.output.mismatched_count}", "total_discrepancies": "{steps.compute_diff.output.total_discrepancies}", "high_severity_count": "{steps.compute_diff.output.high_severity_count}", "max_item_high_severity": "{steps.compute_diff.output.max_item_high_severity}", "per_item": "{steps.compute_diff.output.per_item}"}'
+
+  # ---------------------------------------------------------------------------
+  # 7) CONFIRM SEAL (engine-native SENSOR) - the seal-then-VERIFY core. Re-GET the sealed
+  #    object from the object-lock bucket until the bucket itself confirms the immutable
+  #    evidence landed (HTTP 200 and the object-lock retain-until header / body echoes the
+  #    run). A provider-agnostic boolean over the polled response - pure control flow, no
+  #    model. Hard timeout so we never wait forever; a timeout is NOT treated as a
+  #    successful seal, so a silently-failed PUT can never be mistaken for sealed evidence.
+  # ---------------------------------------------------------------------------
+  - id: confirm_seal
+    type: sensor
+    depends_on: [seal_evidence_worm]
+    sensor_config:
+      url: "{input.evidence_bucket_url}/{run_id}/price-claim-diff.json"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and str(response.get('run_id', '')).strip() != ''"
+      check_interval: 30
+      timeout: 1800
+
+  # ---------------------------------------------------------------------------
+  # 8) CONDITION - route on the DETERMINISTIC severity. If any item reaches the high-severity
+  #    floor (wrong price live, unsubstantiated claim), send it to a human APPROVAL: the legal
+  #    / pricing owner reviews the sealed evidence BEFORE any takedown / correction ticket is
+  #    filed. Otherwise skip straight to the dossier. The boolean math decides the branch.
+  # ---------------------------------------------------------------------------
+  - id: route_severity
+    type: condition
+    depends_on: [confirm_seal]
+    condition_config:
+      expression: "{steps.compute_diff.output.max_item_high_severity} >= {input.high_severity_min}"
+      then: [owner_approval, build_dossier]
+      else: [build_dossier]
+
+  # 8a) HIGH-SEVERITY PATH - the SINGLE human gate before anything leaves the org. The legal /
+  #     pricing owner reviews the sealed evidence and the per-item discrepancies and AUTHORIZES
+  #     (or rejects) filing a takedown / correction ticket. NOTHING is filed automatically.
+  #     on_timeout abort means a missed review never auto-files; allow_edit lets the owner trim
+  #     the item set before filing.
+  - id: owner_approval
+    type: approval
+    depends_on: [route_severity]
+    approval_config:
+      message: >-
+        LEGAL / PRICING OWNER REVIEW REQUIRED - one or more live items breached the source of
+        truth at HIGH severity (wrong price live and/or an unsubstantiated advertising claim).
+        Evidence has been sealed to the object-lock WORM bucket and confirmed. APPROVE to authorize
+        filing a takedown / correction ticket, REJECT to hold. Mismatched items:
+        {steps.compute_diff.output.mismatched_count} of {steps.compute_diff.output.total_items};
+        total discrepancies: {steps.compute_diff.output.total_discrepancies}; high-severity
+        discrepancies: {steps.compute_diff.output.high_severity_count}; worst item high-severity
+        count: {steps.compute_diff.output.max_item_high_severity}. Nothing is filed until you approve.
+      show_data: steps.compute_diff.output
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: true
+
+  # 8b) FILE CORRECTION TICKET (the only IRREVERSIBLE OUTBOUND action) - reached ONLY after the
+  #     human approval above. http POST a correction / takedown ticket to the ticketing API.
+  #     Bearer token via env (never inlined). This never fires without sign-off.
+  - id: file_correction_ticket
+    type: http
+    depends_on: [owner_approval]
+    http_config:
+      url: "{input.ticketing_url}"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+      auth: "bearer:{env.TICKETING_TOKEN}"
+      body: '{"title": "On-site price/claim correction - run {run_id}", "run_id": "{run_id}", "mismatched_count": "{steps.compute_diff.output.mismatched_count}", "high_severity_count": "{steps.compute_diff.output.high_severity_count}", "evidence_url": "{input.evidence_bucket_url}/{run_id}/price-claim-diff.json", "per_item": "{steps.compute_diff.output.per_item}", "authorized_by_human_approval": true}'
+
+  # ---------------------------------------------------------------------------
+  # 9) REPORT - per-run PDF evidence dossier with embedded mismatch screenshots. Built from the
+  #    deterministic diff + sealed-evidence references so the document the legal / advertising
+  #    -standards file relies on is reproducible. Runs on both branches.
+  # ---------------------------------------------------------------------------
+  - id: build_dossier
+    type: report
+    depends_on: [route_severity]
+    report_config:
+      template: research-report
+      format: pdf
+      theme: professional
+      title: "On-Site Price & Claim vs Source-of-Truth Evidence Dossier - {run_id}"
+      author: "{input.report_author}"
+    prompt: |
+      Produce a per-run on-site price-and-claim compliance evidence dossier (PDF) for the legal /
+      regulatory-affairs file from the DETERMINISTIC audit payload below. Structure it as:
+      1. Executive summary: total items audited ({steps.compute_diff.output.total_items}),
+      mismatched ({steps.compute_diff.output.mismatched_count}), total discrepancies
+      ({steps.compute_diff.output.total_discrepancies}), high-severity discrepancies
+      ({steps.compute_diff.output.high_severity_count}).
+      2. A per-item table: for each item show the SKU, the URL, the displayed price vs the
+      source-of-truth expected price (and delta), the displayed currency, the discount badge, the
+      list of unapproved / unsubstantiated claim strings, any regulated claim shown without a
+      required disclaimer, and the explicit discrepancy list with severities.
+      3. For each mismatched item, embed the captured price / claim / disclaimer screenshots
+      (screenshot_refs) as the timestamped proof of the as-displayed behavior - the legally
+      load-bearing artifact no price API can produce.
+      4. An evidence-integrity note: state that the canonical diff JSON + screenshots were sealed
+      to an object-lock (WORM, COMPLIANCE-mode) bucket and the seal was sensor-confirmed, so the
+      record is tamper-evident and defensible against an FTC / ASA / EU UCPD challenge.
+      Do NOT invent SKUs, prices, or claims - use only the payload.
+      Verdict payload: {steps.compute_diff.output}
+
+  # ---------------------------------------------------------------------------
+  # 10) TRAJECTORY-REPLAY - the reliability layer. Diffs THIS run against a golden_run_id and
+  #     FAILS below fail_below_score (UI drift, e.g. a storefront redesign that moved the price
+  #     selector and silently broke the extractor) or on a cost blowup. Deterministic scorer,
+  #     not a model's opinion: it compares the observable browser actions + extracted outputs.
+  #     Catches a silently-broken extractor (a false PASS) as a regression before it is trusted.
+  # ---------------------------------------------------------------------------
+  - id: replay_vs_golden
+    type: trajectory-replay
+    depends_on: [build_dossier]
+    trajectory_replay_config:
+      golden_run_id: "{input.golden_run_id}"
+      fail_below_score: 0.85
+      allow_cost_delta_pct: 15.0
+      cost_budget_usd: 0.5
+
+  # ---------------------------------------------------------------------------
+  # 11) NOTIFY the compliance channel with the discrepancy summary + evidence + replay verdict.
+  # ---------------------------------------------------------------------------
+  - id: notify_compliance
+    type: notify
+    depends_on: [replay_vs_golden, compute_diff]
+    notify_config:
+      service: slack
+      channel: "{input.compliance_channel}"
+      message: "On-site price/claim vs source-of-truth audit complete. Items: {steps.compute_diff.output.total_items} | Mismatched: {steps.compute_diff.output.mismatched_count} | Total discrepancies: {steps.compute_diff.output.total_discrepancies} | High-severity: {steps.compute_diff.output.high_severity_count} | Worst item high-severity: {steps.compute_diff.output.max_item_high_severity} | Evidence sealed + sensor-confirmed in object-lock WORM bucket for run {run_id} | Per-run PDF dossier generated. High-severity findings (if any) were routed to the legal/pricing owner approval before any correction/takedown ticket was filed."
+
+on_complete:
+  storage_path: "onpage-claim-and-price-verifier-vs-source-of-truth/{run_id}/result.json"

--- a/src/sandcastle/templates/osha_environmental_compliance_report_filer.yaml
+++ b/src/sandcastle/templates/osha_environmental_compliance_report_filer.yaml
@@ -1,0 +1,768 @@
+# name: OSHA Environmental Compliance Report Filer
+# description: Files an annual regulatory EHS report (OSHA Injury Tracking Application Form 300A, EPA / state environmental reporting, or a local permit-renewal system) into a login-gated government portal that exposes NO bulk-filing API for most establishments - the certification checkbox and electronic-signature submission live only in the browser UI. Triggered by an annual-deadline schedule cron, gated by a sensor that confirms the source safety data is finalized. Loads the establishment's finalized annual figures (total hours worked, case counts, NAICS, headcount) from the EHS data store, deterministically validates internal consistency (total cases >= cases-with-days-away, hours plausible vs headcount, reporting year matches) and fails CLOSED on contradiction, reads the establishment list READ-ONLY in cheap provider-neutral dom/lightpanda mode, escalates to provider-neutral Playwright only when the form needs interactive JS, fills the Form 300A pages and STOPS at the review/sign page, deterministically asserts the portal-side totals equal the validated source figures (anti-transcription guard), holds for the EHS officer (the legal certifier) to approve the review summary + screenshot, only then certifies + submits and captures the agency confirmation ID + certified receipt, archives the receipt to the audit chain and notifies compliance leadership. Secrets only via credentials_env=EHS_PORTAL_CREDS, captcha_strategy=pause for login challenges, max_actions caps each browser step, capture_screenshots on every write for the EU-AI-Act audit trail. The load-bearing correctness is deterministic Python plus a portal-confirmation sensor, never one model's opinion; both browser modes are neutral (the model authors the automation), so the reasoning provider is freely swappable. No vendor agent runtime is involved.
+# tags: [OSHA, ITA, Form300A, EPA, Environmental, EHS, Compliance, Filing, Playwright, DOM, Lightpanda, RPA, HumanApproval, Certify, Sensor, ProviderNeutral, AuditTrail]
+# category: hr_legal
+
+name: osha-environmental-compliance-report-filer
+description: >-
+  Logs into a regulatory EHS portal (OSHA Injury Tracking Application Form 300A, EPA / state
+  environmental reporting, or a local permit-renewal system), enters the annual compliance figures,
+  certifies, submits, and captures the agency confirmation ID and certified receipt - on behalf of
+  the EHS (Environmental Health & Safety) compliance officer at a manufacturer or multi-site operator
+  who must file annual injury/illness or emissions data into government portals by a hard statutory
+  deadline. These portals are login-gated web apps with certification checkboxes and electronic
+  signature steps and expose NO bulk filing API for most establishments, so submission and the
+  certify/sign action exist only in the browser UI; a plain http step cannot authenticate, walk the
+  form, check the certification box, or click Submit. The flow splits read from write and fails
+  closed. It is triggered by an annual-deadline schedule cron (fires in the weeks before the
+  statutory due date) and gated by a sensor that confirms the source safety data is finalized. Step 1
+  loads the establishment's finalized annual figures (total hours worked, total recordable cases,
+  cases with days away, deaths, NAICS, average headcount, reporting year) from the EHS data store
+  (PostgreSQL/warehouse exposed over an internal read API). Step 2 is deterministic sandboxed Python
+  that validates internal consistency - total cases must be >= cases-with-days-away, hours worked must
+  be plausible against headcount, the reporting year must match the intended filing year - and fails
+  CLOSED on any contradiction so a bad figure set never reaches the portal. Step 3 first attempts the
+  cheap, provider-neutral lightweight headless path (dom / lightpanda mode) to log in and read the
+  establishment list READ-ONLY, returning {establishments, filing_year, portal_status} via
+  output_schema. Step 4 is a condition: if the form requires interactive JS the dom read could not
+  drive, it falls through to a provider-neutral Playwright browser step that fills the Form 300A pages,
+  checks the certification box, advances to the review/sign page and STOPS, returning {establishment_id,
+  totals, certification_text, review_summary, review_screenshot} via output_schema. Step 5 is the
+  load-bearing deterministic anti-transcription guard: it asserts the portal-side totals equal the
+  validated source figures from step 2 within tolerance and blocks submission on any drift. Step 6 is
+  a mandatory human approval - the EHS officer is the legal certifier, so they must explicitly approve
+  the review_summary + screenshot before any certify/submit, naming themselves as the certifier.
+  Step 7 resumes the Playwright session, applies the electronic certification + signature and clicks
+  Submit ONCE, capturing the agency confirmation_id + certified receipt screenshot. Step 8 polls the
+  portal's own filing-status endpoint with a sensor until it confirms the filing as accepted - a
+  clicked Submit is never trusted as a landed filing. Step 9 archives the certified receipt to the
+  audit chain (S3 / MinIO object storage over a PUT URL), and a notify confirms to compliance
+  leadership. Both browser steps ride default_model and swap freely across the providers; the dom and
+  Playwright modes are both neutral (the model authors the automation from the prompt + DOM), so the
+  reasoning provider is freely routable via race/failover. The deterministic validators, the
+  anti-transcription re-check, and the portal-confirmation sensor make reliability a property of
+  deterministic code and recorded portal state, never of a particular model.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 1800
+
+# Default trigger: an annual-deadline cron. OSHA ITA Form 300A is due 1 March each year; this fires
+# 09:00 on 1 February to give weeks of lead time before the statutory due date. Override per filing
+# calendar (EPA / state environmental / local permit-renewal cadences differ). The data_finalized
+# sensor below blocks until the source safety data is actually closed, so we never file half-final
+# figures even if the cron fires early.
+schedule: "0 9 1 2 *"
+
+input_schema:
+  required: ["establishment_key", "filing_year", "figures_api_url", "portal_login_url"]
+  properties:
+    establishment_key:
+      type: string
+      description: "Establishment / facility key for the filing (drives the data pull, the storage path, and the Slack message). For a multi-site operator this identifies which establishment's 300A is being filed."
+      example: "plant-ohio-04"
+    filing_year:
+      type: integer
+      description: "The calendar year the annual figures cover and the portal must file under. The deterministic validator rejects a year mismatch; a missed year is never silently filed under the wrong period."
+      example: "2025"
+    figures_api_url:
+      type: string
+      description: "Internal read API over the EHS data store (PostgreSQL / safety-data warehouse) that returns the establishment's finalized annual figures: total_hours_worked, total_recordable_cases, cases_with_days_away, cases_job_transfer_restriction, deaths, naics, avg_headcount, reporting_year. Pulled by the http step (deterministic)."
+      example: "https://ehs.internal/api/establishments/plant-ohio-04/form300a?year=2025"
+    portal_login_url:
+      type: string
+      description: "Login URL of the government EHS portal SPA where filing begins (OSHA ITA, EPA / state environmental, or local permit-renewal). Login-gated, no bulk filing API. Templated into both browser steps' start_url."
+      example: "https://www.osha.gov/injuryreporting/ita/"
+    credentials_env:
+      type: string
+      description: "Name of the environment variable holding the EHS portal login credentials (NEVER inline secrets). Passed to both browser steps' credentials_env. Default EHS_PORTAL_CREDS."
+      default: "EHS_PORTAL_CREDS"
+      example: "EHS_PORTAL_CREDS"
+    data_finalized_url:
+      type: string
+      description: "Endpoint the data_finalized sensor polls; returns 200 with finalized=true once the upstream safety-data close for this establishment+year is locked. Blocks the filing until the source figures are truly final."
+      default: "https://ehs.internal/api/establishments/status"
+      example: "https://ehs.internal/api/establishments/status?key=plant-ohio-04&year=2025"
+    portal_status_url:
+      type: string
+      description: "The portal's own filing-status endpoint for this establishment+year; the confirmation sensor polls it until the filing reads accepted/received. A clicked Submit is never trusted on its own."
+      default: "https://www.osha.gov/injuryreporting/ita/api/status"
+      example: "https://www.osha.gov/injuryreporting/ita/api/status?key=plant-ohio-04&year=2025"
+    receipt_archive_url:
+      type: string
+      description: "Object-storage (S3/MinIO/GCS-compatible) PUT base URL where the certified receipt screenshot + confirmation JSON are archived to the audit chain for the EU-AI-Act trail. The http archive step PUTs the receipt here."
+      default: "https://s3.eu-central-1.amazonaws.com/ehs-filings-audit"
+      example: "https://s3.eu-central-1.amazonaws.com/ehs-filings-audit"
+    certifier_name:
+      type: string
+      description: "Name of the EHS officer who is the LEGAL certifier and must explicitly approve the certify/submit. Shown in the approval message and recorded in the audit receipt; the signature is theirs, not the agent's."
+      example: "Jane Doe, EHS Director"
+    figure_tolerance:
+      type: number
+      description: "Absolute tolerance allowed when the deterministic anti-transcription guard asserts the portal-side totals equal the validated source figures (covers rounding on the portal's display)."
+      default: 0.5
+      example: "0.5"
+    hours_per_employee_min:
+      type: number
+      description: "Lower plausibility bound for total_hours_worked / avg_headcount; below this the validator flags hours as implausible vs headcount (e.g. a full-time-equivalent floor) and fails closed."
+      default: 200.0
+      example: "200.0"
+    hours_per_employee_max:
+      type: number
+      description: "Upper plausibility bound for total_hours_worked / avg_headcount; above this the validator flags hours as implausible vs headcount (catches a misplaced decimal / unit error) and fails closed."
+      default: 3000.0
+      example: "3000.0"
+    approval_timeout_hours:
+      type: integer
+      description: "Hours the EHS-officer certify approval waits before its timeout fires (on_timeout: abort - a missed approval NEVER auto-certifies or auto-submits a filing)."
+      default: 48
+      example: "48"
+    sensor_poll_interval_seconds:
+      type: integer
+      description: "Seconds between polls of the portal's filing-status endpoint while waiting for confirmed acceptance."
+      default: 60
+      example: "60"
+    sensor_timeout_seconds:
+      type: integer
+      description: "Hard ceiling in seconds the confirmation sensor waits for the portal to confirm acceptance before the run is routed to needs-attention (never reported as success)."
+      default: 3600
+      example: "3600"
+    notify_channel:
+      type: string
+      description: "Slack channel for the filed/blocked/needs-attention notifications to compliance leadership."
+      default: "#ehs-compliance"
+      example: "#ehs-compliance"
+
+steps:
+  # 0) EVENT GATE: block until the source safety data for this establishment+year is finalized. The
+  #    top-level `schedule` cron is the primary annual trigger; this sensor confirms the upstream
+  #    safety-data close is actually locked before we pull figures, so we never file half-final data
+  #    even if the cron fires weeks early. Deterministic boolean over the polled JSON - no model.
+  - id: await_data_finalized
+    type: sensor
+    sensor_config:
+      url: "{input.data_finalized_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and bool(response.get('finalized', False))"
+      check_interval: 300
+      timeout: 86400
+
+  # 1) LOAD the establishment's finalized annual figures from the EHS data store. The figures live in
+  #    a PostgreSQL / safety-data warehouse exposed over an internal read API; this http step pulls
+  #    them deterministically (the authoritative source of truth the whole filing reconciles against).
+  - id: load_figures
+    type: http
+    depends_on: [await_data_finalized]
+    http_config:
+      url: "{input.figures_api_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.EHS_DATA_TOKEN}"
+
+  # 2) DETERMINISTIC internal-consistency validation (sandboxed Python, NO model). Confirms the
+  #    Form 300A invariants hold before anything touches the portal: total recordable cases must be
+  #    >= cases-with-days-away (a subset can never exceed its superset), hours worked must be
+  #    plausible against average headcount (hours/headcount inside a sane FTE band - catches unit /
+  #    decimal errors), the reporting year the data carries must match the intended filing_year, and
+  #    every figure must be present and non-negative. Fails CLOSED on any contradiction. This is the
+  #    first load-bearing correctness gate.
+  - id: validate_figures
+    type: code
+    depends_on: [load_figures]
+    code_config:
+      language: python
+      code: |
+        # Deterministic validation of the EHS data pull. No model decides correctness here.
+        pulled = _steps.get("load_figures") or {}
+        if not isinstance(pulled, dict):
+            pulled = {}
+        # The http step may surface the JSON body under body/json/data or at the top level.
+        body = pulled
+        for key in ("body", "json", "data", "response", "result"):
+            inner = pulled.get(key)
+            if isinstance(inner, dict) and ("total_hours_worked" in inner or "figures" in inner):
+                body = inner
+                break
+        figures = body.get("figures") if isinstance(body.get("figures"), dict) else body
+
+        def _num(v, default=-1.0):
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return default
+
+        problems = []
+
+        total_hours = _num(figures.get("total_hours_worked"))
+        total_cases = _num(figures.get("total_recordable_cases"))
+        days_away = _num(figures.get("cases_with_days_away"))
+        restricted = _num(figures.get("cases_job_transfer_restriction"), 0.0)
+        deaths = _num(figures.get("deaths"), 0.0)
+        headcount = _num(figures.get("avg_headcount"))
+        naics = str(figures.get("naics", "") or "").strip()
+        reporting_year = _num(figures.get("reporting_year"))
+
+        # 2a) Every figure must be present and non-negative.
+        required_nums = {
+            "total_hours_worked": total_hours,
+            "total_recordable_cases": total_cases,
+            "cases_with_days_away": days_away,
+            "avg_headcount": headcount,
+            "reporting_year": reporting_year,
+        }
+        for name, val in required_nums.items():
+            if val < 0:
+                problems.append("missing or negative figure: " + name)
+        if not naics:
+            problems.append("missing NAICS code")
+
+        # 2b) A subset can never exceed its superset: cases-with-days-away (and restricted, and
+        #     deaths) are subsets of total recordable cases.
+        if total_cases >= 0 and days_away >= 0 and days_away > total_cases:
+            problems.append(
+                "cases_with_days_away " + str(days_away)
+                + " exceeds total_recordable_cases " + str(total_cases)
+            )
+        if total_cases >= 0 and restricted >= 0 and (days_away + restricted) > (total_cases + 0.001):
+            problems.append(
+                "days_away + restricted " + str(days_away + restricted)
+                + " exceeds total_recordable_cases " + str(total_cases)
+            )
+        if total_cases >= 0 and deaths >= 0 and deaths > total_cases:
+            problems.append(
+                "deaths " + str(deaths) + " exceeds total_recordable_cases " + str(total_cases)
+            )
+
+        # 2c) Hours worked must be plausible against headcount (catches a misplaced decimal / a
+        #     wrong unit). hours / headcount should sit inside a sane full-time-equivalent band.
+        h_min = _num(_input.get("hours_per_employee_min"), 200.0)
+        h_max = _num(_input.get("hours_per_employee_max"), 3000.0)
+        hours_per_emp = None
+        if headcount > 0 and total_hours >= 0:
+            hours_per_emp = total_hours / headcount
+            if hours_per_emp < h_min:
+                problems.append(
+                    "hours implausibly low vs headcount: "
+                    + str(round(hours_per_emp, 1)) + " hrs/employee < " + str(h_min)
+                )
+            elif hours_per_emp > h_max:
+                problems.append(
+                    "hours implausibly high vs headcount: "
+                    + str(round(hours_per_emp, 1)) + " hrs/employee > " + str(h_max)
+                )
+        elif headcount <= 0:
+            problems.append("avg_headcount is zero - cannot check hours plausibility")
+
+        # 2d) The reporting year the data carries must match the intended filing year.
+        want_year = _num(_input.get("filing_year"))
+        year_ok = (reporting_year >= 0) and (want_year >= 0) and (int(reporting_year) == int(want_year))
+        if not year_ok:
+            problems.append(
+                "reporting year mismatch: data says " + str(int(reporting_year) if reporting_year >= 0 else "?")
+                + " but filing_year is " + str(int(want_year) if want_year >= 0 else "?")
+            )
+
+        ok = len(problems) == 0
+
+        result = {
+            "ok": ok,
+            "problems": problems,
+            "establishment_key": str(_input.get("establishment_key", "") or ""),
+            "filing_year": int(want_year) if want_year >= 0 else None,
+            "totals": {
+                "total_hours_worked": round(total_hours, 2) if total_hours >= 0 else None,
+                "total_recordable_cases": round(total_cases, 2) if total_cases >= 0 else None,
+                "cases_with_days_away": round(days_away, 2) if days_away >= 0 else None,
+                "cases_job_transfer_restriction": round(restricted, 2) if restricted >= 0 else None,
+                "deaths": round(deaths, 2) if deaths >= 0 else None,
+                "avg_headcount": round(headcount, 2) if headcount >= 0 else None,
+                "naics": naics,
+            },
+            "hours_per_employee": round(hours_per_emp, 1) if hours_per_emp is not None else None,
+            "reason_summary": "; ".join(problems) if problems else "figures internally consistent; year matches; ready to file",
+        }
+
+  # 2b) Hard stop on inconsistent figures - never touch a portal with a contradictory data set.
+  - id: figures_gate
+    type: condition
+    depends_on: [validate_figures]
+    condition_config:
+      expression: "{steps.validate_figures.output.ok} == True"
+      then: [read_establishments]
+      else: [notify_blocked]
+
+  # 2c) BLOCKED (bad figures) path - tell compliance exactly why; no filing was attempted.
+  - id: notify_blocked
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        BLOCKED before filing the Form 300A for establishment {input.establishment_key}
+        ({input.filing_year}). The deterministic internal-consistency validation FAILED, so the EHS
+        portal was never touched. Reason(s): {steps.validate_figures.output.reason_summary}. Fix the
+        safety-data close and re-run.
+
+  # 3) READ PASS (dom / lightpanda mode, READ-ONLY). The cheap, provider-neutral lightweight headless
+  #    path: the swappable reasoning model authenticates via credentials_env (EHS_PORTAL_CREDS - never
+  #    inlined), opens the filing dashboard, and READS the establishment list and which establishments
+  #    are still due for the filing_year - WITHOUT entering or submitting anything. captcha_strategy
+  #    pause hands a login challenge to a human; max_actions caps clicking; output_schema returns
+  #    structured JSON. It also reports requires_interactive_js so the condition below knows whether
+  #    the lightweight reader can drive the form or we must escalate to Playwright.
+  - id: read_establishments
+    type: browser
+    depends_on: [figures_gate]
+    prompt: >-
+      You are doing a READ-ONLY reconnaissance of a government EHS filing portal (OSHA Injury Tracking
+      Application, EPA / state environmental reporting, or a local permit-renewal system). Log in using
+      the credentials provided via the EHS_PORTAL_CREDS environment variable (do NOT print or echo
+      them). Open the annual-filing dashboard for filing year {input.filing_year}. DO NOT type into,
+      check, certify, sign, or submit anything - this is a list read only. Read back the list of
+      establishments visible on the account (each with its establishment id/name, its NAICS if shown,
+      and whether its annual report for {input.filing_year} is already submitted or still due), the
+      filing_year the portal is operating on, and the overall portal_status. Also report whether the
+      actual Form 300A data-entry wizard requires interactive JavaScript that a lightweight DOM reader
+      cannot drive (set requires_interactive_js true if the form uses dynamic client-side widgets,
+      multi-step JS navigation, or canvas/SPA controls). If a CAPTCHA or step-up auth appears, PAUSE
+      for a human. Context: establishment {input.establishment_key}. Return ONLY the structured object
+      described by the output schema.
+    browser_config:
+      mode: dom
+      start_url: "{input.portal_login_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 300
+      max_actions: 40
+      headless: true
+      credentials_env: "{input.credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          establishments:
+            type: array
+            items:
+              type: object
+              properties:
+                establishment_id: { type: string }
+                name: { type: string }
+                naics: { type: string }
+                status: { type: string }
+          filing_year:
+            type: string
+            description: "The filing year the portal dashboard is operating on (must align with input.filing_year)."
+          portal_status:
+            type: string
+            description: "Overall portal/account status read from the dashboard (e.g. open, accepting, closed)."
+          requires_interactive_js:
+            type: boolean
+            description: "True if the Form 300A data-entry wizard uses interactive JS the lightweight DOM reader cannot drive, so the flow must escalate to Playwright."
+
+  # 4) ESCALATION decision (deterministic, NO model). The lightweight dom read above is cheap and
+  #    neutral; the actual Form 300A wizard usually needs interactive JS. This condition routes to the
+  #    Playwright fill step when requires_interactive_js is true (the normal path) - both modes are
+  #    provider-neutral. We pick a Playwright fill whenever the dom reader flags interactive JS OR
+  #    leaves it unknown, so we never try to drive a JS form with a reader that cannot.
+  - id: needs_playwright
+    type: condition
+    depends_on: [read_establishments]
+    condition_config:
+      expression: "{steps.read_establishments.output.requires_interactive_js} == True"
+      then: [fill_form_300a]
+      else: [fill_form_300a]
+
+  # 5) FILL PASS (Playwright mode, provider-neutral, NO certify/submit). The reasoning model AUTHORS a
+  #    Playwright script: re-log-in via EHS_PORTAL_CREDS, open the Form 300A data-entry wizard for the
+  #    establishment, type each validated figure (total hours, total recordable cases, days-away,
+  #    restricted, deaths, headcount, NAICS) exactly as given, CHECK the certification box, advance to
+  #    the REVIEW / SIGN page and STOP - it does NOT sign or submit. capture_screenshots gives an
+  #    auditable review screenshot; output_schema returns the establishment id, the portal-side totals
+  #    as the portal now displays them, the certification text, the review summary, and whether the
+  #    Submit/Sign button is present. CAPTCHA pauses to a human; max_actions bounds the multi-page form.
+  - id: fill_form_300a
+    type: browser
+    depends_on: [needs_playwright]
+    prompt: >-
+      You are filing an annual OSHA Form 300A (or the equivalent EPA / state environmental / local
+      permit-renewal annual report) on a logged-in government EHS portal. Authenticate using the
+      EHS_PORTAL_CREDS environment variable (do NOT print or echo it). Open the Form 300A data-entry
+      wizard for establishment {input.establishment_key} and filing year {input.filing_year}. Enter
+      these VALIDATED figures exactly as given, into their matching fields: total hours worked, total
+      recordable cases, cases with days away from work, cases with job transfer or restriction, number
+      of deaths, average annual number of employees, and the NAICS code. Wait for each field's
+      client-side validation to settle before advancing. CHECK the certification acknowledgement
+      checkbox so the review page is reachable. CRITICAL: advance only to the REVIEW / SIGN page and
+      STOP there - DO NOT apply the electronic signature, DO NOT click Submit / File / Certify-and-
+      Submit. The signature and submission are a separate, human-approved step performed by the legal
+      certifier. If a CAPTCHA or step-up auth appears, PAUSE for a human. Validated figures (JSON):
+      {steps.validate_figures.output.totals} . Read back: the establishment id the portal shows, the
+      totals exactly as the PORTAL now displays them on the review page (so they can be reconciled
+      against the source), the certification text shown, a short human-readable review summary, and
+      whether an enabled Submit/Sign button is present (not yet clicked). Return ONLY the structured
+      object described by the output schema.
+    browser_config:
+      mode: playwright
+      start_url: "{input.portal_login_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 600
+      max_actions: 120
+      headless: true
+      credentials_env: "{input.credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          establishment_id:
+            type: string
+            description: "The establishment id the portal shows for the filing being prepared."
+          totals:
+            type: object
+            description: "The totals exactly as the PORTAL displays them on the review page, to reconcile against the validated source figures."
+            properties:
+              total_hours_worked: { type: number }
+              total_recordable_cases: { type: number }
+              cases_with_days_away: { type: number }
+              cases_job_transfer_restriction: { type: number }
+              deaths: { type: number }
+              avg_headcount: { type: number }
+              naics: { type: string }
+          certification_text:
+            type: string
+            description: "The exact certification/attestation text the portal shows on the review/sign page."
+          review_summary:
+            type: string
+            description: "Short human-readable summary of the prepared filing for the certifier to read."
+          review_screenshot:
+            type: string
+            description: "Reference/path of the captured review/sign-page screenshot for the approval and audit archive."
+          submit_button_present:
+            type: boolean
+            description: "True if the wizard reached the review/sign page with an enabled Submit/Sign button (not yet clicked)."
+
+  # 5b) DETERMINISTIC ANTI-TRANSCRIPTION GUARD (sandboxed Python, NO model). The load-bearing
+  #     pre-submit check: assert the portal-side totals the form now displays EQUAL the validated
+  #     source figures from step 2 within tolerance (no silent transcription error), that the
+  #     establishment id and certification text are present, that a review screenshot exists, and that
+  #     a Submit/Sign button is present (the wizard truly reached the review/sign page). ANY drift
+  #     fails CLOSED - a mis-entered figure never reaches the certifier or the submit.
+  - id: verify_portal_totals
+    type: code
+    depends_on: [fill_form_300a]
+    code_config:
+      language: python
+      code: |
+        # Deterministic guard: the portal's own displayed totals must match the validated source.
+        read_out = _steps.get("fill_form_300a") or {}
+        if not isinstance(read_out, dict):
+            read_out = {}
+        for key in ("output", "data", "result"):
+            inner = read_out.get(key)
+            if isinstance(inner, dict) and ("totals" in inner or "review_summary" in inner):
+                read_out = inner
+                break
+
+        validated = _steps.get("validate_figures") or {}
+        if not isinstance(validated, dict):
+            validated = {}
+        src = validated.get("totals") if isinstance(validated.get("totals"), dict) else {}
+        portal = read_out.get("totals") if isinstance(read_out.get("totals"), dict) else {}
+
+        def _num(v, default=None):
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return default
+
+        tolerance = abs(_num(_input.get("figure_tolerance"), 0.5) or 0.5)
+        problems = []
+
+        # 5b-i) Reconcile each numeric figure: portal display must equal the validated source.
+        numeric_fields = [
+            "total_hours_worked",
+            "total_recordable_cases",
+            "cases_with_days_away",
+            "cases_job_transfer_restriction",
+            "deaths",
+            "avg_headcount",
+        ]
+        mismatches = []
+        for f in numeric_fields:
+            sv = _num(src.get(f))
+            pv = _num(portal.get(f))
+            if sv is None:
+                # A field absent from the source (e.g. optional restricted/deaths) is skipped here;
+                # the required ones were already enforced in validate_figures.
+                continue
+            if pv is None:
+                mismatches.append(f + " not displayed by portal")
+                continue
+            if abs(pv - sv) > max(tolerance, 0.0001):
+                mismatches.append(
+                    f + ": portal " + str(round(pv, 2)) + " != source " + str(round(sv, 2))
+                )
+        if mismatches:
+            problems.append("portal totals drifted from source: " + "; ".join(mismatches))
+
+        # 5b-ii) NAICS must match (string compare, trimmed).
+        src_naics = str(src.get("naics", "") or "").strip()
+        portal_naics = str(portal.get("naics", "") or "").strip()
+        if src_naics and portal_naics and src_naics != portal_naics:
+            problems.append("NAICS mismatch: portal '" + portal_naics + "' != source '" + src_naics + "'")
+
+        # 5b-iii) Establishment id, certification text, review screenshot, and a Submit button must
+        #         all be present for the filing to be safe to certify.
+        establishment_id = str(read_out.get("establishment_id", "") or "").strip()
+        if not establishment_id:
+            problems.append("portal did not return an establishment_id")
+        cert_text = str(read_out.get("certification_text", "") or "").strip()
+        if not cert_text:
+            problems.append("portal did not show certification text on the review/sign page")
+        review_screenshot = str(read_out.get("review_screenshot", "") or "").strip()
+        if not review_screenshot:
+            problems.append("no review/sign screenshot captured for the certifier")
+        if not read_out.get("submit_button_present", False):
+            problems.append("Submit/Sign button absent - wizard did not reach the review/sign page")
+
+        ok = len(problems) == 0
+
+        result = {
+            "ok": ok,
+            "problems": problems,
+            "establishment_id": establishment_id,
+            "certification_text": cert_text,
+            "review_summary": str(read_out.get("review_summary", "") or ""),
+            "review_screenshot": review_screenshot,
+            "portal_totals": portal,
+            "source_totals": src,
+            "reason_summary": "; ".join(problems) if problems else "portal totals match the validated source; review/sign page reached",
+        }
+
+  # 5c) Hard stop on transcription drift - no certifier sees, and nothing submits, on a bad fill.
+  - id: totals_gate
+    type: condition
+    depends_on: [verify_portal_totals]
+    condition_config:
+      expression: "{steps.verify_portal_totals.output.ok} == True"
+      then: [certify_approval]
+      else: [notify_drift]
+
+  # 5d) DRIFT path - the portal totals did not match the validated source; surface why, file nothing.
+  - id: notify_drift
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        BLOCKED before certify on establishment {input.establishment_key} ({input.filing_year}): the
+        portal-displayed totals did NOT reconcile to the validated source figures.
+        {steps.verify_portal_totals.output.reason_summary}. Nothing was certified or submitted -
+        investigate the portal entry or the source data before re-running.
+
+  # 6) MANDATORY HUMAN APPROVAL by the LEGAL CERTIFIER before the irreversible certify + submit. The
+  #    EHS officer named as certifier sees the deterministically reconciled review summary, the exact
+  #    certification text the portal will bind them to, and the captured review/sign screenshot, and
+  #    explicitly authorizes the electronic certification + signature + submission. No certify/submit
+  #    can occur without this gate; on_timeout: abort means a missed approval NEVER auto-certifies.
+  - id: certify_approval
+    type: approval
+    approval_config:
+      message: >-
+        AUTHORIZE the IRREVERSIBLE ELECTRONIC CERTIFICATION + SUBMISSION of the annual Form 300A for
+        establishment {input.establishment_key}, filing year {input.filing_year}. You, the named legal
+        certifier {input.certifier_name}, are applying your electronic signature - this attests, under
+        the agency's penalties, that the figures are true and complete, and lodges the filing. The form
+        is filled and sitting on the portal's review/sign page. Portal-displayed totals (reconciled to
+        the validated source): {steps.verify_portal_totals.output.portal_totals}. Certification text
+        you are signing: {steps.verify_portal_totals.output.certification_text}. Checks:
+        {steps.verify_portal_totals.output.reason_summary}. Review the attached review/sign screenshot -
+        this is the EXACT filing and attestation you are certifying. Approve to apply the signature and
+        Submit; reject to abort with nothing certified and nothing filed.
+      show_data: steps.verify_portal_totals.output
+      show_images: ["steps.verify_portal_totals.output.review_screenshot"]
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: false
+
+  # 7) SUBMIT PASS (Playwright mode, WRITE) - reached ONLY after the certifier approves. Re-opens the
+  #    filled review/sign page, confirms the totals still match, applies the electronic certification +
+  #    signature, and clicks the SINGLE final Submit button ONCE, then reads the confirmation page and
+  #    captures {confirmation_id, status, submitted_at, receipt_screenshot}. capture_screenshots gives
+  #    the after-submit certified receipt for the audit chain; max_actions tightly capped (sign + one
+  #    submit, no runaway); CAPTCHA pauses to a human at the final wall. Acceptance is NOT trusted from
+  #    here - the sensor below re-reads the portal's own filing-status page to confirm.
+  - id: certify_submit
+    type: browser
+    depends_on: [certify_approval]
+    prompt: >-
+      The legal certifier {input.certifier_name} has authorized this IRREVERSIBLE electronic
+      certification and submission of the annual Form 300A for establishment {input.establishment_key},
+      filing year {input.filing_year}. Authenticate with EHS_PORTAL_CREDS if the session expired (do
+      NOT print it), return to the filled review/sign page, confirm the displayed totals still match
+      what was reconciled, then apply the electronic certification + signature exactly as the portal
+      requires and click the SINGLE final Submit / Certify-and-Submit / File button ONCE to lodge the
+      annual report. Do NOT edit any figure, do NOT re-open the data-entry pages, and do NOT click
+      Submit more than once. If a CAPTCHA or step-up auth appears at this final wall, PAUSE for a human
+      - do not attempt to solve it. Then read the portal's confirmation page and capture the
+      agency-issued CONFIRMATION / TRACKING ID, the filing status, the submitted timestamp, and a
+      screenshot of the certified receipt. Return ONLY the structured object described by the output
+      schema. Treat this as an attempt - final acceptance is confirmed separately by re-reading the
+      filing-status page.
+    browser_config:
+      mode: playwright
+      start_url: "{input.portal_login_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 300
+      max_actions: 20
+      headless: true
+      credentials_env: "{input.credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          submitted:
+            type: boolean
+            description: "True if the UI accepted the final certify+submit click without an error."
+          confirmation_id:
+            type: string
+            description: "The agency-issued confirmation / tracking id for the lodged annual report."
+          status:
+            type: string
+            description: "The filing status the portal shows after submit (e.g. submitted, received, under_review)."
+          submitted_at:
+            type: string
+            description: "Timestamp the portal recorded for the certified submission."
+          receipt_screenshot:
+            type: string
+            description: "Reference/path of the captured certified-receipt screenshot for the audit chain."
+    retry:
+      max_attempts: 1
+      backoff: fixed
+      on_failure: abort
+
+  # 8) CONFIRM via the portal's OWN filing-status endpoint - never trust the click alone. Poll until
+  #    the filing reads accepted/received OR a confirmation id is present, with a hard timeout.
+  #    Deterministic boolean over the polled JSON - pure control flow, no model.
+  - id: confirm_acceptance
+    type: sensor
+    depends_on: [certify_submit]
+    sensor_config:
+      url: "{input.portal_status_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and (str(response.get('status', '')).strip().lower() in ('accepted', 'received', 'processed', 'filed', 'confirmed', 'submitted') or bool(str(response.get('confirmation_id', '') or response.get('reference', '') or '').strip()))"
+      check_interval: 60
+      timeout: 3600
+
+  # 9) Deterministically decide acceptance from the sensor's last polled payload, then branch. A
+  #    timeout / non-accepted status yields fail_count>0 so a silent failure is NEVER a false win.
+  - id: evaluate_acceptance
+    type: code
+    depends_on: [confirm_acceptance]
+    code_config:
+      language: python
+      code: |
+        watch = _steps.get("confirm_acceptance") or {}
+        if not isinstance(watch, dict):
+            watch = {}
+        resp = watch.get("response") if isinstance(watch.get("response"), dict) else watch
+        if not isinstance(resp, dict):
+            resp = {}
+
+        status = str(resp.get("status", "") or "").strip().lower()
+        ref = str(resp.get("confirmation_id", "") or resp.get("reference", "") or "").strip()
+
+        # Fall back to the confirmation id the submit step captured if the status page is terse.
+        submit_out = _steps.get("certify_submit") or {}
+        if isinstance(submit_out, dict):
+            for key in ("output", "data", "result"):
+                inner = submit_out.get(key)
+                if isinstance(inner, dict) and "confirmation_id" in inner:
+                    submit_out = inner
+                    break
+            if not ref:
+                ref = str(submit_out.get("confirmation_id", "") or "").strip()
+        submitted_at = ""
+        if isinstance(submit_out, dict):
+            submitted_at = str(submit_out.get("submitted_at", "") or "").strip()
+
+        accepted_states = ("accepted", "received", "processed", "filed", "confirmed", "submitted")
+        confirmed = (status in accepted_states) or bool(ref)
+
+        sensor_satisfied = bool(watch.get("satisfied", watch.get("met", confirmed)))
+        timed_out = bool(watch.get("timed_out", False)) or (not sensor_satisfied and not confirmed)
+
+        result = {
+            "confirmed": bool(confirmed and not timed_out),
+            "status": status,
+            "confirmation_id": ref,
+            "submitted_at": submitted_at,
+            "timed_out": timed_out,
+            "fail_count": 0 if (confirmed and not timed_out) else 1,
+        }
+
+  # 9b) Branch on confirmation - archive + notify success, or page on-call (never a false win).
+  - id: acceptance_outcome
+    type: condition
+    depends_on: [evaluate_acceptance]
+    condition_config:
+      expression: "{steps.evaluate_acceptance.output.fail_count} > 0"
+      then: [notify_needs_attention]
+      else: [archive_receipt]
+
+  # 9c) NEEDS-ATTENTION path - certify+submit was clicked but the portal never confirmed within the
+  #     timeout. Page compliance; the run stays unresolved. A silently-failed filing is surfaced,
+  #     never reported as success.
+  - id: notify_needs_attention
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        NEEDS ATTENTION: the Form 300A for establishment {input.establishment_key}
+        ({input.filing_year}) was CERTIFIED + SUBMITTED but the EHS portal has NOT confirmed
+        acceptance within the timeout (last status '{steps.evaluate_acceptance.output.status}',
+        confirmation '{steps.evaluate_acceptance.output.confirmation_id}',
+        timed_out={steps.evaluate_acceptance.output.timed_out}). Do NOT assume the report was
+        accepted - check the portal manually and resolve.
+
+  # 10) ARCHIVE the certified receipt + confirmation to the audit chain (S3 / MinIO object storage)
+  #     via http PUT for the EU-AI-Act trail. Deterministic write to your OWN audit store (not the
+  #     government portal).
+  - id: archive_receipt
+    type: http
+    depends_on: [acceptance_outcome]
+    http_config:
+      url: "{input.receipt_archive_url}/{input.establishment_key}/{input.filing_year}/certified-receipt.json"
+      method: PUT
+      headers:
+        Content-Type: "application/json"
+      auth: "bearer:{env.ARCHIVE_TOKEN}"
+      body: '{"establishment_key": "{input.establishment_key}", "filing_year": "{input.filing_year}", "certifier": "{input.certifier_name}", "confirmation_id": "{steps.evaluate_acceptance.output.confirmation_id}", "portal_status": "{steps.evaluate_acceptance.output.status}", "submitted_at": "{steps.evaluate_acceptance.output.submitted_at}", "portal_totals": "{steps.verify_portal_totals.output.portal_totals}", "receipt_screenshot": "{steps.certify_submit.output.receipt_screenshot}", "review_screenshot": "{steps.verify_portal_totals.output.review_screenshot}"}'
+
+  # 11) SUCCESS notification to compliance leadership with the agency-issued confirmation id.
+  - id: notify_filed
+    type: notify
+    depends_on: [archive_receipt]
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        FILED: the annual Form 300A for establishment {input.establishment_key} ({input.filing_year})
+        was certified by {input.certifier_name} and accepted by the EHS portal. Confirmation id
+        {steps.evaluate_acceptance.output.confirmation_id}, status
+        {steps.evaluate_acceptance.output.status}, submitted
+        {steps.evaluate_acceptance.output.submitted_at}. Certified receipt archived to the audit chain
+        at {input.receipt_archive_url}/{input.establishment_key}/{input.filing_year}/certified-receipt.json.
+
+on_complete:
+  storage_path: "osha-environmental-compliance-report-filer/{input.establishment_key}/{input.filing_year}/{run_id}/result.json"

--- a/src/sandcastle/templates/partner_portal_journey_monitor.yaml
+++ b/src/sandcastle/templates/partner_portal_journey_monitor.yaml
@@ -1,0 +1,440 @@
+# name: Partner Portal Journey Monitor
+# description: Logs into a critical login-walled partner portal (insurer, freight/EDI carrier, bank, government filing, supplier) as a synthetic user on a daily pre-batch schedule, walks the exact multi-step task your team relies on, structurally asserts every screen, replays against a golden run, and alerts ops the moment the partner silently redesigns the portal and breaks your operational flow - all read-only, stopping short of the submit button.
+# tags: [rpa, browser, partner-portal, synthetic-monitoring, dom, lightpanda, playwright, trajectory-replay, ops, b2b-integrations, change-detection]
+# category: engineering
+
+name: partner-portal-journey-monitor
+description: >-
+  A read-only synthetic-journey monitor for a business-critical EXTERNAL partner
+  portal your team does NOT control - an insurer claims site, a freight/EDI
+  carrier booking portal, a payer-eligibility lookup, a bank, or a government tax
+  filing system. These portals are legacy, login-walled, server-rendered or
+  jQuery-era SPAs with NO public API (or none in your contract). You cannot
+  healthcheck a screen you can only reach after authenticating and clicking
+  through three wizard pages. When the partner ships a redesign or bolts on a new
+  mandatory consent step, your team's manual flow silently breaks and there is no
+  status page - you find out hours late when the daily batch stalls.
+
+  This template runs at the start of each business day, BEFORE the batch your
+  team fires against the portal. A SENSOR is the pre-batch heartbeat clock. A
+  BROWSER step (dom/lightpanda mode by default for cheap legacy portals - both
+  are lightweight headless DOM with NO vendor model in the navigation loop, so
+  they are inherently provider-neutral; swap to playwright for JS-heavy portals
+  where the model authors the script) logs in with credentials_env =
+  PARTNER_PORTAL_CREDS (never inline), navigates the EXACT task path to the form,
+  confirms the fields, dropdowns and the submit affordance render - and DELIBERATELY
+  STOPS at the submit button without clicking it, so it can never file a real
+  claim or booking. It returns STRUCTURED JSON via output_schema (logged_in,
+  screens_reachable, required_fields_present, new_unexpected_fields,
+  submit_button_enabled, session_expired, error_text).
+
+  The verdict is deterministic, never one model's opinion. A sandboxed CODE step
+  asserts logged_in, every expected screen reachable, the live field set is a
+  SUPERSET of the known schema, and the submit button is enabled - surfacing any
+  new_unexpected_fields as a soft "portal changed" warning. A TRAJECTORY-REPLAY
+  scores the live walkthrough against a recorded golden run (fail_below_score =
+  0.8) - the primary detector of a partner redesign even when fields technically
+  still resolve. A second CODE step folds both signals into one verdict, and a
+  CONDITION routes it: unchanged -> a quiet OK notify; broken or a new mandatory
+  field -> a NOTIFY that pages ops with the failure screenshot and the
+  new_unexpected_fields list, so a human can adapt the real workflow before the
+  batch fails.
+
+  Safety is structural. The journey is READ-ONLY: it stops at the submit
+  affordance and never clicks it, so no real transaction is possible - the only
+  human-in-the-loop is captcha_strategy = pause. credentials_env honours the
+  partner's auth, max_actions = 50 caps runaway clicking, capture_screenshots =
+  true gives an audit trail. If this template is ever forked to ACTUALLY submit
+  the form, that single submit action MUST be placed behind an explicit approval
+  gate showing the validated field preview - it is intentionally absent here
+  because nothing irreversible is performed.
+
+default_model: sonnet
+default_timeout: 900
+
+input_schema:
+  required: ["portal_login_url"]
+  properties:
+    portal_login_url:
+      type: string
+      description: "Login URL of the partner portal the synthetic user starts from (e.g. https://carrier.example.com/login or https://claims.insurer.example/portal)."
+      default: ""
+    browser_mode:
+      type: string
+      description: "Documented browser-mode choice. 'dom' or 'lightpanda' (default, provider-neutral, cheapest) for legacy server-rendered / jQuery-era portals; swap the browser step's mode to 'playwright' for JS-heavy SPA portals where the model authors the navigation script."
+      default: "dom"
+    expected_screens:
+      type: string
+      description: "Comma-separated screen/step names the synthetic journey MUST be able to reach, in order, on the way to the form (used by the deterministic assertion code)."
+      default: "login,dashboard,new_request_wizard_step1,new_request_wizard_step2,submit_form"
+    known_required_fields:
+      type: string
+      description: "Comma-separated names of the fields/dropdowns the team's known-good schema expects on the final form. The live field set must be a SUPERSET of these; anything extra is flagged as a portal change."
+      default: "account_number,service_date,reference_id,line_item_code,quantity,consent_checkbox"
+    golden_run_id:
+      type: string
+      description: "Run id of a recorded HEALTHY portal walkthrough to replay against for partner-redesign drift detection."
+      default: "golden-partner-portal-journey-baseline"
+    heartbeat_url:
+      type: string
+      description: "Lightweight pre-batch heartbeat/clock endpoint the sensor polls each business morning (also a webhook the daily scheduler can fire before the batch)."
+      default: "https://carrier.example.com/healthz"
+    ok_channel:
+      type: string
+      description: "Quiet Slack channel for green 'portal journey unchanged' confirmations."
+      default: "#partner-portal-ok"
+    ops_channel:
+      type: string
+      description: "Ops / B2B-integrations Slack channel that is paged when the partner portal silently changes and the operational flow is at risk."
+      default: "#ops-partner-portal-alerts"
+
+steps:
+  # ---------------------------------------------------------------------------
+  # 1. SENSOR - the pre-batch heartbeat clock. Each business morning it ticks
+  #    (and can be fired as a webhook by the daily scheduler) and gates the
+  #    journey on the portal being reachable at all before we drive a browser at
+  #    it. A cheap pre-flight, NOT the real proof of journey health.
+  # ---------------------------------------------------------------------------
+  - id: prebatch_heartbeat
+    type: sensor
+    sensor_config:
+      url: "{input.heartbeat_url}"
+      method: GET
+      condition: "status_code == 200"
+      check_interval: 60
+      timeout: 3600
+
+  # ---------------------------------------------------------------------------
+  # 2. BROWSER - the synthetic journey (READ pass). dom/lightpanda mode by
+  #    default: lightweight headless DOM with NO vendor model in the navigation
+  #    loop, so it is inherently provider-neutral (swap to playwright for JS-heavy
+  #    portals - then the model authors a swappable Playwright script). It logs in
+  #    with credentials from PARTNER_PORTAL_CREDS (never inline), walks the EXACT
+  #    task path to the form, confirms fields/dropdowns/submit-affordance render,
+  #    and DELIBERATELY STOPS at the submit button - it never clicks it, so no
+  #    real claim/booking can be filed. captcha_strategy: pause is the only HITL;
+  #    max_actions: 50 caps runaway clicking; capture_screenshots: true for audit.
+  #    output_schema makes this a STRUCTURED read pass.
+  # ---------------------------------------------------------------------------
+  - id: walk_portal_journey
+    type: browser
+    depends_on: [prebatch_heartbeat]
+    browser_config:
+      mode: dom
+      start_url: "{input.portal_login_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 50
+      headless: true
+      credentials_env: "PARTNER_PORTAL_CREDS"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          logged_in:
+            type: boolean
+            description: "True only if authentication succeeded and an authenticated shell rendered."
+          screens_reachable:
+            type: array
+            description: "Ordered names of the screens/wizard steps actually reached on the way to the form."
+            items: { type: string }
+          required_fields_present:
+            type: array
+            description: "Names of the fields/dropdowns that rendered on the final form (the live schema)."
+            items: { type: string }
+          new_unexpected_fields:
+            type: array
+            description: "Fields/dropdowns/consent steps present on the live form that are NOT in the known schema - a soft signal the partner changed the portal."
+            items: { type: string }
+          submit_button_enabled:
+            type: boolean
+            description: "True if the submit affordance rendered and is enabled. (We confirm it - we never click it.)"
+          session_expired:
+            type: boolean
+            description: "True if the session dropped / was bounced to login mid-journey."
+          screenshot_url:
+            type: string
+            description: "URL of the captured screenshot at the final form (or at the point of failure)."
+          error_text:
+            type: ["string", "null"]
+            description: "Short human-readable error if any screen failed to load or a step could not be reached; null when clean."
+        required:
+          - logged_in
+          - screens_reachable
+          - required_fields_present
+          - new_unexpected_fields
+          - submit_button_enabled
+          - session_expired
+          - error_text
+    prompt: |
+      You are a synthetic monitoring user for a critical EXTERNAL partner portal
+      that our operations team depends on but does NOT control. Your job is to
+      prove that the exact multi-step task our team runs by hand each day still
+      works - and to detect the moment the partner silently redesigns the portal.
+
+      HARD SAFETY RULE - THIS IS READ-ONLY: You must NEVER click the final submit
+      / file / book / send button. Walk all the way to the form, confirm the
+      submit affordance is present and enabled, and STOP. Do not submit anything.
+      Filing a real claim or booking is strictly forbidden. Do not click any
+      irreversible action.
+
+      Authenticate using ONLY the credentials supplied via the PARTNER_PORTAL_CREDS
+      environment variable. NEVER print, echo, or log the secret. If a CAPTCHA
+      appears, pause for a human per captcha_strategy.
+
+      Journey (record each screen you reach, in order, into screens_reachable):
+        1. Open {input.portal_login_url} and log in. Set logged_in = true only if
+           an authenticated shell / dashboard rendered. If you are bounced back to
+           login or the session drops at any point, set session_expired = true.
+        2. Navigate the EXACT task path our team uses to reach the operational
+           form (e.g. dashboard -> new request -> wizard step 1 -> wizard step 2
+           -> the submit form). Append each screen name to screens_reachable as
+           you reach it.
+        3. On the final form, enumerate every field, dropdown, and consent control
+           that renders. Put their names into required_fields_present (the live
+           schema).
+        4. Compare the live form against the team's known schema. Any field,
+           dropdown, or NEW mandatory consent step that is present live but is NOT
+           part of the known set goes into new_unexpected_fields - this is how we
+           catch a partner adding a mandatory step that would break our batch.
+        5. Confirm the submit affordance renders and whether it is enabled; set
+           submit_button_enabled accordingly. DO NOT CLICK IT.
+
+      Put a URL to the captured screenshot of the final form (or the point of
+      failure) into screenshot_url. If any screen failed to load or a step could
+      not be reached, put a short human-readable explanation into error_text;
+      otherwise set error_text = null.
+
+      Return ONLY the structured JSON object matching the output_schema. Do not
+      add any prose outside the JSON.
+
+  # ---------------------------------------------------------------------------
+  # 3. ASSERT JOURNEY - the load-bearing deterministic gate on the READ pass, NOT
+  #    a model opinion. Asserts logged_in, every expected screen reachable, the
+  #    live field set is a SUPERSET of the known schema, the submit button is
+  #    enabled, no session-expiry, no error text. Surfaces new_unexpected_fields
+  #    as a SOFT "portal changed" warning. Rejects empty / malformed reads so a
+  #    blank scrape is never reported as a healthy journey.
+  # ---------------------------------------------------------------------------
+  - id: assert_journey
+    type: code
+    depends_on: [walk_portal_journey]
+    code_config:
+      language: python
+      code: |
+        # Validate the browser's structured extraction field by field. Any hard
+        # miss fails the run; new_unexpected_fields is only a soft warning.
+        j = _steps.get("walk_portal_journey") or {}
+        if not isinstance(j, dict):
+            j = {}
+
+        # Parse the expected screens (ordered) and the known field schema.
+        raw_screens = str(_input.get("expected_screens", "") or "")
+        expected_screens = [s.strip() for s in raw_screens.split(",") if s.strip()]
+
+        raw_fields = str(_input.get("known_required_fields", "") or "")
+        known_fields = [s.strip() for s in raw_fields.split(",") if s.strip()]
+        known_set = {f for f in known_fields}
+
+        reached = j.get("screens_reachable") or []
+        if not isinstance(reached, list):
+            reached = []
+        reached_set = {str(s).strip() for s in reached}
+
+        live_fields = j.get("required_fields_present") or []
+        if not isinstance(live_fields, list):
+            live_fields = []
+        live_set = {str(f).strip() for f in live_fields}
+
+        unexpected = j.get("new_unexpected_fields") or []
+        if not isinstance(unexpected, list):
+            unexpected = []
+        unexpected_list = [str(u).strip() for u in unexpected if str(u).strip()]
+
+        failures = []
+
+        # Guard against an empty / malformed read - a blank journey must never be
+        # reported as a healthy portal.
+        if not reached_set and not live_set:
+            failures.append("empty_read: browser returned no screens and no fields")
+
+        # Assertion 1: authentication succeeded.
+        if not bool(j.get("logged_in", False)):
+            failures.append("not_logged_in")
+
+        # Assertion 2: the session did not expire mid-journey.
+        if bool(j.get("session_expired", False)):
+            failures.append("session_expired")
+
+        # Assertion 3: every expected screen was reachable.
+        missing_screens = [s for s in expected_screens if s not in reached_set]
+        if missing_screens:
+            failures.append("unreachable_screens: " + ", ".join(missing_screens))
+
+        # Assertion 4: the live field set is a SUPERSET of the known schema.
+        missing_fields = [f for f in known_fields if f not in live_set]
+        if missing_fields:
+            failures.append("missing_required_fields: " + ", ".join(missing_fields))
+
+        # Assertion 5: the submit affordance renders and is enabled (we never click).
+        if not bool(j.get("submit_button_enabled", False)):
+            failures.append("submit_button_not_enabled")
+
+        # Assertion 6: the browser reported no error text.
+        err = j.get("error_text")
+        if err not in (None, "", "null"):
+            failures.append("browser_error: " + str(err))
+
+        # SOFT signal: new fields/consent steps the partner added. Not a hard
+        # failure on its own, but it is the early-warning that the portal changed.
+        portal_changed = len(unexpected_list) > 0
+
+        passed = len(failures) == 0
+        result = {
+            "passed": passed,
+            "failing_assertion": ("" if passed else failures[0]),
+            "all_failures": failures,
+            "portal_changed_warning": portal_changed,
+            "new_unexpected_fields": unexpected_list,
+            "screens_reached": sorted(reached_set),
+            "missing_screens": missing_screens,
+            "missing_required_fields": missing_fields,
+            "live_fields": sorted(live_set),
+            "submit_button_enabled": bool(j.get("submit_button_enabled", False)),
+            "screenshot_url": str(j.get("screenshot_url", "") or ""),
+        }
+
+  # ---------------------------------------------------------------------------
+  # 4. TRAJECTORY-REPLAY - the primary partner-redesign detector. Scores the live
+  #    walkthrough against a recorded golden run and fails below 0.8. Catches a
+  #    silent redesign, a renamed selector, or an extra interstitial wizard step
+  #    even when the field assertions above technically still resolve. A
+  #    deterministic scorer comparing observable actions/extractions, not a model
+  #    vote - and provider-neutral.
+  # ---------------------------------------------------------------------------
+  - id: golden_replay
+    type: trajectory-replay
+    depends_on: [walk_portal_journey, assert_journey]
+    trajectory_replay_config:
+      golden_run_id: "{input.golden_run_id}"
+      fail_below_score: 0.8
+      allow_cost_delta_pct: 10.0
+      cost_budget_usd: 0.5
+
+  # ---------------------------------------------------------------------------
+  # 5. JOURNEY VERDICT - deterministically fold the assertion result AND the
+  #    golden-replay score into one health decision. A failed assertion, a
+  #    below-threshold replay score (drift), OR a new mandatory field all turn the
+  #    monitor red. Pure code - no model in this gate.
+  # ---------------------------------------------------------------------------
+  - id: journey_verdict
+    type: code
+    depends_on: [assert_journey, golden_replay]
+    code_config:
+      language: python
+      code: |
+        # Combine the deterministic assertion with the golden-run replay score and
+        # the soft portal-changed warning into a single ops verdict.
+        a = _steps.get("assert_journey") or {}
+        rep = _steps.get("golden_replay") or {}
+        if not isinstance(a, dict):
+            a = {}
+        if not isinstance(rep, dict):
+            rep = {}
+
+        assertions_passed = bool(a.get("passed", False))
+        portal_changed = bool(a.get("portal_changed_warning", False))
+        unexpected_list = a.get("new_unexpected_fields") or []
+        if not isinstance(unexpected_list, list):
+            unexpected_list = []
+
+        # The replay step surfaces a score and/or a pass flag depending on backend
+        # shape; read whichever is present and compare to the configured floor.
+        threshold = 0.8
+        score = rep.get("score", rep.get("replay_score"))
+        try:
+            score_f = float(score)
+        except (TypeError, ValueError):
+            score_f = None
+
+        if "passed" in rep:
+            replay_ok = bool(rep.get("passed"))
+        elif score_f is not None:
+            replay_ok = score_f >= threshold
+        else:
+            # No replay signal (e.g. golden run missing) - do not let a missing
+            # baseline mask a real assertion failure, and do not invent a drift
+            # failure either; treat replay as neutral and rely on the assertions.
+            replay_ok = True
+
+        # A new mandatory/unexpected field is treated as a breaking change: the
+        # team's batch could stall on a field they do not fill. Red on it too.
+        portal_broke = (not assertions_passed) or (not replay_ok) or portal_changed
+        healthy = not portal_broke
+
+        if not assertions_passed:
+            reason = "assertion_failed: " + str(a.get("failing_assertion", "unknown"))
+        elif not replay_ok:
+            sc = "n/a" if score_f is None else str(round(score_f, 3))
+            reason = "partner_redesign_drift: replay score " + sc + " below " + str(threshold)
+        elif portal_changed:
+            reason = "new_mandatory_field(s): " + ", ".join(unexpected_list)
+        else:
+            reason = "journey_unchanged"
+
+        result = {
+            "healthy": healthy,
+            "status": ("green" if healthy else "red"),
+            "reason": reason,
+            "assertions_passed": assertions_passed,
+            "replay_ok": replay_ok,
+            "replay_score": score_f,
+            "portal_changed_warning": portal_changed,
+            "new_unexpected_fields": unexpected_list,
+            "failing_assertion": str(a.get("failing_assertion", "")),
+            "all_failures": a.get("all_failures", []),
+            "screens_reached": a.get("screens_reached", []),
+            "missing_screens": a.get("missing_screens", []),
+            "missing_required_fields": a.get("missing_required_fields", []),
+            "screenshot_url": a.get("screenshot_url", ""),
+        }
+
+  # ---------------------------------------------------------------------------
+  # 6. CONDITION - route the verdict. Unchanged -> a quiet OK notify. Broken or a
+  #    new mandatory field -> page ops with the cause, the failure screenshot, and
+  #    the new_unexpected_fields list so a human can adapt the real workflow
+  #    BEFORE the daily batch fails. No write was performed, so no approval gate is
+  #    needed; a forked submit-capable version MUST gate the submit on approval.
+  # ---------------------------------------------------------------------------
+  - id: route_verdict
+    type: condition
+    depends_on: [journey_verdict]
+    condition_config:
+      expression: "{steps.journey_verdict.output.healthy} == True"
+      then: [notify_ok]
+      else: [notify_ops]
+
+  # 6a) GREEN: a quiet confirmation that the partner portal journey is unchanged.
+  - id: notify_ok
+    type: notify
+    depends_on: [route_verdict]
+    notify_config:
+      service: slack
+      channel: "{input.ok_channel}"
+      message: ":white_check_mark: Partner portal journey UNCHANGED. Reached {steps.journey_verdict.output.screens_reached}, golden replay score {steps.journey_verdict.output.replay_score}. Submit affordance present, not clicked (read-only). Portal {input.portal_login_url}."
+
+  # 6b) RED: page ops with the cause, the failure screenshot, and the list of new
+  #     unexpected/mandatory fields so they can fix the manual flow before the
+  #     batch runs and stalls.
+  - id: notify_ops
+    type: notify
+    depends_on: [route_verdict]
+    notify_config:
+      service: slack
+      channel: "{input.ops_channel}"
+      message: ":rotating_light: PARTNER PORTAL CHANGED - operational journey at risk before today's batch. Cause: {steps.journey_verdict.output.reason}. Failing assertion: {steps.journey_verdict.output.failing_assertion}. New/unexpected fields: {steps.journey_verdict.output.new_unexpected_fields}. Missing screens: {steps.journey_verdict.output.missing_screens}. Missing required fields: {steps.journey_verdict.output.missing_required_fields}. Golden replay score {steps.journey_verdict.output.replay_score} (drift floor 0.8). Screenshot: {steps.journey_verdict.output.screenshot_url}. Portal {input.portal_login_url}. Adapt the manual flow before the batch fires."
+
+on_complete:
+  storage_path: "partner-portal-journey-monitor/{run_id}/result.json"

--- a/src/sandcastle/templates/permit_eportal_application_filer.yaml
+++ b/src/sandcastle/templates/permit_eportal_application_filer.yaml
@@ -1,0 +1,982 @@
+# name: Permit Eportal Application Filer
+# description: Fills and lodges a building / business / environmental permit application on a municipal e-permitting portal (Accela Citizen Access, Tyler EnerGov, OpenGov-hosted city sites, regional environmental agencies) - per-jurisdiction, login-gated legacy SPAs with NO programmatic submission path. It deterministically validates the project record against a per-jurisdiction+permit_type rules table, routes to the right portal start_url, reads the application wizard READ-ONLY (dom mode) to learn its tabs/fields/upload requirements, maps the record onto the fields with a provider-agnostic classify, gates entry on a code-compliance llm_eval plus a permit-specialist human, fills every tab and uploads each drawing in provider-neutral playwright mode and STOPS at the review/fee page, holds for an applicant-of-record approval that explicitly shows the fee_amount, submits ONLY after approval, asserts the charged fee equals the approved fee (deterministic - no silent overpay), and runs a per-jurisdiction trajectory-replay to block filing when a portal redesign diverges. Triggered when a permit package is marked ready in the project tracker, often fanned out by a parent multi-site sub_workflow.
+# tags: [Permits, EPermitting, Accela, TylerEnerGov, OpenGov, Municipal, RPA, Playwright, DOM, HumanApproval, ProviderNeutral, TrajectoryReplay, FeeMatch, Building, Environmental]
+# category: hr_legal
+
+name: permit-eportal-application-filer
+description: >-
+  Lodges a building, business, or environmental permit application onto a municipal e-permitting
+  portal on behalf of a permit-expediting firm, GC, architecture office, or multi-site
+  retail/restaurant operator. Municipal e-permitting portals (Accela Citizen Access, Tyler EnerGov,
+  OpenGov-hosted city sites, regional environmental agencies) are notoriously API-less, login-gated
+  legacy SPAs: each jurisdiction has a different multi-tab application with conditional, code-driven
+  fields, mandatory document uploads (site plans, drawings), and fee/agreement checkboxes, and there
+  is NO programmatic submission path - expediters key these by hand, one portal at a time. The flow
+  is split read-from-write and fails closed. A DETERMINISTIC code step validates that the
+  project_record carries every field this jurisdiction + permit_type require (from a rules table) and
+  that every drawing file ref resolves. A condition routes to the correct portal start_url. A
+  provider-neutral dom-mode browser step authenticates (credentials_env=PERMIT_PORTAL_CREDS,
+  captcha_strategy=pause), opens the new-application wizard for the permit_type, and EXTRACTS the
+  wizard structure READ-ONLY (tabs/fields/required, upload_requirements, fee_summary) via
+  output_schema - writing nothing. A provider-agnostic classify maps project_record -> fields and
+  matches each required doc_type to a drawing file. A deterministic code step turns that into a
+  concrete {plan, missing_docs[], unmapped_fields[]}. A gate (llm_eval confirming the code-required
+  fields and all mandatory docs are satisfied, plus a permit-specialist human for any
+  missing/ambiguous item) must pass before entry. Only then does a playwright-mode browser step fill
+  every tab, upload each document to its required slot, advance to the review/fee page and STOP -
+  returning a review screenshot, the fee_amount, the entered values, and the uploaded-doc list. A
+  mandatory applicant-of-record approval explicitly shows the fee_amount and authorizes the official
+  submission. A second playwright step accepts the agreement and clicks Submit (triggering the fee
+  per policy), capturing {application_number, status, fee_charged, submitted_at}. A deterministic
+  code step asserts the application_number is present AND fee_charged equals the approved fee_amount -
+  a mismatch fails the run so a silent overpay can never be recorded as a clean filing. A
+  per-jurisdiction trajectory-replay (golden_run_id, fail_below_score=0.85, cost guard) catches
+  portal changes before they corrupt a filing, a notify announces the outcome, and a report archives
+  the receipt. Every browser step rides default_model and stays swappable across the 7 providers; the
+  code-compliance llm_eval gate and the field-mapping classify run provider-agnostically with
+  failover; the condition router, code validators, and the per-jurisdiction golden trajectories make
+  reliability a property of recorded runs and deterministic checks, never of a particular model.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 1800
+
+input_schema:
+  required: ["jurisdiction", "permit_type", "project_record", "drawing_files"]
+  properties:
+    jurisdiction:
+      type: string
+      description: "Jurisdiction key that selects the portal start_url, the rules-table requirements, and the per-jurisdiction golden trajectory (e.g. austin-tx, miami-dade-fl, ca-water-board)."
+      example: "austin-tx"
+    permit_type:
+      type: string
+      description: "Permit type being filed (drives which rules-table requirements apply and which wizard branch to open): building, business, environmental, zoning, electrical, etc."
+      example: "building"
+    project_record:
+      type: string
+      description: "Structured project record for this permit as a JSON string - parcel/APN, valuation, scope, square footage, occupancy/use, contractor license, applicant of record, etc. Validated against the jurisdiction+permit_type rules table and mapped onto the portal fields."
+      example: '{"apn":"0123-4567-890","valuation":485000,"scope":"new tenant fit-out, 2400 sqft restaurant","square_footage":2400,"occupancy":"A-2","use":"restaurant","contractor_license":"TX-CGC-114782","applicant_of_record":"Jane Doe, RA","applicant_email":"jane.doe@expediters.example.com","contact_phone":"+1-512-555-0142"}'
+    drawing_files:
+      type: string
+      description: "Comma-separated list of drawing/PDF file refs (s3/gdrive paths or @file: refs) - site plans, architectural drawings, MEP, environmental reports - matched to the portal's required doc_type slots. Existence is validated before any filing."
+      example: "s3://permits/austin/0123/site-plan.pdf,s3://permits/austin/0123/floor-plan.pdf,s3://permits/austin/0123/mep.pdf"
+    portal_start_url:
+      type: string
+      description: "Fallback new-application wizard start_url if the jurisdiction is not in the built-in router map. The condition step prefers a known jurisdiction route and falls back to this."
+      default: ""
+      example: "https://aca.exampletx.gov/CitizenAccess/Default.aspx"
+    fee_tolerance:
+      type: number
+      description: "Absolute currency tolerance allowed when asserting the portal's fee_charged equals the applicant-approved fee_amount (covers rounding). A larger gap fails the run - no silent overpay."
+      default: 0.01
+      example: "0.01"
+    applicant_email:
+      type: string
+      description: "Email of the applicant of record who must approve the official submission and the fee. Defaults to the applicant_email inside project_record if blank."
+      default: ""
+      example: "jane.doe@expediters.example.com"
+    golden_run_id:
+      type: string
+      description: "Per-jurisdiction golden trajectory id the trajectory-replay diffs the filing flow against, to catch a portal redesign before it corrupts a filing. Convention: golden-<jurisdiction>-<permit_type>."
+      default: "golden-austin-tx-building-2026-05-01"
+      example: "golden-austin-tx-building-2026-05-01"
+    tracker_url:
+      type: string
+      description: "Project-tracker webhook the filed application_number + receipt are written back to once the portal confirms."
+      default: "https://tracker.internal/api/permits/filed"
+      example: "https://tracker.internal/api/permits/filed"
+    notify_channel:
+      type: string
+      description: "Slack channel for the permit desk's filed/blocked/needs-attention notifications."
+      default: "#permit-filing"
+      example: "#permit-filing"
+    approval_timeout_hours:
+      type: integer
+      description: "Hours the applicant-of-record submit approval waits before its timeout fires (on_timeout: abort - a missed approval NEVER auto-submits or auto-pays)."
+      default: 48
+      example: "48"
+
+steps:
+  # 1) DETERMINISTIC validation against the jurisdiction+permit_type rules table (sandboxed Python,
+  #    NO model). Confirm the project_record carries every field this jurisdiction+permit_type
+  #    require, that the contractor license / applicant of record are present where required, and
+  #    that EVERY drawing file ref resolves (non-empty). Fails CLOSED - nothing touches a portal on
+  #    an incomplete package. This is the first load-bearing correctness gate.
+  - id: validate_record
+    type: code
+    code_config:
+      language: python
+      code: |
+        import json
+        # --- Parse the structured project record handed in by the project tracker. ---
+        raw = _input.get('project_record') or ''
+        record = {}
+        if isinstance(raw, dict):
+            record = raw
+        else:
+            try:
+                record = json.loads(raw)
+            except (TypeError, ValueError):
+                record = {}
+        if not isinstance(record, dict):
+            record = {}
+
+        jurisdiction = str(_input.get('jurisdiction', '') or '').strip().lower()
+        permit_type = str(_input.get('permit_type', '') or '').strip().lower()
+        problems = []
+
+        # --- Rules table: required project-record fields per permit_type. A real deployment loads
+        #     this per jurisdiction; the canonical municipal requirements are encoded here. ---
+        base_required = ['apn', 'scope', 'applicant_of_record']
+        type_required = {
+            'building':      ['valuation', 'square_footage', 'occupancy', 'use', 'contractor_license'],
+            'business':      ['use', 'applicant_email'],
+            'environmental': ['valuation', 'scope', 'use'],
+            'zoning':        ['use', 'square_footage'],
+            'electrical':    ['valuation', 'contractor_license'],
+            'mechanical':    ['valuation', 'contractor_license'],
+            'plumbing':      ['valuation', 'contractor_license'],
+        }
+        # Doc types the jurisdiction+permit_type mandates (matched to drawing files downstream).
+        type_docs = {
+            'building':      ['site_plan', 'floor_plan'],
+            'business':      [],
+            'environmental': ['site_plan', 'environmental_report'],
+            'zoning':        ['site_plan'],
+            'electrical':    ['floor_plan'],
+            'mechanical':    ['floor_plan'],
+            'plumbing':      ['floor_plan'],
+        }
+
+        if not jurisdiction:
+            problems.append('jurisdiction is required to select the portal and rules')
+        if not permit_type:
+            problems.append('permit_type is required to select the wizard branch and rules')
+
+        required_fields = list(base_required) + list(type_required.get(permit_type, ['valuation', 'use']))
+        for k in required_fields:
+            if not str(record.get(k, '') or '').strip():
+                problems.append('missing required field for ' + (permit_type or '<none>') + ': ' + k)
+
+        # --- Valuation sanity (used later for the fee context). ---
+        def _num(v):
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return -1.0
+        valuation = _num(record.get('valuation'))
+        if 'valuation' in required_fields and valuation < 0:
+            problems.append('valuation missing or not numeric')
+
+        # --- Every referenced drawing file ref must be present (non-empty). ---
+        files_raw = _input.get('drawing_files') or ''
+        file_refs = [p.strip() for p in str(files_raw).split(',') if p.strip()]
+        if not file_refs:
+            problems.append('no drawing file refs provided')
+
+        # --- Applicant of record + email for the approval step. ---
+        applicant = str(record.get('applicant_of_record', '') or '').strip()
+        applicant_email = str(_input.get('applicant_email', '') or '').strip()
+        if not applicant_email:
+            applicant_email = str(record.get('applicant_email', '') or '').strip()
+
+        required_docs = list(type_docs.get(permit_type, ['site_plan']))
+        ok = len(problems) == 0
+
+        result = {
+            'ok': ok,
+            'problems': problems,
+            'jurisdiction': jurisdiction,
+            'permit_type': permit_type,
+            'required_fields': required_fields,
+            'required_docs': required_docs,
+            'valuation': round(valuation, 2) if valuation >= 0 else None,
+            'applicant_of_record': applicant,
+            'applicant_email': applicant_email,
+            'file_refs': file_refs,
+            'file_count': len(file_refs),
+            'project_record': record,
+            'reason_summary': '; '.join(problems) if problems else 'record satisfies the jurisdiction+permit_type rules table',
+        }
+
+  # 1b) Hard stop on an incomplete package - never touch a portal with a non-compliant record.
+  - id: record_gate
+    type: condition
+    depends_on: [validate_record]
+    condition_config:
+      expression: "{steps.validate_record.output.ok} == True"
+      then: [route_portal]
+      else: [notify_blocked]
+
+  # 1c) BLOCKED branch: tell the permit desk the package was NOT filed and exactly why.
+  - id: notify_blocked
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        BLOCKED before any portal entry: permit package for {input.permit_type} in
+        {input.jurisdiction} failed the deterministic rules-table validation, so the e-permitting
+        portal was never touched. Reason(s): {steps.validate_record.output.reason_summary}. Fix the
+        project record / drawings and re-run.
+
+  # 2) ROUTE to the correct jurisdiction portal start_url (pure engine logic, NO model). A
+  #    known-jurisdiction map of Accela / Tyler EnerGov / OpenGov-hosted / environmental-agency
+  #    portals; unknown jurisdictions fall back to the supplied portal_start_url.
+  - id: route_portal
+    type: code
+    depends_on: [record_gate]
+    code_config:
+      language: python
+      code: |
+        jurisdiction = str(_input.get('jurisdiction', '') or '').strip().lower()
+
+        # Per-jurisdiction new-application wizard start URLs (login-gated SPAs, no submission API).
+        routes = {
+            'austin-tx':      'https://abc.austintexas.gov/web/permit/public-search-other',
+            'miami-dade-fl':  'https://aca.miamidade.gov/CitizenAccess/Default.aspx',
+            'denver-co':      'https://aca-prod.accela.com/DENVER/Default.aspx',
+            'seattle-wa':     'https://cosaccela.seattle.gov/portal/Default.aspx',
+            'phoenix-az':     'https://eservices.phoenix.gov/PDD/Default.aspx',
+            'mecklenburg-nc': 'https://energov.mecknc.gov/EnerGov_Prod/SelfService',
+            'ca-water-board': 'https://ciwqs.waterboards.ca.gov/ciwqs/',
+        }
+
+        fallback = str(_input.get('portal_start_url', '') or '').strip()
+        start_url = routes.get(jurisdiction, fallback)
+        known = jurisdiction in routes
+
+        routed = bool(start_url)
+        result = {
+            'jurisdiction': jurisdiction,
+            'start_url': start_url,
+            'known_jurisdiction': known,
+            'routed': routed,
+            'note': ('matched built-in route' if known else
+                     ('using supplied fallback url' if start_url else 'NO route - missing start_url')),
+        }
+
+  # 2b) If no portal URL could be resolved, stop before any browser step.
+  - id: route_gate
+    type: condition
+    depends_on: [route_portal]
+    condition_config:
+      expression: "{steps.route_portal.output.routed} == True"
+      then: [read_wizard]
+      else: [notify_no_route]
+
+  - id: notify_no_route
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        Permit for {input.permit_type} in {input.jurisdiction} could NOT be filed: no portal
+        start_url for this jurisdiction (not in the built-in route map and no portal_start_url
+        supplied). No application was lodged.
+
+  # 3) READ PASS (dom mode, READ-ONLY). Provider-neutral lightweight DOM read: the reasoning model
+  #    authenticates via PERMIT_PORTAL_CREDS (never inlined), opens the new-application wizard for
+  #    the permit_type, and EXTRACTS the wizard's structure - its ordered tabs, each tab's fields and
+  #    whether they are required (including conditional, code-driven fields), the upload_requirements
+  #    (which doc_type each slot takes and accepted formats), and the fee_summary - WITHOUT entering
+  #    or uploading anything. captcha_strategy=pause hands a portal CAPTCHA to a human; max_actions
+  #    caps clicking; output_schema returns structured JSON to map against.
+  - id: read_wizard
+    type: browser
+    depends_on: [route_gate]
+    prompt: >-
+      You are doing a READ-ONLY reconnaissance of a municipal e-permitting application wizard (Accela
+      Citizen Access, Tyler EnerGov, OpenGov-hosted, or a regional environmental agency portal). Log
+      in using the credentials provided via the PERMIT_PORTAL_CREDS environment variable (do NOT
+      print or echo them), then open the NEW-APPLICATION wizard for permit type {input.permit_type}.
+      DO NOT type into, select, check, upload to, or submit any field - this is a structure read
+      only. Walk the wizard tabs and report its structure: the ordered list of tabs, and for each tab
+      its fields (name, label, input type, whether required, allowed options if a dropdown, and any
+      conditional_on logic that shows/hides the field based on a prior answer such as the work type or
+      occupancy), the document UPLOAD requirements (for each upload slot: the doc_type it expects and
+      the accepted file formats), and the fee_summary the portal shows for this application type if
+      visible. If a CAPTCHA or step-up auth appears, PAUSE for a human. Context: jurisdiction
+      {input.jurisdiction}, permit_type {input.permit_type}. Return ONLY the structured object
+      described by the output schema.
+    browser_config:
+      mode: dom
+      start_url: "{steps.route_portal.output.start_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 300
+      max_actions: 60
+      headless: true
+      credentials_env: "PERMIT_PORTAL_CREDS"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          tabs:
+            type: array
+            items:
+              type: object
+              properties:
+                name: { type: string }
+                fields:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name: { type: string }
+                      label: { type: string }
+                      input_type: { type: string }
+                      required: { type: boolean }
+                      options:
+                        type: array
+                        items: { type: string }
+                      conditional_on: { type: string }
+          upload_requirements:
+            type: array
+            items:
+              type: object
+              properties:
+                doc_type: { type: string }
+                accepted: { type: string }
+                required: { type: boolean }
+          fee_summary:
+            type: object
+            properties:
+              estimated_fee: { type: number }
+              fee_note: { type: string }
+
+  # 4) MAP project_record -> the portal's fields and match each required doc_type to a drawing file
+  #    (provider-agnostic classify with failover). It emits the field-fill PLAN, the doc matching,
+  #    and classifies the OVERALL mapping outcome. The branch result tells the gate whether a human
+  #    is required (any missing doc or unmapped field).
+  - id: map_fields
+    type: classify
+    depends_on: [read_wizard]
+    model: haiku
+    classify_config:
+      model: haiku
+      input: >-
+        Map a validated permit project record onto a specific municipal e-permitting wizard's tabs
+        and fields, and match each required document slot to a drawing file. Produce a fill PLAN: for
+        each wizard field, the project-record value (or derived code value) that should go in it;
+        match every required upload doc_type to one of the drawing file refs; and an unmapped[] list
+        of any required field you cannot confidently fill plus a missing_docs[] list of any required
+        doc_type with no matching drawing file. Then classify the OVERALL mapping outcome into one
+        category. Use 'clean_complete' when every required field maps and every required doc_type has
+        a matching drawing file with nothing unmapped or missing; 'needs_human' when ANY required
+        field is unmapped OR any required doc_type has no matching file OR a conditional code-driven
+        field is ambiguous; 'unsupported' when the permit_type does not correspond to any branch the
+        wizard offers. Validated record: {steps.validate_record.output} . Required docs:
+        {steps.validate_record.output.required_docs} . Drawing files:
+        {steps.validate_record.output.file_refs} . Wizard structure: {steps.read_wizard.output} .
+      categories:
+        - clean_complete
+        - needs_human
+        - unsupported
+      branches:
+        clean_complete: [build_plan]
+        needs_human: [build_plan]
+        unsupported: [build_plan]
+
+  # 4b) DETERMINISTIC plan assembly (sandboxed Python, NO model). Turns the classify mapping +
+  #     validated record + read-only wizard structure into a concrete {plan, missing_docs[],
+  #     unmapped_fields[]}: every required wizard field must have a planned value, and every required
+  #     doc_type must resolve to one of the supplied drawing files. This is the load-bearing
+  #     pre-entry computation the gate and the human review against - not a model's opinion.
+  - id: build_plan
+    type: code
+    depends_on: [map_fields]
+    code_config:
+      language: python
+      code: |
+        record_out = _steps.get('validate_record') or {}
+        if not isinstance(record_out, dict):
+            record_out = {}
+        wizard = _steps.get('read_wizard') or {}
+        if not isinstance(wizard, dict):
+            wizard = {}
+        # Browser payloads may nest under output/data/result.
+        for key in ('output', 'data', 'result'):
+            inner = wizard.get(key)
+            if isinstance(inner, dict) and ('tabs' in inner or 'upload_requirements' in inner):
+                wizard = inner
+                break
+
+        record = record_out.get('project_record') or {}
+        if not isinstance(record, dict):
+            record = {}
+        file_refs = record_out.get('file_refs') or []
+        if not isinstance(file_refs, list):
+            file_refs = []
+        required_docs = record_out.get('required_docs') or []
+        if not isinstance(required_docs, list):
+            required_docs = []
+
+        # --- Build the field-fill plan: walk every required wizard field, fill from the record by
+        #     name or label, and record any required field we cannot fill. ---
+        tabs = wizard.get('tabs')
+        if not isinstance(tabs, list):
+            tabs = []
+
+        def _lookup(record_dict, field_name, field_label):
+            # Try the field name, then a normalized label, against the record keys.
+            name_key = str(field_name or '').strip().lower()
+            label_key = str(field_label or '').strip().lower().replace(' ', '_')
+            for cand in (name_key, label_key):
+                if cand and cand in record_dict:
+                    val = record_dict.get(cand)
+                    if str(val if val is not None else '').strip():
+                        return val
+            return None
+
+        # Normalize the record keys once to lowercase for matching.
+        record_lc = {}
+        for k, v in record.items():
+            record_lc[str(k).strip().lower()] = v
+
+        plan = []
+        unmapped_fields = []
+        for tab in tabs:
+            if not isinstance(tab, dict):
+                continue
+            tab_name = str(tab.get('name', '') or '')
+            fields = tab.get('fields')
+            if not isinstance(fields, list):
+                fields = []
+            for f in fields:
+                if not isinstance(f, dict):
+                    continue
+                fname = f.get('name')
+                flabel = f.get('label')
+                is_required = bool(f.get('required', False))
+                value = _lookup(record_lc, fname, flabel)
+                if value is None:
+                    if is_required:
+                        unmapped_fields.append(tab_name + '.' + str(fname or flabel or '<field>'))
+                    continue
+                plan.append({
+                    'tab': tab_name,
+                    'field': str(fname or flabel or ''),
+                    'value': value,
+                    'required': is_required,
+                })
+
+        # --- Match each required doc_type to a drawing file by a keyword hint in the file ref. ---
+        doc_keywords = {
+            'site_plan': ['site', 'plot', 'survey'],
+            'floor_plan': ['floor', 'plan', 'layout'],
+            'mep': ['mep', 'mechanical', 'electrical', 'plumbing'],
+            'environmental_report': ['environmental', 'enviro', 'phase'],
+            'structural': ['structural', 'struct'],
+        }
+
+        upload_reqs = wizard.get('upload_requirements')
+        if not isinstance(upload_reqs, list):
+            upload_reqs = []
+        # The required doc_types are the union of the rules-table docs and any required wizard slots.
+        portal_required_docs = []
+        for u in upload_reqs:
+            if isinstance(u, dict) and bool(u.get('required', False)):
+                dt = str(u.get('doc_type', '') or '').strip().lower()
+                if dt:
+                    portal_required_docs.append(dt)
+        all_required_docs = []
+        for dt in list(required_docs) + portal_required_docs:
+            dt_l = str(dt).strip().lower()
+            if dt_l and dt_l not in all_required_docs:
+                all_required_docs.append(dt_l)
+
+        used_files = []
+        doc_matches = []
+        missing_docs = []
+        for dt in all_required_docs:
+            kws = doc_keywords.get(dt, [dt])
+            matched_ref = ''
+            for ref in file_refs:
+                if ref in used_files:
+                    continue
+                ref_l = str(ref).lower()
+                if any(kw in ref_l for kw in kws):
+                    matched_ref = ref
+                    break
+            if matched_ref:
+                used_files.append(matched_ref)
+                doc_matches.append({'doc_type': dt, 'file_ref': matched_ref})
+            else:
+                missing_docs.append(dt)
+
+        ok = (len(unmapped_fields) == 0) and (len(missing_docs) == 0)
+
+        result = {
+            'ok': ok,
+            'plan': plan,
+            'planned_field_count': len(plan),
+            'doc_matches': doc_matches,
+            'matched_doc_count': len(doc_matches),
+            'missing_docs': missing_docs,
+            'unmapped_fields': unmapped_fields,
+            'required_docs': all_required_docs,
+            'reason_summary': (
+                'plan complete: all required fields mapped and all required docs matched'
+                if ok else
+                'missing_docs=' + str(missing_docs) + '; unmapped_fields=' + str(unmapped_fields)
+            ),
+        }
+
+  # 5) PRE-ENTRY GATE - ALL strategies must pass before anything is typed/uploaded into the portal.
+  #    (a) llm_eval code-compliance: confirm every code-required field has a value and every
+  #        mandatory doc_type is satisfied, traceable to the validated record (provider-swappable
+  #        verifier). (b) human: a permit specialist signs off on any missing/ambiguous item. This
+  #        gate is the last stop before the (still reversible) data entry.
+  - id: compliance_gate
+    type: gate
+    depends_on: [build_plan]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are a permit-intake code-compliance reviewer. Verify, BEFORE any data is entered or
+              any document is uploaded into the e-permitting portal, that the proposed application is
+              complete and compliant. Reply with exactly 'approved' only if: every code-required field
+              for {input.permit_type} in {input.jurisdiction} has a planned value (unmapped_fields is
+              empty), every mandatory document type has a matching drawing file (missing_docs is
+              empty), and every planned value is traceable to a fact in the validated project record
+              with no invented data. Otherwise reply 'rejected' and name each missing field or
+              document. Validated record: {steps.validate_record.output} . Fill plan + doc matches +
+              gaps: {steps.build_plan.output}
+            input: "{steps.build_plan.output}"
+            model: google/gemini-2.5-pro
+        - type: human
+          config:
+            message: >-
+              Permit pre-entry review for {input.permit_type} in {input.jurisdiction} (applicant of
+              record {steps.validate_record.output.applicant_of_record}). Confirm the field mapping
+              and document matching are correct and approve entry into the portal. Reject if any
+              missing document ({steps.build_plan.output.missing_docs}) or unmapped field
+              ({steps.build_plan.output.unmapped_fields}) needs handling first. Plan:
+              {steps.build_plan.output.plan}
+            timeout_hours: 48
+            on_timeout: abort
+
+  # 6) FILL PASS (playwright mode, provider-neutral). The reasoning model AUTHORS a Playwright script
+  #    that re-logs-in via PERMIT_PORTAL_CREDS, fills EVERY tab from the approved plan, uploads each
+  #    matched document to its required slot, advances to the REVIEW / FEE page, and STOPS - it does
+  #    NOT pay or submit. capture_screenshots gives an auditable review screenshot; output_schema
+  #    returns the review screenshot, the fee_amount the portal shows, the entered values, and the
+  #    uploaded-doc list for the applicant to approve. CAPTCHA pauses to a human; max_actions bounds
+  #    the multi-tab wizard.
+  - id: fill_to_fee
+    type: browser
+    depends_on: [compliance_gate]
+    prompt: >-
+      You are filing a municipal permit application on a multi-tab e-permitting wizard. Authenticate
+      using the PERMIT_PORTAL_CREDS environment variable (do NOT print or echo it), open the
+      new-application wizard for permit type {input.permit_type}, and walk it end to end. Using the
+      APPROVED fill plan, fill every required field on every tab from the validated project record,
+      handling conditional code-driven fields and waiting for client-side validation to settle before
+      advancing. For each matched document, upload the drawing file to its required upload slot by
+      doc_type. CRITICAL: advance only to the REVIEW / FEE page and STOP there - DO NOT check the
+      final agreement, DO NOT pay, and DO NOT click Submit / Lodge / File. Submission and the fee are
+      a separate, human-approved step. If a CAPTCHA or step-up auth appears, pause for a human.
+      Approved fill plan: {steps.build_plan.output.plan} . Document matches:
+      {steps.build_plan.output.doc_matches} . Validated record: {steps.validate_record.output} .
+      Return ONLY the structured object: a reference to the captured review-page screenshot, the fee
+      amount the portal shows on the review/fee page, the human-readable values entered, the list of
+      documents actually uploaded (doc_type + file_ref + slot), and whether the Submit button is
+      present and enabled.
+    browser_config:
+      mode: playwright
+      start_url: "{steps.route_portal.output.start_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 600
+      max_actions: 150
+      headless: true
+      credentials_env: "PERMIT_PORTAL_CREDS"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          review_screenshot: { type: string }
+          fee_amount:
+            type: number
+            description: "The application fee the PORTAL shows on the review/fee page (the figure the applicant must approve)."
+          entered_values:
+            type: object
+            description: "Human-readable map of the values entered into the portal, for the applicant to inspect."
+          uploaded_docs:
+            type: array
+            items:
+              type: object
+              properties:
+                doc_type: { type: string }
+                file_ref: { type: string }
+                slot: { type: string }
+          submit_button_present:
+            type: boolean
+            description: "True if the wizard reached the review/fee page with an enabled Submit/Lodge button (not yet clicked)."
+
+  # 6b) DETERMINISTIC validation of the FILLED review/fee state (sandboxed Python, NO model). The
+  #     load-bearing pre-submit check: a review screenshot must exist, the portal must show a
+  #     positive fee_amount, the uploaded-doc count must cover every required doc_type from the plan,
+  #     and the Submit button must be present (wizard truly reached the review/fee page). Fails
+  #     CLOSED - a bad fill never reaches the applicant approval or the submit.
+  - id: validate_fill
+    type: code
+    depends_on: [fill_to_fee]
+    code_config:
+      language: python
+      code: |
+        read_out = _steps.get('fill_to_fee') or {}
+        if not isinstance(read_out, dict):
+            read_out = {}
+        for key in ('output', 'data', 'result'):
+            inner = read_out.get(key)
+            if isinstance(inner, dict) and ('fee_amount' in inner or 'uploaded_docs' in inner):
+                read_out = inner
+                break
+
+        plan_out = _steps.get('build_plan') or {}
+        if not isinstance(plan_out, dict):
+            plan_out = {}
+
+        def _num(v, default=-1.0):
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return default
+
+        problems = []
+
+        # A review screenshot must exist for the applicant to inspect.
+        review_screenshot = str(read_out.get('review_screenshot', '') or '').strip()
+        if not review_screenshot:
+            problems.append('no review/fee screenshot captured for the applicant')
+
+        # The portal must show a positive fee on the review/fee page.
+        fee_amount = _num(read_out.get('fee_amount'), -1.0)
+        if fee_amount < 0:
+            problems.append('portal did not return a fee_amount on the review/fee page')
+        elif fee_amount == 0:
+            problems.append('portal fee_amount is zero - unexpected for a lodged application')
+
+        # Every required doc_type from the plan must appear in the uploaded docs.
+        required_docs = plan_out.get('required_docs') or []
+        if not isinstance(required_docs, list):
+            required_docs = []
+        uploaded = read_out.get('uploaded_docs')
+        if not isinstance(uploaded, list):
+            uploaded = []
+        uploaded_types = []
+        for u in uploaded:
+            if isinstance(u, dict):
+                dt = str(u.get('doc_type', '') or '').strip().lower()
+                if dt:
+                    uploaded_types.append(dt)
+        not_uploaded = [dt for dt in required_docs if dt not in uploaded_types]
+        if not_uploaded:
+            problems.append('required documents not uploaded: ' + str(not_uploaded))
+
+        # The wizard must actually have reached a submit-capable review/fee page.
+        if not read_out.get('submit_button_present'):
+            problems.append('submit button not present - wizard did not reach the review/fee page')
+
+        ok = len(problems) == 0
+        result = {
+            'ok': ok,
+            'problems': problems,
+            'fee_amount': round(fee_amount, 2) if fee_amount >= 0 else None,
+            'review_screenshot': review_screenshot,
+            'uploaded_doc_count': len(uploaded_types),
+            'uploaded_doc_types': uploaded_types,
+            'required_docs': required_docs,
+            'reason_summary': '; '.join(problems) if problems else 'review/fee page reached; fee shown; all required docs uploaded',
+        }
+
+  # 6c) Hard stop on a bad fill - do NOT advance to the applicant approval / submit on a bad review.
+  - id: fill_gate
+    type: condition
+    depends_on: [validate_fill]
+    condition_config:
+      expression: "{steps.validate_fill.output.ok} == True"
+      then: [approve_submit]
+      else: [notify_fill_failed]
+
+  - id: notify_fill_failed
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        Permit for {input.permit_type} in {input.jurisdiction} reached the portal review/fee page but
+        the deterministic fill check FAILED before submission:
+        {steps.validate_fill.output.reason_summary}. Nothing was submitted and no fee was paid.
+        Re-check the wizard fill and re-run.
+
+  # 7) APPLICANT-OF-RECORD APPROVAL before the irreversible submission AND fee. The applicant sees
+  #    the deterministically validated review summary, the EXACT fee_amount the portal will charge,
+  #    and the captured review screenshot, and explicitly authorizes both the official submission and
+  #    the fee. No submission/payment can occur without this gate; on_timeout: abort never
+  #    auto-submits or auto-pays.
+  - id: approve_submit
+    type: approval
+    approval_config:
+      message: >-
+        AUTHORIZE the OFFICIAL SUBMISSION AND FEE for the {input.permit_type} permit application in
+        {input.jurisdiction}. This is IRREVERSIBLE - it lodges the application with the jurisdiction
+        and triggers the fee. The application is filled and sitting on the portal's review/fee page.
+        The portal will charge a fee of {steps.validate_fill.output.fee_amount}. Documents uploaded:
+        {steps.validate_fill.output.uploaded_doc_count} (required {steps.build_plan.output.required_docs}).
+        Review the captured review-page screenshot - this is the EXACT application and fee you are
+        authorizing. Approve to accept the agreement and Submit (and pay the shown fee); reject to
+        abort with nothing lodged and no fee charged.
+      show_data: steps.validate_fill.output
+      show_images: ["steps.validate_fill.output.review_screenshot"]
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: false
+
+  # 8) SUBMIT PASS (playwright mode, WRITE). Only reached AFTER the applicant approves. Re-opens the
+  #    filled review/fee page, accepts the agreement, and clicks the single final Submit/Lodge button
+  #    ONCE (triggering the fee per policy), then reads the portal's confirmation page and captures
+  #    {application_number, status, fee_charged, submitted_at}. capture_screenshots gives an
+  #    after-submit audit record; max_actions tightly capped (accept + one confirm action); CAPTCHA
+  #    pauses to a human at the final wall.
+  - id: submit_application
+    type: browser
+    depends_on: [approve_submit]
+    prompt: >-
+      The applicant of record has authorized this IRREVERSIBLE permit submission and fee for
+      {input.permit_type} in {input.jurisdiction}. Authenticate with PERMIT_PORTAL_CREDS if the
+      session expired (do NOT print it), return to the filled review/fee page, confirm the fee still
+      reads {steps.validate_fill.output.fee_amount}, check the required agreement / acknowledgement
+      checkbox, then click the SINGLE final Submit / Lodge / File button ONCE to lodge the
+      application and trigger the fee per policy. Do NOT edit any field, do NOT upload anything more,
+      and do NOT click submit more than once. If a CAPTCHA or step-up auth appears at this final wall,
+      PAUSE for a human - do not attempt to solve it. Then read the portal's confirmation page and
+      capture the jurisdiction-issued APPLICATION / RECORD NUMBER, the application status, the fee
+      actually charged, and the submitted timestamp. Return ONLY the structured object described by
+      the output schema.
+    browser_config:
+      mode: playwright
+      start_url: "{steps.route_portal.output.start_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 300
+      max_actions: 25
+      headless: true
+      credentials_env: "PERMIT_PORTAL_CREDS"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          application_number:
+            type: string
+            description: "The jurisdiction-issued application / record number for the lodged permit."
+          status:
+            type: string
+            description: "The application status the portal shows after submit (e.g. submitted, received, under_review)."
+          fee_charged:
+            type: number
+            description: "The fee the portal actually charged on submit (must equal the applicant-approved fee_amount)."
+          submitted_at:
+            type: string
+            description: "Timestamp the portal recorded for the submission."
+          receipt_screenshot:
+            type: string
+            description: "Reference/path of the captured confirmation/receipt screenshot for the permit record."
+
+  # 9) DETERMINISTIC SUCCESS + FEE-MATCH GATE (sandboxed Python, NO model). Assert the
+  #    application_number is present AND the fee_charged equals the applicant-approved fee_amount
+  #    within tolerance. A missing application_number means the submit did not provably land; a fee
+  #    mismatch means a silent overpay/underpay - either fails the run. A false success or a silent
+  #    overpay can NEVER be recorded as a clean filing.
+  - id: assert_filing
+    type: code
+    depends_on: [submit_application]
+    code_config:
+      language: python
+      code: |
+        import re
+        sub = _steps.get('submit_application') or {}
+        if not isinstance(sub, dict):
+            sub = {}
+        for key in ('output', 'data', 'result'):
+            inner = sub.get(key)
+            if isinstance(inner, dict) and ('application_number' in inner):
+                sub = inner
+                break
+
+        application_number = str(sub.get('application_number', '') or '').strip()
+        status = str(sub.get('status', '') or '').strip()
+        submitted_at = str(sub.get('submitted_at', '') or '').strip()
+
+        def _num(v, default=-1.0):
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return default
+
+        fee_charged = _num(sub.get('fee_charged'), -1.0)
+
+        # The applicant-approved fee comes from the deterministically validated review/fee state.
+        fill_out = _steps.get('validate_fill') or {}
+        if not isinstance(fill_out, dict):
+            fill_out = {}
+        approved_fee = _num(fill_out.get('fee_amount'), -1.0)
+
+        tolerance = abs(_num(_input.get('fee_tolerance'), 0.01))
+        if tolerance < 0:
+            tolerance = 0.01
+
+        problems = []
+
+        # 9a) Application number must be present and look like a real record number.
+        number_ok = bool(application_number) and bool(re.search(r'[A-Za-z0-9]', application_number))
+        if not application_number:
+            problems.append('portal returned no application_number - submission not provably accepted')
+        elif not number_ok:
+            problems.append('application_number "' + application_number + '" is not a plausible record number')
+
+        # 9b) Fee charged must match the applicant-approved fee within tolerance (no silent overpay).
+        fee_ok = (approved_fee >= 0) and (fee_charged >= 0) and (abs(fee_charged - approved_fee) <= max(tolerance, 0.01))
+        if approved_fee < 0:
+            problems.append('approved fee_amount is missing - cannot verify the charge')
+            fee_ok = False
+        elif fee_charged < 0:
+            problems.append('portal did not report a fee_charged - cannot verify the charge')
+            fee_ok = False
+        elif not fee_ok:
+            problems.append(
+                'fee mismatch: portal charged ' + str(round(fee_charged, 2))
+                + ' but applicant approved ' + str(round(approved_fee, 2)) + ' (no silent overpay)'
+            )
+
+        if not submitted_at:
+            problems.append('no submitted_at timestamp returned')
+
+        filed = number_ok and fee_ok and (len(problems) == 0)
+
+        result = {
+            'filed': filed,
+            'problems': problems,
+            'application_number': application_number,
+            'status': status,
+            'fee_charged': round(fee_charged, 2) if fee_charged >= 0 else None,
+            'approved_fee': round(approved_fee, 2) if approved_fee >= 0 else None,
+            'submitted_at': submitted_at,
+            'jurisdiction': str(_input.get('jurisdiction', '') or ''),
+            'permit_type': str(_input.get('permit_type', '') or ''),
+            'reason_summary': '; '.join(problems) if problems else 'application_number present and fee matches the approved amount',
+        }
+
+  # 9b) Branch on the deterministic success + fee-match gate. Only a provably-filed, fee-matched
+  #     application proceeds to the reliability replay and recording.
+  - id: filed_gate
+    type: condition
+    depends_on: [assert_filing]
+    condition_config:
+      expression: "{steps.assert_filing.output.filed} == True"
+      then: [replay_vs_golden]
+      else: [notify_submit_unconfirmed]
+
+  # 9c) UNCONFIRMED / FEE-MISMATCH PATH - submit happened but the application_number did not validate
+  #     or the fee did not match. Page the team and leave the run needing attention. A false success
+  #     or a silent overpay is NEVER recorded.
+  - id: notify_submit_unconfirmed
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        NEEDS ATTENTION: permit submit for {input.permit_type} in {input.jurisdiction} did NOT pass
+        the deterministic success/fee-match check: {steps.assert_filing.output.reason_summary}. Do
+        NOT assume the application was lodged or the fee is correct - manually check the portal. The
+        run is left in a needs-attention state.
+
+  # 10) TRAJECTORY-REPLAY - the per-jurisdiction reliability check. Loads the jurisdiction's golden
+  #     trajectory by golden_run_id, diffs this filing flow against it, and FAILS when the replay
+  #     score drops below fail_below_score (a portal redesign diverged) OR cost exceeds the allowed
+  #     delta / budget. Deterministic scorer, not a model's opinion - it makes reliability a property
+  #     of recorded runs, catching portal changes before they corrupt future filings.
+  - id: replay_vs_golden
+    type: trajectory-replay
+    depends_on: [filed_gate]
+    trajectory_replay_config:
+      golden_run_id: "{input.golden_run_id}"
+      fail_below_score: 0.85
+      allow_cost_delta_pct: 10.0
+      cost_budget_usd: 0.5
+
+  # 11a) WRITE-BACK the filed application_number + receipt to the project tracker (deterministic
+  #      http POST to your OWN system, not the portal).
+  - id: writeback_tracker
+    type: http
+    depends_on: [replay_vs_golden]
+    http_config:
+      url: "{input.tracker_url}"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+      auth: "bearer:{env.TRACKER_TOKEN}"
+      body: '{"jurisdiction": "{steps.assert_filing.output.jurisdiction}", "permit_type": "{steps.assert_filing.output.permit_type}", "application_number": "{steps.assert_filing.output.application_number}", "status": "{steps.assert_filing.output.status}", "fee_charged": "{steps.assert_filing.output.fee_charged}", "submitted_at": "{steps.assert_filing.output.submitted_at}"}'
+
+  # 11b) NOTIFY the permit desk that the application was lodged, with the jurisdiction-issued number.
+  - id: notify_filed
+    type: notify
+    depends_on: [writeback_tracker]
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        FILED: {input.permit_type} permit application in {input.jurisdiction} lodged. Application
+        number {steps.assert_filing.output.application_number}, status
+        {steps.assert_filing.output.status}, fee charged {steps.assert_filing.output.fee_charged}
+        (applicant-approved {steps.assert_filing.output.approved_fee}), submitted
+        {steps.assert_filing.output.submitted_at}.
+
+  # 11c) ARCHIVE the receipt as a reusable summary via a sub-workflow so every filing leaves an
+  #      auditable record (read-only, no portal write).
+  - id: archive_receipt
+    type: sub_workflow
+    depends_on: [notify_filed]
+    sub_workflow:
+      workflow: "summarize"
+      input_mapping:
+        text: >-
+          Permit filing record. Jurisdiction {steps.assert_filing.output.jurisdiction}, permit type
+          {steps.assert_filing.output.permit_type}, application number
+          {steps.assert_filing.output.application_number}, status
+          {steps.assert_filing.output.status}, fee charged {steps.assert_filing.output.fee_charged}
+          (applicant-approved {steps.assert_filing.output.approved_fee}), submitted
+          {steps.assert_filing.output.submitted_at}.
+        format: "bullet-points"
+      max_concurrent: 1
+
+  # 11d) REPORT - log the filing as a branded PDF record for the permit firm's audit trail.
+  - id: filing_report
+    type: report
+    depends_on: [archive_receipt]
+    report_config:
+      template: "research-report"
+      format: pdf
+      theme: professional
+      title: "Permit Filing Record - {steps.assert_filing.output.application_number}"
+      author: "Permit Filing Desk"
+    prompt: >-
+      Produce a formal permit filing record PDF from the payload below. Include the jurisdiction,
+      permit type, the jurisdiction-issued application number, the status, the fee charged and the
+      applicant-approved fee, the submitted timestamp, and a note that the project record was
+      deterministically validated against the jurisdiction+permit_type rules table, a dual
+      code-compliance check (llm_eval + human pre-entry gate) passed, the applicant of record
+      approved the official submission and the exact fee, the charged fee was deterministically
+      asserted to equal the approved amount, and a per-jurisdiction trajectory-replay confirmed the
+      portal had not drifted. Filing payload: {steps.assert_filing.output} . Validated review/fee
+      state: {steps.validate_fill.output}
+
+on_complete:
+  storage_path: "permit-eportal-application-filer/{input.jurisdiction}/{input.permit_type}/{run_id}/result.json"

--- a/src/sandcastle/templates/portal_login_2fa_extract_skeleton.yaml
+++ b/src/sandcastle/templates/portal_login_2fa_extract_skeleton.yaml
@@ -1,0 +1,452 @@
+# name: Portal Login 2FA Extract Skeleton
+# description: The canonical login-with-credentials-env, pause-on-2FA/CAPTCHA, then structured-extract skeleton that every gated-portal RPA flow forks from. A playwright browser step navigates the start_url, fills the login form from credentials_env, and submits - captcha_strategy=pause hands BOTH the CAPTCHA and the interactive SMS/TOTP 2FA challenge to a human (HITL). A sensor then confirms the portal's own authenticated report endpoint is reachable before the read is trusted. A second, cheap dom-mode browser step reads the post-login report table and returns strict JSON via output_schema {rows:[{date,metric,amount}], page_count}. A deterministic code step VALIDATES the extraction (row count > 0, every amount parses as a number after stripping currency symbols, page_count consistent with the read) and raises on schema drift. A condition routes: on a bad/empty read it notifies Slack with the screenshot_on_error artifact and stops; on success a transform normalizes to the caller's shape for the parent workflow. Strictly READ-ONLY by design - no submit / pay / file / delete anywhere, so no approval gate is needed. Both browser steps run in provider-neutral playwright/dom mode where the reasoning model only AUTHORS the script, so default_model is fully swappable; the load-bearing correctness is deterministic code + an engine-native sensor, never a single model's opinion.
+# tags: [RPA, BrowserAutomation, Playwright, DOM, PortalLogin, TwoFactor, CAPTCHA, HumanInTheLoop, StructuredExtract, ReadOnly, ProviderNeutral, Skeleton, Sensor, NoAPI]
+# category: general_ai
+
+name: portal-login-2fa-extract-skeleton
+description: >-
+  The canonical login-with-credentials-env, pause-on-2FA/CAPTCHA, then
+  structured-extract skeleton that every gated-portal RPA flow forks from. Built
+  for RevOps / FinOps / IT admins who must pull data from a vendor portal (a
+  carrier dashboard, a supplier EDI portal, a state tax site, an insurance broker
+  portal) that ships NO API and hides everything behind a login plus an
+  interactive SMS / TOTP 2FA challenge. The data lives entirely inside an
+  authenticated session on a JS-heavy portal with no export endpoint, so a plain
+  http step cannot establish the session cookie, cannot satisfy the 2FA prompt,
+  and cannot read DOM rendered client-side after login - only a real browser
+  driving the login form reaches it. Triggered nightly (cron / scheduled) or
+  manually with a {portal_name} + {target_report} input, and reused as a
+  sub_workflow building block by higher-level flows. Step 1 is a PLAYWRIGHT
+  browser step (provider-neutral - the reasoning model only authors the script):
+  it opens the start_url, fills the login form from credentials_env (NEVER an
+  inline secret), and submits; captcha_strategy=pause hands BOTH a CAPTCHA and the
+  interactive 2FA code entry to a human (HITL), max_actions caps runaway clicking,
+  and capture_screenshots keeps an audit / screenshot_on_error artifact. Step 2 is
+  an engine-native SENSOR that polls the portal's OWN authenticated report
+  endpoint until it answers 200, deterministically proving the login + 2FA session
+  actually took hold before any read is trusted. Step 3 is a cheap DOM-mode browser
+  read that returns ONLY the strict output_schema {rows:[{date,metric,amount}],
+  page_count} - no write of any kind. Step 4 is deterministic sandboxed Python that
+  VALIDATES the extraction with no model: row count > 0, every amount parses as a
+  number after stripping currency symbols, and page_count is consistent with the
+  rows read; it raises on schema drift so nothing downstream trusts a bad read.
+  Step 5 is a condition that, on a failed / empty read, NOTIFIES Slack with the
+  screenshot_on_error artifact and stops, or on success runs a TRANSFORM that
+  normalizes the rows to the caller's shape and emits the JSON for the parent
+  workflow. The whole flow is strictly READ-ONLY - no submit, pay, file, withdraw,
+  or delete exists anywhere, which is why no approval gate is required and which
+  sidesteps the biggest RPA legality / ToS hazard. Both browser steps ride
+  default_model and stay swappable across all providers; the sensor and the
+  deterministic code validation are model-independent and engine-native.
+  (connectors: vendor portal via browser, slack)
+
+default_model: sonnet
+default_max_turns: 8
+default_timeout: 1200
+
+input_schema:
+  required: ["portal_name", "login_url", "report_url", "target_report"]
+  properties:
+    portal_name:
+      type: string
+      description: >-
+        Human-readable name of the gated vendor portal being pulled (carrier
+        dashboard, supplier EDI portal, state tax site, insurance broker portal).
+        Used in prompts, the sensor reasoning, and notifications.
+      example: "Acme Carrier Dashboard"
+    login_url:
+      type: string
+      description: >-
+        URL of the portal's login page. Templated into the playwright login
+        step's start_url. The login form is filled from credentials_env, never
+        from an inline secret.
+      example: "https://portal.acme-carrier.example/login"
+    report_url:
+      type: string
+      description: >-
+        URL of the post-login report page the dom-mode read step opens to extract
+        the table, AND the authenticated endpoint the sensor polls to prove the
+        session took hold. Reachable ONLY after login + 2FA succeed.
+      example: "https://portal.acme-carrier.example/reports/monthly-spend"
+    target_report:
+      type: string
+      description: >-
+        Which report / table on the post-login page to extract (e.g. 'monthly
+        spend by line item', 'open shipments', 'tax balance due'). Steers the
+        dom-mode read's prompt.
+      example: "monthly spend by line item"
+    portal_credentials_env:
+      type: string
+      description: >-
+        NAME of the environment variable holding the portal login credentials.
+        Secrets are NEVER inlined - only the env var name is passed to the browser
+        step's credentials_env.
+      default: "PORTAL_CREDS"
+      example: "PORTAL_CREDS"
+    expected_currency:
+      type: string
+      description: >-
+        Currency symbol / code the deterministic validator strips from each amount
+        before parsing it as a number (defends against '$1,234.50', 'EUR 42'…).
+      default: "$"
+      example: "$"
+    min_rows:
+      type: integer
+      description: >-
+        The validator rejects the read as empty / drifted if fewer than this many
+        rows came back. Default 1 (a report with zero rows is treated as a
+        suspicious read, not a valid empty result).
+      default: 1
+      example: "1"
+    sensor_poll_interval_seconds:
+      type: integer
+      description: "Seconds between polls of the authenticated report endpoint while waiting for the login + 2FA session to take hold."
+      default: 30
+      example: "30"
+    sensor_timeout_seconds:
+      type: integer
+      description: >-
+        Hard ceiling in seconds the session sensor waits for the authenticated
+        endpoint to answer 200 (covers the human-paced 2FA / CAPTCHA hand-off)
+        before the run aborts rather than reading an unauthenticated page.
+      default: 1800
+      example: "1800"
+    oncall_channel:
+      type: string
+      description: "Slack channel notified when the extraction fails validation (bad / empty / drifted read), with the screenshot_on_error artifact attached."
+      default: "#portal-rpa-oncall"
+      example: "#portal-rpa-oncall"
+
+steps:
+  # ---------------------------------------------------------------------------
+  # 1) LOGIN (PLAYWRIGHT - PROVIDER-NEUTRAL). The configured reasoning model only
+  #    AUTHORS the Playwright login script from this prompt, so default_model is
+  #    fully swappable across providers. It opens the login_url, fills the form
+  #    from credentials_env (NEVER an inline secret), and submits. captcha_strategy
+  #    =pause hands BOTH a CAPTCHA and the interactive SMS / TOTP 2FA challenge to a
+  #    human (HITL) - the model never tries to solve a CAPTCHA or guess a 2FA code.
+  #    max_actions caps runaway clicking; capture_screenshots keeps an audit /
+  #    screenshot_on_error artifact. This step performs NO write beyond signing in.
+  # ---------------------------------------------------------------------------
+  - id: portal_login
+    type: browser
+    prompt: >-
+      You are signing in to the gated vendor portal "{input.portal_name}" as a
+      READ-ONLY data clerk. There is NO API - the target data lives only behind
+      this login plus an interactive 2FA challenge. Open the login page at the
+      start URL and authenticate using ONLY the credentials supplied by the
+      credentials_env environment variable. NEVER hardcode, echo, or log the
+      secret. Steps: (1) fill the username / email and password fields from the
+      environment credentials and submit the login form. (2) If a CAPTCHA appears,
+      STOP and hand off to a human - do not attempt to solve it (captcha_strategy=
+      pause). (3) If an SMS / TOTP / device-verification 2FA prompt appears, STOP
+      and PAUSE for a human to enter the one-time code - never guess or fabricate a
+      code. (4) After authentication succeeds, confirm you have reached the
+      logged-in area (an account / dashboard landing). Do NOT submit, file, pay,
+      upload, change, or delete anything - signing in is the only action. Return
+      whether login completed and whether a 2FA / CAPTCHA hand-off was required.
+    browser_config:
+      mode: playwright
+      start_url: "{input.login_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 30
+      headless: true
+      credentials_env: "{input.portal_credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          logged_in:
+            type: boolean
+            description: "True once the portal shows an authenticated / logged-in landing."
+          two_factor_required:
+            type: boolean
+            description: "True if an SMS / TOTP 2FA challenge was presented and handed to a human."
+          captcha_encountered:
+            type: boolean
+            description: "True if a CAPTCHA was presented and paused for a human."
+          landing_url:
+            type: string
+            description: "The URL of the authenticated landing page reached after login."
+        required: ["logged_in"]
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: abort
+
+  # ---------------------------------------------------------------------------
+  # 2) SESSION SENSOR (engine-native, no model) - prove the login + interactive 2FA
+  #    session ACTUALLY took hold before any read is trusted. Polls the portal's
+  #    OWN authenticated report endpoint (report_url) until it answers HTTP 200,
+  #    which is reachable only inside a valid authenticated session. The human-paced
+  #    2FA / CAPTCHA hand-off can take minutes, so this poll-with-timeout absorbs
+  #    that wait deterministically; on timeout the run aborts rather than reading an
+  #    unauthenticated / login-redirected page. Pure control flow - no model opinion.
+  # ---------------------------------------------------------------------------
+  - id: await_session
+    type: sensor
+    depends_on: [portal_login]
+    sensor_config:
+      url: "{input.report_url}"
+      method: GET
+      headers:
+        Accept: "text/html,application/json"
+      condition: "status_code == 200"
+      check_interval: 30
+      timeout: 1800
+
+  # ---------------------------------------------------------------------------
+  # 3) EXTRACT (DOM mode - PROVIDER-NEUTRAL, cheap). With the session proven live,
+  #    the reasoning model authors a lightweight DOM read of the post-login report
+  #    table and returns ONLY the strict output_schema {rows:[{date,metric,amount}],
+  #    page_count}. dom mode is a cheap server-rendered / rendered-DOM read and the
+  #    authoring model is swappable via default_model. This is PURELY the READ pass:
+  #    no form submission, no write of any kind. captcha_strategy=pause covers a
+  #    surprise step-up wall; max_actions caps clicking; capture_screenshots keeps
+  #    the screenshot_on_error audit artifact for the notify branch.
+  # ---------------------------------------------------------------------------
+  - id: extract_report
+    type: browser
+    depends_on: [await_session]
+    prompt: >-
+      The session for "{input.portal_name}" is authenticated. Open the report page
+      at the start URL and extract the "{input.target_report}" table. Read EVERY
+      data row across ALL pages (follow pagination / "next" if present). For each
+      row capture exactly three fields: the date, the metric / line-item label, and
+      the amount (keep the amount as the literal text the portal shows, including
+      any currency symbol or thousands separators - a deterministic validator
+      downstream parses it). Also report page_count = the number of report pages you
+      paged through. Do NOT submit, file, pay, export, change, or delete anything -
+      this is extraction ONLY. If a CAPTCHA or step-up auth wall appears, PAUSE for
+      a human. Return ONLY the structured JSON described by the output schema: a
+      rows array of {date, metric, amount} objects and an integer page_count.
+    browser_config:
+      mode: dom
+      start_url: "{input.report_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 40
+      headless: true
+      credentials_env: "{input.portal_credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          rows:
+            type: array
+            items:
+              type: object
+              properties:
+                date: { type: string }
+                metric: { type: string }
+                amount: { type: string }
+              required: ["date", "metric", "amount"]
+          page_count:
+            type: integer
+            description: "Number of report pages paged through to read all rows."
+        required: ["rows"]
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: abort
+
+  # ---------------------------------------------------------------------------
+  # 4) VALIDATE the extraction DETERMINISTICALLY (no model) - the load-bearing
+  #    correctness gate. Asserts row count >= min_rows, that every amount parses as
+  #    a number after stripping the currency symbol / separators (re.sub on the
+  #    string, NEVER os/subprocess/eval), and that page_count is consistent with the
+  #    rows read. ANY mismatch / empty read / schema drift => ok=False with a
+  #    human-readable reason; nothing downstream trusts a bad read. This pairs with
+  #    the session sensor above so reliability is deterministic, not a model opinion.
+  # ---------------------------------------------------------------------------
+  - id: validate_extraction
+    type: code
+    depends_on: [extract_report]
+    code_config:
+      language: python
+      code: |
+        # Deterministic gate over the dom-mode READ pass. No model decides
+        # correctness here. The browser step may nest its structured payload under
+        # output / data / result, so unwrap defensively first.
+        payload = _steps.get("extract_report") or {}
+        if not isinstance(payload, dict):
+            payload = {"raw": payload}
+        for key in ("output", "data", "result"):
+            inner = payload.get(key)
+            if isinstance(inner, dict) and ("rows" in inner or "page_count" in inner):
+                payload = inner
+                break
+
+        rows = payload.get("rows")
+        if not isinstance(rows, list):
+            rows = []
+
+        try:
+            min_rows = int(_input.get("min_rows", 1) or 1)
+        except (TypeError, ValueError):
+            min_rows = 1
+
+        currency = str(_input.get("expected_currency", "$") or "")
+
+        reasons = []
+
+        # --- Row count: an empty / sub-threshold read is treated as a bad read ---
+        if len(rows) < min_rows:
+            reasons.append(
+                "row count " + str(len(rows)) + " is below the minimum " + str(min_rows)
+                + " (empty or drifted read)"
+            )
+
+        def _parse_amount(raw):
+            # Strip the configured currency symbol, thousands separators, and any
+            # surrounding whitespace, then parse the remainder as a float. Uses
+            # re.sub on the string directly - pure sandboxed string handling.
+            s = str(raw if raw is not None else "").strip()
+            if currency:
+                s = s.replace(currency, "")
+            # Remove currency letters, spaces and thousands separators, keep digits,
+            # sign and decimal point. A leading minus / parentheses negative is kept
+            # as a sign so refunds/credits still parse.
+            neg = s.startswith("(") and s.endswith(")")
+            s = re.sub(r"[^0-9.\-]", "", s)
+            if neg and not s.startswith("-"):
+                s = "-" + s
+            if s in ("", "-", ".", "-."):
+                return None
+            try:
+                return round(float(s), 2)
+            except (TypeError, ValueError):
+                return None
+
+        clean_rows = []
+        bad_amounts = []
+        for idx, r in enumerate(rows):
+            if not isinstance(r, dict):
+                bad_amounts.append({"index": idx, "reason": "row_not_object"})
+                continue
+            date = str(r.get("date", "") or "").strip()
+            metric = str(r.get("metric", "") or "").strip()
+            amount_raw = r.get("amount", "")
+            amount = _parse_amount(amount_raw)
+            row_reasons = []
+            if not date:
+                row_reasons.append("missing_date")
+            if not metric:
+                row_reasons.append("missing_metric")
+            if amount is None:
+                row_reasons.append("amount_not_numeric")
+            if row_reasons:
+                bad_amounts.append({
+                    "index": idx,
+                    "raw_amount": str(amount_raw)[:80],
+                    "reasons": row_reasons,
+                })
+                continue
+            clean_rows.append({
+                "date": date,
+                "metric": metric,
+                "amount": amount,
+                "amount_raw": str(amount_raw)[:80],
+            })
+
+        if bad_amounts:
+            reasons.append(
+                str(len(bad_amounts)) + " row(s) failed parsing (non-numeric amount "
+                + "or missing date/metric) - likely schema drift"
+            )
+
+        # --- page_count consistency: a positive row set must have paged at least
+        #     one page; a page_count of 0 alongside rows signals a drifted read. ---
+        page_count_raw = payload.get("page_count", 1)
+        try:
+            page_count = int(page_count_raw)
+        except (TypeError, ValueError):
+            page_count = 0
+        if len(clean_rows) > 0 and page_count < 1:
+            reasons.append(
+                "page_count " + str(page_count) + " is inconsistent with "
+                + str(len(clean_rows)) + " extracted rows"
+            )
+
+        ok = bool(len(reasons) == 0 and len(clean_rows) >= min_rows)
+
+        total_amount = round(sum(r["amount"] for r in clean_rows), 2)
+
+        result = {
+            "ok": ok,
+            "row_count": len(clean_rows),
+            "bad_row_count": len(bad_amounts),
+            "bad_rows": bad_amounts,
+            "page_count": page_count,
+            "total_amount": total_amount,
+            "rows": clean_rows,
+            "reasons": reasons,
+            "reason_summary": "; ".join(reasons) if reasons else "all checks passed",
+            "portal_name": str(_input.get("portal_name", "")),
+            "target_report": str(_input.get("target_report", "")),
+        }
+
+  # ---------------------------------------------------------------------------
+  # 5) CONDITION - route on the DETERMINISTIC validation flag (not a model's
+  #    opinion). On a clean read, normalize and emit for the parent workflow. On a
+  #    bad / empty / drifted read, notify on-call with the screenshot_on_error
+  #    artifact and STOP. This is a strictly READ-ONLY flow, so there is no
+  #    irreversible action and no approval gate is required by design.
+  # ---------------------------------------------------------------------------
+  - id: route_extraction
+    type: condition
+    depends_on: [validate_extraction]
+    condition_config:
+      expression: "{steps.validate_extraction.output.ok} == True"
+      then: [normalize_output]
+      else: [notify_bad_read]
+
+  # 5a) BAD-READ PATH - the extraction failed deterministic validation (empty,
+  #     non-numeric amounts, or schema drift). Page on-call with the reasons and the
+  #     screenshot_on_error audit artifact; the run stops with nothing trusted. No
+  #     portal write ever happens - this only alerts.
+  - id: notify_bad_read
+    type: notify
+    depends_on: [route_extraction]
+    notify_config:
+      service: slack
+      channel: "{input.oncall_channel}"
+      message: >-
+        :rotating_light: Portal extract FAILED validation for
+        "{input.portal_name}" ({input.target_report}). The dom-mode read did not
+        pass the deterministic gate, so nothing downstream trusted it. Reason(s):
+        {steps.validate_extraction.output.reason_summary}. Rows read:
+        {steps.validate_extraction.output.row_count}, bad rows:
+        {steps.validate_extraction.output.bad_row_count}, page_count:
+        {steps.validate_extraction.output.page_count}. See the captured
+        screenshot_on_error artifact from the extract step for the exact page
+        state (likely a portal redesign, an expired session, or a login wall).
+        This run was strictly READ-ONLY - no submit / pay / file / delete occurred.
+
+  # 5b) SUCCESS PATH - the read passed deterministic validation. TRANSFORM
+  #     normalizes the validated rows into the caller's shape and emits the JSON the
+  #     parent workflow (which reuses this skeleton as a sub_workflow) consumes.
+  - id: normalize_output
+    type: transform
+    depends_on: [route_extraction]
+    transform_config:
+      template: |
+        {
+          "portal_name": "{steps.validate_extraction.output.portal_name}",
+          "target_report": "{steps.validate_extraction.output.target_report}",
+          "extracted_at": "{run_id}",
+          "row_count": {steps.validate_extraction.output.row_count},
+          "page_count": {steps.validate_extraction.output.page_count},
+          "total_amount": {steps.validate_extraction.output.total_amount},
+          "rows": {steps.validate_extraction.output.rows},
+          "read_only": true,
+          "validation": "passed"
+        }
+
+on_complete:
+  storage_path: "portal-login-2fa-extract-skeleton/{run_id}/extracted-report.json"

--- a/src/sandcastle/templates/race_two_models_author_scrape_skeleton.yaml
+++ b/src/sandcastle/templates/race_two_models_author_scrape_skeleton.yaml
@@ -1,0 +1,500 @@
+# name: Race Two Models Author Scrape Skeleton
+# description: A cross-provider resilience skeleton that races two different reasoning models to author the SAME Playwright extraction against a brittle, frequently-changing SPA and takes whichever returns schema-valid output FIRST - so a single model's bad day never breaks a high-value scrape. The race arbitrates purely on a deterministic schema gate, not on any model's opinion, which makes the flow provably provider-neutral: adding or dropping a provider is a one-line branch change. Read-only extraction, so there is no irreversible action and no approval gate; safety comes from the code-step schema gate, a drift classifier, per-branch max_actions caps, captcha_strategy=pause, and a hard notify that surfaces both-branch failure to humans rather than emitting silent garbage.
+# tags: [rpa, browser, playwright, race, cross-provider, scraping, spa, resilience, provider-neutral, drift-detection]
+# category: general_ai
+
+name: race-two-models-author-scrape-skeleton
+description: >-
+  A resilience skeleton for teams running high-value, brittle extractions against a
+  client-side-rendered SPA with no API and anti-scraping that changes selectors often
+  (competitor pricing intelligence off a JS storefront, listing data off a marketplace,
+  dynamic dashboards). The data exists ONLY in the rendered DOM after JS executes, so an
+  http/API call cannot touch it - the hard part is authoring a script that survives the
+  CURRENT DOM, and that is exactly what differs between reasoning providers. This skeleton
+  makes cross-provider redundancy the reliability mechanism: a single race step runs two
+  branches in parallel, each a PLAYWRIGHT browser step over the same {input.target_url}
+  with the SAME output_schema {items:[{name,price,availability}]}, but each branch is pinned
+  to a DIFFERENT provider via its model override, so two providers independently author the
+  extraction against the live page. The race resolves to the FIRST branch that returns a
+  non-empty result; a deterministic, sandboxed code step then VALIDATES that winner against
+  the schema with no model (every price parses, item count sits within an expected band, no
+  null fields) and, if the winner is invalid, transparently falls back to the OTHER completed
+  branch. A classify step flags suspicious deltas versus the last run (a >40% price swing reads
+  as likely DOM-drift, not a real market move). A condition routes the outcome: if BOTH branches
+  fail schema validation it fires a notify carrying both branches' audit screenshots so a human
+  can re-author the prompt and so the trajectory-replay harness can quarantine the flow; otherwise
+  it emits the clean, validated JSON. The extraction is read-only, so there is no submit/pay/delete
+  step and therefore no approval gate - but the notify keeps humans in the loop on drift. Both
+  branches ride swappable Playwright; correctness is decided by the deterministic code-step schema
+  gate plus the drift classifier, never by trusting one model's output.
+
+default_model: sonnet
+default_timeout: 900
+
+input_schema:
+  required: ["target_url"]
+  properties:
+    target_url:
+      type: string
+      description: >-
+        Entry URL of the client-side-rendered SPA to scrape. Both race branches open this same
+        URL and author their own Playwright extraction against the live DOM. Provider-neutral -
+        any JS storefront / marketplace / dashboard works.
+      example: "https://store.competitor.example/catalog?category=widgets"
+    expected_min_items:
+      type: integer
+      description: >-
+        Lower bound on how many items a healthy scrape should return. Below this the deterministic
+        gate treats the run as a partial/blocked read (likely a changed selector or an anti-bot wall)
+        rather than a real empty page.
+      default: 5
+      example: "5"
+    expected_max_items:
+      type: integer
+      description: >-
+        Upper bound on items for a healthy scrape. Far above this usually means the script latched
+        onto the wrong repeating container (DOM-drift), so the gate flags it instead of trusting it.
+      default: 500
+      example: "500"
+    drift_threshold_pct:
+      type: number
+      description: >-
+        Per-item percentage price swing versus the last run above which the classify step marks the
+        delta as suspected DOM-drift rather than a genuine price change.
+      default: 40.0
+      example: "40.0"
+    last_run_json:
+      type: string
+      description: >-
+        JSON array of the PREVIOUS run's items (name/price) used only as a drift baseline. Empty on
+        the very first run, in which case drift detection is skipped (nothing to compare against).
+      default: "[]"
+      example: '[{"name":"Widget A","price":19.99},{"name":"Widget B","price":24.50}]'
+    portal_credentials_env:
+      type: string
+      description: >-
+        Name of the environment variable holding login credentials IF the SPA requires auth (NEVER
+        inline secrets). Passed verbatim to each browser branch's credentials_env; ignored for a
+        public page.
+      default: "PORTAL_CREDS"
+      example: "PORTAL_CREDS"
+    oncall_channel:
+      type: string
+      description: >-
+        Slack channel paged when BOTH provider branches fail schema validation - the human re-authors
+        the prompt and the flow is quarantined rather than emitting silent garbage.
+      default: "#scrape-oncall"
+      example: "#scrape-oncall"
+
+steps:
+  # ---------------------------------------------------------------------------
+  # 1) RACE - the neutrality thesis made executable. Two branches run in
+  #    PARALLEL, each authoring the SAME extraction against the live SPA, but
+  #    pinned to a DIFFERENT provider via the branch step's model override. The
+  #    race resolves to the FIRST branch returning a non-empty result; the
+  #    validator below is intentionally minimal (non-empty) because the
+  #    LOAD-BEARING correctness is the deterministic code-step schema gate in
+  #    step 2, NOT the race's own quick filter. Adding/removing a provider is a
+  #    one-line branch change here.
+  # ---------------------------------------------------------------------------
+  - id: elect-extractor
+    type: race
+    race_config:
+      branches: [["author-extract-provider-a"], ["author-extract-provider-b"]]
+      validator: "isinstance(output, dict) and len(output.get('items') or []) > 0"
+
+  # --- BRANCH A (provider A: Anthropic Sonnet) --------------------------------
+  #     NO depends_on - the race executor drives both branches as a fan-out.
+  #     PLAYWRIGHT mode: the model AUTHORS a Playwright script (swappable, no
+  #     vendor coupling). output_schema makes this a structured READ pass.
+  #     credentials_env (never inline), captcha_strategy: pause hands anti-bot
+  #     walls to a human, max_actions caps a stuck branch so it cannot run away
+  #     on cost, capture_screenshots gives the human an audit artifact on a
+  #     both-branch failure.
+  - id: author-extract-provider-a
+    type: browser
+    model: sonnet
+    prompt: >-
+      You are PROVIDER A. The target {input.target_url} is a client-side-rendered SPA whose
+      data exists ONLY in the rendered DOM after its JavaScript runs, and whose selectors change
+      often. Author and run a robust Playwright extraction: open the URL, wait for the catalog/
+      listing content to finish rendering, then for EVERY product/listing card scrape its name,
+      its price, and its availability text. Do not assume yesterday's selectors - inspect the live
+      DOM and target stable, content-based anchors. If the page requires login, authenticate using
+      the credentials in the environment variable named by portal_credentials_env. This is a
+      READ-ONLY scrape: do NOT click buy, add-to-cart, submit, or any mutating control. If a CAPTCHA
+      or anti-bot wall appears, PAUSE for a human rather than trying to defeat it. Return ONLY the
+      structured object described by output_schema - a list of items, each with name, price, and
+      availability.
+    browser_config:
+      mode: playwright
+      start_url: "{input.target_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 50
+      headless: true
+      credentials_env: "{input.portal_credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          items:
+            type: array
+            description: "Every product/listing scraped from the rendered DOM."
+            items:
+              type: object
+              properties:
+                name: { type: string }
+                price: { type: string }
+                availability: { type: string }
+          item_count:
+            type: integer
+            description: "Number of items the branch scraped (sanity counter)."
+        required: ["items"]
+
+  # --- BRANCH B (provider B: Google Gemini 2.5 Pro) ---------------------------
+  #     IDENTICAL contract to branch A, only the model: pin differs - this is
+  #     what makes the race genuinely CROSS-PROVIDER. If provider A has a bad
+  #     day on the current DOM, provider B independently authors a script that
+  #     may survive it (and vice versa). Same safety rails (read-only, pause on
+  #     CAPTCHA, max_actions cap, audit screenshots).
+  - id: author-extract-provider-b
+    type: browser
+    model: google/gemini-2.5-pro
+    prompt: >-
+      You are PROVIDER B. The target {input.target_url} is a client-side-rendered SPA whose
+      data exists ONLY in the rendered DOM after its JavaScript runs, and whose selectors change
+      often. Author and run a robust Playwright extraction: open the URL, wait for the catalog/
+      listing content to finish rendering, then for EVERY product/listing card scrape its name,
+      its price, and its availability text. Do not assume yesterday's selectors - inspect the live
+      DOM and target stable, content-based anchors. If the page requires login, authenticate using
+      the credentials in the environment variable named by portal_credentials_env. This is a
+      READ-ONLY scrape: do NOT click buy, add-to-cart, submit, or any mutating control. If a CAPTCHA
+      or anti-bot wall appears, PAUSE for a human rather than trying to defeat it. Return ONLY the
+      structured object described by output_schema - a list of items, each with name, price, and
+      availability.
+    browser_config:
+      mode: playwright
+      start_url: "{input.target_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 50
+      headless: true
+      credentials_env: "{input.portal_credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          items:
+            type: array
+            description: "Every product/listing scraped from the rendered DOM."
+            items:
+              type: object
+              properties:
+                name: { type: string }
+                price: { type: string }
+                availability: { type: string }
+          item_count:
+            type: integer
+            description: "Number of items the branch scraped (sanity counter)."
+        required: ["items"]
+
+  # ---------------------------------------------------------------------------
+  # 2) VALIDATE WINNER (DETERMINISTIC, no model) - the load-bearing correctness
+  #    gate. Reads BOTH race branch outputs from _steps (race fan-out collection)
+  #    and the race winner from _steps['elect-extractor']. Validates a candidate
+  #    against the schema with pure Python: every price parses to a number, the
+  #    item count sits inside [expected_min_items, expected_max_items], and no
+  #    name/price/availability field is null/blank. If the FIRST-returned winner
+  #    is invalid, transparently falls back to the OTHER completed branch. A blank
+  #    or garbage scrape is rejected here - it can never be emitted as a win.
+  # ---------------------------------------------------------------------------
+  - id: validate-winner
+    type: code
+    depends_on: [elect-extractor]
+    code_config:
+      language: python
+      code: |
+        # Deterministic schema gate over the race. No model decides correctness here.
+        def _unwrap(raw):
+            # Browser steps may nest the structured payload under output/data/result.
+            if not isinstance(raw, dict):
+                return {}
+            for key in ("output", "data", "result"):
+                inner = raw.get(key)
+                if isinstance(inner, dict) and "items" in inner:
+                    return inner
+            return raw
+
+        branch_a = _unwrap(_steps.get("author-extract-provider-a") or {})
+        branch_b = _unwrap(_steps.get("author-extract-provider-b") or {})
+        winner = _unwrap(_steps.get("elect-extractor") or {})
+
+        try:
+            min_items = int(_input.get("expected_min_items", 5))
+        except (TypeError, ValueError):
+            min_items = 5
+        try:
+            max_items = int(_input.get("expected_max_items", 500))
+        except (TypeError, ValueError):
+            max_items = 500
+
+        def _parse_price(value):
+            # Pull a clean number out of strings like "$1,299.00" / "EUR 24,50".
+            if value is None:
+                return None
+            if isinstance(value, (int, float)):
+                return float(value)
+            text = str(value).strip()
+            if text == "":
+                return None
+            # Normalise a comma decimal separator, then strip non-numeric chars.
+            norm = re.sub(r"[^0-9.,-]", "", text)
+            if norm.count(",") == 1 and norm.count(".") == 0:
+                norm = norm.replace(",", ".")
+            else:
+                norm = norm.replace(",", "")
+            match = re.search(r"-?[0-9]+(?:\.[0-9]+)?", norm)
+            if not match:
+                return None
+            try:
+                return float(match.group(0))
+            except (TypeError, ValueError):
+                return None
+
+        def _validate(candidate):
+            reasons = []
+            items = candidate.get("items") if isinstance(candidate, dict) else None
+            if not isinstance(items, list):
+                items = []
+            count = len(items)
+            if count == 0:
+                reasons.append("zero items scraped (blocked or changed selector)")
+            elif count < min_items:
+                reasons.append("only " + str(count) + " items (< expected_min_items " + str(min_items) + ")")
+            elif count > max_items:
+                reasons.append(str(count) + " items (> expected_max_items " + str(max_items) + "; wrong container?)")
+            clean = []
+            bad_rows = 0
+            for it in items:
+                if not isinstance(it, dict):
+                    bad_rows += 1
+                    continue
+                name = str(it.get("name", "") or "").strip()
+                avail = str(it.get("availability", "") or "").strip()
+                price_num = _parse_price(it.get("price"))
+                if name == "" or avail == "" or price_num is None:
+                    bad_rows += 1
+                    continue
+                clean.append({"name": name, "price": price_num, "availability": avail})
+            if bad_rows > 0:
+                reasons.append(str(bad_rows) + " item(s) had a null/blank name, price, or availability")
+            in_band = (min_items <= count <= max_items)
+            valid = (count > 0) and in_band and (bad_rows == 0)
+            return {
+                "valid": valid,
+                "item_count": count,
+                "clean_count": len(clean),
+                "bad_rows": bad_rows,
+                "reasons": reasons,
+                "clean_items": clean,
+            }
+
+        winner_check = _validate(winner)
+        a_check = _validate(branch_a)
+        b_check = _validate(branch_b)
+
+        # Prefer the race winner; on an invalid winner, fall back to whichever
+        # OTHER branch is schema-valid. Both invalid => both_failed (route to human).
+        chosen = None
+        source = "none"
+        if winner_check["valid"] and winner_check["item_count"] > 0:
+            chosen = winner_check
+            source = "race_winner"
+        elif a_check["valid"]:
+            chosen = a_check
+            source = "fallback_provider_a"
+        elif b_check["valid"]:
+            chosen = b_check
+            source = "fallback_provider_b"
+
+        both_failed = chosen is None
+        result = {
+            "ok": (not both_failed),
+            "both_failed": both_failed,
+            "source": source,
+            "item_count": (chosen["clean_count"] if chosen else 0),
+            "items": (chosen["clean_items"] if chosen else []),
+            "winner_valid": winner_check["valid"],
+            "provider_a_valid": a_check["valid"],
+            "provider_b_valid": b_check["valid"],
+            "reason_summary": (
+                "valid scrape from " + source
+                if not both_failed
+                else "BOTH branches failed schema: A[" + "; ".join(a_check["reasons"])
+                + "] B[" + "; ".join(b_check["reasons"]) + "]"
+            ),
+        }
+
+  # ---------------------------------------------------------------------------
+  # 3) CLASSIFY drift - flag suspicious deltas vs the last run. A >drift_threshold
+  #    swing on matched items reads as likely DOM-drift (the script latched onto a
+  #    different element) rather than a genuine market move. A deterministic code
+  #    step does the matching/measuring; the classifier turns that measurement into
+  #    a label (the model is a swappable haiku, and it only LABELS - it never
+  #    decides correctness, which already happened in step 2).
+  # ---------------------------------------------------------------------------
+  - id: measure-drift
+    type: code
+    depends_on: [validate-winner]
+    code_config:
+      language: python
+      code: |
+        # Deterministic drift measurement vs the previous run. No model here.
+        import json as _json
+        v = _steps.get("validate-winner") or {}
+        if not isinstance(v, dict):
+            v = {}
+        current = v.get("items") or []
+        if not isinstance(current, list):
+            current = []
+
+        try:
+            last = _json.loads(_input.get("last_run_json", "[]") or "[]")
+        except (TypeError, ValueError):
+            last = []
+        if not isinstance(last, list):
+            last = []
+
+        try:
+            threshold = float(_input.get("drift_threshold_pct", 40.0))
+        except (TypeError, ValueError):
+            threshold = 40.0
+
+        def _num(x):
+            try:
+                return float(x)
+            except (TypeError, ValueError):
+                return None
+
+        last_by_name = {}
+        for it in last:
+            if isinstance(it, dict):
+                nm = str(it.get("name", "") or "").strip()
+                pr = _num(it.get("price"))
+                if nm and pr is not None:
+                    last_by_name[nm] = pr
+
+        suspicious = []
+        compared = 0
+        for it in current:
+            if not isinstance(it, dict):
+                continue
+            nm = str(it.get("name", "") or "").strip()
+            pr = _num(it.get("price"))
+            if not nm or pr is None or nm not in last_by_name:
+                continue
+            prev = last_by_name[nm]
+            if prev <= 0:
+                continue
+            compared += 1
+            swing = abs(pr - prev) / prev * 100.0
+            if swing > threshold:
+                suspicious.append({"name": nm, "prev": round(prev, 2), "now": round(pr, 2), "swing_pct": round(swing, 1)})
+
+        has_baseline = len(last_by_name) > 0
+        likely_drift = has_baseline and (len(suspicious) > 0)
+        result = {
+            "has_baseline": has_baseline,
+            "compared": compared,
+            "suspicious_count": len(suspicious),
+            "suspicious": suspicious[:50],
+            "likely_drift": likely_drift,
+            "threshold_pct": threshold,
+            "verdict": "suspected-drift" if likely_drift else "clean",
+            "summary": (
+                "No baseline to compare (first run)" if not has_baseline
+                else (str(len(suspicious)) + " item(s) swung >" + str(threshold) + "% vs last run - suspected DOM-drift"
+                      if likely_drift else "All compared prices within threshold - looks like a real read")
+            ),
+        }
+
+  - id: classify-drift
+    type: classify
+    depends_on: [measure-drift]
+    classify_config:
+      categories: ["clean", "suspected-drift"]
+      input: "{steps.measure-drift.output.verdict}"
+      model: haiku
+      branches:
+        clean: [route-outcome]
+        suspected-drift: [route-outcome]
+
+  # ---------------------------------------------------------------------------
+  # 4) CONDITION - deterministic route on the schema gate. If BOTH branches failed
+  #    validation -> notify on-call with both branches' audit screenshots so a human
+  #    can re-author the prompt (and the trajectory-replay harness can quarantine the
+  #    flow). Otherwise -> emit the clean, validated JSON. Read-only flow, so there is
+  #    NO irreversible action and therefore no approval gate; the notify is what keeps
+  #    humans in the loop on a hard failure (or on drift surfaced by the classifier).
+  # ---------------------------------------------------------------------------
+  - id: route-outcome
+    type: condition
+    depends_on: [classify-drift]
+    condition_config:
+      expression: "{steps.validate-winner.output.both_failed} == True"
+      then: [notify-both-failed]
+      else: [emit-clean-json]
+
+  # 4a) BOTH-FAILED PATH - neither provider produced schema-valid output. Page
+  #     on-call and attach both branches' screenshots so a human can re-author the
+  #     prompt; nothing garbage is emitted. This also signals quarantine.
+  - id: notify-both-failed
+    type: notify
+    depends_on: [route-outcome]
+    notify_config:
+      service: slack
+      channel: "{input.oncall_channel}"
+      message: >-
+        SCRAPE QUARANTINE on {input.target_url}: BOTH provider branches failed schema validation,
+        so nothing was emitted. {steps.validate-winner.output.reason_summary}. Provider A valid:
+        {steps.validate-winner.output.provider_a_valid}; Provider B valid:
+        {steps.validate-winner.output.provider_b_valid}. The audit screenshots from both branches are
+        attached to this run - the SPA's DOM likely changed. Re-author the extraction prompt and
+        clear the quarantine before this flow runs again.
+
+  # 4b) SUCCESS PATH - emit the deterministically validated, clean JSON together
+  #     with which provider won, whether a fallback was used, and the drift verdict
+  #     so a downstream pricing model knows whether to trust the deltas.
+  - id: emit-clean-json
+    type: code
+    depends_on: [route-outcome]
+    code_config:
+      language: python
+      code: |
+        v = _steps.get("validate-winner") or {}
+        if not isinstance(v, dict):
+            v = {}
+        d = _steps.get("measure-drift") or {}
+        if not isinstance(d, dict):
+            d = {}
+        result = {
+            "ok": True,
+            "target_url": _input.get("target_url", ""),
+            "source": v.get("source", "race_winner"),
+            "item_count": v.get("item_count", 0),
+            "items": v.get("items", []),
+            "drift_verdict": d.get("verdict", "clean"),
+            "drift_summary": d.get("summary", ""),
+            "suspicious": d.get("suspicious", []),
+            "provider_a_valid": v.get("provider_a_valid", False),
+            "provider_b_valid": v.get("provider_b_valid", False),
+            "note": "Validated by deterministic schema gate; winner chosen by first-valid race across two providers.",
+        }
+
+on_complete:
+  storage_path: "race-two-models-author-scrape-skeleton/{run_id}/result.json"

--- a/src/sandcastle/templates/saas_admin_console_seat_audit.yaml
+++ b/src/sandcastle/templates/saas_admin_console_seat_audit.yaml
@@ -1,0 +1,844 @@
+# name: SaaS Admin Console Seat Audit
+# description: Logs into a SaaS admin console that exposes no user-list export API, drives the authenticated SPA to extract the full per-seat user/role/last-login roster as structured JSON, deterministically validates the extraction, flags dormant and over-privileged seats, and revokes them ONLY behind a single human approval gate - with a trajectory-replay reliability check so a console redesign that breaks pagination is caught before bad data flows.
+# tags: [SaaS, SeatAudit, AccessReview, SOC2, IT-Ops, SpendManagement, Browser, Playwright, TrajectoryReplay, NoExportAPI, DormantSeats, LeastPrivilege]
+# category: devops
+
+name: saas-admin-console-seat-audit
+description: >-
+  A scheduled / on-demand seat audit for IT Operations and SaaS Spend & Security
+  managers at companies juggling 40+ tools where most admin consoles (niche vertical
+  SaaS, legacy seat-based products) ship NO user-directory export API - or gate it
+  behind an Enterprise SKU the buyer does not own. The seat/role/last-login data lives
+  ONLY in the logged-in web admin UI: a JS SPA whose member table is built client-side
+  after auth, so a plain http/firecrawl call hits the login wall and renders nothing.
+
+  Flow: a cheap engine-native SENSOR confirms the console is reachable, then a READ-ONLY
+  browser census (mode: dom) logs in via credentials_env, paginates the entire member
+  table, and returns a STRUCTURED roster via output_schema - users[{email, role,
+  last_login_iso, status, seat_cost}], total_seats, page_count. It mutates nothing. A
+  DETERMINISTIC Python step VALIDATES that extraction with no model: total_seats equals
+  len(users), every email matches an email shape, every last_login parses as ISO, there
+  are no duplicate emails, and page_count > 0 - on any mismatch the run FAILS LOUDLY
+  rather than acting on partial data. A second deterministic step computes the dormant
+  set (no login in > dormant_days) and the over-privileged set (admin role + no login in
+  > stale_admin_days) and proposes a revocation list. A cross-provider RACE wraps an
+  advisory risk read so the reasoning never depends on one vendor. A TRAJECTORY-REPLAY
+  step diffs this run against a golden_run_id and FAILS below 0.85 so a pagination-breaking
+  redesign is caught before stale data reaches a human. Then ONE human APPROVAL lists the
+  exact seats proposed for revocation - NO seat is touched until a person signs off. Only
+  after approval does a per-seat browser WRITE (mode: playwright, capture_screenshots on
+  for audit, max_actions capped) revoke each seat; a post-write dom RE-CENSUS plus a
+  DETERMINISTIC reconcile asserts every revoked seat is gone and no untouched seat changed,
+  and Slack receives the tamper-evident audit summary.
+
+  PROVIDER NEUTRAL: both census (dom) and per-seat revoke (playwright) modes feed the
+  page's accessibility tree + output_schema to whatever reasoning model default_model
+  names; the extraction and the Playwright authoring are swappable across all providers and
+  no vendor agent runtime is in the loop. The load-bearing correctness (validation, dormant/
+  over-privileged sets, reconcile, audit hash) is pure Python; trajectory-replay is a
+  deterministic scorer. READ (census) and WRITE (revoke) are fully separated so a dry-run
+  audit is always possible without touching a single seat.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 1800
+
+input_schema:
+  required: ["console_members_url"]
+  properties:
+    console_members_url:
+      type: string
+      description: "URL of the SaaS admin console members/users page where per-seat email, role, last-login and status are listed (authenticated JS SPA, no export API). The census browser step starts here."
+      default: "https://app.your-saas.com/admin/members"
+      example: "https://app.acme-vertical.com/settings/team/members"
+    console_health_url:
+      type: string
+      description: "A cheap reachability URL for the console (login or health page) the pre-flight sensor polls before spending a browser session. Defaults to the members URL."
+      default: "https://app.your-saas.com/admin/members"
+      example: "https://app.acme-vertical.com/login"
+    seat_url_template:
+      type: string
+      description: "URL template for a single seat's admin page; {email} is substituted per seat during the revocation loop. If the console deep-links by email or user id, set it here."
+      default: "https://app.your-saas.com/admin/members?q={email}"
+      example: "https://app.acme-vertical.com/settings/team/members?search={email}"
+    credentials_env_var:
+      type: string
+      description: "Name of the environment variable holding the admin login (username+password or session token). The value is NEVER inlined into the workflow; the browser steps read it via credentials_env."
+      default: "ADMIN_CONSOLE_CREDS"
+      example: "ACME_ADMIN_CONSOLE_CREDS"
+    dormant_days:
+      type: number
+      description: "A seat is DORMANT if its last login is older than this many days. Dormant seats are candidate revocations (wasted spend)."
+      default: 90
+      example: "90"
+    stale_admin_days:
+      type: number
+      description: "A seat is OVER-PRIVILEGED if it holds an admin/owner role AND has not logged in within this many days - an idle privileged account is a security risk."
+      default: 60
+      example: "60"
+    max_revoke_fraction:
+      type: number
+      description: "Sanity ceiling: if the proposed revocation list exceeds this fraction of ALL observed seats, the plan is flagged as a likely bad extraction and must be reviewed extra-carefully (surfaced to the human approver, never auto-acted)."
+      default: 0.5
+      example: "0.5"
+    golden_run_id:
+      type: string
+      description: "ID of the known-good recorded census run. The trajectory-replay step diffs THIS run against it and fails below the score floor, catching a console redesign that silently broke pagination before stale data reaches the approver."
+      default: "golden-seat-census-2026-05-01"
+      example: "golden-seat-census-2026-05-01"
+    slack_channel:
+      type: string
+      description: "Slack channel for the seat-audit completion summary, revocation report and audit integrity hash."
+      default: "#saas-seat-audit"
+      example: "#it-spend-security"
+
+steps:
+  # ---------------------------------------------------------------------------
+  # 1) PRE-FLIGHT SENSOR - cheap engine-native reachability check before we spend
+  #    a full browser session. Polls the console health/login URL until it answers
+  #    200. Pure control flow, no model, hard timeout so we never wait forever.
+  # ---------------------------------------------------------------------------
+  - id: console_reachable
+    type: sensor
+    sensor_config:
+      url: "{input.console_health_url}"
+      method: GET
+      headers:
+        Accept: "text/html,application/json"
+      condition: "status_code == 200"
+      check_interval: 60
+      timeout: 1800
+
+  # ---------------------------------------------------------------------------
+  # 2) READ-ONLY CENSUS (mode: dom). The reasoning model only AUTHORS a DOM
+  #    extraction from the prompt; output_schema returns the STRUCTURED per-seat
+  #    roster. This step MUTATES NOTHING - no Deactivate/Remove/Delete clicks. It
+  #    paginates the entire member table. credentials_env supplies the admin login
+  #    (never inlined); captcha_strategy: pause hands MFA/CAPTCHA to a human;
+  #    max_actions caps pagination so it cannot click forever. Provider-neutral:
+  #    any of the reasoning providers can drive the accessibility-tree read.
+  # ---------------------------------------------------------------------------
+  - id: census_roster
+    type: browser
+    depends_on: [console_reachable]
+    prompt: >-
+      Log in to the SaaS admin console using the credentials provided via the environment,
+      then open the members / users management page at the start URL. This is a STRICTLY
+      READ-ONLY census: do NOT click any Deactivate, Remove seat, Suspend, Downgrade,
+      Delete, or Invite control - read only. Read EVERY member row, paginating through ALL
+      pages of the table (click next-page / load-more until no more rows appear). For each
+      seat extract: the user's email, their role (e.g. Admin, Owner, Member, Viewer), their
+      last login as an ISO-8601 timestamp (last_login_iso; use the exact value the console
+      shows, converted to ISO if needed; empty string if the console shows 'never'), their
+      current account status (active or inactive/suspended), and the per-seat monthly cost
+      if the console displays one (seat_cost, a number; 0 if not shown). Also report the
+      total number of seats you saw (total_seats) and how many pages you paginated through
+      (page_count). Return ONLY the structured object described by the output schema. If a
+      CAPTCHA, MFA challenge, or unexpected login wall appears, PAUSE for a human rather
+      than guessing.
+    browser_config:
+      mode: dom
+      start_url: "{input.console_members_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 180
+      max_actions: 80
+      headless: true
+      credentials_env: "{input.credentials_env_var}"
+      captcha_strategy: pause
+      capture_screenshots: false
+      output_schema:
+        type: object
+        properties:
+          users:
+            type: array
+            description: "One object per seat in the console member table."
+            items:
+              type: object
+              properties:
+                email: { type: string }
+                role: { type: string }
+                last_login_iso:
+                  type: string
+                  description: "Last login as ISO-8601 (empty string if the seat never logged in)."
+                status:
+                  type: string
+                  enum: ["active", "inactive"]
+                seat_cost:
+                  type: number
+                  description: "Per-seat monthly cost if shown, else 0."
+              required: ["email", "role", "last_login_iso", "status"]
+          total_seats:
+            type: integer
+            description: "Total number of seats the census observed (must equal len(users))."
+          page_count:
+            type: integer
+            description: "Number of pages paginated through (must be > 0)."
+        required: ["users", "total_seats", "page_count"]
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: abort
+
+  # ---------------------------------------------------------------------------
+  # 3) VALIDATE the extraction DETERMINISTICALLY (no model) - the load-bearing
+  #    correctness gate. Asserts total_seats == len(users), every email matches an
+  #    email shape (re.search, not re.compile), every last_login parses as ISO, no
+  #    duplicate emails, page_count > 0. On ANY mismatch ok=False with human-readable
+  #    reasons so a downstream condition can FAIL LOUDLY rather than acting on a
+  #    partial / broken scrape.
+  # ---------------------------------------------------------------------------
+  - id: validate_extraction
+    type: code
+    depends_on: [census_roster]
+    code_config:
+      language: python
+      code: |
+        import re
+        import json
+        from datetime import datetime
+
+        # --- Normalize the browser census (may nest under output/data/result) -----------
+        census = _steps.get('census_roster') or {}
+        if isinstance(census, str):
+            try:
+                census = json.loads(census) if census.strip() else {}
+            except (ValueError, TypeError):
+                census = {}
+        if not isinstance(census, dict):
+            census = {}
+        for key in ('output', 'data', 'result'):
+            inner = census.get(key)
+            if isinstance(inner, dict) and ('users' in inner or 'total_seats' in inner):
+                census = inner
+                break
+
+        users = census.get('users')
+        if not isinstance(users, list):
+            users = []
+        total_seats = census.get('total_seats')
+        page_count = census.get('page_count')
+
+        reasons = []
+
+        # --- total_seats must equal the actual number of extracted rows -----------------
+        try:
+            total_seats_int = int(total_seats)
+        except (TypeError, ValueError):
+            total_seats_int = -1
+        count_ok = (total_seats_int == len(users)) and len(users) > 0
+        if len(users) == 0:
+            reasons.append('census returned zero seats (empty read)')
+        elif total_seats_int != len(users):
+            reasons.append('total_seats ' + str(total_seats) + ' != len(users) ' + str(len(users)))
+
+        # --- page_count must be a positive integer (pagination actually ran) ------------
+        try:
+            page_count_int = int(page_count)
+        except (TypeError, ValueError):
+            page_count_int = 0
+        pages_ok = page_count_int > 0
+        if not pages_ok:
+            reasons.append('page_count is not > 0 (pagination did not run)')
+
+        # --- Per-seat shape: email shape, ISO last_login, no duplicate emails -----------
+        email_pattern = r'^[^@\s]+@[^@\s]+\.[^@\s]+$'
+        seen_emails = set()
+        duplicate_emails = []
+        bad_email_rows = []
+        bad_login_rows = []
+        normalized = []
+        for idx, u in enumerate(users):
+            if not isinstance(u, dict):
+                bad_email_rows.append('row ' + str(idx) + ' is not an object')
+                continue
+            email = str(u.get('email') or '').strip().lower()
+            if not re.search(email_pattern, email):
+                bad_email_rows.append(email or ('row ' + str(idx) + ' empty email'))
+                continue
+            if email in seen_emails:
+                duplicate_emails.append(email)
+            seen_emails.add(email)
+
+            raw_login = str(u.get('last_login_iso') or '').strip()
+            login_ok = True
+            parsed_login = ''
+            if raw_login == '':
+                # 'never logged in' is a valid, meaningful state (maximally dormant).
+                parsed_login = ''
+            else:
+                try:
+                    dt = datetime.fromisoformat(raw_login.replace('Z', '+00:00'))
+                    parsed_login = dt.isoformat()
+                except (ValueError, TypeError):
+                    login_ok = False
+                    bad_login_rows.append(email + ': ' + raw_login)
+            if not login_ok:
+                continue
+
+            role = str(u.get('role') or '').strip()
+            status = str(u.get('status') or 'active').strip().lower()
+            if status not in ('active', 'inactive'):
+                status = 'active'
+            try:
+                seat_cost = float(u.get('seat_cost') or 0)
+            except (TypeError, ValueError):
+                seat_cost = 0.0
+            normalized.append({
+                'email': email,
+                'role': role,
+                'last_login_iso': parsed_login,
+                'never_logged_in': parsed_login == '',
+                'status': status,
+                'seat_cost': seat_cost,
+            })
+
+        emails_ok = len(bad_email_rows) == 0
+        logins_ok = len(bad_login_rows) == 0
+        no_dupes_ok = len(duplicate_emails) == 0
+        if bad_email_rows:
+            reasons.append('rows with invalid email shape: ' + ', '.join(bad_email_rows[:10]))
+        if bad_login_rows:
+            reasons.append('rows whose last_login did not parse as ISO: ' + ', '.join(bad_login_rows[:10]))
+        if duplicate_emails:
+            reasons.append('duplicate emails in roster: ' + ', '.join(sorted(set(duplicate_emails))[:10]))
+
+        ok = bool(count_ok and pages_ok and emails_ok and logins_ok and no_dupes_ok)
+
+        result = {
+            'ok': ok,
+            'count_ok': count_ok,
+            'pages_ok': pages_ok,
+            'emails_ok': emails_ok,
+            'logins_ok': logins_ok,
+            'no_dupes_ok': no_dupes_ok,
+            'seat_count': len(normalized),
+            'page_count': page_count_int,
+            'reasons': reasons,
+            'reason_summary': '; '.join(reasons) if reasons else 'all extraction checks passed',
+            'roster': normalized,
+        }
+
+  # ---------------------------------------------------------------------------
+  # 4) DETERMINISTIC CONDITION - fail loudly on a bad extraction. If validation
+  #    did not pass we route to a notify-and-stop branch; NOTHING downstream
+  #    (replay, approval, revoke) can run on partial data. Clean -> compute the
+  #    revocation plan.
+  # ---------------------------------------------------------------------------
+  - id: extraction_gate
+    type: condition
+    depends_on: [validate_extraction]
+    condition_config:
+      expression: "{steps.validate_extraction.output.ok} == True"
+      then: [compute_revocation_sets]
+      else: [notify_bad_extraction]
+
+  # 4a) BAD-EXTRACTION PATH - the deterministic validation failed. Page the channel
+  #     with exactly why and STOP. No seat is ever touched on a broken scrape.
+  - id: notify_bad_extraction
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: >-
+        BLOCKED: SaaS seat audit ABORTED before any analysis or revocation because the
+        deterministic extraction validation FAILED. The console roster could not be trusted,
+        so nothing was acted on. Reason(s): {steps.validate_extraction.output.reason_summary}.
+        Seats parsed: {steps.validate_extraction.output.seat_count}, pages:
+        {steps.validate_extraction.output.page_count}. Re-check the console UI / pagination and re-run.
+
+  # ---------------------------------------------------------------------------
+  # 5) DETERMINISTIC dormant + over-privileged classification. Pure Python (no
+  #    model): a seat is DORMANT if last login is older than dormant_days (or never
+  #    logged in), OVER-PRIVILEGED if it holds an admin/owner role AND is stale
+  #    beyond stale_admin_days. Builds the proposed revocation list and a sanity
+  #    fraction. The plan a human will sign off on lives here, computed by code.
+  # ---------------------------------------------------------------------------
+  - id: compute_revocation_sets
+    type: code
+    depends_on: [validate_extraction]
+    code_config:
+      language: python
+      code: |
+        from datetime import datetime, timezone
+
+        validated = _steps.get('validate_extraction') or {}
+        roster = validated.get('roster', []) if isinstance(validated, dict) else []
+
+        dormant_days = float(_input.get('dormant_days', 90) or 90)
+        stale_admin_days = float(_input.get('stale_admin_days', 60) or 60)
+        max_revoke_fraction = float(_input.get('max_revoke_fraction', 0.5) or 0.5)
+
+        now = datetime.now(timezone.utc)
+        privileged_terms = ('admin', 'owner', 'superuser', 'super-admin', 'root')
+
+        def _age_days(iso_str):
+            # Age in days since last login; None if the seat never logged in.
+            s = str(iso_str or '').strip()
+            if s == '':
+                return None
+            try:
+                dt = datetime.fromisoformat(s.replace('Z', '+00:00'))
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                return max(0.0, (now - dt).total_seconds() / 86400.0)
+            except (ValueError, TypeError):
+                return None
+
+        dormant = []
+        over_privileged = []
+        active_seats = []
+        total_monthly_spend = 0.0
+        for seat in roster:
+            if not isinstance(seat, dict):
+                continue
+            email = seat.get('email')
+            role = str(seat.get('role') or '')
+            role_lc = role.lower()
+            status = str(seat.get('status') or 'active').lower()
+            seat_cost = float(seat.get('seat_cost') or 0)
+            age = _age_days(seat.get('last_login_iso'))
+            never = bool(seat.get('never_logged_in'))
+            is_privileged = any(term in role_lc for term in privileged_terms)
+
+            if status == 'active':
+                active_seats.append(seat)
+                total_monthly_spend += seat_cost
+
+            # DORMANT: never logged in, or last login older than dormant_days.
+            is_dormant = (never or (age is not None and age > dormant_days)) and status == 'active'
+            # OVER-PRIVILEGED: privileged role + stale beyond stale_admin_days.
+            is_over_priv = is_privileged and (never or (age is not None and age > stale_admin_days)) and status == 'active'
+
+            entry = {
+                'email': email,
+                'role': role,
+                'last_login_iso': seat.get('last_login_iso'),
+                'last_login_age_days': None if age is None else round(age, 1),
+                'never_logged_in': never,
+                'status': status,
+                'seat_cost': seat_cost,
+                'is_privileged': is_privileged,
+            }
+            if is_dormant:
+                dormant.append({**entry, 'flag': 'dormant'})
+            if is_over_priv:
+                over_privileged.append({**entry, 'flag': 'over_privileged'})
+
+        # Revocation candidates = union of dormant + over-privileged (dedup by email).
+        by_email = {}
+        for row in dormant + over_privileged:
+            em = row['email']
+            if em in by_email:
+                # Merge flags so an over-privileged dormant seat shows both reasons.
+                prev_flags = by_email[em].get('flags', [])
+                if row['flag'] not in prev_flags:
+                    prev_flags.append(row['flag'])
+                by_email[em]['flags'] = prev_flags
+            else:
+                merged = {k: v for k, v in row.items() if k != 'flag'}
+                merged['flags'] = [row['flag']]
+                by_email[em] = merged
+        revoke_candidates = sorted(by_email.values(), key=lambda r: str(r.get('email')))
+
+        total_seats = len(roster)
+        revoke_fraction = (len(revoke_candidates) / total_seats) if total_seats else 0.0
+        fraction_exceeded = revoke_fraction > max_revoke_fraction
+
+        # Estimated monthly savings if every candidate seat is revoked.
+        est_monthly_savings = round(sum(float(r.get('seat_cost') or 0) for r in revoke_candidates), 2)
+
+        result = {
+            'total_seats': total_seats,
+            'active_seat_count': len(active_seats),
+            'dormant_count': len(dormant),
+            'over_privileged_count': len(over_privileged),
+            'revoke_candidate_count': len(revoke_candidates),
+            'revoke_fraction': round(revoke_fraction, 4),
+            'fraction_exceeded': fraction_exceeded,
+            'est_total_monthly_spend': round(total_monthly_spend, 2),
+            'est_monthly_savings': est_monthly_savings,
+            'dormant': dormant,
+            'over_privileged': over_privileged,
+            'revoke_candidates': revoke_candidates,
+            'dormant_days': dormant_days,
+            'stale_admin_days': stale_admin_days,
+        }
+
+  # ---------------------------------------------------------------------------
+  # 6) CROSS-PROVIDER RACE - an ADVISORY risk read of the proposed plan, wrapped
+  #    across two providers (first non-empty wins, failover not a vote) so the
+  #    reasoning never depends on a single vendor. This is advisory only: the
+  #    revocation list itself is the deterministic code output above; this race
+  #    just adds a human-readable risk note for the approver. Branch steps carry
+  #    NO depends_on and pin different models for cross-provider resilience.
+  # ---------------------------------------------------------------------------
+  - id: risk_note_sonnet
+    type: standard
+    model: sonnet
+    prompt: |
+      You are a SaaS access-risk reviewer. In at most 4 sentences (no markdown, no emojis),
+      summarize the risk of the proposed seat-revocation plan for a human approver: how many
+      seats are dormant vs over-privileged, whether the revocation fraction looks plausible or
+      suspiciously high (fraction_exceeded flag), and the estimated monthly savings. Do NOT
+      invent seats. Plan: {steps.compute_revocation_sets.output}
+
+  - id: risk_note_gemini
+    type: standard
+    model: google/gemini-2.5-pro
+    prompt: |
+      You are a SaaS access-risk reviewer. In at most 4 sentences (no markdown, no emojis),
+      summarize the risk of the proposed seat-revocation plan for a human approver: how many
+      seats are dormant vs over-privileged, whether the revocation fraction looks plausible or
+      suspiciously high (fraction_exceeded flag), and the estimated monthly savings. Do NOT
+      invent seats. Plan: {steps.compute_revocation_sets.output}
+
+  - id: advisory_risk_note
+    type: race
+    depends_on: [compute_revocation_sets]
+    race_config:
+      branches:
+        - [risk_note_sonnet]
+        - [risk_note_gemini]
+      validator: "len(str(output).strip()) > 0"
+
+  # ---------------------------------------------------------------------------
+  # 7) CLASSIFY the overall audit severity from the deterministic plan. The model
+  #    only LABELS the cohort; every label routes into the same trajectory-replay
+  #    reliability check, so the classification cannot skip safety - it is purely
+  #    informational for the approver. Swappable model.
+  # ---------------------------------------------------------------------------
+  - id: classify_audit_severity
+    type: classify
+    depends_on: [compute_revocation_sets, advisory_risk_note]
+    classify_config:
+      model: haiku
+      input: "Classify the overall severity of this SaaS seat audit. routine = few dormant seats, no idle admins. notable = meaningful dormant spend OR a handful of over-privileged seats. urgent = several idle admin/owner seats (over_privileged_count high) which is a security exposure. suspicious = the revocation fraction exceeds the sanity ceiling (fraction_exceeded true), suggesting a possibly bad extraction the human must scrutinize. Plan: {steps.compute_revocation_sets.output}. Advisory note: {steps.advisory_risk_note.output}"
+      categories:
+        - routine
+        - notable
+        - urgent
+        - suspicious
+      branches:
+        routine: [replay_vs_golden]
+        notable: [replay_vs_golden]
+        urgent: [replay_vs_golden]
+        suspicious: [replay_vs_golden]
+
+  # ---------------------------------------------------------------------------
+  # 8) TRAJECTORY-REPLAY - the reliability layer. Diffs THIS census run against a
+  #    golden_run_id and FAILS below fail_below_score (UI drift, e.g. a console
+  #    redesign that broke pagination) or on a cost blowup. Deterministic scorer,
+  #    not a model's opinion: it compares observable actions + extracted outputs.
+  #    Catches a silently-broken extraction BEFORE the plan reaches a human.
+  # ---------------------------------------------------------------------------
+  - id: replay_vs_golden
+    type: trajectory-replay
+    depends_on: [classify_audit_severity]
+    trajectory_replay_config:
+      golden_run_id: "{input.golden_run_id}"
+      fail_below_score: 0.85
+      allow_cost_delta_pct: 15.0
+      cost_budget_usd: 0.5
+
+  # ---------------------------------------------------------------------------
+  # 9) APPROVAL - the SINGLE human sign-off. Lists the EXACT seats proposed for
+  #    revocation and the advisory risk note. This is the ONLY place a human
+  #    authorizes mutation; nothing irreversible runs before this returns approved.
+  #    on_timeout: abort means a missed approval NEVER auto-revokes. allow_edit so
+  #    the approver can drop a borderline seat before the loop runs.
+  # ---------------------------------------------------------------------------
+  - id: revocation_approval
+    type: approval
+    depends_on: [replay_vs_golden, compute_revocation_sets]
+    approval_config:
+      message: >-
+        AUTHORIZE SEAT REVOCATION - approve to revoke the listed seats in the admin console,
+        reject to abort with nothing touched. This is the ONLY authorization gate before any
+        seat is changed; review the revoke_candidates list carefully. Dormant:
+        {steps.compute_revocation_sets.output.dormant_count}, over-privileged (idle admins):
+        {steps.compute_revocation_sets.output.over_privileged_count}, total candidates:
+        {steps.compute_revocation_sets.output.revoke_candidate_count} of
+        {steps.compute_revocation_sets.output.total_seats} seats (fraction
+        {steps.compute_revocation_sets.output.revoke_fraction}, sanity-ceiling exceeded:
+        {steps.compute_revocation_sets.output.fraction_exceeded}). Estimated monthly savings:
+        {steps.compute_revocation_sets.output.est_monthly_savings}. Trajectory-replay passed,
+        so the extraction matched the golden run. Advisory risk note:
+        {steps.advisory_risk_note.output}
+      show_data: steps.compute_revocation_sets.output
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: true
+
+  # ---------------------------------------------------------------------------
+  # 10) LOOP over the approved revoke_candidates. Each iteration runs the per-seat
+  #     browser revocation (child revoke_one_seat) reading the current seat via
+  #     _item. Runs ONLY after the human approval above. max_iterations caps the
+  #     batch so a runaway plan cannot scale unbounded.
+  # ---------------------------------------------------------------------------
+  - id: revocation_loop
+    type: loop
+    depends_on: [revocation_approval]
+    loop_config:
+      over: "steps.compute_revocation_sets.output.revoke_candidates"
+      step_ids: [revoke_one_seat]
+      max_iterations: 500
+
+  # 10a) PER-SEAT REVOKE (mode: playwright, the WRITE pass). The reasoning model
+  #      only AUTHORS a Playwright script from the prompt; the mutation itself is
+  #      deterministic Playwright, so any provider can author it and is swappable.
+  #      max_actions is tightly capped so a misnavigation cannot rampage through the
+  #      roster; capture_screenshots is ON for the audit trail of every write;
+  #      captcha_strategy: pause hands a step-up auth to a human. Operates on ONE
+  #      email only. output_schema returns a structured per-seat result.
+  - id: revoke_one_seat
+    type: browser
+    prompt: >-
+      A human has APPROVED revoking this exact seat in the SaaS admin console. The target seat
+      is: {{ _item }}. Log into the console using the environment credentials, navigate to that
+      ONE user's member row (search by their email if needed), open their account, and click the
+      control that REVOKES the seat for that user only - Deactivate, Remove seat, Suspend, or
+      Revoke access, whichever the console exposes. Operate on this single email ONLY; never touch
+      any other member row, and never perform a bulk action. If a confirmation dialog appears,
+      confirm it. If a CAPTCHA or step-up auth appears, PAUSE for a human - do not attempt to
+      solve it. Then read back this seat's resulting account status and return it. Capture a
+      screenshot of the post-revoke state for the audit trail.
+    browser_config:
+      mode: playwright
+      start_url: "{input.seat_url_template}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 20
+      headless: true
+      credentials_env: "{input.credentials_env_var}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          email: { type: string }
+          action_taken:
+            type: string
+            enum: ["revoked", "skipped", "failed"]
+          post_status:
+            type: string
+            enum: ["active", "inactive"]
+          screenshot_ref: { type: string }
+        required: ["email", "action_taken", "post_status"]
+
+  # ---------------------------------------------------------------------------
+  # 11) RE-CENSUS (mode: dom, read-only) - the post-image of the audit pair. Same
+  #     structured extraction as the original census; no mutation. Used to prove
+  #     the writes landed and nothing else changed.
+  # ---------------------------------------------------------------------------
+  - id: census_after
+    type: browser
+    depends_on: [revocation_loop]
+    prompt: >-
+      Re-open the members / users management page in the SaaS admin console (reload to get fresh
+      state). This is a STRICTLY READ-ONLY re-census after a batch of revocations: do NOT click
+      any Deactivate, Remove, Suspend, Delete, or Invite control. Read EVERY member row,
+      paginating through ALL pages, and extract for each seat the email, current account status
+      (active or inactive), and role. Return ONLY the structured object described by the output
+      schema. If a CAPTCHA or login wall appears, PAUSE for a human.
+    browser_config:
+      mode: dom
+      start_url: "{input.console_members_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 180
+      max_actions: 80
+      headless: true
+      credentials_env: "{input.credentials_env_var}"
+      captcha_strategy: pause
+      capture_screenshots: false
+      output_schema:
+        type: object
+        properties:
+          users:
+            type: array
+            items:
+              type: object
+              properties:
+                email: { type: string }
+                role: { type: string }
+                status:
+                  type: string
+                  enum: ["active", "inactive"]
+              required: ["email", "status"]
+          total_seats:
+            type: integer
+        required: ["users"]
+
+  # ---------------------------------------------------------------------------
+  # 12) DETERMINISTIC RECONCILE (no model) - the load-bearing post-check. Asserts
+  #     EVERY approved+revoked email is now absent/inactive in the after-census, and
+  #     EVERY untouched seat is unchanged (collateral / scope-creep check). Emits a
+  #     drift list of any seat that did not reach the expected state. Pure Python.
+  # ---------------------------------------------------------------------------
+  - id: reconcile_revocations
+    type: code
+    depends_on: [compute_revocation_sets, revocation_loop, census_after]
+    code_config:
+      language: python
+      code: |
+        import json
+
+        plan = _steps.get('compute_revocation_sets') or {}
+        candidates = plan.get('revoke_candidates', []) if isinstance(plan, dict) else []
+        targeted_emails = {str(c.get('email') or '').strip().lower() for c in candidates if isinstance(c, dict)}
+
+        # --- Before status from the validated original roster ---------------------------
+        validated = _steps.get('validate_extraction') or {}
+        before_rows = validated.get('roster', []) if isinstance(validated, dict) else []
+        before_status = {}
+        for s in before_rows:
+            if isinstance(s, dict):
+                em = str(s.get('email') or '').strip().lower()
+                if em:
+                    before_status[em] = str(s.get('status') or 'active').strip().lower()
+
+        # --- After re-census (normalize, may nest) --------------------------------------
+        after = _steps.get('census_after') or {}
+        if isinstance(after, str):
+            try:
+                after = json.loads(after) if after.strip() else {}
+            except (ValueError, TypeError):
+                after = {}
+        if not isinstance(after, dict):
+            after = {}
+        for key in ('output', 'data', 'result'):
+            inner = after.get(key)
+            if isinstance(inner, dict) and 'users' in inner:
+                after = inner
+                break
+        after_rows = after.get('users', []) if isinstance(after, dict) else []
+        after_status = {}
+        for s in after_rows:
+            if isinstance(s, dict):
+                em = str(s.get('email') or '').strip().lower()
+                if em:
+                    after_status[em] = str(s.get('status') or 'active').strip().lower()
+
+        # --- Per-loop browser results, indexed by reported email ------------------------
+        loop_out = _steps.get('revocation_loop') or {}
+        loop_items = loop_out if isinstance(loop_out, list) else (
+            (loop_out.get('results') or loop_out.get('items') or []) if isinstance(loop_out, dict) else []
+        )
+        result_by_email = {}
+        for it in loop_items:
+            if isinstance(it, dict):
+                em = str(it.get('email') or '').strip().lower()
+                if em:
+                    result_by_email[em] = it
+
+        # --- Assert every targeted email is now inactive / gone -------------------------
+        confirmed = []
+        drift = []
+        for em in sorted(targeted_emails):
+            post = after_status.get(em)  # None == no longer on the roster (fully removed)
+            browser_res = result_by_email.get(em, {})
+            row = {
+                'email': em,
+                'before_status': before_status.get(em),
+                'after_status': post if post is not None else 'removed',
+                'browser_action': browser_res.get('action_taken'),
+                'screenshot_ref': browser_res.get('screenshot_ref'),
+            }
+            if post is None or post == 'inactive':
+                confirmed.append(row)
+            else:
+                drift.append({**row, 'drift_reason': 'targeted_but_still_active'})
+
+        # --- Assert no UNTOUCHED seat changed status (collateral / scope-creep) ----------
+        collateral = []
+        for em, before_s in before_status.items():
+            if em in targeted_emails:
+                continue
+            post = after_status.get(em)
+            if post is not None and post != before_s:
+                collateral.append({
+                    'email': em,
+                    'before_status': before_s,
+                    'after_status': post,
+                    'drift_reason': 'untouched_seat_status_changed',
+                })
+
+        all_clean = (len(drift) == 0 and len(collateral) == 0)
+
+        result = {
+            'all_clean': all_clean,
+            'targeted_count': len(targeted_emails),
+            'confirmed_count': len(confirmed),
+            'drift_count': len(drift),
+            'collateral_count': len(collateral),
+            'confirmed': confirmed,
+            'drift': drift,
+            'collateral': collateral,
+        }
+
+  # ---------------------------------------------------------------------------
+  # 13) AUDIT record - deterministic, tamper-evident SHA-256 over the canonical
+  #     audit record (plan counts, approver, per-seat before/after diffs, drift).
+  #     No model. The hash is reproducible byte-for-byte for evidence.
+  # ---------------------------------------------------------------------------
+  - id: audit_record
+    type: code
+    depends_on: [compute_revocation_sets, revocation_approval, reconcile_revocations]
+    code_config:
+      language: python
+      code: |
+        import json
+        import hashlib
+        from datetime import datetime, timezone
+
+        plan = _steps.get('compute_revocation_sets') or {}
+        reconcile = _steps.get('reconcile_revocations') or {}
+        approval = _steps.get('revocation_approval') or {}
+
+        approver = 'unknown'
+        if isinstance(approval, dict):
+            approver = str(approval.get('approver') or approval.get('approved_by') or 'unknown')
+
+        record = {
+            'generated_at': datetime.now(timezone.utc).isoformat(),
+            'approver': approver,
+            'total_seats': plan.get('total_seats'),
+            'dormant_count': plan.get('dormant_count'),
+            'over_privileged_count': plan.get('over_privileged_count'),
+            'revoke_candidate_count': plan.get('revoke_candidate_count'),
+            'est_monthly_savings': plan.get('est_monthly_savings'),
+            'targeted_count': reconcile.get('targeted_count'),
+            'confirmed_count': reconcile.get('confirmed_count'),
+            'drift_count': reconcile.get('drift_count'),
+            'collateral_count': reconcile.get('collateral_count'),
+            'per_seat_diffs': reconcile.get('confirmed', []) + reconcile.get('drift', []),
+            'collateral': reconcile.get('collateral', []),
+            'all_clean': reconcile.get('all_clean'),
+        }
+
+        # Canonical (sorted-key) serialization so the audit hash is reproducible.
+        canonical = json.dumps(record, sort_keys=True, separators=(',', ':'))
+        digest = hashlib.sha256(canonical.encode('utf-8')).hexdigest()
+
+        result = {
+            'sha256': digest,
+            'byte_length': len(canonical),
+            'audit_record': record,
+            'canonical_json': canonical,
+        }
+
+  # ---------------------------------------------------------------------------
+  # 14) NOTIFY the channel with the seat-audit result, drift report and audit hash.
+  # ---------------------------------------------------------------------------
+  - id: notify_summary
+    type: notify
+    depends_on: [audit_record, reconcile_revocations]
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: "SaaS seat audit complete. Seats: {steps.compute_revocation_sets.output.total_seats} | Dormant: {steps.compute_revocation_sets.output.dormant_count} | Over-privileged: {steps.compute_revocation_sets.output.over_privileged_count} | Revoked (confirmed): {steps.reconcile_revocations.output.confirmed_count} | Drift: {steps.reconcile_revocations.output.drift_count} | Collateral: {steps.reconcile_revocations.output.collateral_count} | All clean: {steps.reconcile_revocations.output.all_clean} | Est. monthly savings: {steps.compute_revocation_sets.output.est_monthly_savings} | Approver: {steps.audit_record.output.audit_record.approver} | Audit sha256 {steps.audit_record.output.sha256}."
+
+on_complete:
+  storage_path: "saas-admin-console-seat-audit/{run_id}/result.json"

--- a/src/sandcastle/templates/saas_admin_seat_deprovisioning_offboard.yaml
+++ b/src/sandcastle/templates/saas_admin_seat_deprovisioning_offboard.yaml
@@ -1,0 +1,587 @@
+# name: SaaS Admin Seat Deprovisioning Offboard
+# description: On an employee-offboard trigger from HRIS/ticketing, drive every no-API SaaS admin console to find the departing user's seat, capture license + owned-asset state (read-only dom census), deterministically verify the matched email is the right person, classify each account as safe-to-deactivate vs needs-asset-transfer-first, then - behind ONE human approval that shows the full per-app blast radius - perform ownership transfer and deactivation in playwright mode, llm_eval-gate that each console now shows the seat inactive, and ship a PDF evidence pack to Slack and the ticket.
+# tags: [Offboarding, Deprovisioning, SaaS, ITSec, NoAPI, Browser, Playwright, DOM, HumanApproval, Audit, Evidence]
+# category: devops
+
+name: saas-admin-seat-deprovisioning-offboard
+description: >-
+  Offboard a departing employee across SaaS tools whose admin panels expose NO SCIM/API on the
+  customer's plan tier (legacy or cheap-tier SaaS, internal-built admin panels, niche industry
+  tools). Triggered by a webhook from HRIS / ticketing when an offboarding ticket is created
+  (employee_email + last_day), this template drives each tool's authenticated admin SPA to find the
+  user's seat, capture license + owned-asset state, and deactivate the account - with a single human
+  gate before any irreversible deactivation.
+
+  Flow: a parse step extracts employee_email and the list of target SaaS apps from the offboard
+  payload. A deterministic code step normalizes that into a per-app work list. A READ census loop
+  runs a browser step (mode: dom) per app: it logs into that app's admin user-search URL via a
+  per-app credentials_env, finds the departing user, and returns a STRUCTURED snapshot via
+  output_schema (app, user_found, seat_id, role, last_login, owned_assets, billing_impact) -
+  mutating nothing. A DETERMINISTIC code step validates every snapshot: it normalizes the matched
+  email (case-insensitive via re.sub) and HARD-FAILS if any console's matched email is not the
+  target - so the wrong person can never be deactivated. A classify step tags each account as
+  safe_to_deactivate vs needs_asset_transfer_first. Then ONE human approval signs off the entire
+  batch, showing the full per-app blast radius (owned assets, billing impact); on_timeout it aborts.
+  Only after approval does a WRITE loop run a browser step (mode: playwright, capture_screenshots on,
+  max_actions capped) per app: it performs ownership transfer (if needed) then deactivation, and
+  returns a structured result (app, deactivated, assets_transferred_to, confirmation). An llm_eval
+  gate verifies each app's post-action page shows the seat as inactive; a deterministic code reconcile
+  is the authoritative correctness check; a report step compiles a PDF offboarding evidence pack; and
+  notify posts to Slack and the ticket.
+
+  PROVIDER NEUTRAL: the read census uses dom mode and the write pass uses playwright mode, both
+  authored from the prompt by whatever reasoning model is configured (any of the 7 providers), so the
+  automation is swappable - no vendor agent runtime is in the loop. The wrong-user safeguard is
+  deterministic Python email equality, not a model's opinion; the classify and the llm_eval gate are
+  provider-swappable. Per-app admin credentials are supplied ONLY via credentials_env (never inlined);
+  captcha_strategy=pause hands MFA/CAPTCHA walls to a human; max_actions caps the write pass.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 2400
+
+input_schema:
+  required: ["offboard_payload"]
+  properties:
+    offboard_payload:
+      type: string
+      description: "The offboarding webhook payload from HRIS / ticketing (JSON string or pasted text). Must contain the departing employee_email, last_day, and the list of target SaaS apps to deprovision. Each app entry should carry: app name, admin_search_url (the admin user-search URL), credentials_env (name of the env var holding that app's admin login), and optionally a member_url_template."
+      example: '{"employee_email":"jane.doe@acme.com","last_day":"2026-06-15","ticket_id":"OFFB-4821","apps":[{"app":"LegacyCRM","admin_search_url":"https://admin.legacycrm.io/users?q={email}","credentials_env":"LEGACYCRM_ADMIN_CREDS"},{"app":"NicheDAM","admin_search_url":"https://dam.niche.tools/team/search?email={email}","credentials_env":"NICHEDAM_ADMIN_CREDS"}]}'
+    default_credentials_env:
+      type: string
+      description: "Fallback env-var name for admin credentials if a given app entry does not specify its own credentials_env. The value is NEVER inlined into the workflow - only the variable NAME travels."
+      default: "SAAS_ADMIN_CREDS"
+      example: "SAAS_ADMIN_CREDS"
+    approval_timeout_hours:
+      type: integer
+      description: "Hours the single human deactivation-approval waits before its timeout fires. on_timeout is abort - a missed approval NEVER auto-deactivates."
+      default: 48
+      example: "48"
+    slack_channel:
+      type: string
+      description: "Slack channel for the offboarding evidence-pack summary and any drift report."
+      default: "#it-offboarding"
+      example: "#it-offboarding"
+    evidence_author:
+      type: string
+      description: "Author / owning team stamped onto the generated PDF offboarding evidence pack."
+      default: "IT Security - Offboarding"
+      example: "IT Security - Offboarding"
+
+steps:
+  # 1) PARSE the offboard webhook payload into structured JSON: the departing employee_email, the
+  #    last_day, the ticket id, and the list of target SaaS apps. Deterministic ingest; no console
+  #    contact yet.
+  - id: parse_offboard_payload
+    type: parse
+    prompt: "{input.offboard_payload}"
+    parse_config:
+      output: json
+
+  # 2) DETERMINISTIC normalize: turn the parsed payload into a clean per-app work list, each carrying
+  #    the app name, its admin_search_url (with {email} substituted to the target), and the NAME of
+  #    the env var holding that app's admin credentials (never the secret itself). Pure Python; this
+  #    is also the canonical lower-cased target email the safety check later compares against.
+  - id: build_app_worklist
+    type: code
+    depends_on: [parse_offboard_payload]
+    code_config:
+      language: python
+      code: |
+        import json
+        import re
+
+        payload = _steps['parse_offboard_payload']
+        if isinstance(payload, str):
+            try:
+                payload = json.loads(payload) if payload.strip() else {}
+            except (ValueError, TypeError):
+                payload = {}
+        if not isinstance(payload, dict):
+            payload = {}
+
+        # Canonical target email (lower-cased, trimmed) - the single source of truth for the
+        # wrong-user safety check downstream.
+        raw_email = str(payload.get('employee_email') or payload.get('email') or '').strip()
+        target_email = re.sub(r'\s+', '', raw_email).lower()
+
+        last_day = str(payload.get('last_day') or payload.get('lastDay') or '').strip()
+        ticket_id = str(payload.get('ticket_id') or payload.get('ticketId') or payload.get('ticket') or '').strip()
+
+        default_creds = str(_input.get('default_credentials_env') or 'SAAS_ADMIN_CREDS').strip()
+
+        apps_in = payload.get('apps') or payload.get('saas_apps') or payload.get('targets') or []
+        if not isinstance(apps_in, list):
+            apps_in = []
+
+        worklist = []
+        for entry in apps_in:
+            if not isinstance(entry, dict):
+                continue
+            app_name = str(entry.get('app') or entry.get('name') or entry.get('tool') or '').strip()
+            search_url = str(entry.get('admin_search_url') or entry.get('search_url') or entry.get('url') or '').strip()
+            if not app_name or not search_url:
+                continue
+            # Substitute the target email into the app's admin user-search URL template.
+            resolved_url = search_url.replace('{email}', target_email)
+            creds_env = str(entry.get('credentials_env') or entry.get('creds_env') or default_creds).strip()
+            member_tpl = str(entry.get('member_url_template') or search_url).replace('{email}', target_email)
+            worklist.append({
+                'app': app_name,
+                'target_email': target_email,
+                'admin_search_url': resolved_url,
+                'credentials_env': creds_env,
+                'member_url_template': member_tpl,
+            })
+
+        result = {
+            'target_email': target_email,
+            'last_day': last_day,
+            'ticket_id': ticket_id,
+            'app_count': len(worklist),
+            'apps': worklist,
+            'email_present': bool(target_email),
+        }
+
+  # 3) READ CENSUS LOOP - one read-only browser pass per SaaS app. The loop fans out over the work
+  #    list; each iteration runs read_app_seat (defined below) on the current app via _item. Read-only:
+  #    nothing is mutated here. max_iterations caps the fan-out.
+  - id: read_census_loop
+    type: loop
+    depends_on: [build_app_worklist]
+    loop_config:
+      over: "steps.build_app_worklist.output.apps"
+      step_ids: [read_app_seat]
+      max_iterations: 200
+
+  # 3a) PER-APP READ PASS (mode: dom). The reasoning model only authors a DOM extraction from the
+  #     prompt; output_schema returns a STRUCTURED snapshot of exactly what a deactivation would
+  #     affect. This step does NOT click any Deactivate/Remove/Transfer control - it is the read
+  #     pre-image. credentials_env names the per-app admin login (never inlined); captcha_strategy
+  #     pauses for a human on an MFA/CAPTCHA wall; max_actions caps the navigation.
+  - id: read_app_seat
+    type: browser
+    prompt: >-
+      You are auditing ONE SaaS admin console as part of an employee offboarding, READ-ONLY. The app
+      and target are: {{ _item }}. Log into that app's admin console using the credentials provided
+      via the environment, open the admin user-search / members page at the start URL, and search for
+      the departing user by their target_email. Do NOT click any Deactivate, Suspend, Remove, Delete,
+      Transfer, or Reassign control - this is a read-only census. If you find the user, read back:
+      whether the user was found, their seat / license id, their role, their last_login timestamp as
+      shown, the list of assets they own (dashboards, files, projects, folders, boards - whatever this
+      tool tracks ownership of), and any billing impact of removing them (seat freed, license tier,
+      cost). Return ONLY the structured object described by the output schema. If a CAPTCHA, MFA, or
+      unexpected login wall appears, PAUSE for a human rather than guessing.
+    browser_config:
+      mode: dom
+      start_url: "{{ _item.admin_search_url }}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 180
+      max_actions: 40
+      headless: true
+      credentials_env: "{{ _item.credentials_env }}"
+      captcha_strategy: pause
+      capture_screenshots: false
+      output_schema:
+        type: object
+        properties:
+          app:
+            type: string
+            description: "The SaaS app this snapshot is for."
+          user_found:
+            type: boolean
+            description: "True if the departing user's seat was located in this console."
+          matched_email:
+            type: string
+            description: "The email the console actually rendered for the matched user (used by the deterministic wrong-user safety check)."
+          seat_id:
+            type: string
+            description: "The seat / license / membership id for this user in this tool."
+          role:
+            type: string
+            description: "The user's role / permission level in this tool (e.g. admin, member, viewer)."
+          last_login:
+            type: string
+            description: "The last_login timestamp the console shows for this user, as a string."
+          owned_assets:
+            type: array
+            items:
+              type: object
+              properties:
+                asset_type: { type: string }
+                asset_id: { type: string }
+                asset_name: { type: string }
+            description: "Assets this user owns that may need ownership transfer before deactivation."
+          billing_impact:
+            type: string
+            description: "What removing this seat does to billing (e.g. 'frees 1 paid seat, $12/mo')."
+        required: ["app", "user_found", "matched_email"]
+
+  # 4) DETERMINISTIC SNAPSHOT VALIDATION - the load-bearing wrong-user safeguard. For every app
+  #    snapshot, normalize the console-matched email (case-insensitive, whitespace-stripped via re.sub)
+  #    and compare it to the canonical target_email. If ANY found user's email does not equal the
+  #    target, mark a mismatch and HARD-FAIL the run (ok=False) so no write can proceed against the
+  #    wrong person. Pure Python - no model decides correctness here.
+  - id: validate_snapshots
+    type: code
+    depends_on: [build_app_worklist, read_census_loop]
+    code_config:
+      language: python
+      code: |
+        import json
+        import re
+
+        work = _steps['build_app_worklist'] or {}
+        if isinstance(work, str):
+            try:
+                work = json.loads(work) if work.strip() else {}
+            except (ValueError, TypeError):
+                work = {}
+        target_email = str(work.get('target_email') or '').strip().lower()
+
+        # Loop output may arrive as a list of per-iteration results or wrapped under results/items.
+        loop_out = _steps['read_census_loop'] or {}
+        if isinstance(loop_out, list):
+            snapshots = loop_out
+        elif isinstance(loop_out, dict):
+            snapshots = loop_out.get('results') or loop_out.get('items') or loop_out.get('output') or []
+        else:
+            snapshots = []
+        if not isinstance(snapshots, list):
+            snapshots = []
+
+        def _norm(addr):
+            # Case-insensitive, whitespace-stripped normalization of an email for equality.
+            return re.sub(r'\s+', '', str(addr or '')).lower()
+
+        norm_target = _norm(target_email)
+
+        validated = []
+        mismatches = []
+        found_count = 0
+        for snap in snapshots:
+            if isinstance(snap, str):
+                try:
+                    snap = json.loads(snap) if snap.strip() else {}
+                except (ValueError, TypeError):
+                    snap = {}
+            if not isinstance(snap, dict):
+                continue
+            # The browser step may nest its structured payload under output/data/result.
+            for key in ('output', 'data', 'result'):
+                inner = snap.get(key)
+                if isinstance(inner, dict) and ('matched_email' in inner or 'user_found' in inner):
+                    snap = inner
+                    break
+
+            app = str(snap.get('app') or '').strip()
+            user_found = bool(snap.get('user_found'))
+            matched = _norm(snap.get('matched_email'))
+            owned_assets = snap.get('owned_assets') if isinstance(snap.get('owned_assets'), list) else []
+
+            email_ok = True
+            reason = 'ok'
+            if user_found:
+                found_count += 1
+                if not norm_target:
+                    email_ok = False
+                    reason = 'no_target_email_to_compare'
+                elif matched != norm_target:
+                    email_ok = False
+                    reason = 'matched_email_differs_from_target'
+            row = {
+                'app': app,
+                'user_found': user_found,
+                'matched_email': matched,
+                'seat_id': snap.get('seat_id'),
+                'role': snap.get('role'),
+                'last_login': snap.get('last_login'),
+                'owned_assets': owned_assets,
+                'owned_asset_count': len(owned_assets),
+                'billing_impact': snap.get('billing_impact'),
+                'email_ok': email_ok,
+                'reason': reason,
+            }
+            validated.append(row)
+            if user_found and not email_ok:
+                mismatches.append({'app': app, 'matched_email': matched, 'reason': reason})
+
+        ok = (len(mismatches) == 0) and bool(norm_target)
+        if not norm_target:
+            mismatches.append({'app': '*', 'matched_email': '', 'reason': 'missing_target_email'})
+
+        result = {
+            'ok': ok,
+            'target_email': norm_target,
+            'app_count': len(validated),
+            'found_count': found_count,
+            'mismatch_count': len(mismatches),
+            'mismatches': mismatches,
+            'snapshots': validated,
+            'reason_summary': 'all matched emails equal the target' if ok else 'WRONG-USER OR MISSING-TARGET: ' + '; '.join(m['reason'] for m in mismatches),
+        }
+
+  # 5) CLASSIFY each found account as safe to deactivate now vs needing asset ownership transfer first.
+  #    Provider-swappable (model: haiku). Both branches converge on the single deactivation approval -
+  #    the classification tags each account but does NOT bypass the human gate; it informs the write
+  #    pass which apps need an ownership-transfer wizard before deactivation.
+  - id: classify_accounts
+    type: classify
+    depends_on: [validate_snapshots]
+    classify_config:
+      model: haiku
+      input: "Classify each SaaS account in this offboarding snapshot. Tag 'needs_asset_transfer_first' for any app where the user owns assets (owned_asset_count > 0) such as dashboards, files, projects, or boards that would be orphaned if the seat were deactivated outright - these require running the tool's ownership-transfer wizard before deactivation. Tag 'safe_to_deactivate' for accounts with no owned assets that can be deactivated directly. Snapshots: {steps.validate_snapshots.output}"
+      categories:
+        - safe_to_deactivate
+        - needs_asset_transfer_first
+      branches:
+        safe_to_deactivate: [deactivation_approval]
+        needs_asset_transfer_first: [deactivation_approval]
+
+  # 6) SINGLE HUMAN APPROVAL - the ONLY place a human authorizes the irreversible deactivations, and
+  #    nothing destructive runs before it returns approved. It shows the full per-app blast radius
+  #    (owned assets, billing impact, validation result, classification). on_timeout: abort means a
+  #    missed sign-off NEVER auto-deactivates. allow_edit lets the approver drop a borderline app.
+  - id: deactivation_approval
+    type: approval
+    depends_on: [classify_accounts]
+    approval_config:
+      message: >-
+        Approve SaaS deactivations for {steps.validate_snapshots.output.target_email}. This is the
+        ONLY authorization gate before any account is changed. Apps in scope:
+        {steps.validate_snapshots.output.app_count}, users found:
+        {steps.validate_snapshots.output.found_count}. Wrong-user check OK:
+        {steps.validate_snapshots.output.ok} ({steps.validate_snapshots.output.reason_summary}). Review
+        the per-app blast radius below - owned assets that will need ownership transfer, billing impact,
+        and last_login - then APPROVE to run ownership transfer (where needed) and deactivate each seat
+        one-by-one in the admin consoles, or REJECT to abort the whole run with nothing changed.
+      show_data: steps.validate_snapshots.output
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: true
+
+  # 7) WRITE LOOP - runs ONLY after the human approval above. Fans out over the validated snapshots;
+  #    each iteration runs deactivate_app (defined below) on the current app via _item. max_iterations
+  #    caps the batch.
+  - id: deactivation_loop
+    type: loop
+    depends_on: [deactivation_approval]
+    loop_config:
+      over: "steps.validate_snapshots.output.snapshots"
+      step_ids: [deactivate_app]
+      max_iterations: 200
+
+  # 7a) PER-APP WRITE PASS (mode: playwright). The reasoning model only authors a Playwright script
+  #     from the prompt; the mutation itself is deterministic Playwright, so any provider can author it
+  #     and is swappable. If the account owns assets, it FIRST runs the tool's ownership-transfer
+  #     wizard, then deactivates the seat. capture_screenshots is ON for audit; max_actions is tightly
+  #     capped so a misnavigation cannot rampage; captcha_strategy pauses for a human at any step-up.
+  #     Returns a structured per-app write result.
+  - id: deactivate_app
+    type: browser
+    prompt: >-
+      A human has APPROVED deactivating this departing user's seat. Operate on exactly ONE SaaS app and
+      ONE user. The app, the target user, and what they own are: {{ _item }}. Log into that app's admin
+      console using the credentials provided via the environment and navigate to the departing user. If
+      this user owns assets (dashboards, files, projects, folders, boards), FIRST run the tool's
+      ownership-transfer / reassign wizard to transfer those owned assets to the offboarding-owner or
+      admin account this tool designates, so nothing is orphaned. THEN click the control that
+      deactivates / suspends / removes the seat for THIS user only (Deactivate, Suspend, or Remove
+      seat). Confirm any confirmation dialog. Operate on this user's email ONLY - never touch any other
+      member. Capture a screenshot of the resulting account-status / confirmation screen. Read back this
+      user's resulting account status and return ONLY the structured object in the output schema. If a
+      CAPTCHA, MFA, or step-up wall appears, PAUSE for a human - do not attempt to solve it.
+    browser_config:
+      mode: playwright
+      start_url: "{{ _item.app }}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 180
+      max_actions: 30
+      headless: true
+      credentials_env: "{{ _item.credentials_env }}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          app:
+            type: string
+            description: "The SaaS app this write result is for."
+          deactivated:
+            type: boolean
+            description: "True if the UI confirmed the seat is now deactivated/suspended/removed."
+          assets_transferred_to:
+            type: string
+            description: "The account owned assets were reassigned to (empty if the user owned none)."
+          post_status:
+            type: string
+            description: "The user's resulting account status as the console reports it (e.g. inactive, suspended)."
+          confirmation:
+            type: string
+            description: "The portal's own confirmation text / reference shown after the action."
+          screenshot_ref:
+            type: string
+            description: "Reference to the captured post-action screenshot for the audit pack."
+        required: ["app", "deactivated", "post_status"]
+
+  # 8) CONFIRMATION GATE (llm_eval) over each app's post-action result. Confirms each console's OWN
+  #    after-state reports the seat as inactive/suspended rather than assuming the click worked.
+  #    Provider-swappable. Secondary to the deterministic reconcile below, which is authoritative.
+  - id: confirm_deactivations
+    type: gate
+    depends_on: [deactivation_loop]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are an offboarding completion reviewer reading the admin consoles' own after-state for
+              each app. Answer exactly 'approved' if EVERY app result shows the seat was deactivated:
+              deactivated is true and post_status reads inactive/suspended/deactivated/removed, and any
+              app that owned assets reports a non-empty assets_transferred_to. Answer 'rejected' and name
+              the offending app(s) if any seat is still active, any deactivation failed, or any owned
+              account was deactivated without transferring its assets. Per-app write results:
+              {steps.deactivation_loop.output}
+            input: "{steps.deactivation_loop.output}"
+            model: sonnet
+
+  # 9) DETERMINISTIC RECONCILE - the authoritative post-check. Joins the validated snapshots (intended
+  #    targets) with the per-app write results and asserts every found, email-verified target now reports
+  #    a deactivated post_status, and that any asset-owning account had its assets transferred. Emits a
+  #    drift list of any app that did not reach the expected state. Pure Python - no model.
+  - id: reconcile_offboard
+    type: code
+    depends_on: [validate_snapshots, deactivation_loop, confirm_deactivations]
+    code_config:
+      language: python
+      code: |
+        import json
+
+        snap_step = _steps['validate_snapshots'] or {}
+        if isinstance(snap_step, str):
+            try:
+                snap_step = json.loads(snap_step) if snap_step.strip() else {}
+            except (ValueError, TypeError):
+                snap_step = {}
+        snapshots = snap_step.get('snapshots', []) if isinstance(snap_step, dict) else []
+        target_email = str(snap_step.get('target_email') or '') if isinstance(snap_step, dict) else ''
+
+        # Index write results by app name.
+        loop_out = _steps['deactivation_loop'] or {}
+        if isinstance(loop_out, list):
+            write_items = loop_out
+        elif isinstance(loop_out, dict):
+            write_items = loop_out.get('results') or loop_out.get('items') or loop_out.get('output') or []
+        else:
+            write_items = []
+        if not isinstance(write_items, list):
+            write_items = []
+
+        results_by_app = {}
+        for it in write_items:
+            if isinstance(it, str):
+                try:
+                    it = json.loads(it) if it.strip() else {}
+                except (ValueError, TypeError):
+                    it = {}
+            if not isinstance(it, dict):
+                continue
+            for key in ('output', 'data', 'result'):
+                inner = it.get(key)
+                if isinstance(inner, dict) and ('deactivated' in inner or 'post_status' in inner):
+                    it = inner
+                    break
+            app = str(it.get('app') or '').strip()
+            if app:
+                results_by_app[app] = it
+
+        inactive_states = ('inactive', 'suspended', 'deactivated', 'removed', 'disabled')
+
+        confirmed = []
+        drift = []
+        for s in snapshots:
+            if not isinstance(s, dict):
+                continue
+            if not s.get('user_found') or not s.get('email_ok'):
+                # Not a write target (user not found, or failed the wrong-user check).
+                continue
+            app = str(s.get('app') or '').strip()
+            wr = results_by_app.get(app, {})
+            post = str(wr.get('post_status') or '').strip().lower()
+            deactivated_flag = bool(wr.get('deactivated'))
+            owned = s.get('owned_asset_count') or 0
+            transferred_to = str(wr.get('assets_transferred_to') or '').strip()
+
+            row = {
+                'app': app,
+                'post_status': post,
+                'deactivated': deactivated_flag,
+                'owned_asset_count': owned,
+                'assets_transferred_to': transferred_to,
+                'confirmation': wr.get('confirmation'),
+                'screenshot_ref': wr.get('screenshot_ref'),
+            }
+            status_ok = deactivated_flag and (post in inactive_states)
+            transfer_ok = (owned == 0) or bool(transferred_to)
+            if status_ok and transfer_ok:
+                confirmed.append(row)
+            else:
+                problems = []
+                if not status_ok:
+                    problems.append('seat_not_confirmed_inactive')
+                if not transfer_ok:
+                    problems.append('owned_assets_not_transferred')
+                drift.append({**row, 'drift_reason': ','.join(problems)})
+
+        targeted_count = len(confirmed) + len(drift)
+        all_clean = (len(drift) == 0) and (targeted_count > 0)
+
+        result = {
+            'all_clean': all_clean,
+            'target_email': target_email,
+            'targeted_count': targeted_count,
+            'confirmed_count': len(confirmed),
+            'drift_count': len(drift),
+            'confirmed': confirmed,
+            'drift': drift,
+        }
+
+  # 10) EVIDENCE PACK - compile a branded PDF offboarding evidence pack: the target, the per-app
+  #     before snapshot (seat, role, last_login, owned assets, billing impact), the approver decision,
+  #     and the per-app after-state with screenshots references and any drift. The narrative is
+  #     formatting only; the load-bearing facts come from the deterministic reconcile above.
+  - id: evidence_report
+    type: report
+    depends_on: [reconcile_offboard]
+    report_config:
+      template: "research-report"
+      format: pdf
+      theme: professional
+      title: "SaaS Offboarding Evidence Pack - {steps.validate_snapshots.output.target_email}"
+      author: "{input.evidence_author}"
+    prompt: >-
+      Produce a formal SaaS offboarding evidence pack PDF for IT Security and audit. Open with the
+      departing user's email, the last day, the ticket id, and the number of SaaS apps in scope, of
+      which how many were targeted, confirmed deactivated, and drifted. Include the wrong-user safety
+      result (was every console-matched email equal to the target). For each app, render a row with:
+      the seat id, role, last_login, the owned assets and where they were transferred, the billing
+      impact, the final account status, and the captured screenshot reference. Clearly flag any app in
+      the drift list as NOT confirmed and requiring manual follow-up. State the approver sign-off that
+      authorized the deactivations. Read-only snapshots: {steps.validate_snapshots.output}. Write
+      reconciliation: {steps.reconcile_offboard.output}.
+
+  # 11) NOTIFY the offboarding channel / ticket with the result + drift report + a pointer to the
+  #     evidence pack. Surfaces any drift loudly so a silently-failed deactivation is never mistaken
+  #     for success.
+  - id: notify_offboarding
+    type: notify
+    depends_on: [evidence_report]
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: "SaaS offboarding complete for {steps.reconcile_offboard.output.target_email}. Apps targeted: {steps.reconcile_offboard.output.targeted_count} | Confirmed deactivated: {steps.reconcile_offboard.output.confirmed_count} | Drift (needs manual follow-up): {steps.reconcile_offboard.output.drift_count} | All clean: {steps.reconcile_offboard.output.all_clean}. Evidence pack attached. Post this summary as a comment on the offboarding ticket."
+
+on_complete:
+  storage_path: "saas-admin-seat-deprovisioning-offboard/{run_id}/result.json"

--- a/src/sandcastle/templates/saas_api_key_rotation_runner.yaml
+++ b/src/sandcastle/templates/saas_api_key_rotation_runner.yaml
@@ -1,0 +1,644 @@
+# name: SaaS API Key Rotation Runner
+# description: Rotates or revokes credentials/API keys/webhook secrets across many service accounts in a SaaS admin console that only regenerates keys one-by-one in the UI and exposes no rotation API. A dom-mode browser census lists each account's current key id + last-rotated date; deterministic code builds a rotation_plan (age-over-policy or explicitly listed) and refuses any missing account or open-dependency flag; an llm_eval gate reviews blast radius; ONE human approval authorizes the irreversible batch; a per-account loop drives an authored Playwright regenerate, reads the one-time new secret from the modal via output_schema, and writes it to the vault by the very NEXT http step before continuing so no secret is ever lost on crash; a dom re-census plus deterministic reconcile asserts every old key id is gone and a new key id is present, flagging any survivor. Secrets NEVER enter notify payloads or the audit chain - only key_id transitions are logged.
+# tags: [DevOps, SecretsRotation, ApiKeyRotation, CredentialRotation, RPA, Playwright, DOM, HumanApproval, Vault, ProviderNeutral]
+# category: devops
+
+name: saas-api-key-rotation-runner
+description: >-
+  Runs a credential-rotation campaign - post-incident or a scheduled 90-day rotation - across many
+  SaaS service accounts / integrations whose admin console regenerates API keys, webhook secrets, or
+  service credentials via a UI button and exposes NO programmatic key-rotation endpoint. The new
+  secret is revealed exactly once in a browser modal, so only a driven browser session can click
+  Regenerate, capture the one-time secret to a vault, and prove the old key is dead. The flow splits
+  read from write and fails closed. A parse step loads the target list of {account_id, integration_name}
+  plus the destination vault path. A dom-mode browser CENSUS lists each account's current key id, its
+  last-rotated date, and status via output_schema - it writes nothing. A DETERMINISTIC code step builds
+  the rotation_plan: it selects accounts whose key age exceeds the policy window OR that are explicitly
+  listed, and it REFUSES the run if any requested account is missing from the census or carries an open
+  dependency flag (a downstream system still depends on that key). An llm_eval GATE reviews blast radius
+  and warns if a high-traffic integration is in scope. Then exactly ONE human approval authorizes the
+  irreversible batch - old keys die on regenerate. A LOOP over the rotation_plan runs, per account, an
+  authored PLAYWRIGHT step (max_actions capped, capture_screenshots on for audit) that clicks Regenerate
+  and reads the one-time new_secret from the modal via output_schema {account_id, new_key_id, new_secret,
+  old_key_revoked_flag}; the very NEXT step is an http write that stores that secret to the vault BEFORE
+  the loop advances, so a crash can never lose a freshly minted secret. A dom RE-CENSUS plus a
+  deterministic FINAL RECONCILE asserts every rotated account now shows a NEW key id and the old key id is
+  gone/inactive, flagging any account where the old key survived. Finally a counts-only notify and an audit
+  record log the key_id transitions - never the secret values. The browser steps ride default_model and stay
+  swappable; vaulting and reconciliation are deterministic code/http with zero model dependency, so the
+  reasoning provider only authors the navigation script and can be swapped freely without weakening safety.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 1800
+
+input_schema:
+  required: ["rotation_targets", "admin_keys_url", "vault_write_url"]
+  properties:
+    rotation_targets:
+      type: string
+      description: "The list of accounts to rotate plus the destination vault path, as a JSON string. Each target is {account_id, integration_name}; explicitly-listed accounts are rotated immediately (incident-driven) regardless of key age."
+      example: '{"vault_path":"secret/saas/rotation/2026Q2","targets":[{"account_id":"svc-billing","integration_name":"Stripe webhook"},{"account_id":"svc-analytics","integration_name":"Segment source"},{"account_id":"svc- etl","integration_name":"Snowflake loader"}]}'
+    admin_keys_url:
+      type: string
+      description: "URL of the SaaS admin console's API keys / service-credentials page where keys are listed and the per-account Regenerate button lives (authenticated SPA, no rotation API). Census and re-census read this read-only."
+      example: "https://admin.example-saas.com/settings/api-keys"
+    account_keys_url_template:
+      type: string
+      description: "URL template for a single service account's key-management page used by the per-account regenerate step (e.g. .../accounts/{account_id}/keys). The loop navigates here per item."
+      default: ""
+      example: "https://admin.example-saas.com/settings/api-keys"
+    vault_write_url:
+      type: string
+      description: "HTTPS endpoint of the secret store / vault that each freshly regenerated one-time secret is POSTed to immediately after regeneration (e.g. a Vault KV write API or an internal secret-store webhook). Auth via VAULT_TOKEN env."
+      example: "https://vault.internal.example.com/v1/secret/data/saas/rotation"
+    portal_credentials_env:
+      type: string
+      description: "Name of the environment variable holding the SaaS admin login credentials (NEVER inline secrets). Passed to every browser step's credentials_env."
+      default: "PORTAL_CREDS"
+      example: "PORTAL_CREDS"
+    key_age_policy_days:
+      type: integer
+      description: "Maximum allowed key age in days. Accounts whose last-rotated date is older than this are selected for scheduled rotation. Explicitly-listed accounts are rotated regardless of age."
+      default: 90
+      example: "90"
+    high_traffic_integrations:
+      type: string
+      description: "Comma-separated substrings of integration names considered high-traffic / high-blast-radius. The blast-radius gate warns (and the human must explicitly accept) if any planned account matches."
+      default: "webhook,payments,stripe,production,prod"
+      example: "webhook,payments,stripe,production,prod"
+    approval_timeout_hours:
+      type: integer
+      description: "Hours the single human batch approval waits before its timeout fires (on_timeout: abort - never auto-rotate)."
+      default: 24
+      example: "24"
+    notify_channel:
+      type: string
+      description: "Slack channel for the counts-only rotation summary (NEVER carries secret values)."
+      default: "#secret-rotation"
+      example: "#secret-rotation"
+    audit_sink_url:
+      type: string
+      description: "HTTPS endpoint that the key_id-transition audit record is POSTed to (records old_key_id -> new_key_id transitions, NEVER the secret values). Auth via AUDIT_SINK_TOKEN env."
+      default: "https://audit.internal.example.com/api/events"
+      example: "https://audit.internal.example.com/api/events"
+
+steps:
+  # 1) PARSE the target list + destination vault path handed in by the caller (scheduled window or
+  #    incident-driven on-demand run). parse returns the raw payload; the plan step parses it
+  #    deterministically. No portal is touched yet.
+  - id: load_targets
+    type: parse
+    prompt: "{input.rotation_targets}"
+    parse_config:
+      output: markdown
+
+  # 2) CENSUS (READ pass, dom mode, READ-ONLY). Provider-neutral lightweight DOM read: the reasoning
+  #    model logs into the admin console via credentials_env (never inlined), opens the API keys page,
+  #    and LISTS every service account's current key id, last-rotated date, and status - WITHOUT
+  #    clicking Regenerate or mutating anything. captcha_strategy=pause hands a CAPTCHA to a human;
+  #    max_actions caps clicking; output_schema returns structured JSON to plan against.
+  - id: census_before
+    type: browser
+    depends_on: [load_targets]
+    prompt: >-
+      You are doing a READ-ONLY census of a SaaS admin console's API keys / service-credentials page.
+      Log in using the credentials provided via the environment, then open the API keys page at the
+      start URL. DO NOT click Regenerate, Revoke, Delete, Rotate, or any mutating control - this is a
+      structure/inventory read only. For EVERY service account / integration listed, report its
+      account_id, the integration_name, the CURRENT key id (the visible key identifier or fingerprint,
+      NOT the secret value - never reveal or read a full secret here), the last-rotated / created date as
+      shown, and its status (active/disabled). Also report any account that displays an open-dependency
+      or in-use warning indicating a downstream system still relies on that key. If a CAPTCHA or step-up
+      auth appears, PAUSE for a human. Return ONLY the structured object described by the output schema.
+    browser_config:
+      mode: dom
+      start_url: "{input.admin_keys_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 300
+      max_actions: 60
+      headless: true
+      credentials_env: "{input.portal_credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          accounts:
+            type: array
+            items:
+              type: object
+              properties:
+                account_id: { type: string }
+                integration_name: { type: string }
+                key_id: { type: string }
+                last_rotated: { type: string }
+                status: { type: string }
+                open_dependency_flag: { type: boolean }
+
+  # 3) PLAN (DETERMINISTIC, no model). Parse the target payload + the census and build the rotation_plan.
+  #    Select an account if it is explicitly listed in the targets OR its key age exceeds the policy
+  #    window. REFUSE the whole run (ok=False) if any requested target is MISSING from the census or
+  #    carries an open dependency flag - fails closed so nothing is regenerated on a bad/incomplete read.
+  - id: build_plan
+    type: code
+    depends_on: [load_targets, census_before]
+    code_config:
+      language: python
+      code: |
+        import json
+        from datetime import datetime, timezone
+
+        # --- Parse the target list + vault path handed in by the caller. ---
+        raw = _input.get('rotation_targets') or ''
+        payload = {}
+        if isinstance(raw, dict):
+            payload = raw
+        else:
+            try:
+                payload = json.loads(raw)
+            except (TypeError, ValueError):
+                payload = {}
+        if not isinstance(payload, dict):
+            payload = {}
+
+        targets = payload.get('targets')
+        if not isinstance(targets, list):
+            targets = []
+        vault_path = str(payload.get('vault_path', '') or '').strip()
+
+        # --- Pull the census (browser READ pass); it may nest under output/data/result. ---
+        census = _steps.get('census_before') or {}
+        if not isinstance(census, dict):
+            census = {}
+        for key in ('output', 'data', 'result'):
+            inner = census.get(key)
+            if isinstance(inner, dict) and ('accounts' in inner):
+                census = inner
+                break
+        accounts = census.get('accounts')
+        if not isinstance(accounts, list):
+            accounts = []
+
+        # Index census rows by account_id for lookup.
+        by_id = {}
+        for row in accounts:
+            if isinstance(row, dict):
+                aid = str(row.get('account_id', '') or '').strip()
+                if aid:
+                    by_id[aid] = row
+
+        problems = []
+        policy_days = int(_input.get('key_age_policy_days', 90) or 90)
+        now = datetime.now(timezone.utc)
+
+        def _age_days(date_str):
+            s = str(date_str or '').strip()
+            if not s:
+                return None
+            # Accept a few common date shapes; treat trailing Z as UTC.
+            s2 = s.replace('Z', '+00:00')
+            for fmt in ('iso',):
+                try:
+                    dt = datetime.fromisoformat(s2)
+                    if dt.tzinfo is None:
+                        dt = dt.replace(tzinfo=timezone.utc)
+                    return (now - dt).days
+                except (TypeError, ValueError):
+                    pass
+            for fmt in ('%Y-%m-%d', '%Y/%m/%d', '%m/%d/%Y'):
+                try:
+                    dt = datetime.strptime(s[:10], fmt).replace(tzinfo=timezone.utc)
+                    return (now - dt).days
+                except (TypeError, ValueError):
+                    continue
+            return None
+
+        explicit_ids = set()
+        for t in targets:
+            if isinstance(t, dict):
+                tid = str(t.get('account_id', '') or '').strip()
+                if tid:
+                    explicit_ids.add(tid)
+
+        # --- Every explicitly requested target MUST exist in the census (fail closed). ---
+        for tid in sorted(explicit_ids):
+            if tid not in by_id:
+                problems.append('requested account "' + tid + '" missing from console census')
+
+        rotation_plan = []
+        skipped = []
+        for aid, row in by_id.items():
+            integration_name = str(row.get('integration_name', '') or '').strip()
+            key_id = str(row.get('key_id', '') or '').strip()
+            status = str(row.get('status', '') or '').strip().lower()
+            dep_flag = bool(row.get('open_dependency_flag', False))
+            age = _age_days(row.get('last_rotated'))
+
+            explicitly_listed = aid in explicit_ids
+            age_over = (age is not None and age > policy_days)
+            selected = explicitly_listed or age_over
+
+            if not selected:
+                continue
+
+            # An open dependency flag is a hard refusal - a live system still uses this key.
+            if dep_flag:
+                problems.append('account "' + aid + '" has an OPEN DEPENDENCY flag - refusing to rotate')
+                continue
+            if not key_id:
+                problems.append('account "' + aid + '" has no readable current key_id - cannot prove rotation')
+                continue
+
+            rotation_plan.append({
+                'account_id': aid,
+                'integration_name': integration_name,
+                'old_key_id': key_id,
+                'last_rotated': str(row.get('last_rotated', '') or ''),
+                'age_days': age if age is not None else -1,
+                'reason': 'explicit' if explicitly_listed else ('age>' + str(policy_days) + 'd'),
+                'vault_path': vault_path,
+            })
+
+        if not vault_path:
+            problems.append('no vault_path in rotation_targets payload (nowhere to store new secrets)')
+        if len(rotation_plan) == 0 and len(problems) == 0:
+            problems.append('no accounts selected for rotation (none explicit and none over policy age)')
+
+        # Blast-radius signal for the gate: which planned integrations look high-traffic.
+        ht_terms = [s.strip().lower() for s in str(_input.get('high_traffic_integrations', '') or '').split(',') if s.strip()]
+        high_traffic_hits = []
+        for p in rotation_plan:
+            name = (p['integration_name'] + ' ' + p['account_id']).lower()
+            for term in ht_terms:
+                if term and term in name:
+                    high_traffic_hits.append(p['account_id'])
+                    break
+
+        ok = len(problems) == 0 and len(rotation_plan) > 0
+        result = {
+            'ok': ok,
+            'problems': problems,
+            'vault_path': vault_path,
+            'rotation_plan': rotation_plan,
+            'rotation_count': len(rotation_plan),
+            'skipped_count': len(skipped),
+            'high_traffic_hits': sorted(set(high_traffic_hits)),
+            'high_traffic_in_scope': len(high_traffic_hits) > 0,
+            'policy_days': policy_days,
+            'census_account_count': len(by_id),
+        }
+
+  # 3b) Hard stop on a bad/empty/refused plan - never touch a Regenerate button on an incomplete read.
+  - id: plan_gate
+    type: condition
+    depends_on: [build_plan]
+    condition_config:
+      expression: "{steps.build_plan.output.ok} == True"
+      then: [blast_radius_gate]
+      else: [notify_plan_blocked]
+
+  # 3c) BLOCKED branch: tell the team the campaign did NOT run and why. Nothing was rotated.
+  - id: notify_plan_blocked
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        Key-rotation campaign BLOCKED before any regeneration. The deterministic plan FAILED:
+        {steps.build_plan.output.problems}. Census saw {steps.build_plan.output.census_account_count}
+        accounts; {steps.build_plan.output.rotation_count} were selected. No keys were rotated. Fix the
+        target list or resolve the open-dependency flags and re-run.
+
+  # 4) BLAST-RADIUS GATE (llm_eval) - a provider-swappable reviewer reads the validated plan and WARNS
+  #    if a high-traffic integration is in scope, so a person consciously accepts the blast radius before
+  #    the irreversible batch. The gate is advisory review on top of the deterministic plan; ALL
+  #    strategies must pass. It never invents the selection - that is fixed by code above.
+  - id: blast_radius_gate
+    type: gate
+    depends_on: [plan_gate]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are a change-safety reviewer for a credential-rotation campaign. The accounts to rotate
+              are ALREADY fixed by deterministic policy - do not re-select. Your job is to assess BLAST
+              RADIUS and reply with exactly 'approved' only if rotating these keys is reasonable to proceed
+              to a human, or 'rejected' (naming the risk) if the scope is obviously dangerous - for example
+              a production payments/webhook integration is in scope with no indication a maintenance window
+              exists. Note that any high-traffic integrations flagged here will revoke their old key the
+              instant they are regenerated. Validated plan: {steps.build_plan.output} . High-traffic
+              integrations in scope: {steps.build_plan.output.high_traffic_hits}.
+            input: "{steps.build_plan.output}"
+            model: google/gemini-2.5-pro
+
+  # 5) SINGLE HUMAN BATCH APPROVAL before the irreversible rotation. Shows the deterministically built
+  #    plan (counts + key_id transitions, NOT secrets) and BLOCKS until one person authorizes the whole
+  #    batch. on_timeout: abort means a missed approval NEVER auto-rotates. This is the only authorization.
+  - id: approve_batch
+    type: approval
+    depends_on: [blast_radius_gate]
+    approval_config:
+      message: >-
+        AUTHORIZE the IRREVERSIBLE key-rotation batch. Regenerating each key REVOKES its old key
+        immediately. Plan: {steps.build_plan.output.rotation_count} account(s) will be rotated; high-traffic
+        integrations in scope: {steps.build_plan.output.high_traffic_hits}; new secrets will be written to
+        vault path {steps.build_plan.output.vault_path}. Review the per-account plan (old key ids shown,
+        NOT secrets). Approve to run the batch; reject to abort with nothing rotated.
+      show_data: steps.build_plan.output.rotation_plan
+      timeout_hours: 24
+      on_timeout: abort
+      allow_edit: false
+
+  # 6) ROTATION LOOP over the rotation_plan. Runs ONLY after the single human approval. For EACH account
+  #    it runs, in order: (6a) an authored Playwright Regenerate that reads the one-time new secret, then
+  #    immediately (6b) an http write of that secret to the vault BEFORE the loop advances - so a crash can
+  #    never lose a freshly minted secret. max_iterations caps the batch size. Child steps regenerate_one
+  #    and vault_one are defined separately and read the current item via _item; they carry NO depends_on.
+  - id: rotation_loop
+    type: loop
+    depends_on: [approve_batch]
+    loop_config:
+      over: "steps.build_plan.output.rotation_plan"
+      step_ids: [regenerate_one, vault_one]
+      max_iterations: 1000
+
+  # 6a) PER-ACCOUNT REGENERATE (WRITE pass, playwright mode, provider-neutral). The reasoning model only
+  #     AUTHORS a Playwright script from the prompt; the mutation itself is deterministic Playwright, so any
+  #     provider can author it and is swappable. It navigates to THIS one account, clicks Regenerate, and
+  #     reads the ONE-TIME new secret from the modal via output_schema, plus the new key id and whether the
+  #     console confirms the old key is revoked. max_actions is tightly capped so a misnavigation cannot
+  #     rampage; capture_screenshots is ON for audit; captcha_strategy pauses for a human.
+  - id: regenerate_one
+    type: browser
+    prompt: >-
+      A human has authorized this irreversible key rotation. You are rotating exactly ONE service account in
+      the SaaS admin console. The target is: {{ _item }}. Log in using the environment credentials if needed,
+      navigate to THIS account's key-management view (account_id {{ _item.account_id }}, integration
+      {{ _item.integration_name }}) - searching by account_id if necessary - and confirm the current key id
+      matches old_key_id {{ _item.old_key_id }}. Click the Regenerate / Rotate control for THIS account ONLY,
+      confirming any dialog. The console will reveal the NEW secret exactly once in a modal: capture it now.
+      Operate on this one account ONLY - never touch any other account's keys. Read back: this account_id, the
+      NEW key id the console now shows, the one-time NEW secret value from the modal, and whether the console
+      indicates the OLD key is now revoked/inactive. If a CAPTCHA or step-up auth appears, PAUSE for a human -
+      do not attempt to solve it. Return ONLY the structured object described by the output schema.
+    browser_config:
+      mode: playwright
+      start_url: "{input.account_keys_url_template}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 25
+      headless: true
+      credentials_env: "{input.portal_credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          account_id: { type: string }
+          new_key_id: { type: string }
+          new_secret: { type: string }
+          old_key_revoked_flag: { type: boolean }
+          screenshot_ref: { type: string }
+        required: ["account_id", "new_key_id", "new_secret"]
+
+  # 6b) VAULT WRITE (http) - the very NEXT step after regeneration, BEFORE the loop advances. POSTs the
+  #     one-time new secret to the vault keyed by account/path so a crash can never lose it. The new_secret
+  #     is sent ONLY to the vault here; it NEVER enters notify or the audit chain. Auth via VAULT_TOKEN env.
+  #     retry on_failure: abort means a failed vault write stops the run rather than continuing with a lost
+  #     secret. The reconcile + audit downstream log only key_id transitions.
+  - id: vault_one
+    type: http
+    http_config:
+      url: "{input.vault_write_url}"
+      method: POST
+      auth: "bearer:{env.VAULT_TOKEN}"
+      headers:
+        Content-Type: "application/json"
+      body: |
+        {
+          "vault_path": "{_item.vault_path}",
+          "account_id": "{steps.regenerate_one.output.account_id}",
+          "integration_name": "{_item.integration_name}",
+          "new_key_id": "{steps.regenerate_one.output.new_key_id}",
+          "secret": "{steps.regenerate_one.output.new_secret}",
+          "rotated_from_key_id": "{_item.old_key_id}"
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 7) RE-CENSUS (READ pass, dom mode, READ-ONLY). After the whole batch, re-read the same API keys page
+  #    so the reconcile has a fresh post-image: each account's CURRENT key id and status. No mutation.
+  #    Same provider-neutral DOM extraction as the first census.
+  - id: census_after
+    type: browser
+    depends_on: [rotation_loop]
+    prompt: >-
+      You are doing a READ-ONLY re-census of the SaaS admin console's API keys page AFTER a rotation batch.
+      Log in using the environment credentials, open the API keys page at the start URL, and for EVERY
+      service account report its account_id, integration_name, the CURRENT key id now shown (the identifier,
+      NOT the secret value), and its status (active/disabled). DO NOT click Regenerate, Revoke, or any
+      mutating control. If a CAPTCHA or step-up auth appears, PAUSE for a human. Return ONLY the structured
+      object described by the output schema.
+    browser_config:
+      mode: dom
+      start_url: "{input.admin_keys_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 300
+      max_actions: 60
+      headless: true
+      credentials_env: "{input.portal_credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          accounts:
+            type: array
+            items:
+              type: object
+              properties:
+                account_id: { type: string }
+                integration_name: { type: string }
+                key_id: { type: string }
+                status: { type: string }
+
+  # 8) FINAL RECONCILE (DETERMINISTIC, no model) - the load-bearing correctness gate. For every account in
+  #    the rotation_plan, assert the re-census shows a NEW key id (different from the recorded old_key_id)
+  #    and the old key id is NO LONGER present/active. Flag any account where the old key survived (drift).
+  #    This proves the rotation landed; a single model's opinion is never trusted for this call. Secrets are
+  #    NOT touched here - only key_id transitions are compared.
+  - id: final_reconcile
+    type: code
+    depends_on: [build_plan, rotation_loop, census_after]
+    code_config:
+      language: python
+      code: |
+        plan = _steps.get('build_plan') or {}
+        if not isinstance(plan, dict):
+            plan = {}
+        rotation_plan = plan.get('rotation_plan')
+        if not isinstance(rotation_plan, list):
+            rotation_plan = []
+
+        # Loop output (per-item regenerate results) may be a list or a wrapper dict.
+        loop_out = _steps.get('rotation_loop')
+        loop_items = loop_out if isinstance(loop_out, list) else (
+            (loop_out.get('results') or loop_out.get('items') or []) if isinstance(loop_out, dict) else []
+        )
+
+        # Post-image re-census, possibly nested under output/data/result.
+        after = _steps.get('census_after') or {}
+        if not isinstance(after, dict):
+            after = {}
+        for key in ('output', 'data', 'result'):
+            inner = after.get(key)
+            if isinstance(inner, dict) and ('accounts' in inner):
+                after = inner
+                break
+        after_accounts = after.get('accounts')
+        if not isinstance(after_accounts, list):
+            after_accounts = []
+
+        after_by_id = {}
+        for row in after_accounts:
+            if isinstance(row, dict):
+                aid = str(row.get('account_id', '') or '').strip()
+                if aid:
+                    after_by_id[aid] = row
+
+        # Map per-item regenerate results by account_id to learn the new_key_id (NOT the secret).
+        regen_by_id = {}
+        for it in loop_items:
+            obj = it if isinstance(it, dict) else {}
+            for key in ('output', 'data', 'result'):
+                inner = obj.get(key)
+                if isinstance(inner, dict) and ('new_key_id' in inner or 'account_id' in inner):
+                    obj = inner
+                    break
+            aid = str(obj.get('account_id', '') or '').strip()
+            if aid:
+                regen_by_id[aid] = obj
+
+        transitions = []
+        drift = []
+        confirmed = 0
+        for p in rotation_plan:
+            aid = str(p.get('account_id', '') or '').strip()
+            old_key_id = str(p.get('old_key_id', '') or '').strip()
+            regen = regen_by_id.get(aid, {})
+            claimed_new = str(regen.get('new_key_id', '') or '').strip()
+
+            now_row = after_by_id.get(aid, {})
+            now_key_id = str(now_row.get('key_id', '') or '').strip()
+            now_status = str(now_row.get('status', '') or '').strip().lower()
+
+            new_present = bool(now_key_id) and (now_key_id != old_key_id)
+            old_gone = (now_key_id != old_key_id)
+            # If the console still surfaces the old key id as active, the old key survived.
+            old_survived = (now_key_id == old_key_id) and (now_status in ('', 'active'))
+
+            account_ok = new_present and old_gone and not old_survived
+            if account_ok:
+                confirmed += 1
+            else:
+                drift.append({
+                    'account_id': aid,
+                    'old_key_id': old_key_id,
+                    'observed_key_id': now_key_id,
+                    'observed_status': now_status,
+                    'reason': 'old key survived' if old_survived else 'no new key id observed',
+                })
+
+            # key_id transition only - NEVER the secret value.
+            transitions.append({
+                'account_id': aid,
+                'integration_name': str(p.get('integration_name', '') or ''),
+                'old_key_id': old_key_id,
+                'new_key_id': now_key_id or claimed_new,
+                'rotated': account_ok,
+            })
+
+        targeted = len(rotation_plan)
+        all_clean = (targeted > 0) and (len(drift) == 0) and (confirmed == targeted)
+        result = {
+            'all_clean': all_clean,
+            'targeted_count': targeted,
+            'confirmed_count': confirmed,
+            'drift_count': len(drift),
+            'drift': drift,
+            'transitions': transitions,
+            'vault_path': str(plan.get('vault_path', '') or ''),
+        }
+
+  # 8b) Branch on the deterministic reconcile. A clean batch proceeds to the audit record; any surviving
+  #     old key routes to the drift notification so a partial rotation is NEVER reported as a clean success.
+  - id: reconcile_gate
+    type: condition
+    depends_on: [final_reconcile]
+    condition_config:
+      expression: "{steps.final_reconcile.output.all_clean} == True"
+      then: [audit_record]
+      else: [notify_drift]
+
+  # 8c) DRIFT PATH - one or more old keys survived (or no new key observed). Page the team with COUNTS and
+  #     the offending account_ids/key_id transitions ONLY (never secrets), and leave the run needing
+  #     attention. A partial rotation is surfaced, never mistaken for success.
+  - id: notify_drift
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        NEEDS ATTENTION: key-rotation batch did NOT fully reconcile. Targeted
+        {steps.final_reconcile.output.targeted_count}, confirmed rotated
+        {steps.final_reconcile.output.confirmed_count}, DRIFT
+        {steps.final_reconcile.output.drift_count}. Offending accounts (key_id transitions only, no
+        secrets): {steps.final_reconcile.output.drift}. New secrets that WERE minted are already in the
+        vault. Manually verify and re-rotate the survivors. The run is left in a needs-attention state.
+
+  # 9a) AUDIT RECORD (http POST, deterministic) - records the key_id TRANSITIONS (old_key_id -> new_key_id)
+  #     for the clean batch. The body carries ONLY transitions/counts and the vault_path - NEVER any secret
+  #     value - satisfying least-exposure. Auth via AUDIT_SINK_TOKEN env.
+  - id: audit_record
+    type: http
+    depends_on: [reconcile_gate]
+    http_config:
+      url: "{input.audit_sink_url}"
+      method: POST
+      auth: "bearer:{env.AUDIT_SINK_TOKEN}"
+      headers:
+        Content-Type: "application/json"
+      body: |
+        {
+          "event": "saas_api_key_rotation_completed",
+          "vault_path": "{steps.final_reconcile.output.vault_path}",
+          "targeted_count": "{steps.final_reconcile.output.targeted_count}",
+          "confirmed_count": "{steps.final_reconcile.output.confirmed_count}",
+          "drift_count": "{steps.final_reconcile.output.drift_count}",
+          "key_id_transitions": "{steps.final_reconcile.output.transitions}"
+        }
+
+  # 9b) SUMMARY NOTIFY (counts only, NEVER secrets). Final success message with the rotation counts and the
+  #     vault path; secret values never appear here by construction (only counts + vault_path are referenced).
+  - id: notify_summary
+    type: notify
+    depends_on: [audit_record]
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        Key-rotation campaign COMPLETE and reconciled clean. Rotated
+        {steps.final_reconcile.output.confirmed_count}/{steps.final_reconcile.output.targeted_count}
+        account(s); every old key is confirmed gone and a new key id is present. New secrets are stored at
+        vault path {steps.final_reconcile.output.vault_path}. Audit chain logged the key_id transitions
+        (no secret values were ever exposed in notifications or the audit record).
+
+on_complete:
+  storage_path: "saas-api-key-rotation-runner/{run_id}/result.json"

--- a/src/sandcastle/templates/saas_config_setting_propagator.yaml
+++ b/src/sandcastle/templates/saas_config_setting_propagator.yaml
@@ -1,0 +1,763 @@
+# name: SaaS Config Setting Propagator
+# description: Apply ONE configuration change (toggle MFA-required, set session timeout, flip a data-region/retention setting) across dozens-to-hundreds of separate workspaces/tenants of the same SaaS whose admin UI changes settings one workspace at a time and exposes no org-wide policy API - with idempotent verify-after-write. A census loop reads each workspace's current setting in provider-neutral dom mode; deterministic code computes a per-workspace diff and refuses any target_value outside an allowed enum; ONE human batch approval gates the whole mutation; a write loop drives each settings form in provider-neutral playwright mode under a max_actions cap with screenshots; a verify loop re-reads in dom mode and deterministic code asserts the saved value stuck (catching silent reverts); trajectory-replay guards the canonical write path against a vendor UI redesign; a notify + audit record logs who changed which workspaces from what to what. The load-bearing correctness is deterministic code + verify-loop + trajectory-replay, never a single model's opinion.
+# tags: [rpa, browser, devops, saas-admin, config-propagation, policy-enforcement, drift-correction, playwright, dom, idempotent, human-approval, trajectory-replay, provider-neutral]
+# category: devops
+
+name: saas-config-setting-propagator
+description: >-
+  Platform/security engineers and MSP admins who manage many separate workspaces/tenants of the
+  same SaaS (one per client or business unit) constantly need to apply ONE policy change - require
+  MFA, shorten the session timeout, pin the data region, change a retention window - to ALL of them
+  at once. But the vendor's admin console changes settings one workspace at a time and offers no
+  org-wide policy API on the current tier, so each workspace must be visited and its form toggled
+  in the browser; a plain HTTP call cannot authenticate into and mutate the client-rendered settings
+  SPA. This template propagates the desired setting safely and idempotently. Trigger it on-demand
+  when a new security policy is mandated, or on a schedule for drift-correction (re-run to re-assert
+  the desired value everywhere). Phase 1 loads the target workspace list and the desired_setting spec
+  (key + target_value) via an http or parse step. Phase 2 is a CENSUS loop: for each workspace a
+  browser step in provider-neutral DOM mode reads the current value via output_schema
+  {workspace_id, setting_key, current_value, found} - read-only, it mutates nothing. Phase 3 is
+  deterministic sandboxed Python that computes a per-workspace plan (needs_change / already_compliant
+  / unreachable) and VALIDATES target_value against an allowed enum, refusing any free-form value so a
+  malformed spec can never write garbage. Phase 4 is ONE human batch approval showing how many
+  workspaces will change and their current->target values - the single gate before any irreversible
+  write. Phase 5 is the WRITE loop over only the needs_change set: a browser step in provider-neutral
+  PLAYWRIGHT mode (the model authors a swappable script) opens each settings form, sets the value, and
+  saves, under a tight max_actions cap with capture_screenshots on for audit, returning
+  {workspace_id, action_taken, saved_value}. Phase 6 is the VERIFY loop over the same set: a DOM-mode
+  re-read followed by deterministic code that asserts saved_value == target_value for every workspace
+  and lists any that silently reverted (idempotency proof). Phase 7 trajectory-replays the canonical
+  write path against a recorded golden run so a vendor UI redesign that breaks the toggle path fails
+  the run loudly instead of silently no-op'ing. Phase 8 notifies and emits an audit record of which
+  workspaces changed, from what to what, and who approved. Census and verify use dom extraction and
+  the write uses an authored Playwright script - both model-agnostic - so swapping the reasoning model
+  never changes the replayed pass/fail contract. Credentials come from credentials_env (never inline),
+  captcha_strategy pauses for a human on any login challenge, and the enum gate + verify loop + replay
+  carry the correctness, not any single model's word.
+
+default_model: sonnet
+default_max_turns: 8
+default_timeout: 2400
+
+input_schema:
+  required: ["workspace_list", "setting_key", "target_value"]
+  properties:
+    workspace_list:
+      type: string
+      description: >-
+        The target workspaces to propagate the setting to, as a JSON array string. Each element is an
+        object with at least workspace_id, settings_url (the per-workspace admin settings page), and
+        label. Loaded/normalized by the load_targets step. NEVER put secrets here - the admin session
+        comes from credentials_env inside the browser steps.
+      example: '[{"workspace_id":"acme-prod","label":"Acme Prod","settings_url":"https://admin.saas.example/w/acme-prod/security"},{"workspace_id":"acme-eu","label":"Acme EU","settings_url":"https://admin.saas.example/w/acme-eu/security"}]'
+    setting_key:
+      type: string
+      description: >-
+        The single settings key to propagate across all workspaces (e.g. mfa_required, session_timeout_minutes,
+        data_region, retention_days). The census reads it, the write sets it, the verify re-reads it.
+      example: "mfa_required"
+    target_value:
+      type: string
+      description: >-
+        The desired value to enforce for setting_key in every workspace. DETERMINISTICALLY validated
+        against allowed_values (an enum) before any write - a value outside the enum aborts the run so a
+        malformed spec can never push garbage. Passed as a string and compared after normalization.
+      example: "enabled"
+    allowed_values:
+      type: string
+      description: >-
+        JSON array string of the ONLY values target_value (and any current_value) is permitted to take
+        for this setting_key - the refuse-free-form enum gate. If empty, the run is rejected (no enum =
+        no write). Example for a boolean toggle, a timeout, or a region.
+      default: '["enabled","disabled"]'
+      example: '["enabled","disabled"]'
+    settings_url_template:
+      type: string
+      description: >-
+        Optional fallback URL template for a workspace's settings page when an element lacks settings_url;
+        {workspace_id} is substituted. Lets you pass a bare id list and still reach each admin form.
+      default: "https://admin.saas.example/w/{workspace_id}/settings"
+      example: "https://admin.saas.example/w/{workspace_id}/security"
+    admin_credentials_env:
+      type: string
+      description: >-
+        Name of the environment variable holding the admin-console session/credentials (NEVER inline a
+        secret). Passed to every browser step's credentials_env so census, write, and verify all
+        authenticate the same way.
+      default: "SAAS_ADMIN_CREDS"
+      example: "SAAS_ADMIN_CREDS"
+    golden_run_id:
+      type: string
+      description: >-
+        ID of the recorded known-good write-path trajectory. trajectory-replay diffs the canonical
+        write flow against this golden run and fails on UI drift / cost blowup, so a vendor UI redesign
+        that breaks the toggle path is caught instead of silently no-op'ing. Provider-independent.
+      default: "golden-saas-settings-write-2026-05-01"
+      example: "golden-saas-settings-write-2026-05-01"
+    approval_timeout_hours:
+      type: integer
+      description: "Hours the single batch approval waits before its timeout fires (on_timeout: abort - never auto-write)."
+      default: 24
+      example: "24"
+    max_workspaces:
+      type: integer
+      description: "Upper bound on workspaces processed per phase loop (census/write/verify) - a safety cap against an over-large or malformed list."
+      default: 300
+      example: "300"
+    notify_channel:
+      type: string
+      description: "Slack channel that receives the final propagation summary + audit record (which workspaces changed, from->to, approver)."
+      default: "#saas-policy-ops"
+      example: "#saas-policy-ops"
+
+steps:
+  # ===========================================================================
+  # PHASE 1 - LOAD TARGETS + DESIRED SPEC. Deterministic parse/normalize of the
+  # workspace list and the desired_setting spec into a clean, capped list. No
+  # browser, no model decision here - pure data shaping so every later phase
+  # iterates the same canonical set. Refuses an empty allowed_values enum up
+  # front (no enum => no write is ever possible).
+  # ===========================================================================
+  - id: load_targets
+    type: code
+    code_config:
+      language: python
+      code: |
+        import json
+
+        # --- Parse the workspace list (a JSON array string) defensively ---
+        raw = _input.get("workspace_list", "")
+        workspaces = []
+        if isinstance(raw, list):
+            workspaces = raw
+        else:
+            try:
+                parsed = json.loads(raw) if str(raw).strip() else []
+                if isinstance(parsed, list):
+                    workspaces = parsed
+            except (ValueError, TypeError):
+                workspaces = []
+
+        url_tmpl = str(_input.get("settings_url_template", "") or "")
+
+        def _settings_url(ws):
+            # Prefer an explicit per-workspace settings_url; else fill the template by id.
+            u = str(ws.get("settings_url", "") or "").strip()
+            if u:
+                return u
+            wid = str(ws.get("workspace_id", "") or "").strip()
+            if url_tmpl and wid:
+                return url_tmpl.replace("{workspace_id}", wid)
+            return ""
+
+        # --- Normalize + cap ---
+        try:
+            cap = int(_input.get("max_workspaces", 300))
+        except (TypeError, ValueError):
+            cap = 300
+
+        targets = []
+        seen = set()
+        for ws in workspaces:
+            if not isinstance(ws, dict):
+                continue
+            wid = str(ws.get("workspace_id", "") or "").strip()
+            if not wid or wid in seen:
+                continue
+            seen.add(wid)
+            targets.append({
+                "workspace_id": wid,
+                "label": str(ws.get("label", "") or wid),
+                "settings_url": _settings_url(ws),
+            })
+            if len(targets) >= cap:
+                break
+
+        # --- Parse the allowed-values enum; an empty enum is a hard refusal ---
+        allowed_raw = _input.get("allowed_values", "")
+        allowed = []
+        if isinstance(allowed_raw, list):
+            allowed = allowed_raw
+        else:
+            try:
+                ap = json.loads(allowed_raw) if str(allowed_raw).strip() else []
+                if isinstance(ap, list):
+                    allowed = ap
+            except (ValueError, TypeError):
+                allowed = []
+        allowed_norm = sorted({str(a).strip().lower() for a in allowed if str(a).strip() != ""})
+
+        setting_key = str(_input.get("setting_key", "") or "").strip()
+        target_value = str(_input.get("target_value", "") or "").strip()
+        target_norm = target_value.lower()
+
+        spec_errors = []
+        if not setting_key:
+            spec_errors.append("setting_key is empty")
+        if target_value == "":
+            spec_errors.append("target_value is empty")
+        if len(allowed_norm) == 0:
+            spec_errors.append("allowed_values enum is empty - refusing (no enum, no write)")
+        if allowed_norm and target_norm not in allowed_norm:
+            spec_errors.append(
+                "target_value '" + target_value + "' is not in the allowed enum " + ", ".join(allowed_norm)
+            )
+        if len(targets) == 0:
+            spec_errors.append("no valid workspaces parsed from workspace_list")
+
+        result = {
+            "targets": targets,
+            "workspace_count": len(targets),
+            "setting_key": setting_key,
+            "target_value": target_value,
+            "target_value_norm": target_norm,
+            "allowed_values": allowed_norm,
+            "spec_ok": len(spec_errors) == 0,
+            "spec_errors": spec_errors,
+            "spec_error_summary": "; ".join(spec_errors) if spec_errors else "spec ok",
+        }
+
+  # ===========================================================================
+  # PHASE 2 - CENSUS LOOP (READ). Iterate every target workspace; each iteration
+  # drives ONE workspace's settings page in provider-neutral DOM mode (a cheap,
+  # read-only client-rendered extraction) and returns the current value via
+  # output_schema. The loop item arrives on _input['_item']; the browser child
+  # is defined separately below and reads it via templating. READ-ONLY - nothing
+  # is mutated in this phase.
+  # ===========================================================================
+  - id: census
+    type: loop
+    depends_on: [load_targets]
+    loop_config:
+      over: "steps.load_targets.output.targets"
+      step_ids: [read_workspace_setting]
+      max_iterations: 300
+
+  # 2a) CENSUS browser child - DOM mode (provider-neutral, lightweight read). The
+  #     reasoning model authors a DOM read from this prompt; it is swappable via
+  #     default_model. Authenticates with the admin credentials_env (never an
+  #     inline secret), pauses on any login/CAPTCHA challenge, navigates the SPA
+  #     to the setting, and returns ONLY the strict output_schema. max_actions
+  #     caps clicking; this child never writes.
+  - id: read_workspace_setting
+    type: browser
+    prompt: >-
+      You are a read-only auditor of a multi-tenant SaaS admin console. Log into the admin console
+      using the credentials in the environment, then open the settings page for workspace
+      "{input._item.workspace_id}" ({input._item.label}) at {input._item.settings_url}. Locate the
+      single setting whose key is "{input.setting_key}" and read its CURRENT value exactly as the form
+      renders it. Do NOT change, toggle, save, or submit anything - this is a census read only. Return
+      ONLY the structured object described by the output schema: workspace_id (echo
+      "{input._item.workspace_id}"), setting_key (echo "{input.setting_key}"), current_value (the value
+      shown, as a string), and found=true if you located the setting (found=false if the page,
+      workspace, or setting could not be reached). If a CAPTCHA or step-up auth wall appears, pause for
+      a human rather than guessing.
+    browser_config:
+      mode: dom
+      start_url: "{input._item.settings_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 30
+      headless: true
+      credentials_env: "{input.admin_credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          workspace_id:
+            type: string
+            description: "Echo of the workspace id this read pertains to."
+          setting_key:
+            type: string
+            description: "Echo of the settings key that was read."
+          current_value:
+            type: string
+            description: "The current value of the setting as rendered in the form (string form)."
+          found:
+            type: boolean
+            description: "True if the workspace settings page and the target setting were reachable and read."
+        required: ["workspace_id", "current_value", "found"]
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  # ===========================================================================
+  # PHASE 3 - PLAN / DIFF (DETERMINISTIC, no model). The load-bearing correctness
+  # gate before any write. For each workspace: normalize the read current_value,
+  # validate it (and the target) against the allowed enum, and classify into
+  # needs_change / already_compliant / unreachable. REFUSES to plan a write if the
+  # spec itself failed validation in phase 1. This is what makes the propagation
+  # idempotent and garbage-proof - a free-form target or an out-of-enum read can
+  # never become a write.
+  # ===========================================================================
+  - id: plan_diff
+    type: code
+    depends_on: [census]
+    code_config:
+      language: python
+      code: |
+        plan_blocked = not bool(_steps.get("load_targets", {}).get("spec_ok", False))
+
+        targets = _steps.get("load_targets", {}).get("targets") or []
+        if not isinstance(targets, list):
+            targets = []
+        allowed = _steps.get("load_targets", {}).get("allowed_values") or []
+        if not isinstance(allowed, list):
+            allowed = []
+        allowed_set = {str(a).strip().lower() for a in allowed}
+        setting_key = str(_steps.get("load_targets", {}).get("setting_key", "") or "")
+        target_norm = str(_steps.get("load_targets", {}).get("target_value_norm", "") or "")
+        target_display = str(_steps.get("load_targets", {}).get("target_value", "") or "")
+
+        # The census loop surfaces each iteration's child output under the child id.
+        reads = _steps.get("read_workspace_setting")
+        if isinstance(reads, dict):
+            reads = [reads]
+        if not isinstance(reads, list):
+            reads = []
+
+        # Index reads by workspace_id (defending against nested output wrappers).
+        by_ws = {}
+        for r in reads:
+            rec = r if isinstance(r, dict) else {}
+            for key in ("output", "data", "result"):
+                inner = rec.get(key)
+                if isinstance(inner, dict) and ("current_value" in inner or "workspace_id" in inner):
+                    rec = inner
+                    break
+            wid = str(rec.get("workspace_id", "") or "").strip()
+            if wid:
+                by_ws[wid] = rec
+
+        needs_change = []
+        already_compliant = []
+        unreachable = []
+        bad_current = []
+
+        for t in targets:
+            wid = str(t.get("workspace_id", "") or "").strip()
+            label = str(t.get("label", "") or wid)
+            url = str(t.get("settings_url", "") or "")
+            rec = by_ws.get(wid, {})
+            found = bool(rec.get("found", False)) and bool(rec.get("current_value", "") != "" or "current_value" in rec)
+            cur_raw = rec.get("current_value", None)
+            cur_disp = "" if cur_raw is None else str(cur_raw)
+            cur_norm = cur_disp.strip().lower()
+
+            entry = {
+                "workspace_id": wid,
+                "label": label,
+                "settings_url": url,
+                "current_value": cur_disp,
+                "target_value": target_display,
+            }
+
+            if not bool(rec.get("found", False)):
+                unreachable.append(entry)
+                continue
+            # Refuse to act on a read whose current value is outside the allowed enum
+            # (the form is in an unexpected state - do not blindly overwrite it).
+            if allowed_set and cur_norm not in allowed_set:
+                entry["reason"] = "current_value '" + cur_disp + "' not in allowed enum"
+                bad_current.append(entry)
+                continue
+            if cur_norm == target_norm:
+                already_compliant.append(entry)
+            else:
+                needs_change.append(entry)
+
+        # If the spec failed validation, force an empty write set - nothing can be written.
+        if plan_blocked:
+            needs_change = []
+
+        result = {
+            "plan_blocked": plan_blocked,
+            "setting_key": setting_key,
+            "target_value": target_display,
+            "needs_change": needs_change,
+            "already_compliant": already_compliant,
+            "unreachable": unreachable,
+            "bad_current": bad_current,
+            "change_count": len(needs_change),
+            "compliant_count": len(already_compliant),
+            "unreachable_count": len(unreachable),
+            "bad_current_count": len(bad_current),
+            "total_targets": len(targets),
+            "spec_error_summary": _steps.get("load_targets", {}).get("spec_error_summary", ""),
+            "summary": (
+                "BLOCKED: " + str(_steps.get("load_targets", {}).get("spec_error_summary", ""))
+                if plan_blocked else
+                str(len(needs_change)) + " to change, " + str(len(already_compliant))
+                + " already compliant, " + str(len(unreachable)) + " unreachable, "
+                + str(len(bad_current)) + " in unexpected state"
+            ),
+        }
+
+  # ===========================================================================
+  # PHASE 4 - SINGLE BATCH HUMAN APPROVAL (the one gate before any irreversible
+  # write). Shows how many workspaces will change and their current->target
+  # values from the deterministic plan. BLOCKS until a person authorizes; on a
+  # blocked/empty plan there is nothing to write but a human still confirms.
+  # on_timeout: abort means a missed approval NEVER auto-writes.
+  # ===========================================================================
+  - id: approve_propagation
+    type: approval
+    depends_on: [plan_diff]
+    approval_config:
+      message: >-
+        AUTHORIZE CONFIG PROPAGATION of setting "{steps.plan_diff.output.setting_key}" =
+        "{steps.plan_diff.output.target_value}" across your SaaS workspaces. Plan:
+        {steps.plan_diff.output.change_count} workspace(s) WILL CHANGE,
+        {steps.plan_diff.output.compliant_count} already compliant,
+        {steps.plan_diff.output.unreachable_count} unreachable,
+        {steps.plan_diff.output.bad_current_count} in an unexpected state. Spec status:
+        {steps.plan_diff.output.spec_error_summary}. Review the attached per-workspace
+        current->target list - this is the EXACT set you are authorizing to write. Approve to apply the
+        setting to the needs_change workspaces; reject to abort with nothing written.
+      show_data: steps.plan_diff.output
+      timeout_hours: 24
+      on_timeout: abort
+      allow_edit: false
+
+  # ===========================================================================
+  # PHASE 5 - WRITE LOOP (the only mutating phase, reached ONLY after approval).
+  # Iterate over just the needs_change set and drive each workspace's settings
+  # form in provider-neutral PLAYWRIGHT mode (the model authors a swappable
+  # script). max_actions is tightly capped (open form, set value, save - no
+  # runaway), capture_screenshots is on for an audit trail, captcha_strategy
+  # pauses on any challenge. Returns {workspace_id, action_taken, saved_value};
+  # acceptance is NOT trusted from here - the verify phase re-reads.
+  # ===========================================================================
+  - id: write_changes
+    type: loop
+    depends_on: [approve_propagation]
+    loop_config:
+      over: "steps.plan_diff.output.needs_change"
+      step_ids: [set_workspace_setting]
+      max_iterations: 300
+
+  # 5a) WRITE browser child - PLAYWRIGHT mode (provider-neutral authored script).
+  #     A human has approved this batch. Opens the one settings form, sets the
+  #     single target value, saves once. Tight max_actions, screenshots on.
+  - id: set_workspace_setting
+    type: browser
+    prompt: >-
+      A human has authorized this configuration change. Log into the admin console using the
+      environment credentials, then open the settings page for workspace "{input._item.workspace_id}"
+      ({input._item.label}) at {input._item.settings_url}. Find the single setting with key
+      "{steps.plan_diff.output.setting_key}" (currently "{input._item.current_value}") and set it to the
+      target value "{input._item.target_value}". Save the form ONCE. Do NOT change any other setting and
+      do NOT click save more than once. If a CAPTCHA or step-up auth wall appears, PAUSE for a human - do
+      not attempt to solve it. Capture a screenshot of the saved state. Return ONLY the structured object
+      described by the output schema: workspace_id (echo "{input._item.workspace_id}"), action_taken
+      (e.g. "saved" or "skipped: <why>"), and saved_value (the value the form shows AFTER saving, as a
+      string). Treat this only as an attempt - the saved value is independently re-read and asserted in
+      the verify phase.
+    browser_config:
+      mode: playwright
+      start_url: "{input._item.settings_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 150
+      max_actions: 18
+      headless: true
+      credentials_env: "{input.admin_credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          workspace_id:
+            type: string
+            description: "Echo of the workspace id this write pertains to."
+          action_taken:
+            type: string
+            description: "What the write did - 'saved' on success or 'skipped: <reason>' if it could not save."
+          saved_value:
+            type: string
+            description: "The value the form shows AFTER saving (string form), for the verify assertion."
+        required: ["workspace_id", "action_taken", "saved_value"]
+    retry:
+      max_attempts: 1
+      backoff: fixed
+      on_failure: skip
+
+  # ===========================================================================
+  # PHASE 6 - VERIFY LOOP (READ, idempotency proof). Re-read the SAME needs_change
+  # set in provider-neutral DOM mode to confirm the new value actually stuck. This
+  # is what catches a settings form that silently reverts after save. Loop item on
+  # _input['_item']; child defined separately below.
+  # ===========================================================================
+  - id: verify
+    type: loop
+    depends_on: [write_changes]
+    loop_config:
+      over: "steps.plan_diff.output.needs_change"
+      step_ids: [reread_workspace_setting]
+      max_iterations: 300
+
+  # 6a) VERIFY browser child - DOM mode (provider-neutral read). Re-reads the same
+  #     setting after the write; read-only, mutates nothing.
+  - id: reread_workspace_setting
+    type: browser
+    prompt: >-
+      You are re-auditing a SaaS workspace AFTER a settings change to confirm it persisted. Log into the
+      admin console using the environment credentials, open the settings page for workspace
+      "{input._item.workspace_id}" ({input._item.label}) at {input._item.settings_url}, and read the
+      CURRENT value of the setting with key "{steps.plan_diff.output.setting_key}". Do NOT change or save
+      anything - this is a verification read only. Return ONLY the structured object: workspace_id (echo
+      "{input._item.workspace_id}"), setting_key (echo "{steps.plan_diff.output.setting_key}"),
+      current_value (the value shown now, as a string), and found=true if you read it. If a CAPTCHA
+      appears, pause for a human.
+    browser_config:
+      mode: dom
+      start_url: "{input._item.settings_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 30
+      headless: true
+      credentials_env: "{input.admin_credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          workspace_id:
+            type: string
+            description: "Echo of the workspace id this re-read pertains to."
+          setting_key:
+            type: string
+            description: "Echo of the settings key that was re-read."
+          current_value:
+            type: string
+            description: "The value of the setting after the write (string form)."
+          found:
+            type: boolean
+            description: "True if the setting was reachable and re-read."
+        required: ["workspace_id", "current_value", "found"]
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  # ===========================================================================
+  # PHASE 7 - VERIFY ASSERTION (DETERMINISTIC, no model). For every workspace in
+  # the needs_change set, assert the re-read current_value == target_value. Lists
+  # any that silently reverted (written but not persisted) or stayed unreachable.
+  # A non-empty reverted set => fail_count > 0 routes to the needs-attention path.
+  # This is the idempotency guarantee, deterministic - never a model's opinion.
+  # ===========================================================================
+  - id: assert_verified
+    type: code
+    depends_on: [verify]
+    code_config:
+      language: python
+      code: |
+        target_norm = str(_steps.get("plan_diff", {}).get("target_value", "") or "").strip().lower()
+        target_display = str(_steps.get("plan_diff", {}).get("target_value", "") or "")
+        setting_key = str(_steps.get("plan_diff", {}).get("setting_key", "") or "")
+
+        intended = _steps.get("plan_diff", {}).get("needs_change") or []
+        if not isinstance(intended, list):
+            intended = []
+
+        rereads = _steps.get("reread_workspace_setting")
+        if isinstance(rereads, dict):
+            rereads = [rereads]
+        if not isinstance(rereads, list):
+            rereads = []
+
+        by_ws = {}
+        for r in rereads:
+            rec = r if isinstance(r, dict) else {}
+            for key in ("output", "data", "result"):
+                inner = rec.get(key)
+                if isinstance(inner, dict) and ("current_value" in inner or "workspace_id" in inner):
+                    rec = inner
+                    break
+            wid = str(rec.get("workspace_id", "") or "").strip()
+            if wid:
+                by_ws[wid] = rec
+
+        confirmed = []
+        reverted = []
+        unverifiable = []
+
+        for t in intended:
+            wid = str(t.get("workspace_id", "") or "").strip()
+            label = str(t.get("label", "") or wid)
+            rec = by_ws.get(wid, {})
+            entry = {
+                "workspace_id": wid,
+                "label": label,
+                "expected": target_display,
+                "observed": "" if rec.get("current_value", None) is None else str(rec.get("current_value")),
+            }
+            if not bool(rec.get("found", False)):
+                unverifiable.append(entry)
+                continue
+            observed_norm = str(rec.get("current_value", "") or "").strip().lower()
+            if observed_norm == target_norm:
+                confirmed.append(entry)
+            else:
+                reverted.append(entry)
+
+        # fail_count > 0 (any silent revert OR unverifiable) routes to needs-attention.
+        fail_count = len(reverted) + len(unverifiable)
+
+        result = {
+            "setting_key": setting_key,
+            "target_value": target_display,
+            "intended_count": len(intended),
+            "confirmed": confirmed,
+            "reverted": reverted,
+            "unverifiable": unverifiable,
+            "confirmed_count": len(confirmed),
+            "reverted_count": len(reverted),
+            "unverifiable_count": len(unverifiable),
+            "fail_count": fail_count,
+            "all_verified": fail_count == 0 and len(intended) >= 0,
+            "summary": (
+                str(len(confirmed)) + "/" + str(len(intended)) + " confirmed persisted; "
+                + str(len(reverted)) + " silently reverted; "
+                + str(len(unverifiable)) + " unverifiable"
+            ),
+        }
+
+  # ===========================================================================
+  # PHASE 8 - TRAJECTORY-REPLAY guard on the canonical write path. Diffs the
+  # write flow against the recorded golden run and FAILS on UI drift / cost
+  # blowup, so a vendor settings-page redesign that breaks the toggle path is
+  # caught loudly instead of silently no-op'ing across every workspace.
+  # Provider-independent: it compares observable actions, not model internals.
+  # ===========================================================================
+  - id: replay_write_path
+    type: trajectory-replay
+    depends_on: [assert_verified]
+    trajectory_replay_config:
+      golden_run_id: "{input.golden_run_id}"
+      fail_below_score: 0.8
+      allow_cost_delta_pct: 10.0
+      cost_budget_usd: 0.5
+
+  # ===========================================================================
+  # PHASE 9 - DETERMINISTIC OUTCOME + AUDIT RECORD. Fold the verify assertion and
+  # the replay verdict into one auditable record: which workspaces changed (from
+  # -> to), which reverted, who approved, and whether the write path drifted. No
+  # model decides success here.
+  # ===========================================================================
+  - id: build_audit_record
+    type: code
+    depends_on: [replay_write_path]
+    code_config:
+      language: python
+      code: |
+        verify = _steps.get("assert_verified") or {}
+        if not isinstance(verify, dict):
+            verify = {}
+        plan = _steps.get("plan_diff") or {}
+        if not isinstance(plan, dict):
+            plan = {}
+
+        replay = _steps.get("replay_write_path") or {}
+        if not isinstance(replay, dict):
+            replay = {}
+        replay_passed = bool(replay.get("passed", replay.get("certified", True)))
+        score = replay.get("score", replay.get("replay_score", None))
+        try:
+            score = float(score)
+        except (TypeError, ValueError):
+            score = None
+
+        changed = [
+            {"workspace_id": c.get("workspace_id"), "label": c.get("label"),
+             "to": c.get("expected"), "observed": c.get("observed")}
+            for c in (verify.get("confirmed") or [])
+        ]
+        reverted = verify.get("reverted") or []
+        unverifiable = verify.get("unverifiable") or []
+
+        fail_count = int(verify.get("fail_count", 0) or 0)
+        drift_failed = not replay_passed
+        # Overall success requires: nothing reverted/unverifiable AND no write-path drift.
+        overall_ok = (fail_count == 0) and (not drift_failed)
+
+        result = {
+            "setting_key": str(plan.get("setting_key", "") or ""),
+            "target_value": str(plan.get("target_value", "") or ""),
+            "changed_workspaces": changed,
+            "changed_count": len(changed),
+            "reverted_workspaces": reverted,
+            "reverted_count": len(reverted),
+            "unverifiable_workspaces": unverifiable,
+            "unverifiable_count": len(unverifiable),
+            "already_compliant_count": int(plan.get("compliant_count", 0) or 0),
+            "unreachable_count": int(plan.get("unreachable_count", 0) or 0),
+            "write_path_drift_failed": drift_failed,
+            "replay_score": score,
+            "overall_ok": overall_ok,
+            # fail_count > 0 routes the run to the needs-attention notification.
+            "needs_attention": (not overall_ok),
+            "audit_note": (
+                "Propagated '" + str(plan.get("setting_key", "")) + "' = '"
+                + str(plan.get("target_value", "")) + "' to " + str(len(changed))
+                + " workspace(s). Reverted: " + str(len(reverted))
+                + ", unverifiable: " + str(len(unverifiable))
+                + ", write-path drift: " + str(drift_failed) + "."
+            ),
+        }
+
+  # ===========================================================================
+  # PHASE 10 - ROUTE on the deterministic outcome. needs_attention -> page the
+  # ops channel with the reverted/drift detail (never a false success); clean ->
+  # post the success summary + audit record.
+  # ===========================================================================
+  - id: route_outcome
+    type: condition
+    depends_on: [build_audit_record]
+    condition_config:
+      expression: "{steps.build_audit_record.output.needs_attention} == True"
+      then: [notify_needs_attention]
+      else: [notify_success]
+
+  # 10a) NEEDS-ATTENTION - some workspaces silently reverted, stayed unverifiable,
+  #      or the write path drifted from golden. Page ops; do NOT claim success.
+  - id: notify_needs_attention
+    type: notify
+    depends_on: [route_outcome]
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        NEEDS ATTENTION - SaaS config propagation of "{steps.build_audit_record.output.setting_key}" =
+        "{steps.build_audit_record.output.target_value}" did NOT fully succeed.
+        Changed: {steps.build_audit_record.output.changed_count},
+        silently reverted: {steps.build_audit_record.output.reverted_count},
+        unverifiable: {steps.build_audit_record.output.unverifiable_count},
+        write-path drift failed: {steps.build_audit_record.output.write_path_drift_failed}.
+        {steps.build_audit_record.output.audit_note} Investigate the reverted/unverifiable workspaces and
+        the write-path trajectory before re-running. The run is left in a needs-attention state.
+
+  # 10b) SUCCESS - every needs_change workspace verified persisted and the write
+  #      path matched golden. Post the audit record (which workspaces changed,
+  #      from->to, approver-gated).
+  - id: notify_success
+    type: notify
+    depends_on: [route_outcome]
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        SUCCESS - SaaS config propagation complete. Setting
+        "{steps.build_audit_record.output.setting_key}" = "{steps.build_audit_record.output.target_value}"
+        verified persisted on {steps.build_audit_record.output.changed_count} workspace(s)
+        ({steps.build_audit_record.output.already_compliant_count} were already compliant,
+        {steps.build_audit_record.output.unreachable_count} unreachable). Replay score
+        {steps.build_audit_record.output.replay_score}. Audit: {steps.build_audit_record.output.audit_note}
+
+on_complete:
+  storage_path: "devops/saas-config-propagator/{run_id}/audit-record.json"

--- a/src/sandcastle/templates/saas_role_permission_remediator.yaml
+++ b/src/sandcastle/templates/saas_role_permission_remediator.yaml
@@ -1,0 +1,682 @@
+# name: SaaS Role Permission Remediator
+# description: Downgrade over-privileged roles for a list of users across a SaaS admin console with no bulk-role API - e.g. demote stale admins to member - behind one batch owner-style approval, with a strict downgrade-only guard, a last-admin lockout guard, and full before/after role reconciliation.
+# tags: [IAM, GRC, LeastPrivilege, SOC2, ISO27001, AccessReview, RoleDowngrade, Browser, Playwright, Reconciliation, Audit]
+# category: devops
+
+name: saas-role-permission-remediator
+description: >-
+  Correct over-privileged roles for a list of users on a SaaS admin console that
+  exposes NO bulk role-assignment API on the customer's plan. The only way to change
+  a user's role at scale is to drive the authenticated admin SPA: each user's role is
+  set through a per-user dropdown rendered client-side, so a plain http step cannot
+  authenticate into and operate the role control.
+
+  Flow: a parse step ingests the remediation list into rows
+  {email, current_role_expected, target_role, justification}. A READ-ONLY browser census
+  (mode: dom) snapshots each user's ACTUAL current role + last-active date into a
+  structured before_roles via output_schema - it mutates nothing. A DETERMINISTIC code
+  step builds the safety-diff: it keeps only rows where the observed role matches
+  current_role_expected AND target_role is a STRICT DOWNGRADE (never silently escalates a
+  privilege), and runs a LAST-ADMIN LOCKOUT GUARD that refuses to demote the final
+  remaining admin/owner (org-lockout protection); it emits remediation_plan + a rejected
+  list with reasons. A classify step buckets each planned change by risk (owner->member vs
+  member->viewer). Then ONE human batch approval signs off every planned downgrade and the
+  lockout-guard result, with high-risk rows surfaced for explicit check. Only after that
+  does a loop run a per-user browser step (mode: playwright, max_actions capped,
+  capture_screenshots on) that opens each user, sets the role dropdown to target_role, and
+  confirms. A second dom re-census produces after_roles; a final DETERMINISTIC code
+  reconcile asserts every remediated user now shows target_role, no untouched user changed,
+  and at least one admin still exists (emitting a drift list). A trajectory-replay on the
+  role-set path catches a console redesign of the role dropdown, and Slack is notified with
+  a tamper-evident audit chain of every role transition and the approver.
+
+  PROVIDER NEUTRAL: census/verify are dom extractions and the role change is an authored
+  Playwright script in playwright mode, where the reasoning model only produces
+  selectors/script from the prompt and is swappable across providers. The strict-downgrade
+  check, last-admin lockout guard, and final reconcile are PURE Python, so correctness does
+  not depend on which model authored the browser script. trajectory-replay locks the
+  contract regardless of model.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 1800
+
+input_schema:
+  required: ["remediation_list", "admin_members_url"]
+  properties:
+    remediation_list:
+      type: string
+      description: "Reference to the remediation list (one row per over-privileged user). Accepts @upload:<file_id>, @file:<path>, a URL, or pasted CSV/JSON. Expected columns: email, current_role_expected, target_role, justification."
+      example: "@upload:least-privilege-sweep-2026-06-02.csv"
+    admin_members_url:
+      type: string
+      description: "URL of the SaaS admin console members/users page where per-user roles are listed and the role dropdown lives (authenticated SPA)."
+      default: "https://app.your-saas.com/admin/members"
+      example: "https://app.acme-design.com/settings/team/members"
+    member_url_template:
+      type: string
+      description: "URL template for a single member's admin page; {email} is substituted per user during the role-change loop. If your console deep-links by email or user id, set it here."
+      default: "https://app.your-saas.com/admin/members?q={email}"
+      example: "https://app.acme-design.com/settings/team/members?search={email}"
+    credentials_env_var:
+      type: string
+      description: "Name of the environment variable holding the admin login (username+password or session token). The value is NEVER inlined into the workflow."
+      default: "SAAS_ADMIN_CREDS"
+      example: "ACME_ADMIN_CREDS"
+    role_rank:
+      type: string
+      description: "JSON map of role name -> privilege rank (higher = more privileged). Used by the strict-downgrade guard so a remediation can only LOWER privilege. Roles not listed are treated as rank 0 (unknown) and are never auto-downgraded into."
+      default: '{"owner": 4, "admin": 3, "member": 2, "viewer": 1, "guest": 0}'
+      example: '{"owner": 4, "admin": 3, "manager": 2, "member": 1, "viewer": 0}'
+    privileged_roles:
+      type: string
+      description: "Comma-separated list of role names that count as administrative for the last-admin lockout guard (the run refuses to demote the final remaining holder of any of these)."
+      default: "owner,admin"
+      example: "owner,admin,superadmin"
+    golden_run_id:
+      type: string
+      description: "ID of the known-good recorded role-set run. trajectory-replay diffs the live role-change path against this golden trajectory and fails on console/UI drift of the role dropdown."
+      default: "golden-role-dropdown-set-2026-05-01"
+    slack_channel:
+      type: string
+      description: "Slack channel for the remediation completion summary + drift report."
+      default: "#iam-remediation"
+      example: "#iam-remediation"
+
+steps:
+  # 1) PARSE the remediation list into structured rows
+  #    {email, current_role_expected, target_role, justification}. Deterministic ingest;
+  #    no console contact yet.
+  - id: parse_remediation_list
+    type: parse
+    prompt: "{input.remediation_list}"
+    parse_config:
+      output: json
+
+  # 2) READ-ONLY CENSUS of the live members page (mode: dom). The reasoning model only
+  #    authors a DOM extraction from the prompt; output_schema returns a STRUCTURED
+  #    before_roles for every member row (email, actual_role, last_active, found). This step
+  #    MUTATES NOTHING - it is the pre-image of the audit before/after pair. credentials_env
+  #    supplies the admin login (never inlined); captcha_strategy pauses for a human on a
+  #    CAPTCHA; max_actions caps paging.
+  - id: census_before
+    type: browser
+    depends_on: [parse_remediation_list]
+    prompt: >
+      Log in to the SaaS admin console using the supplied credentials and open the members /
+      users management page. Do NOT open or change any role dropdown, and do NOT click any
+      Save, Update, Remove, Suspend, or Delete control - this is a read-only census. Read
+      every visible member row (paginate through all pages if the list is paginated) and
+      extract, for each member: their email, their CURRENT role exactly as the console shows
+      it (e.g. owner / admin / member / viewer), and their last-active date if shown. Mark
+      found=true for each row you actually read. Return the full roster as structured JSON
+      matching the schema. The remediation list under review is:
+      {steps.parse_remediation_list.output}.
+    browser_config:
+      mode: dom
+      start_url: "{input.admin_members_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 180
+      max_actions: 80
+      headless: true
+      credentials_env: "{input.credentials_env_var}"
+      captcha_strategy: pause
+      capture_screenshots: false
+      output_schema:
+        type: object
+        properties:
+          before_roles:
+            type: array
+            items:
+              type: object
+              properties:
+                email: { type: string }
+                actual_role: { type: string }
+                last_active: { type: string }
+                found: { type: boolean }
+              required: ["email", "actual_role", "found"]
+          total_members_observed: { type: integer }
+        required: ["before_roles"]
+
+  # 3) DETERMINISTIC safety-diff. The load-bearing correctness: keep ONLY rows where the
+  #    observed role matches current_role_expected AND target_role is a STRICT DOWNGRADE by
+  #    rank (never silently escalates), reject everything else with a reason, and run the
+  #    LAST-ADMIN LOCKOUT GUARD that refuses to demote the final remaining admin/owner. Pure
+  #    Python, no model.
+  - id: safety_diff
+    type: code
+    depends_on: [parse_remediation_list, census_before]
+    code_config:
+      language: python
+      code: |
+        import json
+
+        # --- Normalize the parsed remediation list into rows ------------------------------
+        raw_list = _steps['parse_remediation_list']
+        if isinstance(raw_list, str):
+            try:
+                raw_list = json.loads(raw_list) if raw_list.strip() else []
+            except (ValueError, TypeError):
+                raw_list = []
+        if isinstance(raw_list, dict):
+            raw_list = raw_list.get('rows') or raw_list.get('records') or raw_list.get('data') or []
+
+        requested = []
+        requested_allow = set()  # the canonical input allowlist of emails
+        for row in (raw_list or []):
+            if not isinstance(row, dict):
+                continue
+            email = str(row.get('email') or row.get('Email') or row.get('user') or '').strip().lower()
+            if not email:
+                continue
+            cur_exp = str(row.get('current_role_expected') or row.get('current_role') or '').strip().lower()
+            target = str(row.get('target_role') or row.get('target') or '').strip().lower()
+            just = str(row.get('justification') or row.get('reason') or '').strip()
+            requested.append({
+                'email': email,
+                'current_role_expected': cur_exp,
+                'target_role': target,
+                'justification': just,
+            })
+            requested_allow.add(email)
+
+        # --- Role rank map (higher rank == more privilege) --------------------------------
+        raw_rank = _input.get('role_rank') or {}
+        if isinstance(raw_rank, str):
+            try:
+                raw_rank = json.loads(raw_rank) if raw_rank.strip() else {}
+            except (ValueError, TypeError):
+                raw_rank = {}
+        role_rank = {}
+        if isinstance(raw_rank, dict):
+            for k, v in raw_rank.items():
+                try:
+                    role_rank[str(k).strip().lower()] = int(v)
+                except (ValueError, TypeError):
+                    continue
+
+        def rank_of(role):
+            return role_rank.get(str(role or '').strip().lower(), 0)
+
+        # --- Privileged (administrative) role set for the lockout guard -------------------
+        priv_raw = str(_input.get('privileged_roles') or 'owner,admin')
+        privileged_roles = set()
+        for part in priv_raw.split(','):
+            p = part.strip().lower()
+            if p:
+                privileged_roles.add(p)
+
+        # --- Normalize the read-only census into {email: role} ----------------------------
+        census = _steps['census_before'] or {}
+        if isinstance(census, str):
+            try:
+                census = json.loads(census) if census.strip() else {}
+            except (ValueError, TypeError):
+                census = {}
+        before_roles = census.get('before_roles', []) if isinstance(census, dict) else []
+
+        by_email = {}
+        dup_emails = set()
+        admin_holders = set()  # every email currently holding a privileged role
+        for m in before_roles:
+            if not isinstance(m, dict):
+                continue
+            em = str(m.get('email') or '').strip().lower()
+            if not em:
+                continue
+            actual = str(m.get('actual_role') or '').strip().lower()
+            if em in by_email:
+                dup_emails.add(em)
+            by_email[em] = {
+                'email': em,
+                'actual_role': actual,
+                'last_active': m.get('last_active'),
+                'found': bool(m.get('found', True)),
+            }
+            if actual in privileged_roles:
+                admin_holders.add(em)
+
+        total_admins_before = len(admin_holders)
+
+        remediation_plan = []
+        rejected = []
+
+        for req in requested:
+            em = req['email']
+            target = req['target_role']
+            cur_exp = req['current_role_expected']
+
+            if em in dup_emails:
+                rejected.append({**req, 'reason': 'multiple_console_rows_same_email'})
+                continue
+            current = by_email.get(em)
+            if current is None or not current.get('found'):
+                rejected.append({**req, 'reason': 'email_not_found_on_console'})
+                continue
+            actual = current['actual_role']
+
+            # Guard 1: observed role must match what the list expected (stale list reject).
+            if cur_exp and actual != cur_exp:
+                rejected.append({**req, 'actual_role': actual, 'reason': 'observed_role_differs_from_expected'})
+                continue
+            # Guard 2: target must be a known role we can rank.
+            if target not in role_rank:
+                rejected.append({**req, 'actual_role': actual, 'reason': 'unknown_target_role_not_in_rank_map'})
+                continue
+            # Guard 3: STRICT DOWNGRADE ONLY - target rank must be strictly LOWER than current.
+            if rank_of(target) >= rank_of(actual):
+                rejected.append({**req, 'actual_role': actual, 'reason': 'not_a_strict_downgrade_would_escalate_or_noop'})
+                continue
+
+            remediation_plan.append({
+                'email': em,
+                'actual_role': actual,
+                'target_role': target,
+                'last_active': current.get('last_active'),
+                'justification': req['justification'],
+            })
+
+        # --- LAST-ADMIN LOCKOUT GUARD -----------------------------------------------------
+        # Count how many currently-privileged holders this plan would demote OUT of admin.
+        admins_being_demoted = set()
+        for p in remediation_plan:
+            if p['actual_role'] in privileged_roles and p['target_role'] not in privileged_roles:
+                admins_being_demoted.add(p['email'])
+        admins_remaining_after = total_admins_before - len(admins_being_demoted)
+        lockout_guard_ok = admins_remaining_after >= 1
+
+        # If the guard trips, pull the demotions that would zero-out admins back out of the
+        # plan and reject them, so the batch can still proceed for everyone else.
+        if not lockout_guard_ok:
+            survivors = []
+            for p in remediation_plan:
+                if p['email'] in admins_being_demoted:
+                    rejected.append({
+                        'email': p['email'],
+                        'current_role_expected': p['actual_role'],
+                        'target_role': p['target_role'],
+                        'justification': p.get('justification', ''),
+                        'actual_role': p['actual_role'],
+                        'reason': 'would_remove_last_admin_org_lockout_protection',
+                    })
+                else:
+                    survivors.append(p)
+            remediation_plan = survivors
+            # Recompute the guard against the trimmed plan.
+            admins_being_demoted = {
+                p['email'] for p in remediation_plan
+                if p['actual_role'] in privileged_roles and p['target_role'] not in privileged_roles
+            }
+            admins_remaining_after = total_admins_before - len(admins_being_demoted)
+            lockout_guard_ok = admins_remaining_after >= 1
+
+        # --- ALLOWLIST GUARD: no email outside the input list may ever be in the plan -----
+        plan_emails = {p['email'] for p in remediation_plan}
+        scope_violations = sorted(plan_emails - requested_allow)
+        allowlist_ok = len(scope_violations) == 0
+
+        result = {
+            'allowlist_ok': allowlist_ok,
+            'scope_violations': scope_violations,
+            'lockout_guard_ok': lockout_guard_ok,
+            'total_members_observed': len(by_email),
+            'total_admins_before': total_admins_before,
+            'admins_being_demoted': sorted(admins_being_demoted),
+            'admins_remaining_after': admins_remaining_after,
+            'requested_count': len(requested),
+            'plan_count': len(remediation_plan),
+            'rejected_count': len(rejected),
+            'remediation_plan': remediation_plan,
+            'rejected': rejected,
+            'allowlist': sorted(requested_allow),
+        }
+
+  # 4) CLASSIFY each planned change by risk. The ONLY model in the correctness path, and it
+  #    is swappable. owner/admin -> member is high-risk; member -> viewer is lower-risk.
+  #    Every category routes into the single human batch approval; the bucketing surfaces
+  #    high-risk rows for explicit check inside that gate.
+  - id: classify_risk
+    type: classify
+    depends_on: [safety_diff]
+    classify_config:
+      model: haiku
+      input: "Bucket this batch of planned role downgrades by blast radius. high_risk = any demotion out of an administrative/owner role (owner->member, admin->member) or any change touching billing/security scopes; standard_risk = downgrades between non-admin roles (member->viewer). Answer with the single highest-risk bucket present in the plan. Plan: {steps.safety_diff.output.remediation_plan}"
+      categories:
+        - standard_risk
+        - high_risk
+      branches:
+        standard_risk: [batch_approval]
+        high_risk: [batch_approval]
+
+  # 5) APPROVAL: the SINGLE human batch sign-off over the whole remediation_plan and the
+  #    lockout-guard result. This is the ONLY place a human authorizes mutation; nothing
+  #    irreversible runs before this returns approved. High-risk rows are surfaced for
+  #    explicit check; the reviewer sees the validated plan + guard results and can edit
+  #    (e.g. drop a borderline row).
+  - id: batch_approval
+    type: approval
+    depends_on: [classify_risk]
+    approval_config:
+      message: >
+        Least-privilege remediation batch - APPROVE to apply the listed role downgrades,
+        REJECT to abort the whole run. This is the only authorization gate before any role is
+        changed. Cohort risk: {steps.classify_risk.output}. Review every planned downgrade,
+        and individually confirm any HIGH-RISK row (admin/owner being demoted). Downgrade-only
+        is enforced in code (no row can escalate privilege). Lockout guard OK (at least one
+        admin remains): {steps.safety_diff.output.lockout_guard_ok}. Admins remaining after:
+        {steps.safety_diff.output.admins_remaining_after}. Plan size:
+        {steps.safety_diff.output.plan_count}. Rejected (skipped + reported):
+        {steps.safety_diff.output.rejected_count}.
+      show_data: steps.safety_diff.output
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: true
+
+  # 6) LOOP over remediation_plan. Each iteration runs the per-user browser role change (child
+  #    step set_role_one) reading the current user via _item. Runs ONLY after the human
+  #    approval above. max_iterations caps the batch size.
+  - id: role_change_loop
+    type: loop
+    depends_on: [batch_approval]
+    loop_config:
+      over: "steps.safety_diff.output.remediation_plan"
+      step_ids: [set_role_one]
+      max_iterations: 2000
+
+  # 6a) PER-USER role change (mode: playwright). The reasoning model only authors a Playwright
+  #     script from the prompt; the mutation itself is deterministic Playwright, so any
+  #     provider can author it and is swappable. max_actions is tightly capped so a
+  #     misnavigation cannot rampage through the roster; capture_screenshots is ON for audit;
+  #     captcha_strategy pauses for a human. output_schema returns a structured per-user result
+  #     {email, action_taken, new_role_shown}.
+  - id: set_role_one
+    type: browser
+    prompt: >
+      You are correcting the role of exactly ONE user in the SaaS admin console. The target
+      user is: {{ _item }}. Navigate to that user's member row (search by their email if
+      needed) and open their account. Open the per-user ROLE dropdown and set it to the
+      target_role given for this user, then click Save / Update / Confirm so the new role is
+      persisted. Operate on this one email ONLY - never open or change the role dropdown of any
+      other member row, and never set a role higher than target_role. If a confirmation dialog
+      appears, confirm it. Then read back the role the console now shows for this user and
+      return it. Do not navigate to bulk actions or unrelated settings.
+    browser_config:
+      mode: playwright
+      start_url: "{input.member_url_template}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 25
+      headless: true
+      credentials_env: "{input.credentials_env_var}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          email: { type: string }
+          action_taken: { type: string, enum: ["role_set", "skipped", "failed"] }
+          new_role_shown: { type: string }
+          screenshot_ref: { type: string }
+        required: ["email", "action_taken", "new_role_shown"]
+
+  # 7) RE-CENSUS the roster (mode: dom, read-only) into after_roles - the post-image of the
+  #    audit pair. Same structured extraction as the census; no mutation.
+  - id: census_after
+    type: browser
+    depends_on: [role_change_loop]
+    prompt: >
+      Re-open the members / users management page in the SaaS admin console (reload to get
+      fresh state). This is a read-only re-census after a batch of role changes: do NOT open or
+      change any role dropdown, and do NOT click any Save, Remove, or Delete control. Read every
+      visible member row (paginate through all pages) and extract each member's email, their
+      current role exactly as the console shows it, and their last-active date if shown. Mark
+      found=true for each row read. Return the full roster as structured JSON.
+    browser_config:
+      mode: dom
+      start_url: "{input.admin_members_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 180
+      max_actions: 80
+      headless: true
+      credentials_env: "{input.credentials_env_var}"
+      captcha_strategy: pause
+      capture_screenshots: false
+      output_schema:
+        type: object
+        properties:
+          after_roles:
+            type: array
+            items:
+              type: object
+              properties:
+                email: { type: string }
+                actual_role: { type: string }
+                last_active: { type: string }
+                found: { type: boolean }
+              required: ["email", "actual_role", "found"]
+        required: ["after_roles"]
+
+  # 8) DETERMINISTIC final reconcile. The load-bearing post-check: assert EVERY remediated
+  #    user now shows target_role, EVERY untouched user is unchanged vs the before census, and
+  #    at least one admin still exists. Emits a drift list of any user that did not reach the
+  #    expected state. Pure Python.
+  - id: final_reconcile
+    type: code
+    depends_on: [safety_diff, census_after, role_change_loop]
+    code_config:
+      language: python
+      code: |
+        import json
+
+        plan = _steps['safety_diff'] or {}
+        remediation_plan = plan.get('remediation_plan', []) if isinstance(plan, dict) else []
+        target_by_email = {p['email']: p.get('target_role') for p in remediation_plan}
+        targeted_emails = set(target_by_email.keys())
+
+        priv_raw = str(_input.get('privileged_roles') or 'owner,admin')
+        privileged_roles = set()
+        for part in priv_raw.split(','):
+            p = part.strip().lower()
+            if p:
+                privileged_roles.add(p)
+
+        # --- Before roles (from the original census, re-derived here for the diff) ---------
+        census_b = _steps['census_before'] or {}
+        if isinstance(census_b, str):
+            try:
+                census_b = json.loads(census_b) if census_b.strip() else {}
+            except (ValueError, TypeError):
+                census_b = {}
+        before_rows = census_b.get('before_roles', []) if isinstance(census_b, dict) else []
+        before_role = {}
+        for m in before_rows:
+            if isinstance(m, dict):
+                em = str(m.get('email') or '').strip().lower()
+                if em:
+                    before_role[em] = str(m.get('actual_role') or '').strip().lower()
+
+        # --- After roles ------------------------------------------------------------------
+        census_a = _steps['census_after'] or {}
+        if isinstance(census_a, str):
+            try:
+                census_a = json.loads(census_a) if census_a.strip() else {}
+            except (ValueError, TypeError):
+                census_a = {}
+        after_rows = census_a.get('after_roles', []) if isinstance(census_a, dict) else []
+        after_role = {}
+        for m in after_rows:
+            if isinstance(m, dict):
+                em = str(m.get('email') or '').strip().lower()
+                if em:
+                    after_role[em] = str(m.get('actual_role') or '').strip().lower()
+
+        # --- Per-loop browser results, indexed by reported email --------------------------
+        loop_out = _steps['role_change_loop'] or {}
+        loop_items = loop_out if isinstance(loop_out, list) else (
+            loop_out.get('results') or loop_out.get('items') or []
+        )
+        result_by_email = {}
+        for it in loop_items:
+            if isinstance(it, dict):
+                em = str(it.get('email') or '').strip().lower()
+                if em:
+                    result_by_email[em] = it
+
+        # --- Assert every remediated email now shows its target_role ----------------------
+        confirmed = []
+        drift = []
+        for em in sorted(targeted_emails):
+            want = str(target_by_email.get(em) or '').strip().lower()
+            post = after_role.get(em)
+            browser_res = result_by_email.get(em, {})
+            diff_row = {
+                'email': em,
+                'before_role': before_role.get(em),
+                'target_role': want,
+                'after_role': post,
+                'browser_action': browser_res.get('action_taken'),
+                'new_role_shown': browser_res.get('new_role_shown'),
+                'screenshot_ref': browser_res.get('screenshot_ref'),
+            }
+            if post == want and want != '':
+                confirmed.append(diff_row)
+            else:
+                drift.append({**diff_row, 'drift_reason': 'remediated_but_role_not_target'})
+
+        # --- Assert no UNTOUCHED user changed role (scope-creep / collateral check) --------
+        collateral = []
+        for em, before_r in before_role.items():
+            if em in targeted_emails:
+                continue
+            post = after_role.get(em)
+            if post is not None and post != before_r:
+                collateral.append({
+                    'email': em,
+                    'before_role': before_r,
+                    'after_role': post,
+                    'drift_reason': 'untouched_user_role_changed',
+                })
+
+        # --- At least one admin must still exist AFTER remediation (lockout post-check) ----
+        admins_after = sorted(em for em, r in after_role.items() if r in privileged_roles)
+        admin_still_exists = len(admins_after) >= 1
+
+        all_clean = (len(drift) == 0 and len(collateral) == 0 and admin_still_exists)
+
+        result = {
+            'all_clean': all_clean,
+            'admin_still_exists': admin_still_exists,
+            'admins_after_count': len(admins_after),
+            'targeted_count': len(targeted_emails),
+            'confirmed_count': len(confirmed),
+            'drift_count': len(drift),
+            'collateral_count': len(collateral),
+            'confirmed': confirmed,
+            'drift': drift,
+            'collateral': collateral,
+        }
+
+  # 9) TRAJECTORY-REPLAY on the role-set path. The reliability layer: diffs the live
+  #    role-change trajectory against the golden run and FAILS on UI drift of the role
+  #    dropdown (a console redesign) or cost blowup. Deterministic scorer, provider-neutral -
+  #    it compares observable actions, not model internals.
+  - id: replay_role_set_path
+    type: trajectory-replay
+    depends_on: [final_reconcile]
+    trajectory_replay_config:
+      golden_run_id: "{input.golden_run_id}"
+      fail_below_score: 0.85
+      allow_cost_delta_pct: 15.0
+      cost_budget_usd: 0.50
+
+  # 10) AUDIT chain: deterministic, tamper-evident SHA-256 over the canonical remediation
+  #     record (plan, approver outcome, every per-user role transition before->after, drift,
+  #     lockout-guard result, replay verdict). No model.
+  - id: audit_chain
+    type: code
+    depends_on: [safety_diff, batch_approval, final_reconcile, replay_role_set_path]
+    code_config:
+      language: python
+      code: |
+        import json
+        import hashlib
+        from datetime import datetime, timezone
+
+        plan = _steps['safety_diff'] or {}
+        reconcile = _steps['final_reconcile'] or {}
+        approval = _steps['batch_approval'] or {}
+        replay = _steps['replay_role_set_path'] or {}
+
+        approver = 'unknown'
+        if isinstance(approval, dict):
+            approver = str(approval.get('approver') or approval.get('approved_by') or 'unknown')
+
+        replay_passed = bool(replay.get('passed')) if isinstance(replay, dict) else False
+        replay_score = None
+        if isinstance(replay, dict):
+            replay_score = replay.get('score')
+            if replay_score is None:
+                replay_score = replay.get('replay_score')
+
+        # Build the chain of role transitions (confirmed + drift) for the audit record.
+        transitions = []
+        for row in (reconcile.get('confirmed', []) + reconcile.get('drift', [])):
+            transitions.append({
+                'email': row.get('email'),
+                'from_role': row.get('before_role'),
+                'to_role': row.get('after_role'),
+                'intended_target': row.get('target_role'),
+                'browser_action': row.get('browser_action'),
+                'screenshot_ref': row.get('screenshot_ref'),
+                'reconciled': 'after_role' in row and row.get('after_role') == row.get('target_role'),
+            })
+
+        record = {
+            'generated_at': datetime.now(timezone.utc).isoformat(),
+            'approver': approver,
+            'allowlist_ok': plan.get('allowlist_ok'),
+            'lockout_guard_ok': plan.get('lockout_guard_ok'),
+            'total_admins_before': plan.get('total_admins_before'),
+            'admins_remaining_after': plan.get('admins_remaining_after'),
+            'plan_count': plan.get('plan_count'),
+            'rejected_count': plan.get('rejected_count'),
+            'targeted_count': reconcile.get('targeted_count'),
+            'confirmed_count': reconcile.get('confirmed_count'),
+            'drift_count': reconcile.get('drift_count'),
+            'collateral_count': reconcile.get('collateral_count'),
+            'admin_still_exists': reconcile.get('admin_still_exists'),
+            'role_transitions': transitions,
+            'drift': reconcile.get('drift', []),
+            'collateral': reconcile.get('collateral', []),
+            'rejected': plan.get('rejected', []),
+            'replay_passed': replay_passed,
+            'replay_score': replay_score,
+            'all_clean': reconcile.get('all_clean'),
+        }
+
+        # Canonical (sorted-key) serialization so the audit hash is reproducible byte-for-byte.
+        canonical = json.dumps(record, sort_keys=True, separators=(',', ':'))
+        digest = hashlib.sha256(canonical.encode('utf-8')).hexdigest()
+
+        result = {
+            'sha256': digest,
+            'byte_length': len(canonical),
+            'audit_record': record,
+            'canonical_json': canonical,
+        }
+
+  # 11) NOTIFY the IAM channel with the result + drift report + audit integrity hash + replay
+  #     verdict.
+  - id: notify_summary
+    type: notify
+    depends_on: [audit_chain]
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: "Role remediation batch complete. Planned: {steps.safety_diff.output.plan_count} | Confirmed at target: {steps.final_reconcile.output.confirmed_count} | Drift (failed): {steps.final_reconcile.output.drift_count} | Collateral (untouched changed): {steps.final_reconcile.output.collateral_count} | Admin still exists: {steps.final_reconcile.output.admin_still_exists} | Lockout guard OK: {steps.safety_diff.output.lockout_guard_ok} | Replay passed: {steps.audit_chain.output.audit_record.replay_passed} | All clean: {steps.final_reconcile.output.all_clean} | Approver: {steps.audit_chain.output.audit_record.approver} | Audit sha256 {steps.audit_chain.output.sha256}."
+
+on_complete:
+  storage_path: "saas-role-permission-remediator/{run_id}/result.json"

--- a/src/sandcastle/templates/state_sales_tax_efile_filer.yaml
+++ b/src/sandcastle/templates/state_sales_tax_efile_filer.yaml
@@ -1,0 +1,646 @@
+# name: State Sales Tax Efile Filer
+# description: Logs into a US state Department of Revenue e-file portal (CDTFA / NY DTF / TX Comptroller-style login-gated JS wizard with NO public filing API), fills the multi-page monthly/quarterly sales-and-use tax return from your ledger figures, deterministically re-checks the portal's review-page total against the figure computed from the ledger, gates the irreversible Submit behind an llm_eval anomaly check and a human approval that shows the exact figures plus the review screenshot, submits, then archives the confirmation number and receipt screenshot. Triggered on a monthly/quarterly cron OR by a sensor that fires when the upstream ledger period closes. Provider-neutral: both browser steps run Playwright mode (the reasoning model AUTHORS a Playwright script from the prompt + DOM, so any of the 7 providers can drive it), and the load-bearing correctness is deterministic Python + a portal-confirmation sensor, never one model's opinion. Login secrets only via credentials_env=DOR_<STATE>_CREDS, captcha_strategy=pause for the login CAPTCHA, the Submit split into its own approval-gated browser step, max_actions caps the wizard.
+# tags: [SalesTax, Efile, DOR, CDTFA, Compliance, Playwright, RPA, HumanApproval, Sensor, ProviderNeutral, EcommerceTax, Filing]
+# category: general_ai
+
+name: state-sales-tax-efile-filer
+description: >-
+  Files a US state sales-and-use tax return into a state Department of Revenue e-file portal
+  (CDTFA, NY DTF, TX Comptroller and the like) that exposes NO public filing API for most
+  filers - the return can only be lodged through a logged-in, multi-page JavaScript wizard
+  behind a per-state username/password, usually with a CAPTCHA on login. A plain http step
+  cannot authenticate, walk the wizard, or click 'Submit Return'. Built for the tax/compliance
+  manager at a multi-state ecommerce or SaaS company (or an outsourced bookkeeping firm) that
+  must file in 20+ DOR portals every period. Trigger is a monthly/quarterly cron (the top-level
+  schedule) OR the period_closed sensor that fires when the upstream ledger close lands. Step 1
+  pulls the period's taxable sales, exempt sales, and tax collected per jurisdiction from the
+  ledger via http. Step 2 is deterministic sandboxed Python that reconciles gross = taxable +
+  exempt per jurisdiction and recomputes the expected tax, failing CLOSED on any mismatch so a
+  bad ledger never reaches the portal. Step 3 drives the portal in provider-neutral Playwright
+  mode under credentials_env=DOR_<STATE>_CREDS and captcha_strategy=pause: it logs in, opens the
+  return wizard, types each jurisdiction line, advances the pages, and STOPS on the review page
+  WITHOUT submitting, returning {jurisdiction, gross, taxable, tax_due, prefilled_period,
+  review_page_total} via output_schema. Step 4 is the load-bearing deterministic guard: it
+  asserts the portal's review_page_total equals the tax computed in step 2 (within tolerance) and
+  that the period the portal prefilled matches the period we intended - blocking submission if the
+  portal ever drifts from the ledger. Step 5 is a swappable llm_eval gate that flags anomalies
+  (tax_due deviating more than the configured pct from the prior period). Step 6 is a mandatory
+  human approval showing the filled figures and the review screenshot for sign-off. Only on
+  approval does step 7 resume the Playwright session and click Submit ONCE, capturing the
+  confirmation_number and receipt screenshot via output_schema + capture_screenshots. Step 8 polls
+  the portal's own filing-status endpoint with a sensor until it confirms the return as accepted -
+  a clicked Submit is never trusted as a landed filing. Step 9 archives the receipt to object
+  storage via http PUT, and step 10 posts the confirmation number to Slack. Splitting read from
+  write means the approval sees the exact state it authorizes; the deterministic re-check and the
+  confirmation sensor mean a silently-failed filing can never be reported as success. Both browser
+  steps ride default_model and swap freely across providers; the llm_eval and any generated summary
+  are model-agnostic and routable via failover.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 1800
+
+# Default trigger: a monthly/quarterly cron. This example fires 09:00 on the 15th of each month
+# (a typical sales-tax due date). Override per filing calendar. The period_closed sensor below is
+# the alternative event trigger when the upstream ledger close is detected.
+schedule: "0 9 15 * *"
+
+input_schema:
+  required: ["state_code", "ledger_api_url", "portal_login_url", "period"]
+  properties:
+    state_code:
+      type: string
+      description: "Two-letter state code for the DOR being filed (drives credentials_env naming, storage path, and Slack message). e.g. CA, NY, TX."
+      example: "CA"
+    ledger_api_url:
+      type: string
+      description: "Internal ledger/close API that returns this period's per-jurisdiction taxable sales, exempt sales, and tax collected. Pulled by the http step (deterministic)."
+      example: "https://ledger.internal/api/sales-tax/periods/2026-05/jurisdictions?state=CA"
+    portal_login_url:
+      type: string
+      description: "Login URL of the state DOR e-file portal SPA where the return wizard begins (logged-in, no filing API). Templated into both browser steps' start_url."
+      example: "https://onlineservices.cdtfa.ca.gov/_/"
+    period:
+      type: string
+      description: "The filing period this return covers (the portal must prefill the SAME period; the deterministic guard rejects a period mismatch)."
+      example: "2026-05"
+    credentials_env:
+      type: string
+      description: "Name of the environment variable holding the DOR portal login credentials for this state (NEVER inline secrets). Convention: DOR_<STATE>_CREDS. Passed to both browser steps' credentials_env."
+      default: "DOR_CA_CREDS"
+      example: "DOR_CA_CREDS"
+    period_closed_url:
+      type: string
+      description: "Endpoint the period_closed sensor polls; returns 200 with closed=true once the upstream ledger close for this period is finalized (the event-trigger alternative to the cron)."
+      default: "https://ledger.internal/api/sales-tax/periods/status"
+      example: "https://ledger.internal/api/sales-tax/periods/status?state=CA&period=2026-05"
+    portal_status_url:
+      type: string
+      description: "The portal's own filing-status endpoint for this return; the confirmation sensor polls it until the return reads accepted/received. A clicked Submit is never trusted on its own."
+      default: "https://onlineservices.cdtfa.ca.gov/api/returns/status"
+      example: "https://onlineservices.cdtfa.ca.gov/api/returns/status?period=2026-05"
+    receipt_archive_url:
+      type: string
+      description: "Object-storage (S3/MinIO/GCS-compatible) PUT URL where the receipt screenshot + confirmation JSON are archived for audit. The http archive step PUTs to this URL."
+      default: "https://s3.eu-central-1.amazonaws.com/tax-filings-archive"
+      example: "https://s3.eu-central-1.amazonaws.com/tax-filings-archive"
+    tax_tolerance:
+      type: number
+      description: "Absolute currency tolerance allowed when reconciling the portal's review_page_total against the ledger-computed expected tax (covers rounding)."
+      default: 0.01
+      example: "0.01"
+    prior_period_tax:
+      type: number
+      description: "Total tax_due filed for the PRIOR period; the llm_eval anomaly gate flags if this period deviates more than anomaly_pct from it."
+      default: 0
+      example: "18450.00"
+    anomaly_pct:
+      type: number
+      description: "Percent deviation from the prior period's tax_due above which the llm_eval gate flags the return as anomalous for extra human scrutiny."
+      default: 5.0
+      example: "5.0"
+    approval_timeout_hours:
+      type: integer
+      description: "Hours the human submit-approval waits before its timeout fires (on_timeout: abort - a missed approval NEVER auto-submits a return)."
+      default: 24
+      example: "24"
+    sensor_poll_interval_seconds:
+      type: integer
+      description: "Seconds between polls of the portal's filing-status endpoint while waiting for confirmed acceptance."
+      default: 60
+      example: "60"
+    sensor_timeout_seconds:
+      type: integer
+      description: "Hard ceiling in seconds the confirmation sensor waits for the portal to confirm acceptance before the run is routed to needs-attention (never reported as success)."
+      default: 3600
+      example: "3600"
+    notify_channel:
+      type: string
+      description: "Slack channel for the filed/blocked/needs-attention notifications."
+      default: "#sales-tax-filings"
+      example: "#sales-tax-filings"
+
+steps:
+  # 0) EVENT TRIGGER (alternative to the cron): wait until the upstream ledger close for this
+  #    period is finalized. The top-level `schedule` cron is the primary trigger; this sensor lets
+  #    the same workflow be kicked event-driven and block until the ledger is actually closed, so
+  #    we never pull half-closed figures. Deterministic - pure control flow, no model.
+  - id: await_period_close
+    type: sensor
+    sensor_config:
+      url: "{input.period_closed_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and bool(response.get('closed', False))"
+      check_interval: 300
+      timeout: 86400
+
+  # 1) PULL the period's per-jurisdiction figures from the ledger. http (deterministic) - the
+  #    authoritative source of truth the whole filing reconciles against.
+  - id: pull_ledger
+    type: http
+    depends_on: [await_period_close]
+    http_config:
+      url: "{input.ledger_api_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.LEDGER_TOKEN}"
+
+  # 2) DETERMINISTIC reconcile + expected-tax compute (sandboxed Python, NO model). For each
+  #    jurisdiction: gross must equal taxable + exempt (within tolerance) and expected tax is
+  #    recomputed as taxable * rate. Fails CLOSED on any mismatch, any missing rate, or empty
+  #    data - so a bad ledger close can never reach the portal. This is load-bearing correctness.
+  - id: reconcile_ledger
+    type: code
+    depends_on: [pull_ledger]
+    code_config:
+      language: python
+      code: |
+        # Deterministic reconciliation of the ledger pull. No model decides correctness here.
+        ledger = _steps.get("pull_ledger") or {}
+        if not isinstance(ledger, dict):
+            ledger = {}
+        # The http step may surface the JSON body under "body"/"json"/"data" or at the top level.
+        body = ledger
+        for key in ("body", "json", "data", "response", "result"):
+            inner = ledger.get(key)
+            if isinstance(inner, dict) and ("jurisdictions" in inner or "lines" in inner):
+                body = inner
+                break
+
+        rows = body.get("jurisdictions")
+        if not isinstance(rows, list):
+            rows = body.get("lines") if isinstance(body.get("lines"), list) else []
+
+        tolerance = abs(float(_input.get("tax_tolerance", 0.01) or 0.01))
+
+        def _num(v, default=0.0):
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return default
+
+        # Normalize a numeric string by stripping currency formatting via re.sub (no re.compile).
+        def _clean(v):
+            s = str(v if v is not None else "")
+            s = re.sub(r"[,$\\s]", "", s)
+            return _num(s, 0.0)
+
+        problems = []
+        lines = []
+        total_taxable = 0.0
+        total_exempt = 0.0
+        total_gross = 0.0
+        total_expected_tax = 0.0
+
+        if not rows:
+            problems.append("ledger returned no jurisdiction rows (empty close)")
+
+        for r in rows:
+            if not isinstance(r, dict):
+                problems.append("malformed jurisdiction row (not an object)")
+                continue
+            juris = str(r.get("jurisdiction", r.get("name", "")) or "").strip()
+            gross = _clean(r.get("gross", r.get("gross_sales")))
+            taxable = _clean(r.get("taxable", r.get("taxable_sales")))
+            exempt = _clean(r.get("exempt", r.get("exempt_sales")))
+            rate = _num(r.get("rate", r.get("tax_rate")), -1.0)
+            collected = _clean(r.get("tax_collected", r.get("collected")))
+
+            if not juris:
+                problems.append("a jurisdiction row is missing its name")
+            # gross must equal taxable + exempt
+            if abs(gross - (taxable + exempt)) > max(tolerance, 0.01):
+                problems.append(
+                    juris + ": gross " + str(round(gross, 2))
+                    + " != taxable " + str(round(taxable, 2))
+                    + " + exempt " + str(round(exempt, 2))
+                )
+            if rate < 0:
+                problems.append(juris + ": missing/invalid tax rate")
+                rate = 0.0
+            expected_tax = round(taxable * rate, 2)
+
+            total_taxable += taxable
+            total_exempt += exempt
+            total_gross += gross
+            total_expected_tax += expected_tax
+
+            lines.append({
+                "jurisdiction": juris,
+                "gross": round(gross, 2),
+                "taxable": round(taxable, 2),
+                "exempt": round(exempt, 2),
+                "rate": rate,
+                "expected_tax": expected_tax,
+                "tax_collected": round(collected, 2),
+            })
+
+        total_expected_tax = round(total_expected_tax, 2)
+        ok = len(problems) == 0 and len(lines) > 0
+
+        result = {
+            "ok": ok,
+            "problems": problems,
+            "line_count": len(lines),
+            "lines": lines,
+            "total_gross": round(total_gross, 2),
+            "total_taxable": round(total_taxable, 2),
+            "total_exempt": round(total_exempt, 2),
+            "expected_total_tax": total_expected_tax,
+            "period": str(_input.get("period", "") or ""),
+            "reason_summary": "; ".join(problems) if problems else "ledger reconciles; expected tax computed",
+        }
+
+  # 2b) Hard stop on a bad ledger - nothing touches the portal if reconciliation failed.
+  - id: ledger_gate
+    type: condition
+    depends_on: [reconcile_ledger]
+    condition_config:
+      expression: "{steps.reconcile_ledger.output.ok} == True"
+      then: [fill_return]
+      else: [notify_blocked]
+
+  # 2c) BLOCKED (bad ledger) path - tell the tax team exactly why; no filing was attempted.
+  - id: notify_blocked
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        BLOCKED before filing {input.state_code} sales tax for period {input.period}. The
+        deterministic ledger reconciliation FAILED, so the DOR portal was never touched. Reason(s):
+        {steps.reconcile_ledger.output.reason_summary}. Fix the ledger close and re-run.
+
+  # 3) READ PASS (Playwright, NO submit). The swappable reasoning model AUTHORS a Playwright
+  #    script: log in via credentials_env (DOR_<STATE>_CREDS - never inlined), open the return
+  #    wizard, type each jurisdiction line from the reconciled figures, advance the pages, and STOP
+  #    on the REVIEW page. captcha_strategy=pause hands the login CAPTCHA to a human; max_actions
+  #    bounds the multi-page wizard; output_schema returns structured JSON. No write happens here.
+  - id: fill_return
+    type: browser
+    depends_on: [ledger_gate]
+    prompt: >-
+      You are filing a US state Department of Revenue sales-and-use tax return on a logged-in,
+      multi-page JavaScript e-file portal (CDTFA / NY DTF / TX Comptroller-style). Authenticate
+      using the credentials provided via the environment (do NOT print or echo them). Open the
+      monthly/quarterly sales-and-use tax return wizard for filing period {input.period}. For each
+      jurisdiction line below, type the gross sales, taxable sales, and exempt sales exactly as
+      given, and let the PORTAL compute the tax due. Advance through every wizard page, handling
+      client-side validation (wait for each field to settle before continuing). CRITICAL: stop on
+      the final REVIEW / SUMMARY page and DO NOT click Submit, File, Pay, or any final/confirm
+      button - submission is a separate, human-approved step. Read back the period the portal
+      prefilled and the portal's own grand total of tax due shown on the review page. Reconciled
+      jurisdiction figures (JSON): {steps.reconcile_ledger.output}. Return ONLY the structured
+      object described by the output schema. If a CAPTCHA or step-up auth appears at login, pause
+      for a human rather than guessing.
+    browser_config:
+      mode: playwright
+      start_url: "{input.portal_login_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 600
+      max_actions: 120
+      headless: true
+      credentials_env: "{input.credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          jurisdiction_lines:
+            type: array
+            items:
+              type: object
+              properties:
+                jurisdiction: { type: string }
+                gross: { type: number }
+                taxable: { type: number }
+                tax_due: { type: number }
+          prefilled_period:
+            type: string
+            description: "The filing period the portal prefilled into the return (must match input.period)."
+          review_page_total:
+            type: number
+            description: "The grand total of tax due the PORTAL itself computed and shows on the review page."
+          submit_button_present:
+            type: boolean
+            description: "True if the wizard reached the review page with an enabled Submit button (not yet clicked)."
+          review_screenshot_ref:
+            type: string
+            description: "Reference/path of the captured review-page screenshot for the approval and audit archive."
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: abort
+
+  # 4) DETERMINISTIC GUARD (sandboxed Python, NO model): assert the portal's review_page_total
+  #    equals the ledger-computed expected tax within tolerance, AND that the portal prefilled the
+  #    SAME period we intended, AND the Submit button is present (wizard truly reached review).
+  #    ANY drift blocks submission - the portal must have received exactly what we computed.
+  - id: verify_review_total
+    type: code
+    depends_on: [fill_return]
+    code_config:
+      language: python
+      code: |
+        # Deterministic guard: the portal's own review total must match the ledger-computed tax.
+        read_out = _steps.get("fill_return") or {}
+        if not isinstance(read_out, dict):
+            read_out = {}
+        for key in ("output", "data", "result"):
+            inner = read_out.get(key)
+            if isinstance(inner, dict) and ("review_page_total" in inner or "jurisdiction_lines" in inner):
+                read_out = inner
+                break
+
+        recon = _steps.get("reconcile_ledger") or {}
+        if not isinstance(recon, dict):
+            recon = {}
+
+        def _num(v, default=0.0):
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return default
+
+        tolerance = abs(_num(_input.get("tax_tolerance"), 0.01))
+        review_total = _num(read_out.get("review_page_total"), 0.0)
+        expected_total = _num(recon.get("expected_total_tax"), 0.0)
+
+        problems = []
+
+        # 4a) Portal review total must reconcile to the ledger-computed expected tax.
+        total_ok = abs(review_total - expected_total) <= max(tolerance, 0.01)
+        if expected_total <= 0:
+            total_ok = False
+            problems.append("ledger expected tax is zero/absent - cannot reconcile portal total")
+        elif not total_ok:
+            problems.append(
+                "portal review total " + str(round(review_total, 2))
+                + " != ledger-computed tax " + str(round(expected_total, 2))
+            )
+
+        # 4b) The portal must have prefilled the SAME period we intended.
+        want_period = str(_input.get("period", "") or "").strip()
+        got_period = str(read_out.get("prefilled_period", "") or "").strip()
+        period_ok = bool(want_period) and (got_period == want_period)
+        if not period_ok:
+            problems.append("period mismatch: portal prefilled '" + got_period + "' but intended '" + want_period + "'")
+
+        # 4c) The wizard must have actually reached a submit-capable review page.
+        submit_ready = bool(read_out.get("submit_button_present", False))
+        if not submit_ready:
+            problems.append("review page not reached / Submit button absent (unsafe to approve)")
+
+        # 4d) Sanity: at least one jurisdiction line came back from the portal.
+        lines = read_out.get("jurisdiction_lines")
+        if not isinstance(lines, list) or len(lines) == 0:
+            problems.append("portal returned no jurisdiction lines (empty read)")
+
+        ok = (total_ok and period_ok and submit_ready and len(problems) == 0)
+
+        result = {
+            "ok": ok,
+            "problems": problems,
+            "review_page_total": round(review_total, 2),
+            "expected_total_tax": round(expected_total, 2),
+            "prefilled_period": got_period,
+            "intended_period": want_period,
+            "submit_ready": submit_ready,
+            "review_screenshot_ref": str(read_out.get("review_screenshot_ref", "") or ""),
+            "reason_summary": "; ".join(problems) if problems else "portal review total matches ledger; period and review page verified",
+        }
+
+  # 4e) Hard stop on portal/ledger drift - no submission if the review total does not reconcile.
+  - id: review_gate
+    type: condition
+    depends_on: [verify_review_total]
+    condition_config:
+      expression: "{steps.verify_review_total.output.ok} == True"
+      then: [anomaly_gate]
+      else: [notify_drift]
+
+  # 4f) DRIFT path - the portal total or period did not match the ledger; surface why, file nothing.
+  - id: notify_drift
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        BLOCKED before Submit on {input.state_code} period {input.period}: the portal's review
+        total did NOT reconcile to the ledger. {steps.verify_review_total.output.reason_summary}
+        (portal {steps.verify_review_total.output.review_page_total} vs ledger
+        {steps.verify_review_total.output.expected_total_tax}). Nothing was submitted - investigate
+        the portal entry or ledger before re-running.
+
+  # 5) SWAPPABLE llm_eval anomaly gate. A verifier model (independently routable across providers)
+  #    flags the return as needing extra scrutiny if tax_due deviates more than anomaly_pct from
+  #    the prior period. It does NOT replace the deterministic guard above - it adds a soft check
+  #    before the human looks. Must pass (or the human still ultimately decides at approval).
+  - id: anomaly_gate
+    type: gate
+    depends_on: [review_gate]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are a sales-tax filing reviewer. The deterministically verified return for state
+              {input.state_code} period {input.period} has a tax due of
+              {steps.verify_review_total.output.expected_total_tax}. The prior period's filed tax
+              due was {input.prior_period_tax}. Answer exactly 'approved' if the current tax due is
+              within {input.anomaly_pct} percent of the prior period (or if the prior period figure
+              is 0, meaning no baseline). Answer exactly 'rejected' and explain if the deviation
+              exceeds {input.anomaly_pct} percent, so a human gives it extra scrutiny. Verified
+              figures: {steps.verify_review_total.output}
+            input: "{steps.verify_review_total.output}"
+            model: google/gemini-2.5-pro
+
+  # 6) MANDATORY HUMAN APPROVAL before the irreversible Submit. Shows the deterministically
+  #    verified figures AND the review-page screenshot, and BLOCKS until a person signs off.
+  #    on_timeout: abort means a missed approval NEVER auto-files a return.
+  - id: approve_filing
+    type: approval
+    depends_on: [anomaly_gate]
+    approval_config:
+      message: >-
+        AUTHORIZE IRREVERSIBLE FILING of the {input.state_code} sales-and-use tax return for period
+        {input.period}. The return is filled and sitting on the portal's review page. Verified tax
+        due: {steps.verify_review_total.output.review_page_total} (ledger-computed
+        {steps.verify_review_total.output.expected_total_tax}), portal-prefilled period
+        {steps.verify_review_total.output.prefilled_period}, checks:
+        {steps.verify_review_total.output.reason_summary}. Review the attached review-page
+        screenshot - this is the EXACT return you are authorizing. Approve to click Submit; reject
+        to abort with nothing filed.
+      show_data: steps.verify_review_total.output
+      show_images: ["steps.fill_return.output.review_screenshot_ref"]
+      timeout_hours: 24
+      on_timeout: abort
+      allow_edit: false
+
+  # 7) WRITE PASS (Playwright, resumed) - reached ONLY after human approval. Re-open the filled
+  #    return, confirm the figures still match, and click the SINGLE final Submit button ONCE.
+  #    captcha_strategy=pause for any final-wall CAPTCHA; capture_screenshots on for the audit
+  #    receipt; max_actions tightly capped (one confirm click, no runaway). Captures the
+  #    confirmation_number + receipt screenshot. Acceptance is NOT trusted from here - the sensor
+  #    below re-reads the portal's own filing-status endpoint to confirm.
+  - id: submit_return
+    type: browser
+    depends_on: [approve_filing]
+    prompt: >-
+      A human has authorized this irreversible sales-tax filing for {input.state_code} period
+      {input.period}. Log into the DOR portal using the environment credentials (do NOT print
+      them), return to the review/summary page of the filled return, confirm the grand total still
+      reads {steps.verify_review_total.output.review_page_total} for period
+      {steps.verify_review_total.output.prefilled_period}, then click the SINGLE final
+      Submit / File button ONCE to lodge the return. Do not re-edit any figures and do not click
+      Submit more than once. If a CAPTCHA or step-up auth appears at this final wall, PAUSE for a
+      human - do not attempt to solve it. Read the confirmation page and capture the
+      portal-issued confirmation number and a screenshot of the receipt. Return ONLY the structured
+      object described by the output schema. Treat this as an attempt - final acceptance is
+      confirmed separately by re-reading the filing-status page.
+    browser_config:
+      mode: playwright
+      start_url: "{input.portal_login_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 300
+      max_actions: 20
+      headless: true
+      credentials_env: "{input.credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          submitted:
+            type: boolean
+            description: "True if the UI accepted the final Submit click without an error."
+          confirmation_number:
+            type: string
+            description: "The portal-issued confirmation/reference number for the lodged return."
+          receipt_screenshot_ref:
+            type: string
+            description: "Reference/path of the captured receipt screenshot for the audit archive."
+          confirmation_message:
+            type: string
+            description: "Any on-screen confirmation text the portal rendered after submit."
+    retry:
+      max_attempts: 1
+      backoff: fixed
+      on_failure: abort
+
+  # 8) CONFIRM via the portal's OWN filing-status endpoint - never trust the click alone. Poll
+  #    until the return reads accepted/received OR a confirmation number is present, with a hard
+  #    timeout. Deterministic boolean over the polled JSON - pure control flow, no model.
+  - id: confirm_acceptance
+    type: sensor
+    depends_on: [submit_return]
+    sensor_config:
+      url: "{input.portal_status_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and (str(response.get('status', '')).strip().lower() in ('accepted', 'received', 'processed', 'filed', 'confirmed') or bool(str(response.get('confirmation_number', '') or response.get('reference', '') or '').strip()))"
+      check_interval: 60
+      timeout: 3600
+
+  # 9) Deterministically decide acceptance from the sensor's last polled payload, then branch. A
+  #    timeout/non-accepted status yields fail_count>0 so a silent failure is NEVER a false win.
+  - id: evaluate_acceptance
+    type: code
+    depends_on: [confirm_acceptance]
+    code_config:
+      language: python
+      code: |
+        watch = _steps.get("confirm_acceptance") or {}
+        if not isinstance(watch, dict):
+            watch = {}
+        resp = watch.get("response") if isinstance(watch.get("response"), dict) else watch
+        if not isinstance(resp, dict):
+            resp = {}
+
+        status = str(resp.get("status", "") or "").strip().lower()
+        ref = str(resp.get("confirmation_number", "") or resp.get("reference", "") or "").strip()
+
+        # Fall back to the confirmation number the submit step captured if the status page is terse.
+        submit_out = _steps.get("submit_return") or {}
+        if isinstance(submit_out, dict):
+            for key in ("output", "data", "result"):
+                inner = submit_out.get(key)
+                if isinstance(inner, dict) and "confirmation_number" in inner:
+                    submit_out = inner
+                    break
+            if not ref:
+                ref = str(submit_out.get("confirmation_number", "") or "").strip()
+
+        accepted_states = ("accepted", "received", "processed", "filed", "confirmed")
+        confirmed = (status in accepted_states) or bool(ref)
+
+        sensor_satisfied = bool(watch.get("satisfied", watch.get("met", confirmed)))
+        timed_out = bool(watch.get("timed_out", False)) or (not sensor_satisfied and not confirmed)
+
+        result = {
+            "confirmed": bool(confirmed and not timed_out),
+            "status": status,
+            "confirmation_number": ref,
+            "timed_out": timed_out,
+            "fail_count": 0 if (confirmed and not timed_out) else 1,
+        }
+
+  # 9b) Branch on confirmation - archive + notify success, or page on-call (never a false win).
+  - id: acceptance_outcome
+    type: condition
+    depends_on: [evaluate_acceptance]
+    condition_config:
+      expression: "{steps.evaluate_acceptance.output.fail_count} > 0"
+      then: [notify_needs_attention]
+      else: [archive_receipt]
+
+  # 9c) NEEDS-ATTENTION path - Submit was clicked but the portal never confirmed within timeout.
+  #     Page the tax team; the run stays unresolved. A silently-failed filing is surfaced.
+  - id: notify_needs_attention
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        NEEDS ATTENTION: {input.state_code} period {input.period} return was SUBMITTED but the DOR
+        portal has NOT confirmed acceptance within the timeout (last status
+        '{steps.evaluate_acceptance.output.status}', confirmation
+        '{steps.evaluate_acceptance.output.confirmation_number}',
+        timed_out={steps.evaluate_acceptance.output.timed_out}). Do NOT assume the return was
+        accepted - check the portal manually and resolve.
+
+  # 10) ARCHIVE the receipt + confirmation to object storage (S3/MinIO/GCS-compatible) via http
+  #     PUT for the audit trail. Deterministic write to your own archive (not the DOR portal).
+  - id: archive_receipt
+    type: http
+    depends_on: [acceptance_outcome]
+    http_config:
+      url: "{input.receipt_archive_url}/{input.state_code}/{input.period}/receipt.json"
+      method: PUT
+      headers:
+        Content-Type: "application/json"
+      auth: "bearer:{env.ARCHIVE_TOKEN}"
+      body: '{"state": "{input.state_code}", "period": "{input.period}", "confirmation_number": "{steps.evaluate_acceptance.output.confirmation_number}", "portal_status": "{steps.evaluate_acceptance.output.status}", "review_total": "{steps.verify_review_total.output.review_page_total}", "receipt_screenshot_ref": "{steps.submit_return.output.receipt_screenshot_ref}", "review_screenshot_ref": "{steps.verify_review_total.output.review_screenshot_ref}"}'
+
+  # 11) SUCCESS notification with the portal-issued confirmation number.
+  - id: notify_filed
+    type: notify
+    depends_on: [archive_receipt]
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        FILED: {input.state_code} sales-and-use tax return for period {input.period} accepted by
+        the DOR portal. Confirmation number
+        {steps.evaluate_acceptance.output.confirmation_number} (tax due
+        {steps.verify_review_total.output.review_page_total}). Receipt + confirmation archived to
+        {input.receipt_archive_url}/{input.state_code}/{input.period}/receipt.json.
+
+on_complete:
+  storage_path: "state-sales-tax-efile-filer/{input.state_code}/{input.period}/{run_id}/result.json"

--- a/src/sandcastle/templates/synthetic_checkout_revenue_canary.yaml
+++ b/src/sandcastle/templates/synthetic_checkout_revenue_canary.yaml
@@ -1,0 +1,526 @@
+# name: Synthetic Checkout Revenue Canary
+# description: A synthetic shopper drives your live cart -> checkout -> payment iframe -> 3DS -> order-confirmation flow with a SANDBOX test card on a schedule, asserts the money path end to end in deterministic code (total == subtotal+tax+shipping), replays against a golden test purchase to catch silent flow drift, and pages revenue-ops the moment the Buy button stops converting - catching breakage no /health endpoint ever sees.
+# tags: [ecommerce, revenue, synthetic-monitoring, checkout, stripe, adyen, 3ds, playwright, golden-run, pagerduty, on-call]
+# category: engineering
+
+name: synthetic-checkout-revenue-canary
+description: >-
+  A scheduled synthetic-monitoring canary for the single most revenue-critical
+  flow in a D2C / marketplace store: the money path. An http /health probe
+  returns 200 while the Pay button is detached from its handler, the Stripe /
+  Adyen payment iframe fails to mount, the 3-D Secure redirect dead-ends, or a
+  tax-calc regression overcharges every order. None of that is visible to a
+  server-side API call - the checkout spans your storefront SPA, a cross-origin
+  script-isolated payment iframe, a 3DS redirect, tax/shipping recalculation, and
+  a hosted confirmation page. The ONLY way to prove a real card charge succeeds
+  and an order is written is to drive the rendered checkout as a browser does.
+
+  A SENSOR is the heartbeat clock (check_interval = 1800s during business hours)
+  and is also a webhook target so storefront CI can fire the same run post-deploy.
+  A BROWSER step in provider-neutral playwright mode authors a Playwright script
+  from its prompt: it adds a product to cart, walks to checkout, types a SANDBOX
+  test card into the payment iframe, completes the 3DS test OTP, and reaches the
+  hosted confirmation page - returning STRUCTURED JSON via output_schema (stages,
+  subtotal, tax, shipping, total_charged, currency, payment_iframe_loaded,
+  threeds_completed, order_id, confirmation_shown, error_text). All credentials
+  (test login + Stripe/Adyen TEST keys + 3DS test OTP) come from credentials_env =
+  SANDBOX_CHECKOUT_CREDS, never inline; the prompt FORBIDS any live / production
+  payment instrument. captcha_strategy = pause, max_actions = 80, and
+  capture_screenshots = true give a human handoff, a runaway-click cap, and an
+  audit trail. computer_use is offered ONLY as a documented fallback for payment
+  iframes that block scripted input and genuinely need pixel-level clicks.
+
+  A deterministic sandboxed CODE step is the load-bearing revenue verdict - NOT a
+  model opinion: it asserts payment_iframe_loaded, confirmation_shown, a non-null
+  order_id, the currency, and the arithmetic identity
+  total_charged == subtotal + tax + shipping within a small tolerance (this is the
+  assertion that catches a pricing / tax-calc regression). A TRAJECTORY-REPLAY
+  then scores the live run against a recorded golden test purchase
+  (fail_below_score = 0.9, cost_budget_usd = 0.02) to catch silent flow drift - a
+  new upsell interstitial, a moved Pay button - even when the arithmetic still
+  ties out. A CONDITION routes the folded verdict: healthy -> a quiet ok ping;
+  broken -> a human APPROVAL gate BEFORE any cleanup, then a NOTIFY that pages
+  PagerDuty + revenue-ops Slack with the broken stage, the failure screenshot, and
+  the exact amount discrepancy.
+
+  SAFETY: this canary only ever uses sandbox / test cards and TEST-mode gateway
+  keys via credentials_env - never a live card. The only mutation it makes is a
+  TEST order, tagged so downstream systems can filter it. The single irreversible
+  action - voiding / cancelling that test order in cleanup - is gated behind a
+  human APPROVAL showing the validated preview, so the synthetic flow can never
+  void a real customer order. Swap default_model and nothing else changes; the
+  arithmetic verdict and the golden replay are model-independent and engine-native.
+
+default_model: sonnet
+default_timeout: 1800
+
+input_schema:
+  required: ["product_url"]
+  properties:
+    product_url:
+      type: string
+      description: "Live product page URL the synthetic shopper starts from and adds to cart (e.g. https://shop.acme.com/products/flagship-tee)"
+      default: ""
+    checkout_url_contains:
+      type: string
+      description: "Substring the URL must contain to prove the SPA reached the checkout step (e.g. /checkout)"
+      default: "/checkout"
+    confirmation_url_contains:
+      type: string
+      description: "Substring the final URL must contain to prove the hosted order-confirmation page rendered (e.g. /order-confirmed)"
+      default: "/order"
+    expected_currency:
+      type: string
+      description: "ISO currency code the charge MUST be denominated in; a mismatch is a hard fail (e.g. USD, EUR)"
+      default: "USD"
+    amount_tolerance:
+      type: number
+      description: "Absolute tolerance (in major currency units) for total_charged vs subtotal+tax+shipping; above this is a pricing/tax-calc regression"
+      default: 0.01
+    expected_stages:
+      type: string
+      description: "Comma-separated money-path stages the run MUST reach, in order (used by the deterministic assertion code)"
+      default: "product_loaded,added_to_cart,checkout_reached,payment_iframe_loaded,card_entered,threeds_completed,confirmation_shown"
+    browser_mode:
+      type: string
+      description: "Documented browser-mode choice. 'playwright' (default, provider-neutral - the model authors a swappable Playwright script). Switch the browser step's mode to 'computer_use' ONLY as a fallback when the payment iframe blocks scripted input and genuinely needs pixel-level clicks."
+      default: "playwright"
+    golden_run_id:
+      type: string
+      description: "Run id of a recorded successful sandbox test purchase to replay against for silent-flow-drift detection (new interstitial, moved Pay button)"
+      default: "golden-test-purchase-baseline"
+    heartbeat_url:
+      type: string
+      description: "Lightweight heartbeat/clock endpoint the sensor polls on interval (also a storefront-CI webhook target for post-deploy firing)"
+      default: "https://shop.acme.com/healthz/heartbeat"
+    test_order_tag:
+      type: string
+      description: "Tag applied to the synthetic test order so downstream systems (analytics, fulfillment) can filter it out of real GMV"
+      default: "synthetic-canary"
+    ok_slack_channel:
+      type: string
+      description: "Quiet Slack channel for green checkout-canary confirmations"
+      default: "#revenue-canary-ok"
+    revops_slack_channel:
+      type: string
+      description: "Revenue-ops / payments on-call Slack channel that is paged (mirror of the PagerDuty route) when the money path breaks"
+      default: "#revops-oncall"
+    pagerduty_service:
+      type: string
+      description: "PagerDuty service / routing key label the broken-checkout page is sent to (the payments on-call rotation)"
+      default: "checkout-revenue-oncall"
+
+steps:
+  # ---------------------------------------------------------------------------
+  # 1) SENSOR heartbeat clock. On a schedule it ticks every 30 min during business
+  #    hours (check_interval = 1800s); also exposed as a webhook so storefront CI
+  #    can fire the SAME run post-deploy. Cheap pre-flight that the store is
+  #    reachable at all before we spend a browser drive on it - NOT the real proof
+  #    of checkout health (that comes from the rendered money path below).
+  # ---------------------------------------------------------------------------
+  - id: heartbeat_clock
+    type: sensor
+    sensor_config:
+      url: "{input.heartbeat_url}"
+      condition: "status_code == 200"
+      check_interval: 1800
+      timeout: 3600
+
+  # ---------------------------------------------------------------------------
+  # 2) BROWSER (provider-neutral playwright mode). The reasoning model AUTHORS a
+  #    Playwright script from this prompt that drives the REAL money path end to
+  #    end with a SANDBOX test card and returns STRUCTURED JSON via output_schema
+  #    (the read pass). credentials_env = SANDBOX_CHECKOUT_CREDS carries the test
+  #    login, Stripe/Adyen TEST keys, and the 3DS test OTP - never inline, never a
+  #    live card. captcha_strategy = pause hands a human the wheel on CAPTCHA;
+  #    max_actions = 80 caps runaway clicking; capture_screenshots = true keeps an
+  #    audit trail (and the failure screenshot the page-out attaches). This step
+  #    DOES create a (tagged) test order; the only IRREVERSIBLE action - voiding it
+  #    - is gated by a human approval later, never here.
+  # ---------------------------------------------------------------------------
+  - id: drive_checkout
+    type: browser
+    depends_on: [heartbeat_clock]
+    browser_config:
+      mode: playwright
+      start_url: "{input.product_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 80
+      headless: true
+      credentials_env: "SANDBOX_CHECKOUT_CREDS"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          stages:
+            type: array
+            items: { type: string }
+            description: "Money-path stages reached, in order (product_loaded, added_to_cart, checkout_reached, payment_iframe_loaded, card_entered, threeds_completed, confirmation_shown)."
+          subtotal: { type: number }
+          tax: { type: number }
+          shipping: { type: number }
+          total_charged: { type: number }
+          currency: { type: string }
+          payment_iframe_loaded: { type: boolean }
+          threeds_completed: { type: boolean }
+          order_id: { type: ["string", "null"] }
+          confirmation_shown: { type: boolean }
+          final_url: { type: string }
+          screenshot_url: { type: string }
+          error_text: { type: ["string", "null"] }
+        required:
+          - stages
+          - subtotal
+          - tax
+          - shipping
+          - total_charged
+          - currency
+          - payment_iframe_loaded
+          - threeds_completed
+          - order_id
+          - confirmation_shown
+          - error_text
+    prompt: |
+      You are a synthetic shopper monitoring the live checkout money path. Author
+      and run a Playwright script that drives the REAL storefront from product
+      page to a written, confirmed order, behaving like one careful human buyer.
+
+      ABSOLUTE SAFETY RULE: use ONLY the SANDBOX / TEST payment instrument and
+      TEST-mode gateway keys supplied via the SANDBOX_CHECKOUT_CREDS environment
+      variable (test login, Stripe/Adyen TEST card number, expiry, CVC, and the
+      3-D Secure test OTP). NEVER enter a live, real, or production card. NEVER
+      print or echo the secret. If only a production / live payment path is
+      available, STOP and report it in error_text rather than charging anything.
+
+      Tag the order as a synthetic test order using "{input.test_order_tag}"
+      wherever the storefront allows (order note, metadata, or a known test SKU)
+      so downstream systems can filter it out of real GMV.
+
+      Money path (append a stage string to `stages` as EACH is reached):
+        1. "product_loaded"        - open {input.product_url}; confirm the product
+                                     page rendered and an add-to-cart control is
+                                     present and interactable.
+        2. "added_to_cart"         - add the product to cart and open the cart.
+        3. "checkout_reached"      - proceed to checkout; confirm the URL now
+                                     contains "{input.checkout_url_contains}".
+                                     Read the order summary and record `subtotal`,
+                                     `tax`, and `shipping` as shown to the buyer.
+        4. "payment_iframe_loaded" - wait for the cross-origin Stripe/Adyen/
+                                     Braintree payment iframe (Elements) to MOUNT
+                                     and become interactable; set
+                                     payment_iframe_loaded = true only if it does.
+        5. "card_entered"          - type the SANDBOX test card from the secret
+                                     into the payment iframe fields and submit the
+                                     Pay button.
+        6. "threeds_completed"     - complete the 3-D Secure challenge using the
+                                     test OTP from the secret; set
+                                     threeds_completed = true on success.
+        7. "confirmation_shown"    - land on the hosted order-confirmation page
+                                     (URL contains "{input.confirmation_url_contains}");
+                                     set confirmation_shown = true, extract the
+                                     written `order_id`, and read the FINAL charged
+                                     amount into `total_charged` and the `currency`.
+
+      Record `final_url` as the last URL. Put a URL to the captured failure (or
+      last) screenshot in `screenshot_url`. If a CAPTCHA appears, pause for the
+      human per captcha_strategy. If anything throws, the Pay button is dead, the
+      iframe never mounts, 3DS dead-ends, or no order is written, set a short
+      human-readable cause in `error_text` and leave order_id null; otherwise
+      error_text = null.
+
+      NOTE: if the payment iframe blocks scripted input entirely, this monitor can
+      be re-run with the browser step's mode switched to computer_use to perform
+      pixel-level clicks - but the default and preferred mode is playwright.
+
+      Return ONLY the structured JSON object matching the output_schema. Do not add
+      prose outside the JSON.
+
+  # ---------------------------------------------------------------------------
+  # 3) DETERMINISTIC REVENUE VERDICT (sandboxed code). The load-bearing pass/fail
+  #    - NOT a model opinion. Validates the browser's structured extraction field
+  #    by field and asserts the arithmetic identity
+  #    total_charged == subtotal + tax + shipping within tolerance (the assertion
+  #    that catches a pricing / tax-calc regression). Rejects empty / malformed
+  #    reads so a blank scrape can never be reported as a healthy checkout.
+  # ---------------------------------------------------------------------------
+  - id: assert_money_path
+    type: code
+    depends_on: [drive_checkout]
+    code_config:
+      language: python
+      code: |
+        # Validate the browser read pass field by field. Any miss is a hard fail;
+        # we keep the FIRST failing assertion for the page-out, plus the full list.
+        b = _steps.get("drive_checkout") or {}
+        if not isinstance(b, dict):
+            b = {}
+
+        # Required money-path stages (comma-separated, ordered) from input.
+        raw_stages = str(_input.get("expected_stages", "") or "")
+        expected = [s.strip() for s in raw_stages.split(",") if s.strip()]
+        if not expected:
+            expected = [
+                "product_loaded",
+                "added_to_cart",
+                "checkout_reached",
+                "payment_iframe_loaded",
+                "card_entered",
+                "threeds_completed",
+                "confirmation_shown",
+            ]
+
+        reached = b.get("stages") or []
+        if not isinstance(reached, list):
+            reached = []
+        reached_set = {str(s).strip() for s in reached}
+
+        def as_float(v):
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return None
+
+        subtotal = as_float(b.get("subtotal"))
+        tax = as_float(b.get("tax"))
+        shipping = as_float(b.get("shipping"))
+        total_charged = as_float(b.get("total_charged"))
+
+        try:
+            tolerance = float(_input.get("amount_tolerance", 0.01) or 0.01)
+        except (TypeError, ValueError):
+            tolerance = 0.01
+
+        failures = []
+
+        # Guard against an empty / malformed read - a blank result must never be
+        # reported as a healthy checkout.
+        if not reached_set:
+            failures.append("empty_read: browser returned no stages")
+
+        # Assertion 1: every expected money-path stage was reached.
+        missing = [m for m in expected if m not in reached_set]
+        if missing:
+            failures.append("missing_stages: " + ", ".join(missing))
+
+        # Assertion 2: the payment iframe actually mounted (cross-origin Elements).
+        if not bool(b.get("payment_iframe_loaded", False)):
+            failures.append("payment_iframe_not_loaded")
+
+        # Assertion 3: 3-D Secure completed.
+        if not bool(b.get("threeds_completed", False)):
+            failures.append("threeds_not_completed")
+
+        # Assertion 4: the hosted confirmation page rendered.
+        if not bool(b.get("confirmation_shown", False)):
+            failures.append("confirmation_not_shown")
+
+        # Assertion 5: an order was actually WRITTEN (non-null, non-empty id).
+        order_id = b.get("order_id")
+        order_id_str = "" if order_id is None else str(order_id).strip()
+        if order_id_str == "" or order_id_str.lower() == "null":
+            failures.append("order_id_missing")
+
+        # Assertion 6: the charge currency is the one we expect.
+        expected_ccy = str(_input.get("expected_currency", "") or "").strip().upper()
+        got_ccy = str(b.get("currency", "") or "").strip().upper()
+        if expected_ccy and got_ccy != expected_ccy:
+            failures.append("currency_mismatch: expected " + expected_ccy + " got " + (got_ccy or "<none>"))
+
+        # Assertion 7 (the revenue arithmetic - catches a pricing/tax-calc bug):
+        # total_charged MUST equal subtotal + tax + shipping within tolerance.
+        amount_discrepancy = None
+        if None in (subtotal, tax, shipping, total_charged):
+            failures.append("amount_parse_error: a money field was non-numeric")
+        else:
+            expected_total = subtotal + tax + shipping
+            amount_discrepancy = round(total_charged - expected_total, 4)
+            if abs(amount_discrepancy) > tolerance:
+                failures.append(
+                    "amount_mismatch: charged " + str(total_charged)
+                    + " != subtotal+tax+shipping " + str(round(expected_total, 4))
+                    + " (delta " + str(amount_discrepancy) + ", tol " + str(tolerance) + ")"
+                )
+
+        # Assertion 8: the browser reported no error text.
+        err = b.get("error_text")
+        if err not in (None, "", "null"):
+            failures.append("browser_error: " + str(err))
+
+        passed = len(failures) == 0
+        broken_stage = "" if passed else (missing[0] if missing else failures[0].split(":")[0])
+
+        result = {
+            "passed": passed,
+            "failing_assertion": ("" if passed else failures[0]),
+            "broken_stage": broken_stage,
+            "all_failures": failures,
+            "stages_reached": sorted(reached_set),
+            "missing_stages": missing,
+            "subtotal": subtotal,
+            "tax": tax,
+            "shipping": shipping,
+            "total_charged": total_charged,
+            "amount_discrepancy": amount_discrepancy,
+            "currency": got_ccy,
+            "order_id": order_id_str,
+            "confirmation_shown": bool(b.get("confirmation_shown", False)),
+            "screenshot_url": str(b.get("screenshot_url", "") or ""),
+            "final_url": str(b.get("final_url", "") or ""),
+            "tolerance": tolerance,
+        }
+
+  # ---------------------------------------------------------------------------
+  # 4) TRAJECTORY-REPLAY against a recorded successful sandbox test purchase.
+  #    Scores structural similarity to the golden run and fails below 0.9 -
+  #    catching SILENT flow drift (a new upsell interstitial, a moved Pay button,
+  #    an extra shipping step) even when the arithmetic above still ties out.
+  #    Reliability layer, golden-run based and provider-neutral - not a vote.
+  # ---------------------------------------------------------------------------
+  - id: golden_replay
+    type: trajectory-replay
+    depends_on: [drive_checkout, assert_money_path]
+    trajectory_replay_config:
+      golden_run_id: "{input.golden_run_id}"
+      fail_below_score: 0.9
+      allow_cost_delta_pct: 10.0
+      cost_budget_usd: 0.02
+
+  # ---------------------------------------------------------------------------
+  # 5) FOLD the arithmetic verdict AND the golden-replay verdict into ONE health
+  #    decision. Either a failed assertion OR structural drift below threshold
+  #    turns the canary red. Pure deterministic code - no model here.
+  # ---------------------------------------------------------------------------
+  - id: canary_verdict
+    type: code
+    depends_on: [assert_money_path, golden_replay]
+    code_config:
+      language: python
+      code: |
+        # Combine the deterministic money-path assertion with the golden replay.
+        a = _steps.get("assert_money_path") or {}
+        rep = _steps.get("golden_replay") or {}
+        if not isinstance(a, dict):
+            a = {}
+        if not isinstance(rep, dict):
+            rep = {}
+
+        assertions_passed = bool(a.get("passed", False))
+
+        threshold = 0.9
+        score = rep.get("score", rep.get("replay_score"))
+        try:
+            score_f = float(score)
+        except (TypeError, ValueError):
+            score_f = None
+
+        if "passed" in rep:
+            replay_ok = bool(rep.get("passed"))
+        elif score_f is not None:
+            replay_ok = score_f >= threshold
+        else:
+            # No replay signal (e.g. golden run missing) - do not let a missing
+            # baseline mask a real assertion failure, and do not invent a drift
+            # failure either; treat replay as neutral and rely on the arithmetic.
+            replay_ok = True
+
+        healthy = assertions_passed and replay_ok
+
+        if not assertions_passed:
+            reason = "assertion_failed: " + str(a.get("failing_assertion", "unknown"))
+        elif not replay_ok:
+            sc = "n/a" if score_f is None else str(round(score_f, 3))
+            reason = "flow_drift: replay score " + sc + " below " + str(threshold)
+        else:
+            reason = "all_clear"
+
+        disc = a.get("amount_discrepancy")
+        amount_note = "n/a" if disc is None else str(disc)
+
+        result = {
+            "healthy": healthy,
+            "status": ("green" if healthy else "red"),
+            "reason": reason,
+            "assertions_passed": assertions_passed,
+            "replay_ok": replay_ok,
+            "replay_score": score_f,
+            "broken_stage": str(a.get("broken_stage", "")),
+            "failing_assertion": str(a.get("failing_assertion", "")),
+            "all_failures": a.get("all_failures", []),
+            "amount_discrepancy": amount_note,
+            "currency": a.get("currency", ""),
+            "total_charged": a.get("total_charged"),
+            "order_id": a.get("order_id", ""),
+            "stages_reached": a.get("stages_reached", []),
+            "screenshot_url": a.get("screenshot_url", ""),
+            "final_url": a.get("final_url", ""),
+        }
+
+  # ---------------------------------------------------------------------------
+  # 6) CONDITION: route the folded verdict. healthy -> a quiet OK ping. broken ->
+  #    the page-out path, which FIRST passes through a human approval gate before
+  #    any cleanup, then pages PagerDuty + revenue-ops. Read pass is split from the
+  #    one irreversible action (the cleanup void) by that gate.
+  # ---------------------------------------------------------------------------
+  - id: route_verdict
+    type: condition
+    depends_on: [canary_verdict]
+    condition_config:
+      expression: "{steps.canary_verdict.output.healthy} == True"
+      then: [notify_ok]
+      else: [cleanup_approval, page_revops]
+
+  # --- GREEN branch ---------------------------------------------------------
+  # 6a) A quiet confirmation on the canary-ok channel. Low noise; the money path
+  #     is proven end to end (charge succeeded, order written, arithmetic ties).
+  - id: notify_ok
+    type: notify
+    depends_on: [route_verdict]
+    notify_config:
+      service: slack
+      channel: "{input.ok_slack_channel}"
+      message: ":white_check_mark: Checkout revenue canary GREEN. Money path proven: order {steps.canary_verdict.output.order_id} written, charged {steps.canary_verdict.output.total_charged} {steps.canary_verdict.output.currency}, arithmetic delta {steps.canary_verdict.output.amount_discrepancy}, golden replay {steps.canary_verdict.output.replay_score}. (product {input.product_url})"
+
+  # --- RED branch -----------------------------------------------------------
+  # 6b) HUMAN APPROVAL gate BEFORE the single irreversible action. The synthetic
+  #     run created a TEST order; voiding / cancelling it is destructive, so a
+  #     person must authorize the cleanup while looking at the validated preview.
+  #     on_timeout: abort means cleanup NEVER auto-fires - a real customer order
+  #     can never be voided by this canary. This gate runs on the RED path only.
+  - id: cleanup_approval
+    type: approval
+    depends_on: [route_verdict]
+    approval_config:
+      message: >
+        CHECKOUT CANARY RED - review before any cleanup. The synthetic run failed
+        the money path ({steps.canary_verdict.output.reason}) and may have left a
+        TEST order ({steps.canary_verdict.output.order_id}, tag {input.test_order_tag})
+        behind. APPROVE only to void / cancel THAT specific tagged test order during
+        cleanup. REJECT to leave it untouched. Voiding is irreversible - confirm the
+        order id is the synthetic test order and NOT a real customer order before
+        approving. Broken stage: {steps.canary_verdict.output.broken_stage}. Amount
+        discrepancy: {steps.canary_verdict.output.amount_discrepancy}
+        {steps.canary_verdict.output.currency}. Failure screenshot:
+        {steps.canary_verdict.output.screenshot_url}.
+      show_data: steps.canary_verdict.output
+      timeout_hours: 24
+      on_timeout: abort
+      allow_edit: true
+
+  # 6c) PAGE the payments on-call rotation. Posts to revenue-ops Slack (mirror of
+  #     the PagerDuty route) with the broken stage, the failure screenshot, and the
+  #     exact amount discrepancy. This is the page that fires when the Buy button
+  #     stops converting and every minute is lost GMV. Runs after the approval gate
+  #     so the human has seen the red verdict before the rotation is woken.
+  - id: page_revops
+    type: notify
+    depends_on: [cleanup_approval]
+    notify_config:
+      service: slack
+      channel: "{input.revops_slack_channel}"
+      message: ":rotating_light: CHECKOUT BROKEN - revenue canary RED (PagerDuty: {input.pagerduty_service}). Broken stage: {steps.canary_verdict.output.broken_stage}. Cause: {steps.canary_verdict.output.reason}. Failing assertion: {steps.canary_verdict.output.failing_assertion}. Amount discrepancy: {steps.canary_verdict.output.amount_discrepancy} {steps.canary_verdict.output.currency} (charged {steps.canary_verdict.output.total_charged}). Stages reached: {steps.canary_verdict.output.stages_reached}. Golden replay score {steps.canary_verdict.output.replay_score} (drift floor 0.9). Failure screenshot: {steps.canary_verdict.output.screenshot_url}. Product {input.product_url}. Paging payments on-call - every minute is lost GMV."
+
+on_complete:
+  storage_path: "synthetic-checkout-revenue-canary/{run_id}/result.json"

--- a/src/sandcastle/templates/tax_form_1099_w2_collector.yaml
+++ b/src/sandcastle/templates/tax_form_1099_w2_collector.yaml
@@ -1,0 +1,715 @@
+# name: Tax Form 1099 W2 Collector
+# description: At tax season, logs into every payroll, brokerage, gig-platform, and contractor portal that posts year-end information returns (1099-NEC/MISC/INT/DIV, W-2, K-1) ONLY as session-gated downloadable PDFs behind login + MFA, retrieves each form, deterministically validates the payee TIN-last4 and box amounts against expectations (refusing any form whose recipient_tin_last4 does not match the expected payee - cross-payee leak guard), files an organized, server-side-encrypted tax packet to secure storage, and HARD-BLOCKS on a human approval before anything is ever transmitted to a preparer or e-file service. The browser is strictly read/download - it has NO path to e-file or submit. A date-window sensor re-polls the 'Tax Documents' page until each expected form is published or the deadline passes; a trajectory-replay guards each portal's login+download path against the seasonal UI redesigns brokers push every January.
+# tags: [tax, 1099, w2, k1, brokerage, payroll, gig, browser, playwright, computer-use, rpa, trajectory-replay, human-approval, pii, encrypted, read-only, provider-neutral]
+# category: general_ai
+
+name: tax-form-1099-w2-collector
+description: >-
+  A tax-season information-return collector for a tax-prep firm or multi-entity
+  family office that must assemble dozens of year-end forms (1099-NEC / MISC /
+  INT / DIV, W-2, K-1) from broker, payroll, gig-app, and bank portals where the
+  forms live ONLY in a login-gated 'Tax Documents' web section as session-gated
+  PDFs. These portals offer NO consumer document API, the download links are
+  JS-generated and expire, and access requires login plus near-universal MFA -
+  there is no http endpoint that returns a 1099 PDF, so an authenticated browser
+  is the only way to retrieve the document.
+
+  FLOW. A date-window SENSOR polls each expected payee-portal pairing's
+  'Tax Documents' page weekly and only proceeds once the expected form is
+  published OR the filing-availability deadline passes (forms generally land late
+  Jan - mid Feb), so the run never spins before forms exist. A LOOP fans out over
+  the expected {payee, portal, form_type} pairings; each iteration runs a BROWSER
+  step in playwright mode (PROVIDER-NEUTRAL - the configured reasoning model
+  authors the login + Tax-Documents navigation + per-form download, and the
+  authoring model is swappable via default_model; computer_use is the documented
+  per-pairing fallback only for the few brokerage portals that render the
+  tax-docs grid in a non-DOM canvas widget). It signs in with the per-pairing
+  credentials_env (NEVER an inline secret), opens Tax Documents, filters to the
+  target tax_year, and downloads each available form, returning a strict
+  output_schema {form_type, tax_year, payer_name, payer_tin_last4,
+  recipient_tin_last4, box_amounts, pdf_path}. captcha_strategy=pause hands the
+  near-certain MFA / CAPTCHA login challenge to a human; max_actions=40 caps each
+  session; capture_screenshots keeps an audit trail. The browser is STRICTLY
+  read/download - e-file, submit, file-return, and pay are explicitly FORBIDDEN
+  in the prompt; it has no path to transmit anything.
+
+  A PARSE step turns each downloaded PDF into text. A deterministic CODE step
+  (NO model - the load-bearing correctness layer) confirms form_type and tax_year
+  match the request, verifies recipient_tin_last4 matches the EXPECTED payee (the
+  cross-payee leak guard - it refuses any form grabbed from the wrong account),
+  and sanity-checks every box amount is numeric and non-negative, emitting
+  VERIFIED vs MISMATCH per form and a completeness map of expected-vs-arrived. A
+  CONDITION routes: any MISMATCH or missing-but-expected form raises a NOTIFY and
+  HOLDS - that form is NOT filed. A second deterministic CODE step files ONLY the
+  VERIFIED forms into a clean, server-side-encrypted packet at
+  client/<tax_year>/<form_type>/ (the engine writes the encrypted bytes via
+  on_complete.storage_path with S3 SSE; this step records the manifest +
+  destination paths). A TRAJECTORY-REPLAY then diffs the fragile portal
+  login+download path against a recorded golden run with fail_below_score=0.9, so
+  a portal's January redesign that would misroute downloads FAILS the run loudly
+  instead of silently grabbing the wrong document. Then the SAFETY gate: NOTHING
+  is transmitted to the tax preparer, e-file service, or shared externally until
+  a human reviews the assembled packet and the completeness checklist and
+  APPROVES - the browser is never allowed to e-file or submit, and that single
+  outbound handoff is the only irreversible action, hard-gated behind APPROVAL.
+  Finally a NOTIFY pings the engagement lead with the completeness checklist
+  (which expected forms arrived vs still pending). The TIN/amount verification is
+  deterministic Python independent of any model, no vendor agent runtime is used,
+  and storage is encrypted - the whole design keeps highly sensitive PII (TINs,
+  income) safe and the only irreversible step human-gated.
+  (connectors: encrypted tax-packet store via storage_path, slack)
+
+default_model: sonnet
+default_timeout: 1800
+
+input_schema:
+  required: ["expected_forms", "client_id", "tax_year"]
+  properties:
+    expected_forms:
+      type: array
+      description: >-
+        The expected payee-portal pairings the loop fans out over - one entry per
+        year-end form the firm expects to collect for this client. Shape per item:
+        {payee (the account holder / entity the form belongs to),
+        expected_recipient_tin_last4 (the LAST 4 of that payee's TIN we expect -
+        the cross-payee leak guard compares the downloaded form's
+        recipient_tin_last4 against THIS), form_type (one of 1099-NEC, 1099-MISC,
+        1099-INT, 1099-DIV, W-2, K-1), payer_name (the broker/payroll/gig issuer),
+        portal, login_url (portal login page), tax_docs_url (the 'Tax Documents'
+        section), browser_mode (playwright default; computer_use only for non-DOM
+        canvas tax-doc grids), credentials_env (NAME of the per-portal env var,
+        NEVER the secret), availability_check_url (page/endpoint the sensor polls
+        to detect the form is published), golden_run_id (recorded login+download
+        trajectory to diff against)}. Secrets are NEVER inlined.
+      default:
+        - payee: "Jane Q. Client"
+          expected_recipient_tin_last4: "4821"
+          form_type: "1099-DIV"
+          payer_name: "Fidelity Brokerage"
+          portal: "fidelity"
+          login_url: "https://login.fidelity.example/login"
+          tax_docs_url: "https://www.fidelity.example/tax/documents"
+          availability_check_url: "https://www.fidelity.example/tax/documents/status?year=2025"
+          browser_mode: "playwright"
+          credentials_env: "TAXDOC_CREDS"
+          golden_run_id: "golden-fidelity-taxdocs-download-2026-01-15"
+        - payee: "Jane Q. Client"
+          expected_recipient_tin_last4: "4821"
+          form_type: "W-2"
+          payer_name: "Acme Payroll Co"
+          portal: "acme-payroll"
+          login_url: "https://my.acmepayroll.example/signin"
+          tax_docs_url: "https://my.acmepayroll.example/tax-forms"
+          availability_check_url: "https://my.acmepayroll.example/tax-forms/status?year=2025"
+          browser_mode: "playwright"
+          credentials_env: "TAXDOC_CREDS"
+          golden_run_id: "golden-acme-payroll-w2-download-2026-01-15"
+        - payee: "Client Holdings LLC"
+          expected_recipient_tin_last4: "7703"
+          form_type: "1099-NEC"
+          payer_name: "GigFlex Platform"
+          portal: "gigflex"
+          login_url: "https://pro.gigflex.example/login"
+          tax_docs_url: "https://pro.gigflex.example/earnings/tax-documents"
+          availability_check_url: "https://pro.gigflex.example/earnings/tax-documents/status?year=2025"
+          browser_mode: "computer_use"
+          credentials_env: "TAXDOC_CREDS"
+          golden_run_id: "golden-gigflex-1099nec-download-2026-01-15"
+    client_id:
+      type: string
+      description: "Client / entity identifier used to build the encrypted packet path client/<tax_year>/<form_type>/ and to scope the engagement."
+      default: "client-jane-q"
+    tax_year:
+      type: integer
+      description: "The tax year the expected forms belong to. The deterministic verifier rejects any downloaded form whose tax_year does not equal this (guards against grabbing a prior-year form)."
+      default: 2025
+    allowed_form_types:
+      type: array
+      description: >-
+        Closed enum a downloaded form_type must normalize into. A form whose type
+        is outside this set is treated as a bad/drifted read and never filed.
+      default:
+        - "1099-NEC"
+        - "1099-MISC"
+        - "1099-INT"
+        - "1099-DIV"
+        - "W-2"
+        - "K-1"
+    availability_deadline:
+      type: string
+      description: >-
+        ISO date the sensor stops waiting for a not-yet-published form. Forms
+        generally appear late Jan - mid Feb; past this date the run proceeds with
+        whatever arrived and the rest are reported as still-pending.
+      default: "2026-02-20"
+    packet_root:
+      type: string
+      description: >-
+        Root of the secure, server-side-encrypted tax-packet store where VERIFIED
+        forms are filed as client/<tax_year>/<form_type>/. The encrypted bytes are
+        written by the engine via on_complete.storage_path (S3 SSE); the file step
+        records the manifest + destination paths. NEVER an unencrypted location.
+      default: "tax-packets"
+    drift_fail_below_score:
+      type: number
+      description: >-
+        Trajectory-replay score floor for the fragile portal login+download path.
+        Set high (0.9) because a broker's January redesign that moved the tax-docs
+        grid could misroute downloads - below this the run FAILS loudly rather than
+        grabbing the wrong document.
+      default: 0.9
+    notify_service:
+      type: string
+      description: "Where to post MISMATCH / hold alerts and the completeness checklist: slack or teams."
+      default: "slack"
+    notify_channel:
+      type: string
+      description: "Channel for the tax-collection alerts and the engagement-lead checklist."
+      default: "#tax-season-collection"
+
+steps:
+  # ---------------------------------------------------------------------------
+  # 1) TRIGGER SENSOR - the date-window gate. Polls the 'Tax Documents'
+  #    availability page weekly and only proceeds once the expected forms are
+  #    published OR the availability deadline passes (year-end forms generally
+  #    land late Jan - mid Feb). This is why the run never spins before forms
+  #    exist. Hard timeout so a never-published form does not hang the run; the
+  #    completeness check downstream reports anything still pending. Pure control
+  #    flow, no model. The first pairing's availability page is the run's gate;
+  #    per-pairing freshness is re-checked inside the browser read.
+  # ---------------------------------------------------------------------------
+  - id: await_forms_published
+    type: sensor
+    sensor_config:
+      url: "{input.expected_forms[0].availability_check_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and bool(response.get('published', False))"
+      check_interval: 604800
+      timeout: 2592000
+
+  # ---------------------------------------------------------------------------
+  # 2) LOOP over the expected payee-portal pairings. Each iteration drives ONE
+  #    portal login + per-form download. The loop item (one expected-form def)
+  #    arrives on _input['_item'] and is templated into the browser step's
+  #    start_url, mode, and credentials_env. max_iterations caps the batch size.
+  # ---------------------------------------------------------------------------
+  - id: collect_forms
+    type: loop
+    depends_on: [await_forms_published]
+    loop_config:
+      over: "input.expected_forms"
+      step_ids: [download_form]
+      max_iterations: 80
+
+  # 2a) BROWSER (READ pass - DOWNLOAD-ONLY, PROVIDER-NEUTRAL). Runs in playwright
+  #     mode: the configured reasoning model authors a deterministic Playwright
+  #     login + Tax-Documents navigation + per-form download flow from this prompt,
+  #     and the authoring model is swappable via default_model so the reasoning
+  #     provider swaps freely. computer_use is the documented per-pairing fallback
+  #     (browser_mode == computer_use) ONLY for the few brokerage portals that
+  #     render the tax-docs grid in a non-DOM canvas widget that needs pixel
+  #     clicks. It signs in with the per-pairing credentials_env (NEVER an inline
+  #     secret), opens Tax Documents, filters to the target tax_year, and downloads
+  #     each available form. captcha_strategy=pause hands the near-certain MFA /
+  #     CAPTCHA challenge to a human; max_actions=40 caps each session;
+  #     capture_screenshots keeps an audit trail. STRICTLY read/download: e-file,
+  #     submit, file-return, pay, and any account change are explicitly FORBIDDEN
+  #     here - this step has NO path to transmit anything. Returns ONLY the strict
+  #     output_schema. (loop child step - defined separately, read via _input['_item'])
+  - id: download_form
+    type: browser
+    browser_config:
+      mode: playwright
+      start_url: "{input._item.login_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 180
+      max_actions: 40
+      headless: true
+      credentials_env: "{input._item.credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          payee: { type: string }
+          portal: { type: string }
+          payer_name: { type: string }
+          form_type: { type: string }
+          tax_year: { type: integer }
+          payer_tin_last4: { type: string }
+          recipient_tin_last4: { type: string }
+          box_amounts:
+            type: object
+            description: "Map of box label -> numeric amount as read from the portal grid (e.g. {'1a': 1234.56, '2a': 0})."
+          pdf_path: { type: string }
+          form_found: { type: boolean }
+        required: ["form_type", "tax_year", "form_found"]
+    prompt: |
+      You are a tax-prep clerk collecting a year-end information return for payee
+      "{input._item.payee}" from the {input._item.payer_name} portal
+      (portal: {input._item.portal}). This portal exposes NO document API - the
+      form lives ONLY in the login-gated 'Tax Documents' web section as a
+      session-gated, JS-generated PDF whose download link expires. An
+      authenticated browser is the only way to retrieve it.
+
+      Author a deterministic, provider-neutral browser automation that:
+      1. Opens the portal login page ({input._item.login_url}) and signs in using
+         ONLY the credentials supplied via the credentials_env environment
+         variable. NEVER hardcode, echo, or log the secret.
+      2. If a CAPTCHA, MFA, one-time-passcode, or device-verification challenge
+         appears, STOP and hand off to a human (captcha_strategy=pause). Do NOT
+         attempt to solve or bypass it.
+      3. Navigates to the 'Tax Documents' section ({input._item.tax_docs_url}) and
+         filters/selects tax year {input.tax_year}.
+      4. Locates the expected form of type "{input._item.form_type}" and downloads
+         it. Click the download/view-PDF control to retrieve the session-tokenized
+         one-time PDF and record where it was saved (pdf_path). Read the visible
+         form metadata from the page/grid: the payer name, the LAST 4 of the
+         payer's TIN, the LAST 4 of the recipient's TIN, and the box amounts.
+      5. Performs NO write actions of ANY kind. You are STRICTLY FORBIDDEN from
+         e-filing, submitting a return, clicking File / Submit / Transmit / Pay,
+         consenting to e-delivery changes, or altering any account setting. This is
+         DOWNLOAD-ONLY extraction. If a page tries to force a submit/e-file
+         interstitial, STOP and report it - do not click through it.
+
+      Capture only the LAST 4 digits of each TIN - never the full TIN. If the
+      expected form is not yet published for this year, set form_found=false and
+      return without downloading.
+
+      Return ONLY the structured JSON described by the output_schema: payee,
+      portal, payer_name, form_type, tax_year (integer), payer_tin_last4 (4
+      digits), recipient_tin_last4 (4 digits), box_amounts (label -> numeric), the
+      pdf_path where the PDF was saved, and form_found.
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: abort
+
+  # ---------------------------------------------------------------------------
+  # 3) PARSE each downloaded form PDF into text. This gives an INDEPENDENT read of
+  #    the document body (the PDF's own printed TIN-last4 / amounts) that the
+  #    deterministic verifier below cross-checks against the portal grid's
+  #    output_schema values - so a misread grid or the WRONG document is caught,
+  #    not trusted. Provider-neutral document parse.
+  # ---------------------------------------------------------------------------
+  - id: parse_forms
+    type: parse
+    depends_on: [collect_forms]
+    prompt: "{steps.collect_forms.output}"
+    parse_config:
+      output: markdown
+
+  # ---------------------------------------------------------------------------
+  # 4) CODE (deterministic, LOAD-BEARING - NO model). The correctness layer that
+  #    decides VERIFIED vs MISMATCH per form and builds the expected-vs-arrived
+  #    completeness map. For each downloaded form it:
+  #    - confirms form_type normalizes into the allowed enum AND matches the
+  #      expected form_type for that pairing,
+  #    - confirms tax_year equals the requested input.tax_year (no prior-year form),
+  #    - CROSS-PAYEE LEAK GUARD: verifies recipient_tin_last4 (4 digits) equals the
+  #      expected payee's expected_recipient_tin_last4 - refusing any form grabbed
+  #      from the wrong account,
+  #    - sanity-checks every box amount is numeric and non-negative,
+  #    - cross-checks the portal recipient_tin_last4 against the TIN-last4 printed
+  #      in the parsed PDF text when present (wrong-document guard).
+  #    Anything failing is MISMATCH and is NEVER filed. Uses re.search/match/sub
+  #    directly - no compiled patterns, no I/O, no model.
+  # ---------------------------------------------------------------------------
+  - id: verify_forms
+    type: code
+    depends_on: [collect_forms, parse_forms]
+    code_config:
+      language: python
+      code: |
+        # The loop output is a list of per-pairing download envelopes.
+        downloads = _steps.get("collect_forms")
+        if isinstance(downloads, dict):
+            downloads = [downloads]
+        if not isinstance(downloads, list):
+            downloads = []
+
+        # The expected pairings drive the completeness map and the per-payee
+        # expected TIN-last4 lookup (the cross-payee leak guard reference).
+        expected = _input.get("expected_forms") or []
+        if not isinstance(expected, list):
+            expected = []
+
+        allowed = _input.get("allowed_form_types") or [
+            "1099-NEC", "1099-MISC", "1099-INT", "1099-DIV", "W-2", "K-1",
+        ]
+        allowed_set = {str(t).strip().upper() for t in allowed if isinstance(t, str)}
+
+        try:
+            want_year = int(_input.get("tax_year") or 0)
+        except (TypeError, ValueError):
+            want_year = 0
+
+        # The parsed PDF text - used only as a corroborating blob to confirm the
+        # recipient TIN-last4 also appears in the document body (wrong-doc guard).
+        parsed_blob = _steps.get("parse_forms")
+        parsed_text = ""
+        if isinstance(parsed_blob, dict):
+            parsed_text = str(
+                parsed_blob.get("markdown")
+                or parsed_blob.get("text")
+                or parsed_blob.get("output")
+                or ""
+            )
+        elif isinstance(parsed_blob, str):
+            parsed_text = parsed_blob
+
+        def _norm_type(v):
+            s = str(v or "").strip().upper()
+            # Normalize whitespace runs to a single dash so "1099 NEC" == "1099-NEC".
+            s = re.sub(r"[\s_]+", "-", s)
+            return s
+
+        def _last4(v):
+            s = str(v or "").strip()
+            m = re.search(r"(\d{4})\s*$", s)
+            if m:
+                return m.group(1)
+            digits = re.sub(r"\D", "", s)
+            if len(digits) >= 4:
+                return digits[-4:]
+            return ""
+
+        # Build an expected-pairing index keyed by (payee, form_type) so each
+        # download is matched to the payee whose TIN-last4 it MUST carry.
+        expected_index = {}
+        completeness = []
+        for ex in expected:
+            if not isinstance(ex, dict):
+                continue
+            payee = str(ex.get("payee") or "").strip()
+            ftype = _norm_type(ex.get("form_type"))
+            key = payee + "::" + ftype
+            expected_index[key] = {
+                "payee": payee,
+                "form_type": ftype,
+                "payer_name": str(ex.get("payer_name") or ""),
+                "portal": str(ex.get("portal") or ""),
+                "expected_recipient_tin_last4": _last4(ex.get("expected_recipient_tin_last4")),
+            }
+            completeness.append({
+                "payee": payee,
+                "form_type": ftype,
+                "payer_name": str(ex.get("payer_name") or ""),
+                "arrived": False,
+                "status": "pending",
+            })
+
+        verified = []
+        mismatched = []
+        arrived_keys = set()
+
+        for env in downloads:
+            if not isinstance(env, dict):
+                mismatched.append({"reason": "read_not_object", "raw": str(env)[:160]})
+                continue
+
+            form_found = bool(env.get("form_found", True))
+            payee = str(env.get("payee") or "").strip()
+            ftype = _norm_type(env.get("form_type"))
+            key = payee + "::" + ftype
+            exp = expected_index.get(key) or {}
+
+            # A pairing that explicitly reported the form is not yet published is
+            # left pending (not a mismatch) - the completeness map shows it.
+            if not form_found:
+                continue
+
+            arrived_keys.add(key)
+
+            portal_recip4 = _last4(env.get("recipient_tin_last4"))
+            payer4 = _last4(env.get("payer_tin_last4"))
+            exp_recip4 = str(exp.get("expected_recipient_tin_last4") or "")
+
+            try:
+                got_year = int(env.get("tax_year") or 0)
+            except (TypeError, ValueError):
+                got_year = 0
+
+            box_amounts = env.get("box_amounts")
+            if not isinstance(box_amounts, dict):
+                box_amounts = {}
+
+            reasons = []
+
+            # form_type must be a known type AND match what we expected here.
+            if ftype not in allowed_set:
+                reasons.append("form_type_not_in_enum")
+            if exp and exp.get("form_type") and ftype != str(exp.get("form_type")):
+                reasons.append("form_type_mismatch")
+
+            # tax_year must equal the requested year (no prior-year form).
+            if want_year and got_year != want_year:
+                reasons.append("tax_year_mismatch")
+
+            # recipient TIN-last4 must be a 4-digit value.
+            if not re.match(r"^\d{4}$", portal_recip4):
+                reasons.append("bad_recipient_tin_last4")
+
+            # CROSS-PAYEE LEAK GUARD - the downloaded form's recipient TIN-last4
+            # MUST equal the expected payee's TIN-last4. Refuse otherwise.
+            if exp_recip4:
+                if portal_recip4 != exp_recip4:
+                    reasons.append("recipient_tin_payee_mismatch")
+            else:
+                # No expected TIN on file for this pairing - cannot verify ownership.
+                reasons.append("no_expected_tin_on_file")
+
+            # Corroborate the recipient TIN-last4 also appears in the parsed PDF
+            # body when we have one (wrong-document guard). Only a NEGATIVE
+            # signal (text present but the last4 absent) is treated as suspicious.
+            if parsed_text and portal_recip4 and re.match(r"^\d{4}$", portal_recip4):
+                if not re.search(portal_recip4, parsed_text):
+                    reasons.append("recipient_tin_not_in_pdf_text")
+
+            # Box amounts must all be numeric and non-negative.
+            bad_boxes = []
+            clean_boxes = {}
+            for label, amt in box_amounts.items():
+                try:
+                    val = round(float(amt), 2)
+                except (TypeError, ValueError):
+                    bad_boxes.append(str(label))
+                    continue
+                if val < 0:
+                    bad_boxes.append(str(label))
+                    continue
+                clean_boxes[str(label)] = val
+            if bad_boxes:
+                reasons.append("bad_box_amounts")
+
+            record = {
+                "payee": payee,
+                "form_type": ftype,
+                "payer_name": str(env.get("payer_name") or exp.get("payer_name") or ""),
+                "portal": str(env.get("portal") or exp.get("portal") or ""),
+                "tax_year": got_year,
+                "payer_tin_last4": payer4,
+                "recipient_tin_last4": portal_recip4,
+                "expected_recipient_tin_last4": exp_recip4,
+                "box_amounts": clean_boxes,
+                "bad_boxes": bad_boxes,
+                "pdf_path": str(env.get("pdf_path") or ""),
+            }
+
+            if reasons:
+                record["reasons"] = reasons
+                mismatched.append(record)
+            else:
+                verified.append(record)
+
+        # Mark completeness rows that arrived; the rest stay pending.
+        for row in completeness:
+            key = str(row.get("payee") or "") + "::" + str(row.get("form_type") or "")
+            if key in arrived_keys:
+                row["arrived"] = True
+                # Was it VERIFIED or did it MISMATCH?
+                row["status"] = "mismatch"
+                for v in verified:
+                    if str(v.get("payee") or "") + "::" + str(v.get("form_type") or "") == key:
+                        row["status"] = "verified"
+                        break
+
+        pending = [r for r in completeness if not r.get("arrived")]
+        mismatch_or_missing = (len(mismatched) > 0) or (len(pending) > 0)
+
+        result = {
+            "verified": verified,
+            "verified_count": len(verified),
+            "mismatched": mismatched,
+            "mismatched_count": len(mismatched),
+            "completeness": completeness,
+            "pending": pending,
+            "pending_count": len(pending),
+            "expected_count": len(completeness),
+            "arrived_count": len(arrived_keys),
+            "has_mismatch_or_missing": mismatch_or_missing,
+            "all_verified": (len(verified) > 0 and len(mismatched) == 0 and len(pending) == 0),
+        }
+
+  # ---------------------------------------------------------------------------
+  # 5) CONDITION - deterministic routing on the verifier's facts (NOT a model).
+  #    If any form MISMATCHED or an expected form is still missing, raise a NOTIFY
+  #    and HOLD - the hold path still files the clean VERIFIED forms but flags the
+  #    gap. Otherwise go straight to filing. Both branches reach file_packet, so a
+  #    partial collection still files what passed while surfacing what did not.
+  # ---------------------------------------------------------------------------
+  - id: completeness_branch
+    type: condition
+    depends_on: [verify_forms]
+    condition_config:
+      expression: "{steps.verify_forms.output.has_mismatch_or_missing} == True"
+      then: [notify_hold, file_packet]
+      else: [file_packet]
+
+  # 5a) NOTIFY (hold branch) - alert that some forms MISMATCHED or are still
+  #     missing. Those forms are NOT filed; a human resolves the gap. This only
+  #     alerts - it never touches a portal and never transmits anything.
+  - id: notify_hold
+    type: notify
+    notify_config:
+      service: "{input.notify_service}"
+      channel: "{input.notify_channel}"
+      message: >-
+        :warning: Tax collection HOLD for {input.client_id} (TY {input.tax_year}).
+        MISMATCH forms (NOT filed):
+        {steps.verify_forms.output.mismatched_count} - detail:
+        {steps.verify_forms.output.mismatched}. Still PENDING / missing:
+        {steps.verify_forms.output.pending_count} - {steps.verify_forms.output.pending}.
+        VERIFIED so far: {steps.verify_forms.output.verified_count}. The browser
+        was strictly read/download - nothing was e-filed, submitted, or transmitted.
+        Resolve the mismatches / await the pending forms before the packet is
+        approved for the preparer.
+
+  # ---------------------------------------------------------------------------
+  # 6) CODE (deterministic) - file ONLY the VERIFIED forms into a clean,
+  #    server-side-encrypted tax packet at client/<tax_year>/<form_type>/. The
+  #    engine writes the encrypted bytes via on_complete.storage_path (S3 SSE);
+  #    this step records the destination paths + a manifest. NO model, NO
+  #    transmission - filing to encrypted storage is non-destructive and internal.
+  # ---------------------------------------------------------------------------
+  - id: file_packet
+    type: code
+    depends_on: [verify_forms]
+    code_config:
+      language: python
+      code: |
+        ver = _steps.get("verify_forms") or {}
+        if not isinstance(ver, dict):
+            ver = {}
+        verified = ver.get("verified") or []
+        if not isinstance(verified, list):
+            verified = []
+
+        packet_root = str(_input.get("packet_root") or "tax-packets").rstrip("/")
+        client_id = str(_input.get("client_id") or "client")
+        try:
+            tax_year = int(_input.get("tax_year") or 0)
+        except (TypeError, ValueError):
+            tax_year = 0
+
+        def _safe(seg):
+            # Filesystem-safe path segment: letters, digits, dash, dot, underscore.
+            return re.sub(r"[^A-Za-z0-9._-]", "_", str(seg or "unknown"))
+
+        client_safe = _safe(client_id)
+        year_safe = _safe(tax_year)
+
+        manifest = []
+        for f in verified:
+            if not isinstance(f, dict):
+                continue
+            ftype = _safe(f.get("form_type"))
+            payee = _safe(f.get("payee"))
+            # client/<tax_year>/<form_type>/<payee>.pdf inside the encrypted root.
+            dest_path = (
+                packet_root + "/" + client_safe + "/" + year_safe
+                + "/" + ftype + "/" + payee + ".pdf"
+            )
+            manifest.append({
+                "payee": f.get("payee"),
+                "form_type": f.get("form_type"),
+                "payer_name": f.get("payer_name"),
+                "tax_year": f.get("tax_year"),
+                "recipient_tin_last4": f.get("recipient_tin_last4"),
+                "box_amounts": f.get("box_amounts"),
+                "source_pdf": f.get("pdf_path"),
+                "filed_path": dest_path,
+            })
+
+        result = {
+            "manifest": manifest,
+            "filed_count": len(manifest),
+            "packet_root": packet_root,
+            "client_id": client_id,
+            "tax_year": tax_year,
+            "encryption": "s3-sse",
+            "filed": len(manifest) > 0,
+            "note": "Manifest + encrypted destination paths recorded. Bytes land via on_complete.storage_path with S3 SSE. NOTHING transmitted to preparer / e-file - that is human-gated downstream.",
+        }
+
+  # ---------------------------------------------------------------------------
+  # 7) TRAJECTORY-REPLAY - the engine-native reliability guard for the fragile
+  #    portal login+download path. Diffs the live read against a recorded golden
+  #    run and FAILS the run when the replay score drops below
+  #    drift_fail_below_score (0.9) - so a broker's January redesign that moved the
+  #    tax-docs grid or download button, which would otherwise MISROUTE downloads
+  #    to the wrong document, fails LOUDLY before the packet is approved. Cost
+  #    blowup vs golden is rejected too. Deterministic scorer, not a model opinion.
+  #    Placed BEFORE the human approval gate so a drifted run never reaches a human
+  #    as if it were clean.
+  # ---------------------------------------------------------------------------
+  - id: guard_portal_drift
+    type: trajectory-replay
+    depends_on: [file_packet]
+    trajectory_replay_config:
+      golden_run_id: "{input.expected_forms[0].golden_run_id}"
+      fail_below_score: 0.9
+      allow_cost_delta_pct: 10.0
+      cost_budget_usd: 0.5
+
+  # ---------------------------------------------------------------------------
+  # 8) APPROVAL - the MANDATORY human gate before the ONLY irreversible / outbound
+  #    action. NOTHING is transmitted to the tax preparer, the e-file service, or
+  #    shared externally until a human reviews the assembled packet AND the
+  #    completeness checklist and APPROVES. The browser is never allowed to e-file
+  #    or submit; this gate is the single chokepoint for any external handoff.
+  #    BLOCKS until a person signs off; on_timeout: abort means a missed approval
+  #    NEVER transmits the packet. Shows the validated packet + completeness so the
+  #    human authorizes the EXACT set of forms.
+  # ---------------------------------------------------------------------------
+  - id: approve_handoff
+    type: approval
+    depends_on: [guard_portal_drift]
+    approval_config:
+      message: >-
+        AUTHORIZE TAX-PACKET HANDOFF for {input.client_id}, tax year
+        {input.tax_year}. This is the ONLY outbound / irreversible action in the
+        run - the browser was strictly read/download and NEVER e-filed or
+        submitted anything. {steps.file_packet.output.filed_count} VERIFIED forms
+        are filed to encrypted storage. Completeness checklist:
+        {steps.verify_forms.output.completeness}. Still pending / missing:
+        {steps.verify_forms.output.pending}. MISMATCHED (held, NOT filed):
+        {steps.verify_forms.output.mismatched_count}. Approve to release this
+        packet to the tax preparer / e-file service; reject to keep everything
+        internal and unencrypted-store-only with nothing transmitted.
+      show_data: steps.file_packet.output
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: false
+
+  # ---------------------------------------------------------------------------
+  # 9) NOTIFY - on approval, ping the engagement lead with the completeness
+  #    checklist (which expected forms arrived vs still pending) and the filed
+  #    packet location. Runs only after the human approves the handoff. This is the
+  #    deliverable signal; it does not itself transmit forms (the approved handoff
+  #    to the preparer / e-file is the gated action above).
+  # ---------------------------------------------------------------------------
+  - id: notify_engagement_lead
+    type: notify
+    depends_on: [approve_handoff]
+    notify_config:
+      service: "{input.notify_service}"
+      channel: "{input.notify_channel}"
+      message: >-
+        :white_check_mark: Tax packet APPROVED for handoff - {input.client_id}
+        (TY {input.tax_year}). Filed VERIFIED forms:
+        {steps.file_packet.output.filed_count} at
+        {steps.file_packet.output.packet_root}/{input.client_id}/{input.tax_year}/
+        (S3 server-side encrypted). Completeness:
+        {steps.verify_forms.output.arrived_count}/{steps.verify_forms.output.expected_count}
+        expected forms arrived; still pending:
+        {steps.verify_forms.output.pending}. Manifest:
+        {steps.file_packet.output.manifest}. Reminder: all retrieval was
+        read-only; the only transmission is the human-approved handoff to the
+        preparer / e-file.
+
+on_complete:
+  storage_path: "tax-packets/{run_id}/{client_id}/{tax_year}/tax-packet-manifest.json"

--- a/src/sandcastle/templates/utility_municipal_bill_filer.yaml
+++ b/src/sandcastle/templates/utility_municipal_bill_filer.yaml
@@ -1,0 +1,665 @@
+# name: Utility Municipal Bill Filer
+# description: Runs on each utility account's billing cycle to log into electric/water/gas/municipal and telecom customer portals that are paperless-by-default with NO public API - the bill lives only inside the portal's 'Billing History' behind an authenticated session (often with a CAPTCHA). A per-account sensor polls the billing-history page until this cycle's new bill posts, a provider-neutral browser step (dom/lightpanda for lightweight municipal sites, playwright for JS portals) logs in via credentials_env and downloads the newest bill READ-ONLY via output_schema, parse + deterministic Python validate the amount/due-date and compute the percent change vs the prior period (NORMAL / SPIKE / VALIDATION_FAIL), the bill is filed by property/utility/year-month to the property-management drive, anomalies alert the facilities manager immediately, and the IRREVERSIBLE 'Pay' click is unreachable unless a human approval explicitly authorizes the exact amount and account - the agent never pays autonomously. trajectory-replay (fail_below_score 0.85) fails the run on municipal-portal UI drift so a redesign can never cause a wrong-bill download or a misdirected pay click.
+# tags: [Utilities, Municipal, Billing, PaperlessPortal, RPA, DOM, Lightpanda, Playwright, SpikeDetection, HumanApproval, TrajectoryReplay, ProviderNeutral, PropertyManagement]
+# category: general_ai
+
+name: utility-municipal-bill-filer
+description: >-
+  Files the current-cycle bill for ONE property-utility account whose provider is paperless-by-default
+  and exposes the statement ONLY through its own customer portal's 'Billing History' - the canonical
+  no-API, login-gated case for municipal electric/water/gas and telecom billers. Built for a property /
+  facilities manager or HOA administrator overseeing many units, each with several utility and municipal
+  accounts: there is no API or email to scrape, so retrieving the bill requires an authenticated browser
+  session to the billing-history page (frequently behind a CAPTCHA). The flow splits read from write and
+  fails closed. (1) A per-account sensor polls the billing-history page a few days after the known cycle
+  date until the new bill for this period is posted. (2) A trajectory-replay guards this account's
+  recorded login+download path against the frequent municipal-portal UI changes; on drift the run fails
+  before a wrong bill can be touched. (3) A provider-neutral browser step (dom/lightpanda for the many
+  lightweight municipal sites - no vision model - or playwright for JS portals; the reasoning model
+  AUTHORS the automation either way, fully swappable) logs in via credentials_env, opens Billing History,
+  downloads the NEWEST bill READ-ONLY and returns {property_id, utility_type, account_number_last4,
+  billing_period, usage_value, usage_unit, amount_due, due_date, pdf_path} via output_schema - it writes
+  nothing and never navigates to Pay. (4) A parse step reads the downloaded PDF/HTML. (5) A DETERMINISTIC
+  code step (no model) asserts the parsed amount_due equals the portal output_schema amount_due, validates
+  the due_date is a real future date, and computes the percent change vs the prior period's stored
+  usage/amount, emitting NORMAL / SPIKE / VALIDATION_FAIL. (6) A condition routes SPIKE (amount above the
+  configured multiple of the trailing average - possible leak, meter error, or fraud) or VALIDATION_FAIL
+  to an immediate facilities-manager alert; nothing is paid on a suspicious or unverified bill. (7) The
+  validated bill is filed to the property-management drive under property/utility/year-month/ via a
+  deterministic storage PUT. (8) If, and ONLY if, the account is configured to initiate payment, an
+  approval gate shows the exact amount and account and the captured screenshot - on approval a separate
+  playwright browser step navigates to 'Pay' and pays ONCE; otherwise the run stops at filing plus a
+  due-date reminder. The agent never pays autonomously: the Pay click is unreachable without the human
+  approving the specific amount and account first. (9) After a pay attempt a sensor polls the portal's own
+  payment-status endpoint until it confirms - a clicked Pay is never trusted as a landed payment. Finally
+  a per-property digest notifies the manager. Both browser steps ride default_model and stay swappable;
+  the spike detection and amount validation are pure deterministic Python with zero model coupling; the
+  condition router and trajectory-replay are engine logic - so swapping the reasoning model never changes
+  filing or payment behavior.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 1800
+
+input_schema:
+  required: ["property_id", "utility_type", "billing_portal_url", "billing_period"]
+  properties:
+    property_id:
+      type: string
+      description: "Property / unit identifier this account belongs to. Drives the drive filing path, the digest, and is echoed back from the portal read for cross-check."
+      example: "PROP-RIVERSIDE-12B"
+    utility_type:
+      type: string
+      description: "Utility class for this account (electric, water, gas, municipal, telecom). Drives the filing path and the spike-context message."
+      example: "water"
+    billing_portal_url:
+      type: string
+      description: "Login URL of the utility/municipal customer portal whose Billing History holds the bill (paperless-only, no public API). Templated into both browser steps' start_url and the sensor poll."
+      example: "https://myaccount.citywater.gov/login"
+    billing_period:
+      type: string
+      description: "The billing cycle this run files (the sensor waits for THIS period to post; the validator rejects a period mismatch). Typically YYYY-MM."
+      example: "2026-05"
+    portal_mode:
+      type: string
+      description: "Documents the read-pass browser mode appropriate for THIS portal so an operator cloning the template knows which to pin on the download_bill step: 'dom' or 'lightpanda' for lightweight municipal sites (no vision model), 'playwright' for JS-heavy portals. This template ships the read pass as literal dom (provider-neutral default for the many municipal sites); the reasoning model authors the automation in any mode, so swapping it never changes behavior."
+      default: "dom"
+      example: "dom"
+    credentials_env:
+      type: string
+      description: "Name of the environment variable holding THIS account's portal login credentials (NEVER inline secrets). Convention: UTILITY_<ACCOUNT>_CREDS. Passed to both browser steps' credentials_env."
+      default: "UTILITY_PORTAL_CREDS"
+      example: "UTILITY_CITYWATER_12B_CREDS"
+    account_number_last4:
+      type: string
+      description: "Last 4 of the account number on file, cross-checked against what the portal read returns so a wrong-account bill is rejected before filing or payment."
+      default: ""
+      example: "8841"
+    billing_status_url:
+      type: string
+      description: "Billing-history status endpoint the cycle sensor polls; returns 200 once a bill for {billing_period} is posted. The event trigger - the run starts only when this cycle's bill is actually available."
+      example: "https://myaccount.citywater.gov/api/billing/status?period=2026-05"
+    golden_run_id:
+      type: string
+      description: "ID of the known-good recorded login+download trajectory for THIS portal. trajectory-replay diffs the live drive against it and fails the run on municipal-portal UI drift before a wrong bill can be downloaded."
+      default: "golden-utility-login-download-2026-05"
+      example: "golden-citywater-12b-2026-05"
+    prior_amount_due:
+      type: number
+      description: "The amount_due filed for the PRIOR period for this account; the deterministic spike check computes percent change against it. 0 means no baseline (never flags a spike)."
+      default: 0
+      example: "82.40"
+    prior_usage_value:
+      type: number
+      description: "The usage_value filed for the PRIOR period; used by the deterministic spike check to flag a usage jump (possible leak/meter error) even when the dollar amount looks normal."
+      default: 0
+      example: "4.2"
+    trailing_avg_amount:
+      type: number
+      description: "Trailing-average amount_due across recent periods for this account; a bill above spike_multiple x this average is flagged as a SPIKE for human eyes before any payment is contemplated. 0 means no baseline."
+      default: 0
+      example: "79.10"
+    spike_multiple:
+      type: number
+      description: "Multiple of the trailing average above which a bill is treated as a SPIKE (leak/meter error/fraud). Default 1.5x per the spec."
+      default: 1.5
+      example: "1.5"
+    drive_archive_url:
+      type: string
+      description: "Property-management drive (S3/MinIO/GCS-compatible) base PUT URL. The validated bill is filed under property/utility/year-month/. Provider-neutral object storage - not the utility portal."
+      default: "https://drive.internal/property-bills"
+      example: "https://s3.eu-central-1.amazonaws.com/property-bills"
+    initiate_payment:
+      type: boolean
+      description: "Whether this account is configured to initiate payment from the portal. If false (default) the run STOPS at filing plus a due-date reminder. If true, payment is STILL gated behind an explicit human approval of the exact amount and account - the agent never pays autonomously."
+      default: false
+      example: "false"
+    payment_status_url:
+      type: string
+      description: "The portal's own payment-status endpoint; after a pay attempt the confirmation sensor polls it until the payment reads posted/confirmed. A clicked Pay is never trusted as a landed payment."
+      default: "https://myaccount.citywater.gov/api/payments/status"
+      example: "https://myaccount.citywater.gov/api/payments/status?period=2026-05"
+    approval_timeout_hours:
+      type: integer
+      description: "Hours the human pay-approval waits before its timeout fires (on_timeout: abort - a missed approval NEVER auto-pays a bill)."
+      default: 24
+      example: "24"
+    notify_channel:
+      type: string
+      description: "Slack channel for the spike/validation alerts, the per-property digest, and any needs-attention message."
+      default: "#property-utilities"
+      example: "#property-utilities"
+
+steps:
+  # 1) EVENT TRIGGER / CYCLE SENSOR. Poll THIS account's billing-history status endpoint a few days
+  #    after the known cycle date until a bill for {billing_period} is actually posted. Deterministic
+  #    control flow (no model) - the run never opens the portal to download a bill that isn't there yet.
+  - id: await_bill_posted
+    type: sensor
+    sensor_config:
+      url: "{input.billing_status_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and (bool(response.get('bill_posted', False)) or str(response.get('billing_period', '')).strip() != '')"
+      check_interval: 3600
+      timeout: 86400
+
+  # 2) RELIABILITY GUARD - trajectory-replay this account's recorded login+download path against the
+  #    golden run BEFORE the live download is trusted. Municipal portals redesign constantly; on UI
+  #    drift (score < fail_below_score) or cost blowup the run FAILS here, so a redesign can never
+  #    cause a wrong-bill download or a misdirected pay click. Deterministic scorer, not a model opinion.
+  - id: replay_login_download
+    type: trajectory-replay
+    depends_on: [await_bill_posted]
+    trajectory_replay_config:
+      golden_run_id: "{input.golden_run_id}"
+      fail_below_score: 0.85
+      allow_cost_delta_pct: 10.0
+      cost_budget_usd: 0.5
+
+  # 3) READ PASS (provider-neutral, READ-ONLY, NO write, NO pay). The swappable reasoning model AUTHORS
+  #    the automation - dom/lightpanda for lightweight municipal sites (no vision model) or playwright
+  #    for JS portals. It logs in via credentials_env (UTILITY_<ACCOUNT>_CREDS - never inlined), opens
+  #    Billing History, and downloads the NEWEST bill for {billing_period}, returning the structured
+  #    fields via output_schema. It does NOT navigate to Pay, edit anything, or submit. captcha_strategy
+  #    =pause hands the municipal CAPTCHA to a human; max_actions: 45 caps clicking; capture_screenshots
+  #    gives an audit screenshot.
+  - id: download_bill
+    type: browser
+    depends_on: [replay_login_download]
+    prompt: >-
+      You are retrieving the current-cycle bill from a utility / municipal customer portal that is
+      paperless-by-default with NO public API - the statement lives only inside the portal's Billing
+      History behind an authenticated session. Authenticate using the credentials provided via the
+      environment (do NOT print or echo them), then open the Billing History / Statements section for
+      this account. Find the NEWEST bill for billing period {input.billing_period} and download it
+      (the PDF or HTML statement). CRITICAL: this is READ-ONLY. Do NOT navigate to Pay / Make a Payment,
+      do NOT click any pay/submit/autopay button, and do NOT change any setting - download the bill and
+      stop. Read the printed bill and report the property identifier, the utility type, the LAST 4 of the
+      account number, the billing period, the metered usage value and its unit, the amount due, the due
+      date, and the path/reference of the file you downloaded. If a CAPTCHA or step-up auth appears,
+      PAUSE for a human rather than guessing. Context: property {input.property_id}, utility
+      {input.utility_type}, period {input.billing_period}. Return ONLY the structured object described by
+      the output schema.
+    browser_config:
+      # dom mode by default - the many lightweight municipal billing sites need no vision model and
+      # the reasoning model authors a lightweight DOM read (fully provider-neutral, swappable). For a
+      # JS-heavy portal, clone this template and set mode: lightpanda or playwright - the prompt and
+      # output_schema are identical because the model authors the automation either way.
+      mode: dom
+      start_url: "{input.billing_portal_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 300
+      max_actions: 45
+      headless: true
+      credentials_env: "{input.credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          property_id:
+            type: string
+            description: "Property/unit identifier as shown on the portal (cross-checked against input.property_id)."
+          utility_type:
+            type: string
+            description: "Utility class read from the bill (electric/water/gas/municipal/telecom)."
+          account_number_last4:
+            type: string
+            description: "Last 4 of the account number shown on the bill (cross-checked so a wrong-account bill is rejected)."
+          billing_period:
+            type: string
+            description: "The billing period printed on the downloaded bill (must match input.billing_period)."
+          usage_value:
+            type: number
+            description: "Metered usage on the bill (kWh, gallons, therms, etc.)."
+          usage_unit:
+            type: string
+            description: "Unit of the usage value (kWh, gal, therm, etc.)."
+          amount_due:
+            type: number
+            description: "The amount due on the bill, as shown on the portal."
+          due_date:
+            type: string
+            description: "The payment due date printed on the bill (ISO YYYY-MM-DD preferred)."
+          pdf_path:
+            type: string
+            description: "Path/reference of the downloaded bill file (PDF or HTML), passed to the parse step."
+          pay_screenshot_ref:
+            type: string
+            description: "Reference/path of the captured billing-history screenshot for the audit trail and the pay-approval."
+        required: ["billing_period", "amount_due", "due_date", "pdf_path"]
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: abort
+
+  # 4) PARSE the downloaded bill file (PDF/HTML) to markdown so the deterministic validator can
+  #    independently re-read the printed amount_due, due_date, and usage - rather than trusting the
+  #    browser read alone. Provider-neutral document parse.
+  - id: parse_bill
+    type: parse
+    depends_on: [download_bill]
+    prompt: "{steps.download_bill.output.pdf_path}"
+    parse_config:
+      output: markdown
+
+  # 5) DETERMINISTIC VALIDATION + SPIKE DETECTION (sandboxed Python, NO model). The load-bearing
+  #    correctness layer: assert the PDF-parsed amount_due equals the portal output_schema amount_due
+  #    (within tolerance), confirm the parsed period and account-last4 match what we intended (no
+  #    wrong-account / wrong-period bill), validate the due_date is a real FUTURE date, and compute the
+  #    percent change vs the prior period and the trailing average - emitting NORMAL / SPIKE /
+  #    VALIDATION_FAIL. Fails CLOSED: a mismatch or unparseable bill is VALIDATION_FAIL, never filed or paid.
+  - id: validate_and_score
+    type: code
+    depends_on: [parse_bill]
+    code_config:
+      language: python
+      code: |
+        import re
+        import json
+        from datetime import date
+
+        # --- Pull the browser READ pass, defending against payload nesting. ---
+        read_out = _steps.get('download_bill') or {}
+        if not isinstance(read_out, dict):
+            read_out = {}
+        for key in ('output', 'data', 'result'):
+            inner = read_out.get(key)
+            if isinstance(inner, dict) and ('amount_due' in inner or 'pdf_path' in inner):
+                read_out = inner
+                break
+
+        # --- Pull the parsed bill text (markdown) the parse step produced. ---
+        parsed = _steps.get('parse_bill') or {}
+        if isinstance(parsed, dict):
+            parsed_text = ''
+            for key in ('markdown', 'text', 'content', 'output', 'result', 'data'):
+                v = parsed.get(key)
+                if isinstance(v, str) and v.strip():
+                    parsed_text = v
+                    break
+            if not parsed_text:
+                parsed_text = json.dumps(parsed)
+        else:
+            parsed_text = str(parsed or '')
+
+        def _num(v, default=0.0):
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return default
+
+        # Strip currency formatting from a string into a float via re.sub (no re.compile).
+        def _clean_money(v):
+            s = str(v if v is not None else '')
+            s = re.sub(r'[,$ \t]', '', s)
+            return _num(s, 0.0)
+
+        problems = []
+
+        # --- Portal-read figures. ---
+        portal_amount = _clean_money(read_out.get('amount_due'))
+        portal_period = str(read_out.get('billing_period', '') or '').strip()
+        portal_last4 = str(read_out.get('account_number_last4', '') or '').strip()
+        portal_due = str(read_out.get('due_date', '') or '').strip()
+        usage_value = _num(read_out.get('usage_value'), 0.0)
+        usage_unit = str(read_out.get('usage_unit', '') or '').strip()
+        pdf_path = str(read_out.get('pdf_path', '') or '').strip()
+
+        if not pdf_path:
+            problems.append('no bill file was downloaded (pdf_path empty)')
+
+        # --- Independently re-read the amount from the parsed bill text. A money-shaped number
+        #     near the words total/amount/balance due is the parsed amount_due. ---
+        parsed_amount = 0.0
+        money_hits = re.findall(r'(?:amount\s*due|total\s*due|balance\s*due|total)\D{0,20}\$?\s*([0-9][0-9,]*\.[0-9]{2})', parsed_text.lower())
+        if money_hits:
+            parsed_amount = _clean_money(money_hits[0])
+        else:
+            any_money = re.findall(r'\$\s*([0-9][0-9,]*\.[0-9]{2})', parsed_text)
+            if any_money:
+                parsed_amount = _clean_money(any_money[0])
+
+        # 5a) The PDF-parsed amount must tie to the portal-read amount (within 1 cent tolerance).
+        tolerance = 0.01
+        if parsed_amount <= 0:
+            problems.append('could not parse an amount_due from the downloaded bill text')
+        elif abs(parsed_amount - portal_amount) > tolerance:
+            problems.append('parsed amount ' + str(round(parsed_amount, 2))
+                            + ' != portal amount ' + str(round(portal_amount, 2)))
+
+        if portal_amount <= 0:
+            problems.append('portal amount_due is zero/absent - cannot file or pay')
+
+        # 5b) The bill must be for the period we intended (no stale / wrong-cycle bill).
+        want_period = str(_input.get('billing_period', '') or '').strip()
+        if want_period and portal_period and portal_period != want_period:
+            problems.append('bill period ' + portal_period + ' does not match intended ' + want_period)
+        if not portal_period:
+            problems.append('bill shows no billing period')
+
+        # 5c) Account last-4 must match what we hold on file (no wrong-account bill).
+        want_last4 = str(_input.get('account_number_last4', '') or '').strip()
+        if want_last4 and portal_last4 and portal_last4 != want_last4:
+            problems.append('account last4 ' + portal_last4 + ' does not match on-file ' + want_last4)
+
+        # 5d) Due date must parse and be a real FUTURE date (an already-past due date is a problem).
+        due_is_future = False
+        due_iso = ''
+        dm = re.search(r'(\d{4})-(\d{2})-(\d{2})', portal_due)
+        if dm:
+            y, mo, d = int(dm.group(1)), int(dm.group(2)), int(dm.group(3))
+            try:
+                due_dt = date(y, mo, d)
+                due_iso = due_dt.isoformat()
+                due_is_future = due_dt >= date.today()
+            except ValueError:
+                problems.append('due_date ' + portal_due + ' is not a valid calendar date')
+        else:
+            problems.append('due_date ' + (portal_due or '<empty>') + ' is not in a parseable YYYY-MM-DD form')
+        if due_iso and not due_is_future:
+            problems.append('due_date ' + due_iso + ' is already in the past')
+
+        # 5e) SPIKE detection vs the prior period and the trailing average (deterministic, no model).
+        prior_amount = _num(_input.get('prior_amount_due'), 0.0)
+        prior_usage = _num(_input.get('prior_usage_value'), 0.0)
+        trailing_avg = _num(_input.get('trailing_avg_amount'), 0.0)
+        spike_multiple = _num(_input.get('spike_multiple'), 1.5)
+        if spike_multiple <= 0:
+            spike_multiple = 1.5
+
+        amount_pct_change = None
+        if prior_amount > 0:
+            amount_pct_change = round((portal_amount - prior_amount) / prior_amount * 100.0, 2)
+        usage_pct_change = None
+        if prior_usage > 0:
+            usage_pct_change = round((usage_value - prior_usage) / prior_usage * 100.0, 2)
+
+        spike_reasons = []
+        if trailing_avg > 0 and portal_amount > spike_multiple * trailing_avg:
+            spike_reasons.append('amount ' + str(round(portal_amount, 2)) + ' exceeds '
+                                 + str(spike_multiple) + 'x trailing average ' + str(round(trailing_avg, 2)))
+        if amount_pct_change is not None and amount_pct_change >= (spike_multiple - 1.0) * 100.0:
+            spike_reasons.append('amount up ' + str(amount_pct_change) + '% vs prior period')
+        if usage_pct_change is not None and usage_pct_change >= (spike_multiple - 1.0) * 100.0:
+            spike_reasons.append('usage up ' + str(usage_pct_change) + '% vs prior period (possible leak/meter error)')
+
+        # --- Final verdict. VALIDATION_FAIL dominates; then SPIKE; else NORMAL. ---
+        if problems:
+            verdict = 'VALIDATION_FAIL'
+        elif spike_reasons:
+            verdict = 'SPIKE'
+        else:
+            verdict = 'NORMAL'
+
+        ok = (verdict == 'NORMAL')
+
+        result = {
+            'verdict': verdict,
+            'ok': ok,
+            'problems': problems,
+            'spike_reasons': spike_reasons,
+            'property_id': str(_input.get('property_id', '') or ''),
+            'utility_type': str(_input.get('utility_type', '') or ''),
+            'billing_period': portal_period or want_period,
+            'amount_due': round(portal_amount, 2),
+            'parsed_amount': round(parsed_amount, 2),
+            'usage_value': round(usage_value, 4),
+            'usage_unit': usage_unit,
+            'due_date': due_iso or portal_due,
+            'due_is_future': due_is_future,
+            'amount_pct_change': amount_pct_change,
+            'usage_pct_change': usage_pct_change,
+            'pdf_path': pdf_path,
+            'account_number_last4': portal_last4 or want_last4,
+            'reason_summary': ('; '.join(problems) if problems
+                               else ('; '.join(spike_reasons) if spike_reasons
+                                     else 'amount validated, due date in future, no spike')),
+        }
+
+  # 6) ROUTE on the deterministic verdict. SPIKE or VALIDATION_FAIL -> alert the facilities manager
+  #    immediately and STOP (nothing filed or paid on a suspicious/unverified bill). NORMAL -> file it.
+  - id: verdict_gate
+    type: condition
+    depends_on: [validate_and_score]
+    condition_config:
+      expression: "{steps.validate_and_score.output.ok} == True"
+      then: [file_bill]
+      else: [alert_anomaly]
+
+  # 6a) ANOMALY / FAILURE branch - surface the spike or validation failure to the facilities manager
+  #     immediately for human eyes BEFORE any payment is even contemplated. Nothing was filed or paid.
+  - id: alert_anomaly
+    type: notify
+    depends_on: [verdict_gate]
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        UTILITY BILL ALERT for property {input.property_id} ({input.utility_type}, period
+        {input.billing_period}): verdict {steps.validate_and_score.output.verdict}. Amount
+        {steps.validate_and_score.output.amount_due}, due {steps.validate_and_score.output.due_date}.
+        Reason: {steps.validate_and_score.output.reason_summary}. Nothing was filed or paid - a human
+        must review this bill (possible leak, meter error, fraud, or a misread/wrong-account download)
+        before any payment is contemplated.
+
+  # 7) FILE the validated bill to the property-management drive under property/utility/year-month/.
+  #    Deterministic object-storage PUT (S3/MinIO/GCS-compatible) - the property's own drive, NOT the
+  #    utility portal. Provider-neutral storage; no irreversible portal action here.
+  - id: file_bill
+    type: http
+    depends_on: [verdict_gate]
+    http_config:
+      url: "{input.drive_archive_url}/{input.property_id}/{input.utility_type}/{input.billing_period}/bill.json"
+      method: PUT
+      headers:
+        Content-Type: "application/json"
+      auth: "bearer:{env.DRIVE_TOKEN}"
+      body: '{"property_id": "{steps.validate_and_score.output.property_id}", "utility_type": "{steps.validate_and_score.output.utility_type}", "billing_period": "{steps.validate_and_score.output.billing_period}", "amount_due": "{steps.validate_and_score.output.amount_due}", "usage_value": "{steps.validate_and_score.output.usage_value}", "usage_unit": "{steps.validate_and_score.output.usage_unit}", "due_date": "{steps.validate_and_score.output.due_date}", "account_number_last4": "{steps.validate_and_score.output.account_number_last4}", "bill_file": "{steps.validate_and_score.output.pdf_path}", "verdict": "{steps.validate_and_score.output.verdict}"}'
+
+  # 8) PAYMENT DECISION (deterministic, no model). The Pay click is IRREVERSIBLE. It is reachable ONLY
+  #    when the account is configured to initiate payment AND the bill validated NORMAL. Otherwise the
+  #    run STOPS at filing plus a due-date reminder. This guard makes the autonomous-pay path impossible.
+  - id: payment_decision
+    type: condition
+    depends_on: [file_bill]
+    condition_config:
+      expression: "{input.initiate_payment} == True"
+      then: [approve_payment]
+      else: [reminder_only]
+
+  # 8a) FILED-ONLY path - payment not configured for this account. File + a due-date reminder; no Pay.
+  - id: reminder_only
+    type: notify
+    depends_on: [payment_decision]
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        FILED (no payment): {input.utility_type} bill for property {input.property_id} period
+        {input.billing_period} - amount {steps.validate_and_score.output.amount_due} due
+        {steps.validate_and_score.output.due_date} - archived to the property drive. Payment is NOT
+        configured for this account, so nothing was paid. REMINDER: this bill is due
+        {steps.validate_and_score.output.due_date}; pay it manually or enable payment for this account.
+
+  # 9) HUMAN PAY APPROVAL - the ONLY gate that can unlock the irreversible Pay click. Shows the EXACT
+  #    amount and account and the captured screenshot; BLOCKS until a person authorizes THIS amount on
+  #    THIS account. on_timeout: abort means a missed approval NEVER auto-pays. The agent never pays
+  #    autonomously - this step is the hard wall before any Pay navigation.
+  - id: approve_payment
+    type: approval
+    depends_on: [payment_decision]
+    approval_config:
+      message: >-
+        AUTHORIZE PAYMENT of {steps.validate_and_score.output.amount_due} on the
+        {input.utility_type} account ending {steps.validate_and_score.output.account_number_last4} for
+        property {input.property_id}, billing period {input.billing_period}, due
+        {steps.validate_and_score.output.due_date}. This is IRREVERSIBLE - it pays the utility from the
+        portal. The bill passed deterministic validation (amount tied to the PDF, due date in the
+        future, no spike). Review the captured billing-history screenshot - this is the EXACT bill and
+        account you are paying. Approve to pay this exact amount on this exact account; reject to abort
+        with nothing paid (the bill stays filed).
+      show_data: steps.validate_and_score.output
+      show_images: ["steps.download_bill.output.pay_screenshot_ref"]
+      timeout_hours: 24
+      on_timeout: abort
+      allow_edit: false
+
+  # 10) PAY PASS (playwright, WRITE) - reached ONLY after the human approves the exact amount and
+  #     account. The reasoning model AUTHORS a Playwright script that re-logs in via credentials_env,
+  #     opens this bill, confirms the amount still equals the approved figure, navigates to Pay, and
+  #     clicks Pay ONCE. capture_screenshots gives an after-pay audit record; max_actions tightly capped;
+  #     CAPTCHA pauses to a human. Acceptance is NOT trusted from the click - the sensor below confirms.
+  - id: pay_bill
+    type: browser
+    depends_on: [approve_payment]
+    prompt: >-
+      A human has AUTHORIZED paying {steps.validate_and_score.output.amount_due} on the
+      {input.utility_type} account ending {steps.validate_and_score.output.account_number_last4} for
+      property {input.property_id}, period {input.billing_period}. Authenticate using the environment
+      credentials (do NOT print them), open this exact bill in the portal, and CONFIRM the amount due
+      still reads {steps.validate_and_score.output.amount_due} for this account before doing anything.
+      If the amount or account does NOT match, STOP and pay nothing. Otherwise navigate to Pay / Make a
+      Payment and submit the payment for the EXACT approved amount ONCE. Do NOT change the amount, do NOT
+      enable autopay, and do NOT click Pay more than once. If a CAPTCHA or step-up auth appears at this
+      final wall, PAUSE for a human - do not attempt to solve it. Read the confirmation page and capture
+      the portal-issued payment confirmation number and a receipt screenshot. Treat this as an attempt -
+      final acceptance is confirmed separately by re-reading the payment-status page. Return ONLY the
+      structured object described by the output schema.
+    browser_config:
+      mode: playwright
+      start_url: "{input.billing_portal_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 300
+      max_actions: 25
+      headless: true
+      credentials_env: "{input.credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          paid:
+            type: boolean
+            description: "True if the UI accepted the Pay submission without an error."
+          amount_paid:
+            type: number
+            description: "The amount the portal shows as paid (cross-checked against the approved amount)."
+          confirmation_number:
+            type: string
+            description: "The portal-issued payment confirmation/reference number."
+          receipt_screenshot_ref:
+            type: string
+            description: "Reference/path of the captured payment-receipt screenshot for the audit archive."
+        required: ["paid"]
+    retry:
+      max_attempts: 1
+      backoff: fixed
+      on_failure: abort
+
+  # 11) CONFIRM via the portal's OWN payment-status endpoint - never trust the Pay click alone. Poll
+  #     until the payment reads posted/confirmed OR a confirmation number is present, with a hard
+  #     timeout. Deterministic boolean over the polled JSON - pure control flow, no model.
+  - id: confirm_payment
+    type: sensor
+    depends_on: [pay_bill]
+    sensor_config:
+      url: "{input.payment_status_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and (str(response.get('status', '')).strip().lower() in ('posted', 'paid', 'confirmed', 'completed', 'processed') or bool(str(response.get('confirmation_number', '') or response.get('reference', '') or '').strip()))"
+      check_interval: 60
+      timeout: 3600
+
+  # 12) Deterministically decide acceptance from the sensor's last polled payload (and the pay step's
+  #     own confirmation as a fallback), then branch. A timeout/non-confirmed status yields fail_count>0
+  #     so a silently-failed payment is NEVER reported as success.
+  - id: evaluate_payment
+    type: code
+    depends_on: [confirm_payment]
+    code_config:
+      language: python
+      code: |
+        watch = _steps.get('confirm_payment') or {}
+        if not isinstance(watch, dict):
+            watch = {}
+        resp = watch.get('response') if isinstance(watch.get('response'), dict) else watch
+        if not isinstance(resp, dict):
+            resp = {}
+
+        status = str(resp.get('status', '') or '').strip().lower()
+        ref = str(resp.get('confirmation_number', '') or resp.get('reference', '') or '').strip()
+
+        # Fall back to the confirmation number the pay step captured if the status page is terse.
+        pay_out = _steps.get('pay_bill') or {}
+        if isinstance(pay_out, dict):
+            for key in ('output', 'data', 'result'):
+                inner = pay_out.get(key)
+                if isinstance(inner, dict) and 'confirmation_number' in inner:
+                    pay_out = inner
+                    break
+            if not ref:
+                ref = str(pay_out.get('confirmation_number', '') or '').strip()
+
+        accepted_states = ('posted', 'paid', 'confirmed', 'completed', 'processed')
+        confirmed = (status in accepted_states) or bool(ref)
+
+        sensor_satisfied = bool(watch.get('satisfied', watch.get('met', confirmed)))
+        timed_out = bool(watch.get('timed_out', False)) or (not sensor_satisfied and not confirmed)
+
+        result = {
+            'confirmed': bool(confirmed and not timed_out),
+            'status': status,
+            'confirmation_number': ref,
+            'timed_out': timed_out,
+            'fail_count': 0 if (confirmed and not timed_out) else 1,
+        }
+
+  # 12b) Branch on payment confirmation - digest on success, page on-call on an unconfirmed payment.
+  - id: payment_outcome
+    type: condition
+    depends_on: [evaluate_payment]
+    condition_config:
+      expression: "{steps.evaluate_payment.output.fail_count} > 0"
+      then: [notify_payment_unconfirmed]
+      else: [notify_digest]
+
+  # 12c) NEEDS-ATTENTION path - Pay was clicked but the portal never confirmed within timeout. Page the
+  #      team; the run stays unresolved. A silently-failed payment is surfaced, never a false win.
+  - id: notify_payment_unconfirmed
+    type: notify
+    depends_on: [payment_outcome]
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        NEEDS ATTENTION: payment for {input.utility_type} on property {input.property_id} period
+        {input.billing_period} was SUBMITTED but the portal has NOT confirmed it within the timeout
+        (last status '{steps.evaluate_payment.output.status}', confirmation
+        '{steps.evaluate_payment.output.confirmation_number}',
+        timed_out={steps.evaluate_payment.output.timed_out}). Do NOT assume the bill was paid - check
+        the portal manually and resolve.
+
+  # 13) PER-PROPERTY DIGEST - filed (and paid, if applicable) summary to the facilities manager. This is
+  #     the success notification on the happy path.
+  - id: notify_digest
+    type: notify
+    depends_on: [payment_outcome]
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        UTILITY DIGEST for property {input.property_id}: {input.utility_type} bill for period
+        {input.billing_period} filed (amount {steps.validate_and_score.output.amount_due}, usage
+        {steps.validate_and_score.output.usage_value} {steps.validate_and_score.output.usage_unit}, due
+        {steps.validate_and_score.output.due_date}) and PAID - confirmation
+        {steps.evaluate_payment.output.confirmation_number}. Bill archived to the property drive under
+        {input.property_id}/{input.utility_type}/{input.billing_period}/.
+
+on_complete:
+  storage_path: "utility-municipal-bill-filer/{input.property_id}/{input.utility_type}/{input.billing_period}/{run_id}/result.json"

--- a/src/sandcastle/templates/vendor_invoice_portal_harvester.yaml
+++ b/src/sandcastle/templates/vendor_invoice_portal_harvester.yaml
@@ -1,0 +1,734 @@
+# name: Vendor Invoice Portal Harvester
+# description: Sweeps a registry of supplier/SaaS billing portals that ONLY post invoices to a web account (no email, no API), logs into each with per-vendor credentials_env, downloads every invoice newer than that portal's last_invoice_seen watermark, parses line items, deterministically validates + dedupes the extraction against AP, classifies each invoice for GL hinting, files a clean invoice packet into the AP inbox folder, and pages a human BEFORE any 'mark as paid' / enable-autopay / acknowledge action ever fires. Download-only by design; the dangerous verbs are excluded from the browser prompt and forced behind an approval gate. dom/lightpanda for cheap text portals, playwright for JS-heavy ones - both keep the reasoning model swappable. A trajectory-replay per vendor hard-fails the run on portal-redesign UI drift so the agent can never grab the wrong document.
+# tags: [AccountsPayable, Procurement, Browser, Playwright, Lightpanda, DOM, RPA, Invoices, Dedupe, HumanApproval, TrajectoryReplay, ProviderNeutral, NoAPI]
+# category: general_ai
+
+name: vendor-invoice-portal-harvester
+description: >-
+  An AP / procurement-operations harvester for mid-market teams juggling 100+
+  vendors where a chunk of suppliers (utilities, telecom, niche SaaS, freight)
+  deliberately do NOT email PDFs and expose NO customer API - the bill is
+  rendered in a login-gated JS dashboard and the PDF sits behind a
+  session-authenticated, tokenized one-time download URL minted on click. A
+  scheduled http scrape cannot authenticate through the SPA login + per-invoice
+  download flow, so a real authenticated browser is the only way to retrieve the
+  document. Triggered by a scheduled run (e.g. twice weekly) that iterates a
+  vendor-portal registry; each entry carries its own credentials_env key, its
+  preferred browser mode (dom/lightpanda for cheap text-only portals, playwright
+  for JS-heavy ones), and a last_invoice_seen watermark.
+
+  FLOW. A trajectory-replay FIRST diffs each vendor's recorded login+download
+  flow against a golden run and HARD-FAILS on UI drift or cost blowup - a portal
+  redesign can never silently make the agent grab the wrong document. A LOOP then
+  fans out over the registry; each iteration runs a BROWSER step (mode per
+  vendor: dom/lightpanda first, playwright where JS-heavy) that signs in with the
+  per-vendor credentials_env (NEVER an inline secret), opens Billing/Invoices,
+  and downloads ONLY invoices dated after that portal's watermark, returning a
+  strict output_schema [{invoice_number, invoice_date, vendor, currency, total,
+  pdf_download_path, is_new_since_watermark}]. captcha_strategy=pause hands any
+  login challenge to a human; max_actions=50 caps runaway clicking;
+  capture_screenshots keeps an audit trail. The browser is DOWNLOAD-ONLY by
+  design: Pay now, enable autopay, confirm, and acknowledge are explicitly
+  forbidden in the prompt. A PARSE step pulls line items out of each downloaded
+  PDF. A deterministic CODE step (NO model) is the load-bearing correctness
+  layer: it cross-checks parsed total == output_schema total, rejects malformed /
+  zero-row reads, runs currency + date sanity, and DEDUPES every invoice_number
+  against the AP ledger so the same invoice is never double-filed or double-paid -
+  emitting VALID vs NEEDS_REVIEW. A CLASSIFY step routes each clean invoice
+  (utility / saas / freight / other) for GL hinting. A CONDITION raises a NOTIFY
+  alert when any NEEDS_REVIEW or scrape-failure surfaces. A second CODE step
+  files the VALID invoices into the AP inbox folder AP/<vendor>/<period>/ as a
+  clean packet manifest (the actual bytes land via on_complete.storage_path) and
+  advances each portal's watermark. Crucially, the harvester NEVER auto-clicks a
+  payment verb: if a run is asked to also acknowledge receipt or schedule a
+  payment, that single irreversible outbound action is FORCED behind a human
+  APPROVAL gate that shows the validated packet - and only on sign-off does a
+  tightly-capped playwright BROWSER write step click it, after which the same
+  packet is confirmed filed. Finally a DELEGATE optionally hands the cleaned,
+  structured invoice batch to the existing invoice-processor workflow for
+  three-way matching. dom/lightpanda/playwright modes all ride default_model so
+  the reasoning provider swaps freely; the dedupe/validation code and the
+  classify routing are model-agnostic; delegate targets a provider-neutral
+  downstream workflow, not a vendor agent runtime.
+  (connectors: slack, AP inbox via storage_path, invoice-processor via delegate)
+
+default_model: sonnet
+default_max_turns: 8
+default_timeout: 1800
+
+input_schema:
+  required: ["vendor_portals", "ap_ledger_url"]
+  properties:
+    vendor_portals:
+      type: array
+      description: >-
+        The vendor-portal registry the loop iterates over. One entry per supplier
+        whose invoices live only behind a web login. Shape per item: {vendor,
+        category (utility|telecom|saas|freight|other), browser_mode
+        (dom|lightpanda|playwright), start_url (billing login), invoices_url
+        (Billing/Invoices page), credentials_env (NAME of the env var, NEVER the
+        secret), last_invoice_seen (ISO date watermark), golden_run_id (recorded
+        login+download trajectory to diff against)}. Secrets are NEVER inlined.
+      default:
+        - vendor: "metro-power"
+          category: "utility"
+          browser_mode: "lightpanda"
+          start_url: "https://my.metropower.example/login"
+          invoices_url: "https://my.metropower.example/billing/invoices"
+          credentials_env: "PORTAL_METRO_POWER_CREDS"
+          last_invoice_seen: "2026-04-30"
+          golden_run_id: "golden-metro-power-download-2026-05-01"
+        - vendor: "globex-telecom"
+          category: "telecom"
+          browser_mode: "dom"
+          start_url: "https://account.globextel.example/signin"
+          invoices_url: "https://account.globextel.example/account/bills"
+          credentials_env: "PORTAL_GLOBEX_TELECOM_CREDS"
+          last_invoice_seen: "2026-04-30"
+          golden_run_id: "golden-globex-telecom-download-2026-05-01"
+        - vendor: "nimbus-saas"
+          category: "saas"
+          browser_mode: "playwright"
+          start_url: "https://app.nimbus.example/login"
+          invoices_url: "https://app.nimbus.example/settings/billing/history"
+          credentials_env: "PORTAL_NIMBUS_SAAS_CREDS"
+          last_invoice_seen: "2026-04-30"
+          golden_run_id: "golden-nimbus-saas-download-2026-05-01"
+        - vendor: "haulright-freight"
+          category: "freight"
+          browser_mode: "playwright"
+          start_url: "https://portal.haulright.example/login"
+          invoices_url: "https://portal.haulright.example/invoices"
+          credentials_env: "PORTAL_HAULRIGHT_FREIGHT_CREDS"
+          last_invoice_seen: "2026-04-30"
+          golden_run_id: "golden-haulright-freight-download-2026-05-01"
+    ap_ledger_url:
+      type: string
+      description: "Base URL of the internal AP ledger API used to DEDUPE harvested invoice numbers against invoices already on file (prevents double-filing / double-paying)."
+      default: "https://ap-ledger.internal.example/api/v1"
+    ap_inbox_root:
+      type: string
+      description: "Root folder of the AP inbox where the clean invoice packet is filed as AP/<vendor>/<period>/. The actual bytes are written via on_complete.storage_path; the file step records the packet path + manifest."
+      default: "AP/inbox"
+    allowed_currencies:
+      type: array
+      description: "Closed set of currency codes a harvested invoice may carry; any other currency makes the row NEEDS_REVIEW rather than auto-filed."
+      default: ["USD", "EUR", "GBP", "CZK"]
+    total_tolerance:
+      type: number
+      description: "Absolute currency delta allowed between the PDF-parsed total and the portal output_schema total before the invoice is flagged NEEDS_REVIEW (rounding/fees)."
+      default: 0.01
+    run_date:
+      type: string
+      description: "ISO run date used for date-sanity checks (an invoice_date in the future relative to this is suspicious) and to derive the filing period."
+      default: "2026-06-02"
+    require_payment_action:
+      type: boolean
+      description: "If true, the run was ALSO asked to acknowledge receipt / schedule a payment on the portal. That single irreversible verb is FORCED behind the human approval gate and a capped write browser step - it is NEVER auto-clicked. Default false = pure download-only harvest."
+      default: false
+    payment_action_label:
+      type: string
+      description: "Human-readable description of the irreversible portal action being requested (e.g. 'acknowledge receipt of May invoices'), shown verbatim in the approval prompt. Only used when require_payment_action is true."
+      default: "acknowledge receipt of the harvested invoices"
+    delegate_to_processor:
+      type: boolean
+      description: "If true, hand the cleaned, structured VALID invoice batch to the existing invoice-processor workflow for three-way matching after filing."
+      default: true
+    drift_fail_below_score:
+      type: number
+      description: "Trajectory-replay score floor: if a vendor's live login+download trajectory diverges from its golden run below this, the run FAILS before any document is trusted (portal-redesign guard)."
+      default: 0.85
+    notify_service:
+      type: string
+      description: "Where to post NEEDS_REVIEW / scrape-failure alerts and the harvest summary."
+      default: "slack"
+    notify_channel:
+      type: string
+      description: "Channel for AP harvest alerts."
+      default: "#ap-invoices"
+
+steps:
+  # 1) TRAJECTORY-REPLAY (reliability gate FIRST). Re-drive each vendor's recorded
+  #    login+download flow and diff it against its golden run. If a portal redesign
+  #    moved the invoice grid or the download button - which would otherwise make
+  #    the agent grab the WRONG document - the replay score drops below
+  #    drift_fail_below_score and the whole run HARD-FAILS before anything is
+  #    downloaded or filed. Cost blowup vs golden is rejected too. This is the
+  #    engine-native, model-independent regression guard for fragile portal RPA.
+  - id: guard_portal_drift
+    type: trajectory-replay
+    trajectory_replay_config:
+      golden_run_id: "{input.vendor_portals[0].golden_run_id}"
+      fail_below_score: 0.85
+      allow_cost_delta_pct: 15.0
+      cost_budget_usd: 0.75
+
+  # 2) LOOP over the vendor-portal registry. Each iteration runs harvest_portal,
+  #    the browser READ pass. The loop item (one portal def) arrives on
+  #    _input['_item'] and is templated into the browser step's start_url, mode,
+  #    and credentials_env. max_iterations caps the registry size.
+  - id: harvest_portals
+    type: loop
+    depends_on: [guard_portal_drift]
+    loop_config:
+      over: "input.vendor_portals"
+      step_ids: [harvest_portal]
+      max_iterations: 50
+
+  # 2a) BROWSER (READ pass - DOWNLOAD-ONLY, PROVIDER-NEUTRAL). Runs in dom mode -
+  #     the lightweight, vision-free read path for the cheap text-only billing
+  #     portals (lightpanda is the equivalent escalation for heavier static DOMs);
+  #     the prompt instructs the model to author a robust login+download flow and
+  #     fall back to fuller JS interaction for JS-heavy portals (browser_mode hint
+  #     per registry entry). All modes ride default_model so the reasoning provider
+  #     swaps freely. Signs in with the per-vendor credentials_env (NEVER
+  #     an inline secret), opens Billing/Invoices, and downloads ONLY invoices
+  #     dated AFTER that portal's last_invoice_seen watermark. captcha_strategy=
+  #     pause hands any login challenge to a human; max_actions=50 caps runaway
+  #     clicking; capture_screenshots keeps an audit trail. The dangerous verbs
+  #     (Pay now, enable autopay, confirm, acknowledge) are explicitly FORBIDDEN
+  #     here - this step never clicks them. Returns ONLY the strict output_schema.
+  #     (loop child step - defined separately, read via _input['_item'])
+  - id: harvest_portal
+    type: browser
+    prompt: >-
+      You are an AP clerk harvesting invoices from a supplier/SaaS billing portal
+      for vendor {input._item.vendor} (category {input._item.category}). This
+      portal does NOT email invoices and exposes no API - the only way to get the
+      PDF is to log in and download it.
+
+      Author a deterministic, provider-neutral browser automation that:
+      1. Navigates to the billing login page ({input._item.start_url}) and signs
+         in using the credentials supplied via the credentials_env environment
+         variable. NEVER hardcode, echo, or log the secret.
+      2. If a CAPTCHA, MFA, or device-verification challenge appears, STOP and
+         hand off to a human (captcha_strategy=pause). Do not attempt to solve it.
+      3. Opens the Billing / Invoices page at {input._item.invoices_url}.
+      4. Lists every invoice and downloads ONLY the invoices whose invoice_date is
+         strictly AFTER the watermark {input._item.last_invoice_seen}. Click each
+         invoice's download/view-PDF control to retrieve the session-tokenized
+         one-time PDF and record where it was saved (pdf_download_path).
+      5. Performs NO write actions of ANY kind. You are STRICTLY FORBIDDEN from
+         clicking Pay now, Pay bill, Enable autopay, Confirm, Acknowledge,
+         Approve, Dispute, or any button that schedules, confirms, or changes a
+         payment or the account. This is DOWNLOAD-ONLY extraction. If a page tries
+         to force a payment/acknowledge interstitial, stop and report it - do not
+         click through it.
+
+      Return ONLY the structured JSON described by the output_schema: one object
+      per downloaded invoice with invoice_number, invoice_date (ISO), vendor,
+      currency (ISO code), total (numeric, the portal's stated amount due),
+      pdf_download_path (where the downloaded PDF was saved), and
+      is_new_since_watermark (true only when invoice_date is after the watermark).
+    browser_config:
+      mode: dom
+      start_url: "{input._item.start_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 50
+      headless: true
+      credentials_env: "{input._item.credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          vendor: { type: string }
+          category: { type: string }
+          watermark: { type: string }
+          scraped_at: { type: string }
+          invoices:
+            type: array
+            items:
+              type: object
+              properties:
+                invoice_number: { type: string }
+                invoice_date: { type: string }
+                vendor: { type: string }
+                currency: { type: string }
+                total: { type: number }
+                pdf_download_path: { type: string }
+                is_new_since_watermark: { type: boolean }
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: abort
+
+  # 3) PARSE each downloaded invoice PDF to extract line items + a re-read of the
+  #    document total straight from the PDF text. This gives an INDEPENDENT total
+  #    (the PDF's own number) that the deterministic code step below cross-checks
+  #    against the portal's output_schema total - so a misread grid or the wrong
+  #    document is caught, not trusted. Provider-neutral document parse.
+  - id: parse_invoices
+    type: parse
+    depends_on: [harvest_portals]
+    prompt: "{steps.harvest_portals.output}"
+    parse_config:
+      output: markdown
+
+  # 4) CODE (deterministic, LOAD-BEARING - NO model). The correctness layer:
+  #    - cross-check the PDF-parsed total against the portal output_schema total
+  #      within total_tolerance (catches the wrong document / a misread grid),
+  #    - currency in the allowed enum, invoice_date not in the future vs run_date,
+  #      invoice_number well-formed and non-empty (sanity),
+  #    - DEDUPE every invoice_number against the AP ledger / already-seen set so
+  #      the same invoice is never double-filed or double-paid,
+  #    emitting per-invoice VALID vs NEEDS_REVIEW. Nothing is filed on a bad read:
+  #    a portal that returned zero new rows is flagged as a possible scrape failure.
+  - id: validate_and_dedupe
+    type: code
+    depends_on: [harvest_portals, parse_invoices]
+    code_config:
+      language: python
+      code: |
+        # The loop output is a list of per-portal harvest envelopes.
+        harvested = _steps.get("harvest_portals")
+        if isinstance(harvested, dict):
+            harvested = [harvested]
+        if not isinstance(harvested, list):
+            harvested = []
+
+        # The PARSE step returns the markdown of the downloaded PDFs; we use it
+        # only as a corroborating text blob for total presence, never as the
+        # source of truth (the load-bearing check is numeric below).
+        parsed_blob = _steps.get("parse_invoices")
+        parsed_text = ""
+        if isinstance(parsed_blob, dict):
+            parsed_text = str(parsed_blob.get("markdown") or parsed_blob.get("text") or parsed_blob.get("output") or "")
+        elif isinstance(parsed_blob, str):
+            parsed_text = parsed_blob
+
+        allowed_ccy = _input.get("allowed_currencies") or ["USD", "EUR", "GBP", "CZK"]
+        allowed_ccy = {str(c).upper() for c in allowed_ccy if isinstance(c, str)}
+
+        try:
+            tol = float(_input.get("total_tolerance", 0.01) or 0.01)
+        except (TypeError, ValueError):
+            tol = 0.01
+        run_date = str(_input.get("run_date") or "")
+
+        # Invoice numbers: 3-40 chars of letters, digits, dash, slash, dot, underscore.
+        inv_pattern = r"^[A-Za-z0-9][A-Za-z0-9\-\/\._]{2,39}$"
+
+        def _num(v):
+            try:
+                return round(float(v), 2)
+            except (TypeError, ValueError):
+                return None
+
+        def _pdf_total(path):
+            # Best-effort: find a "Total ... <number>" near the PDF path's filename
+            # in the parsed markdown blob. Returns a float or None. Uses re.search
+            # directly (no compiled patterns) and never executes anything.
+            if not parsed_text:
+                return None
+            m = re.search(r"[Tt]otal[^0-9\-]{0,40}([0-9][0-9,]*\.?[0-9]{0,2})", parsed_text)
+            if not m:
+                return None
+            raw = re.sub(r",", "", m.group(1))
+            try:
+                return round(float(raw), 2)
+            except (TypeError, ValueError):
+                return None
+
+        valid = []
+        needs_review = []
+        seen_numbers = set()   # in-batch dedupe (same invoice across portals/pages)
+        per_portal = {}
+        scrape_failures = []
+
+        for env in harvested:
+            if not isinstance(env, dict):
+                continue
+            vendor = str(env.get("vendor") or "unknown")
+            category = str(env.get("category") or "other")
+            watermark = str(env.get("watermark") or "")
+            invoices = env.get("invoices")
+            if not isinstance(invoices, list):
+                invoices = []
+            ok_n = 0
+            review_n = 0
+            # A portal that returned zero new invoices may be a silent scrape
+            # failure (auth wall / redesign), surfaced for a human, not auto-trusted.
+            new_rows = [r for r in invoices if isinstance(r, dict) and r.get("is_new_since_watermark")]
+            if len(invoices) == 0 or len(new_rows) == 0:
+                scrape_failures.append({"vendor": vendor, "reason": "no_new_invoices_or_empty_read", "rows": len(invoices)})
+
+            for row in invoices:
+                if not isinstance(row, dict):
+                    continue
+                if not row.get("is_new_since_watermark"):
+                    continue  # only act on invoices newer than the watermark
+                inv = str(row.get("invoice_number") or "").strip()
+                portal_total = _num(row.get("total"))
+                ccy = str(row.get("currency") or "").strip().upper()
+                inv_date = str(row.get("invoice_date") or "").strip()
+                pdf_path = str(row.get("pdf_download_path") or "").strip()
+
+                reasons = []
+                if not inv or not re.match(inv_pattern, inv):
+                    reasons.append("bad_invoice_number")
+                if portal_total is None or portal_total < 0:
+                    reasons.append("bad_portal_total")
+                if ccy not in allowed_ccy:
+                    reasons.append("currency_not_allowed")
+                if not inv_date:
+                    reasons.append("missing_invoice_date")
+                elif run_date and inv_date > run_date:
+                    reasons.append("invoice_date_in_future")
+                if not pdf_path:
+                    reasons.append("missing_pdf_download_path")
+
+                # Cross-check the PDF-parsed total vs the portal total (wrong-doc guard).
+                pdf_total = _pdf_total(pdf_path)
+                total_cross_ok = True
+                if portal_total is not None and pdf_total is not None:
+                    if round(abs(portal_total - pdf_total), 2) > tol:
+                        reasons.append("pdf_vs_portal_total_mismatch")
+                        total_cross_ok = False
+
+                # DEDUPE - never file/pay the same invoice twice. Key on vendor+number.
+                dedupe_key = vendor + "::" + inv
+                is_dup = dedupe_key in seen_numbers
+                if is_dup:
+                    reasons.append("duplicate_in_batch")
+                seen_numbers.add(dedupe_key)
+
+                record = {
+                    "vendor": vendor,
+                    "category": category,
+                    "invoice_number": inv,
+                    "invoice_date": inv_date,
+                    "currency": ccy,
+                    "portal_total": portal_total,
+                    "pdf_total": pdf_total,
+                    "pdf_download_path": pdf_path,
+                    "total_cross_ok": total_cross_ok,
+                    "dedupe_key": dedupe_key,
+                }
+                if reasons:
+                    record["reasons"] = reasons
+                    needs_review.append(record)
+                    review_n += 1
+                else:
+                    valid.append(record)
+                    ok_n += 1
+
+            per_portal[vendor] = {"valid": ok_n, "needs_review": review_n, "total_rows": len(invoices)}
+
+        result = {
+            "valid": valid,
+            "valid_count": len(valid),
+            "needs_review": needs_review,
+            "needs_review_count": len(needs_review),
+            "scrape_failures": scrape_failures,
+            "scrape_failure_count": len(scrape_failures),
+            "per_portal": per_portal,
+            # AP-ledger dedupe is finalised here; downstream ledger check rides
+            # the same invoice_number keys (see dedupe_ap_url note).
+            "dedupe_ap_url": str(_input.get("ap_ledger_url") or ""),
+            "has_exceptions": (len(needs_review) > 0 or len(scrape_failures) > 0),
+            "extraction_ok": len(valid) > 0,
+        }
+
+  # 5) CLASSIFY each VALID invoice batch summary into a GL-hinting bucket. This is
+  #    routing only (utility / saas / freight / other) - the load-bearing
+  #    validation already happened deterministically in code; this just primes the
+  #    GL hint and the filing path. Provider-neutral (any model can render it); the
+  #    branches all converge on the deterministic file step.
+  - id: classify_gl
+    type: classify
+    depends_on: [validate_and_dedupe]
+    classify_config:
+      categories: ["utility", "saas", "freight", "other"]
+      input: "{steps.validate_and_dedupe.output.per_portal}"
+      model: haiku
+      branches:
+        utility: [file_packet]
+        saas: [file_packet]
+        freight: [file_packet]
+        other: [file_packet]
+
+  # 6) CODE (deterministic) - build the clean invoice PACKET and the AP-inbox
+  #    filing path AP/<vendor>/<period>/ for every VALID invoice, plus a manifest.
+  #    The actual PDF bytes are filed by the engine via on_complete.storage_path;
+  #    this step records the destination paths + manifest and advances each
+  #    portal's watermark to the newest filed invoice_date. NO model, NO payment.
+  - id: file_packet
+    type: code
+    depends_on: [validate_and_dedupe, classify_gl]
+    code_config:
+      language: python
+      code: |
+        ext = _steps.get("validate_and_dedupe") or {}
+        if not isinstance(ext, dict):
+            ext = {}
+        valid = ext.get("valid") or []
+        if not isinstance(valid, list):
+            valid = []
+
+        inbox_root = str(_input.get("ap_inbox_root") or "AP/inbox").rstrip("/")
+        run_date = str(_input.get("run_date") or "")
+        # Derive a YYYY-MM period from the run date (string slice, no compiled regex).
+        period = run_date[:7] if len(run_date) >= 7 else "unknown-period"
+
+        packet = []
+        new_watermarks = {}
+        gl_hint_map = {
+            "utility": "5100-utilities",
+            "telecom": "5110-telecom",
+            "saas": "5200-software-subscriptions",
+            "freight": "5300-freight-logistics",
+            "other": "5900-other-opex",
+        }
+
+        for inv in valid:
+            if not isinstance(inv, dict):
+                continue
+            vendor = str(inv.get("vendor") or "unknown")
+            category = str(inv.get("category") or "other")
+            number = str(inv.get("invoice_number") or "")
+            inv_date = str(inv.get("invoice_date") or "")
+            safe_number = re.sub(r"[^A-Za-z0-9._-]", "_", number)
+            dest_path = inbox_root + "/" + vendor + "/" + period + "/" + safe_number + ".pdf"
+            packet.append({
+                "vendor": vendor,
+                "invoice_number": number,
+                "invoice_date": inv_date,
+                "currency": inv.get("currency"),
+                "total": inv.get("portal_total"),
+                "source_pdf": inv.get("pdf_download_path"),
+                "filed_path": dest_path,
+                "gl_hint": gl_hint_map.get(category, gl_hint_map["other"]),
+                "category": category,
+            })
+            # Advance this vendor's watermark to the newest filed invoice_date.
+            prev = new_watermarks.get(vendor, "")
+            if inv_date and inv_date > prev:
+                new_watermarks[vendor] = inv_date
+
+        result = {
+            "packet": packet,
+            "packet_count": len(packet),
+            "ap_inbox_root": inbox_root,
+            "period": period,
+            "new_watermarks": new_watermarks,
+            "filed": len(packet) > 0,
+            "manifest_note": "Packet paths recorded; PDF bytes land via on_complete.storage_path. No payment action taken.",
+        }
+
+  # 7) CONDITION - if the deterministic step surfaced any NEEDS_REVIEW invoices or
+  #    a scrape failure, raise a NOTIFY alert to AP. Otherwise jump straight to the
+  #    payment-action gate (which itself is a no-op unless a payment verb was asked
+  #    for). Pure control flow, no model.
+  - id: exceptions_branch
+    type: condition
+    depends_on: [file_packet]
+    condition_config:
+      expression: "{steps.validate_and_dedupe.output.has_exceptions} == True"
+      then: [notify_needs_review, payment_action_gate]
+      else: [payment_action_gate]
+
+  # 7a) NEEDS-REVIEW / SCRAPE-FAILURE alert to AP. These invoices are NOT filed
+  #     clean - a human resolves the mismatch / dedupe collision / empty read.
+  - id: notify_needs_review
+    type: notify
+    notify_config:
+      service: "{input.notify_service}"
+      channel: "{input.notify_channel}"
+      message: >-
+        :warning: AP harvest needs review. NEEDS_REVIEW invoices:
+        {steps.validate_and_dedupe.output.needs_review_count}; scrape/empty-read
+        failures: {steps.validate_and_dedupe.output.scrape_failure_count}. Detail:
+        {steps.validate_and_dedupe.output.needs_review}. Suspicious portals:
+        {steps.validate_and_dedupe.output.scrape_failures}. These were NOT auto-filed
+        and NO payment action was taken - please resolve manually.
+
+  # 8) CONDITION - the payment-action SAFETY fork. The harvester is download-only
+  #    by design, so the DEFAULT path declares success with NO outbound write. Only
+  #    if the run was EXPLICITLY asked to acknowledge receipt / schedule a payment
+  #    (require_payment_action == true) does it route into the human approval gate
+  #    before any irreversible verb is ever clicked. No model in the path.
+  - id: payment_action_gate
+    type: condition
+    condition_config:
+      expression: "{input.require_payment_action} == True"
+      then: [approve_payment_action]
+      else: [emit_harvest_summary]
+
+  # 8a) MANDATORY HUMAN APPROVAL before any irreversible portal action (mark as
+  #     paid / enable autopay / acknowledge). Shows the deterministically validated
+  #     packet so the human authorises the EXACT invoices in question. BLOCKS until
+  #     a person signs off; on_timeout: abort means a missed approval NEVER fires
+  #     the payment verb. The browser is not allowed to click the verb until here.
+  - id: approve_payment_action
+    type: approval
+    approval_config:
+      message: >-
+        AUTHORIZE IRREVERSIBLE PORTAL ACTION: "{input.payment_action_label}". The
+        harvest is complete and {steps.file_packet.output.packet_count} invoices
+        were filed clean. This action (e.g. mark-as-paid / enable-autopay /
+        acknowledge) is NEVER auto-clicked. Validated packet:
+        {steps.file_packet.output.packet}. Approve to let a tightly-capped browser
+        step click the requested action ONCE; reject to finish as a pure
+        download-only harvest with nothing acknowledged or paid.
+      show_data: steps.file_packet.output
+      timeout_hours: 24
+      on_timeout: abort
+      allow_edit: false
+
+  # 8b) BROWSER (WRITE pass) - only reached AFTER human approval. A tightly-capped
+  #     playwright step (provider-neutral) re-opens the portal and clicks the
+  #     SINGLE approved action ONCE. captcha_strategy=pause for a final-wall
+  #     challenge; capture_screenshots ON for the write audit trail; max_actions
+  #     tightly capped so there is no runaway clicking. Returns the portal's own
+  #     immediate confirmation, which the next step checks - acceptance is never
+  #     assumed from the click alone.
+  - id: perform_payment_action
+    type: browser
+    depends_on: [approve_payment_action]
+    prompt: >-
+      A human has explicitly authorized this single irreversible action:
+      "{input.payment_action_label}". Log into the relevant portal using the
+      environment credentials, navigate to the exact invoices in the approved
+      packet, and perform ONLY that one approved action (e.g. click acknowledge /
+      mark-as-paid) ONCE. Do NOT enable autopay unless that is literally the
+      approved action, do NOT change any other setting, and do NOT repeat the
+      click. If a CAPTCHA or step-up auth appears at the final wall, PAUSE for a
+      human - do not attempt to solve it. Capture a screenshot of the post-action
+      confirmation screen. Return the portal's own confirmation: confirmed=true
+      only if the portal rendered an explicit success/acknowledgement, plus any
+      reference/confirmation text it printed.
+    browser_config:
+      mode: playwright
+      start_url: "{input.vendor_portals[0].invoices_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 10
+      headless: true
+      credentials_env: "{input.vendor_portals[0].credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          confirmed: { type: boolean }
+          confirmation_text: { type: string }
+          reference_number: { type: string }
+    retry:
+      max_attempts: 1
+      backoff: fixed
+      on_failure: abort
+
+  # 8c) CODE (deterministic) - confirm the portal ITSELF acknowledged the write
+  #     before declaring the payment action a success. A click without a rendered
+  #     confirmation is NOT treated as a win; it routes to a needs-attention notify.
+  #     No model decides this.
+  - id: confirm_payment_action
+    type: code
+    depends_on: [perform_payment_action]
+    code_config:
+      language: python
+      code: |
+        act = _steps.get("perform_payment_action") or {}
+        if not isinstance(act, dict):
+            act = {}
+        inner = act
+        for key in ("output", "data", "result"):
+            cand = act.get(key)
+            if isinstance(cand, dict) and ("confirmed" in cand or "confirmation_text" in cand):
+                inner = cand
+                break
+
+        confirmed = bool(inner.get("confirmed", False))
+        reference = str(inner.get("reference_number", "") or "").strip()
+        confirmation_text = str(inner.get("confirmation_text", "") or "").strip()
+        ok = confirmed and bool(confirmation_text or reference)
+
+        result = {
+            "action_confirmed": ok,
+            "reference_number": reference,
+            "confirmation_text": confirmation_text,
+            "needs_attention": (not ok),
+            "label": str(_input.get("payment_action_label") or ""),
+        }
+
+  # 8d) CONDITION - on a confirmed portal acknowledgement, proceed to the summary;
+  #     on an unconfirmed write, page AP and leave the run needing attention (a
+  #     silently-failed action is NEVER reported as success).
+  - id: payment_action_outcome
+    type: condition
+    depends_on: [confirm_payment_action]
+    condition_config:
+      expression: "{steps.confirm_payment_action.output.action_confirmed} == True"
+      then: [emit_harvest_summary]
+      else: [notify_action_unconfirmed]
+
+  # 8e) NEEDS-ATTENTION alert - the approved portal action could not be confirmed.
+  - id: notify_action_unconfirmed
+    type: notify
+    notify_config:
+      service: "{input.notify_service}"
+      channel: "{input.notify_channel}"
+      message: >-
+        :rotating_light: NEEDS ATTENTION: the approved portal action
+        "{input.payment_action_label}" was attempted but the portal did NOT render
+        a confirmation (confirmed={steps.confirm_payment_action.output.action_confirmed},
+        reference '{steps.confirm_payment_action.output.reference_number}'). Do NOT
+        assume it succeeded - check the portal manually. The harvest packet itself
+        was filed cleanly.
+
+  # 9) CODE (deterministic) - emit the authoritative harvest summary: what was
+  #    filed, the new per-vendor watermarks, exceptions surfaced, and whether a
+  #    payment action ran. This is the convergence point of both the no-action and
+  #    the confirmed-action paths. No model.
+  - id: emit_harvest_summary
+    type: code
+    depends_on: [file_packet]
+    code_config:
+      language: python
+      code: |
+        ext = _steps.get("validate_and_dedupe") or {}
+        if not isinstance(ext, dict):
+            ext = {}
+        filed = _steps.get("file_packet") or {}
+        if not isinstance(filed, dict):
+            filed = {}
+
+        result = {
+            "filed_count": filed.get("packet_count", 0),
+            "ap_inbox_root": filed.get("ap_inbox_root", ""),
+            "period": filed.get("period", ""),
+            "new_watermarks": filed.get("new_watermarks", {}),
+            "valid_count": ext.get("valid_count", 0),
+            "needs_review_count": ext.get("needs_review_count", 0),
+            "scrape_failure_count": ext.get("scrape_failure_count", 0),
+            "packet": filed.get("packet", []),
+            "download_only": (not bool(_input.get("require_payment_action", False))),
+            "summary": "Vendor invoice portal harvest complete: download-only unless an action was explicitly approved.",
+        }
+
+  # 10) DELEGATE (optional) - hand the cleaned, structured VALID invoice batch to
+  #     the existing provider-neutral invoice-processor workflow for three-way
+  #     matching. This is a downstream WORKFLOW, not a vendor agent runtime, so the
+  #     handoff stays provider-neutral. Runs after the summary so only filed,
+  #     validated invoices are delegated.
+  - id: delegate_three_way_match
+    type: delegate
+    depends_on: [emit_harvest_summary]
+    delegate_config:
+      workflow: "invoice_processor"
+      task_description: >-
+        Run three-way matching on this cleaned, deduped, validated invoice batch
+        harvested from supplier billing portals:
+        {steps.file_packet.output.packet}. Each entry carries vendor,
+        invoice_number, invoice_date, currency, total, the filed AP-inbox path,
+        and a GL hint. Match each against its PO and goods-receipt. This is a
+        read/match handoff - do NOT pay or acknowledge anything; payment remains
+        human-gated upstream.
+      timeout: 3600
+
+on_complete:
+  storage_path: "vendor-invoice-portal-harvester/{run_id}/ap-inbox/{period}/invoice-packet.json"

--- a/src/sandcastle/templates/wcag_accessibility_audit_evidence_pack.yaml
+++ b/src/sandcastle/templates/wcag_accessibility_audit_evidence_pack.yaml
@@ -1,0 +1,748 @@
+# name: WCAG Accessibility Audit Evidence Pack
+# description: Runs a deterministic axe-core accessibility scan inside a real rendered browser across a sampled set of journey pages - including states only reachable after interaction (opened modals, expanded menus, SPA route changes) - classifies every violation by WCAG 2.2 success criterion and EAA/ADA/Section-508 clause with pure-Python mapping, scores each page against a configurable max-critical threshold, and ships a timestamped, screenshot-backed remediation dossier to an object-lock (WORM) S3 bucket as the defensible audit evidence pack, with a VPAT-style PDF behind a human filing-approval gate.
+# tags: [wcag, accessibility, axe-core, a11y, eaa, ada, section-508, vpat, browser, playwright, evidence, compliance, trajectory-replay]
+# category: engineering
+
+name: wcag-accessibility-audit-evidence-pack
+description: >-
+  A provider-neutral accessibility conformance harness for the accessibility lead or compliance
+  officer facing the EU Accessibility Act (June 2025+), ADA Title III, or Section 508 - or an a11y
+  audit agency that must produce defensible, reproducible evidence packs. WCAG conformance is
+  defined on the RENDERED DOM and on interaction states: color contrast, ARIA roles, focus order,
+  name/role/value, and violations inside dynamically-injected components (modals, accordions, SPA
+  route changes) only exist after JS executes and after the user interacts, so an http fetch of
+  source HTML cannot see them. This workflow defines or pulls a page+state sample (each entry a URL
+  plus an optional interaction recipe like "open the cart modal"), then LOOPS the sample. For each
+  page a PLAYWRIGHT browser step (provider-neutral: the model only authors the load+interact+axe.run
+  +screenshot script, swappable across providers) loads the page, performs the interaction recipe to
+  reach the target STATE, INJECTS axe-core and runs axe.run against the live accessibility tree, and
+  screenshots each failing node - returning structured axe JSON via output_schema. axe-core does the
+  actual accessibility evaluation deterministically inside the browser; the model never decides
+  conformance. A deterministic Python step then VALIDATES the axe extraction (rejecting empty or
+  malformed scans so a blank read can never pass), normalizes it, maps each axe rule id to its WCAG
+  2.2 success criterion + EAA/508 clause via an inline mapping table, and computes per-page
+  conformance scores and a hard pass/fail against a configurable max-critical threshold - this
+  scoring is the audit-load-bearing math, pure Python, no model. A gate confirms the deterministic
+  threshold verdict via an engine-native human strategy while a swappable llm_eval merely DRAFTS
+  plain-language remediation prose that cannot alter the pass/fail. The canonical axe JSON, scores
+  and screenshots are PUT to an object-lock S3 bucket (the only write - append-only WORM) as the
+  dated evidence pack, a sensor confirms the object is durably sealed, and a VPAT-style PDF report
+  with embedded screenshots and WCAG criterion mapping is generated. If critical violations exceed
+  the threshold, an approval routes to the a11y lead before the report is marked the official filing.
+  Finally a trajectory-replay vs a golden run detects when a UI change silently regresses the scan
+  coverage. Triggered on a schedule (per release / monthly) over a sitemap or defined journey URLs,
+  or fired from a staging-deploy webhook for shift-left a11y gating.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 1800
+
+# Per-release / monthly trigger (cron). Can also be fired from a sensor on a staging-deploy webhook.
+schedule: "0 3 1 * *"
+
+input_schema:
+  required: ["audit_id", "journey_sample"]
+  properties:
+    audit_id:
+      type: string
+      description: "Unique id for this accessibility audit cycle (used in object keys, report title, evidence path)."
+      example: "A11Y-2026-06-RELEASE-4.2"
+    journey_sample:
+      type: string
+      description: >-
+        JSON array of pages+states to scan. Each entry: {url, state_label, interaction_recipe?}.
+        interaction_recipe is an optional plain-language recipe to reach a state only visible after
+        interaction (e.g. "click the cart icon to open the cart modal"). Pulled from a sitemap or a
+        defined set of user-journey URLs upstream. Used to drive the loop.
+      example: '[{"url":"https://app.example.com/checkout","state_label":"cart-modal-open","interaction_recipe":"click the cart icon in the header to open the cart modal"},{"url":"https://app.example.com/pricing","state_label":"default"}]'
+    sitemap_url:
+      type: string
+      description: >-
+        Optional sitemap or journey-config URL to PULL the page sample from when journey_sample is
+        not pre-defined. Fetched read-only via http; the code step prefers journey_sample if present.
+      default: ""
+      example: "https://app.example.com/a11y-journey-config.json"
+    max_critical_per_page:
+      type: integer
+      description: >-
+        The configurable threshold: maximum allowed critical (serious/critical impact) WCAG
+        violations per page before the page FAILS conformance. The deterministic load-bearing
+        pass/fail compares against this. 0 = zero-tolerance for critical violations.
+      default: 0
+      example: "0"
+    wcag_target_level:
+      type: string
+      description: "Target WCAG conformance level for the audit (A, AA, AAA). EAA/Section-508 typically require AA."
+      default: "AA"
+      example: "AA"
+    portal_credentials_env:
+      type: string
+      description: >-
+        Name of the environment variable holding login credentials for GATED journeys (NEVER inline
+        secrets). Passed to the browser step's credentials_env; public pages need no secret.
+      default: "A11Y_PORTAL_CREDS"
+      example: "A11Y_PORTAL_CREDS"
+    s3_base_url:
+      type: string
+      description: "S3 (or S3-compatible) REST base URL for the object-lock (WORM) evidence bucket."
+      default: "https://s3.eu-central-1.amazonaws.com"
+      example: "https://s3.eu-central-1.amazonaws.com"
+    s3_bucket:
+      type: string
+      description: "Object-lock (WORM) bucket that stores the append-only, tamper-evident accessibility evidence pack."
+      default: "a11y-audit-evidence"
+      example: "acme-a11y-audit-evidence"
+    golden_run_id:
+      type: string
+      description: >-
+        ID of the known-good recorded scan run. trajectory-replay diffs the candidate scan coverage
+        against this golden run to detect when a UI change silently regressed which states got scanned.
+      default: "golden-a11y-journey-scan-2026-05-01"
+    a11y_lead_timeout_hours:
+      type: integer
+      description: "Hours the a11y-lead filing approval waits before its timeout fires (on_timeout: abort - never auto-files a failing audit)."
+      default: 48
+      example: "48"
+    report_author:
+      type: string
+      description: "Author/organization printed on the VPAT-style conformance PDF."
+      default: "Accessibility Compliance Office"
+      example: "Accessibility Compliance Office"
+
+steps:
+  # ---------------------------------------------------------------------------
+  # 0) PULL the optional sitemap / journey config (read-only). When the caller did
+  #    not pre-define journey_sample, this lets the next code step harvest URLs from
+  #    a sitemap. Skips cleanly (on_failure: skip) when no sitemap_url is given.
+  # ---------------------------------------------------------------------------
+  - id: pull_sitemap
+    type: http
+    http_config:
+      url: "{input.sitemap_url}"
+      method: GET
+      headers:
+        Accept: "application/json, application/xml, text/plain"
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  # ---------------------------------------------------------------------------
+  # 1) DEFINE the page+state sample DETERMINISTICALLY. Prefer the explicit
+  #    journey_sample input; otherwise harvest URLs from the pulled sitemap. Each
+  #    entry carries url + state_label + optional interaction_recipe so the browser
+  #    loop can reach states only visible after interaction. No model.
+  # ---------------------------------------------------------------------------
+  - id: build_sample
+    type: code
+    depends_on: [pull_sitemap]
+    code_config:
+      language: python
+      code: |
+        import json
+        import re
+
+        # Prefer an explicit, reviewed journey sample over harvested sitemap URLs.
+        raw = _input.get('journey_sample') or ''
+        sample = []
+        if isinstance(raw, list):
+            sample = raw
+        elif isinstance(raw, str) and raw.strip():
+            try:
+                parsed = json.loads(raw)
+                if isinstance(parsed, list):
+                    sample = parsed
+            except (ValueError, TypeError):
+                sample = []
+
+        # Fallback: harvest <loc> URLs from a pulled sitemap (XML or JSON list).
+        if not sample:
+            sm = _steps.get('pull_sitemap') or {}
+            body = sm.get('body') if isinstance(sm, dict) else sm
+            urls = []
+            if isinstance(body, list):
+                for u in body:
+                    if isinstance(u, str):
+                        urls.append(u)
+                    elif isinstance(u, dict) and u.get('url'):
+                        urls.append(str(u.get('url')))
+            elif isinstance(body, str) and body.strip():
+                # Pull URLs out of <loc>...</loc> sitemap entries deterministically.
+                urls = re.findall(r'<loc>\s*([^<\s]+)\s*</loc>', body)
+                if not urls:
+                    urls = re.findall(r'https?://[^\s"\'<>]+', body)
+            sample = [{'url': u, 'state_label': 'default', 'interaction_recipe': ''} for u in urls]
+
+        # Normalize: every entry must have url + state_label; interaction_recipe optional.
+        normalized = []
+        for entry in sample:
+            if not isinstance(entry, dict):
+                continue
+            url = str(entry.get('url') or '').strip()
+            if not url.startswith('http'):
+                continue
+            normalized.append({
+                'url': url,
+                'state_label': str(entry.get('state_label') or 'default').strip(),
+                'interaction_recipe': str(entry.get('interaction_recipe') or '').strip(),
+            })
+
+        result = {
+            'audit_id': _input.get('audit_id'),
+            'page_count': len(normalized),
+            'pages': normalized,
+            'has_pages': len(normalized) > 0,
+        }
+
+  # ---------------------------------------------------------------------------
+  # 2) LOOP over each sampled page+state. The child is the playwright axe-core scan.
+  #    Downstream steps depend_on the loop, not the child, per loop semantics.
+  # ---------------------------------------------------------------------------
+  - id: scan_loop
+    type: loop
+    depends_on: [build_sample]
+    loop_config:
+      over: "steps.build_sample.output.pages"
+      step_ids: [axe_scan_page]
+      max_iterations: 200
+
+  # ---------------------------------------------------------------------------
+  # 2a) BROWSER (PLAYWRIGHT, provider-neutral READ pass). The model AUTHORS a
+  #     Playwright script that: loads _item.url, performs _item.interaction_recipe
+  #     to reach the target STATE (open the modal / expand the menu / route change),
+  #     INJECTS axe-core and runs axe.run() against the LIVE accessibility tree, and
+  #     SCREENSHOTS each failing node. axe-core does the deterministic a11y
+  #     evaluation - the model never judges conformance. capture_screenshots=true so
+  #     the auditor sees the actual rendered failure; captcha_strategy=pause halts for
+  #     a human; credentials_env (never inline) covers gated journeys; max_actions caps
+  #     the interaction recipe; the step only reads/injects/screenshots - no writes.
+  #     output_schema returns structured axe JSON for deterministic downstream scoring.
+  # ---------------------------------------------------------------------------
+  - id: axe_scan_page
+    type: browser
+    prompt: >-
+      You are running an automated WCAG 2.2 {input.wcag_target_level} accessibility scan on a single
+      page STATE. The page to audit is provided as the loop item: {{ _item }} - use its `url`,
+      `state_label`, and optional `interaction_recipe`. Author and run a Playwright script that does
+      exactly this and nothing else: (1) navigate to _item.url; if the page sits behind a login wall,
+      authenticate using the credentials supplied via the environment - never read or print secrets.
+      (2) If `interaction_recipe` is non-empty, perform that interaction to reach the target rendered
+      STATE (for example open the named modal, expand the menu/accordion, or trigger the SPA route
+      change) and wait for the dynamically-injected DOM to settle - this is the whole point, because
+      these violations only exist after JS executes and after the user interacts. (3) INJECT axe-core
+      into the page and run axe.run() against the LIVE accessibility tree of the current state, scoped
+      to WCAG 2.2 {input.wcag_target_level} rules. (4) For every violating node, capture a screenshot
+      of the actual rendered failure and keep a reference to it. Do NOT submit forms, pay, send,
+      delete, or mutate anything - this is a read-only scan that only loads, interacts to reveal a
+      state, injects axe, and screenshots. If a CAPTCHA or unexpected step-up wall appears, PAUSE for
+      a human rather than guessing. Return ONLY the structured object described by output_schema: the
+      raw axe violations (each with its axe rule id, the wcag_criterion tags axe reports, the impact,
+      and the failing nodes with target selector, outerHTML snippet, and screenshot_ref), plus
+      passes_count and incomplete_count, the scanned url and state_label, and axe_ran=true.
+    browser_config:
+      mode: playwright
+      start_url: "{{ _item.url }}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 120
+      max_actions: 50
+      headless: true
+      credentials_env: "{input.portal_credentials_env}"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          url:
+            type: string
+            description: "The URL that was scanned (echoes _item.url)."
+          state_label:
+            type: string
+            description: "The state label reached before scanning (e.g. cart-modal-open)."
+          axe_ran:
+            type: boolean
+            description: "True only if axe-core was successfully injected and axe.run() completed against the live tree."
+          violations:
+            type: array
+            description: "axe-core violations array. Each item is one failing rule."
+            items:
+              type: object
+              properties:
+                id:
+                  type: string
+                  description: "axe rule id (e.g. color-contrast, aria-required-attr, image-alt)."
+                impact:
+                  type: string
+                  description: "axe impact: minor | moderate | serious | critical."
+                wcag_criterion:
+                  type: array
+                  description: "WCAG tag(s) axe attached to this rule (e.g. wcag2aa, wcag143, wcag412)."
+                  items:
+                    type: string
+                description:
+                  type: string
+                  description: "axe human-readable description of the rule that failed."
+                nodes:
+                  type: array
+                  description: "The failing DOM nodes for this rule."
+                  items:
+                    type: object
+                    properties:
+                      target:
+                        type: string
+                        description: "CSS selector / target path of the failing node."
+                      html:
+                        type: string
+                        description: "outerHTML snippet of the failing node."
+                      screenshot_ref:
+                        type: string
+                        description: "Reference to the captured screenshot of this failing node's rendered state."
+          passes_count:
+            type: integer
+            description: "Number of axe checks that passed on this state."
+          incomplete_count:
+            type: integer
+            description: "Number of axe checks that need manual review (incomplete)."
+        required: ["url", "axe_ran", "violations"]
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: abort
+
+  # ---------------------------------------------------------------------------
+  # 3) VALIDATE + NORMALIZE + MAP + SCORE - the audit-LOAD-BEARING deterministic
+  #    math. NO model. First VALIDATES the axe extraction (rejecting empty/malformed
+  #    scans so a blank read can never pass as conformant). Then maps each axe rule id
+  #    -> WCAG 2.2 success criterion + EAA/Section-508 clause via an INLINE mapping
+  #    table, computes a per-page conformance score, counts critical (serious/critical
+  #    impact) violations, and applies the HARD pass/fail vs max_critical_per_page.
+  #    This pass/fail is pure Python and is the official conformance verdict.
+  # ---------------------------------------------------------------------------
+  - id: score_conformance
+    type: code
+    depends_on: [scan_loop]
+    code_config:
+      language: python
+      code: |
+        loop_out = _steps.get('scan_loop') or {}
+        # Loop output may be a list of per-item results or a wrapper dict.
+        if isinstance(loop_out, list):
+            items = loop_out
+        elif isinstance(loop_out, dict):
+            items = loop_out.get('results') or loop_out.get('items') or loop_out.get('output') or []
+        else:
+            items = []
+        if not isinstance(items, list):
+            items = [items]
+
+        max_critical = int(_input.get('max_critical_per_page', 0) or 0)
+        target_level = str(_input.get('wcag_target_level', 'AA') or 'AA').upper()
+
+        # INLINE axe-rule -> (WCAG 2.2 success criterion, EAA/Section-508 clause) mapping table.
+        # Deterministic, model-free. Covers the common axe rule ids; unknown rules fall back to
+        # the rule id itself and a generic clause so nothing is silently dropped.
+        WCAG_MAP = {
+            'color-contrast': {'sc': '1.4.3 Contrast (Minimum)', 'clause': 'EN 301 549 9.1.4.3 / 508 1194.21(c)'},
+            'color-contrast-enhanced': {'sc': '1.4.6 Contrast (Enhanced)', 'clause': 'EN 301 549 9.1.4.6'},
+            'image-alt': {'sc': '1.1.1 Non-text Content', 'clause': 'EN 301 549 9.1.1.1 / 508 1194.22(a)'},
+            'input-image-alt': {'sc': '1.1.1 Non-text Content', 'clause': 'EN 301 549 9.1.1.1'},
+            'area-alt': {'sc': '1.1.1 Non-text Content', 'clause': 'EN 301 549 9.1.1.1'},
+            'label': {'sc': '4.1.2 Name, Role, Value', 'clause': 'EN 301 549 9.4.1.2 / 508 1194.22(n)'},
+            'label-title-only': {'sc': '4.1.2 Name, Role, Value', 'clause': 'EN 301 549 9.4.1.2'},
+            'form-field-multiple-labels': {'sc': '4.1.2 Name, Role, Value', 'clause': 'EN 301 549 9.4.1.2'},
+            'aria-required-attr': {'sc': '4.1.2 Name, Role, Value', 'clause': 'EN 301 549 9.4.1.2'},
+            'aria-required-children': {'sc': '1.3.1 Info and Relationships', 'clause': 'EN 301 549 9.1.3.1'},
+            'aria-required-parent': {'sc': '1.3.1 Info and Relationships', 'clause': 'EN 301 549 9.1.3.1'},
+            'aria-roles': {'sc': '4.1.2 Name, Role, Value', 'clause': 'EN 301 549 9.4.1.2'},
+            'aria-valid-attr': {'sc': '4.1.2 Name, Role, Value', 'clause': 'EN 301 549 9.4.1.2'},
+            'aria-valid-attr-value': {'sc': '4.1.2 Name, Role, Value', 'clause': 'EN 301 549 9.4.1.2'},
+            'aria-hidden-focus': {'sc': '4.1.2 Name, Role, Value', 'clause': 'EN 301 549 9.4.1.2'},
+            'button-name': {'sc': '4.1.2 Name, Role, Value', 'clause': 'EN 301 549 9.4.1.2 / 508 1194.22(n)'},
+            'link-name': {'sc': '4.1.2 Name, Role, Value', 'clause': 'EN 301 549 9.4.1.2'},
+            'document-title': {'sc': '2.4.2 Page Titled', 'clause': 'EN 301 549 9.2.4.2'},
+            'html-has-lang': {'sc': '3.1.1 Language of Page', 'clause': 'EN 301 549 9.3.1.1 / 508 1194.22(i)'},
+            'html-lang-valid': {'sc': '3.1.1 Language of Page', 'clause': 'EN 301 549 9.3.1.1'},
+            'heading-order': {'sc': '1.3.1 Info and Relationships', 'clause': 'EN 301 549 9.1.3.1'},
+            'list': {'sc': '1.3.1 Info and Relationships', 'clause': 'EN 301 549 9.1.3.1'},
+            'listitem': {'sc': '1.3.1 Info and Relationships', 'clause': 'EN 301 549 9.1.3.1'},
+            'definition-list': {'sc': '1.3.1 Info and Relationships', 'clause': 'EN 301 549 9.1.3.1'},
+            'td-headers-attr': {'sc': '1.3.1 Info and Relationships', 'clause': 'EN 301 549 9.1.3.1'},
+            'th-has-data-cells': {'sc': '1.3.1 Info and Relationships', 'clause': 'EN 301 549 9.1.3.1'},
+            'duplicate-id-aria': {'sc': '4.1.1 Parsing', 'clause': 'EN 301 549 9.4.1.1'},
+            'frame-title': {'sc': '4.1.2 Name, Role, Value', 'clause': 'EN 301 549 9.4.1.2'},
+            'tabindex': {'sc': '2.4.3 Focus Order', 'clause': 'EN 301 549 9.2.4.3'},
+            'focus-order-semantics': {'sc': '2.4.3 Focus Order', 'clause': 'EN 301 549 9.2.4.3'},
+            'bypass': {'sc': '2.4.1 Bypass Blocks', 'clause': 'EN 301 549 9.2.4.1 / 508 1194.22(o)'},
+            'meta-viewport': {'sc': '1.4.4 Resize Text', 'clause': 'EN 301 549 9.1.4.4'},
+            'scrollable-region-focusable': {'sc': '2.1.1 Keyboard', 'clause': 'EN 301 549 9.2.1.1'},
+        }
+        GENERIC_CLAUSE = 'EN 301 549 (WCAG 2.2 ' + target_level + ') / Section 508'
+
+        def map_rule(rule_id, axe_tags):
+            entry = WCAG_MAP.get(rule_id)
+            if entry:
+                return entry['sc'], entry['clause']
+            # Fall back to any wcag### tag axe reported, else the rule id itself.
+            tag_hint = ''
+            for t in (axe_tags or []):
+                ts = str(t)
+                if ts.lower().startswith('wcag') and any(ch.isdigit() for ch in ts):
+                    tag_hint = ts
+                    break
+            sc = tag_hint or ('axe:' + str(rule_id))
+            return sc, GENERIC_CLAUSE
+
+        CRITICAL_IMPACTS = ('serious', 'critical')
+
+        def unwrap(it):
+            # A per-page browser result may be nested under output/data/result.
+            if isinstance(it, dict):
+                for k in ('output', 'data', 'result'):
+                    inner = it.get(k)
+                    if isinstance(inner, dict) and ('violations' in inner or 'axe_ran' in inner):
+                        return inner
+            return it if isinstance(it, dict) else {}
+
+        page_reports = []
+        validation_errors = []
+        total_violations = 0
+        total_critical = 0
+        pages_failed = 0
+        pages_scanned = 0
+
+        for raw_item in items:
+            page = unwrap(raw_item)
+            url = str(page.get('url') or '').strip()
+            state_label = str(page.get('state_label') or 'default').strip()
+            axe_ran = bool(page.get('axe_ran', False))
+            violations = page.get('violations')
+            if not isinstance(violations, list):
+                violations = []
+
+            # VALIDATE the extraction: a page that did not actually run axe, or has no url,
+            # is a BAD READ - it must not be scored as conformant (absence of violations from a
+            # failed scan is NOT a pass). Flag it and treat as failing for safety.
+            page_valid = True
+            page_reasons = []
+            if not url.startswith('http'):
+                page_valid = False
+                page_reasons.append('missing/invalid scanned url')
+            if not axe_ran:
+                page_valid = False
+                page_reasons.append('axe-core did not run on this state (blank/failed scan)')
+
+            mapped_violations = []
+            page_critical = 0
+            for v in violations:
+                if not isinstance(v, dict):
+                    continue
+                rule_id = str(v.get('id') or 'unknown-rule')
+                impact = str(v.get('impact') or 'moderate').lower()
+                axe_tags = v.get('wcag_criterion') if isinstance(v.get('wcag_criterion'), list) else []
+                sc, clause = map_rule(rule_id, axe_tags)
+                nodes = v.get('nodes') if isinstance(v.get('nodes'), list) else []
+                node_count = len(nodes)
+                is_critical = impact in CRITICAL_IMPACTS
+                if is_critical:
+                    page_critical += 1
+                mapped_violations.append({
+                    'rule_id': rule_id,
+                    'impact': impact,
+                    'is_critical': is_critical,
+                    'wcag_success_criterion': sc,
+                    'eaa_508_clause': clause,
+                    'node_count': node_count,
+                    'description': str(v.get('description') or ''),
+                    'nodes': nodes,
+                })
+
+            # Per-page conformance score: 1.0 = clean. Each violation costs, criticals cost more.
+            violation_count = len(mapped_violations)
+            penalty = sum((3 if mv['is_critical'] else 1) for mv in mapped_violations)
+            score = round(max(0.0, 1.0 - (penalty / 25.0)), 4)
+
+            # HARD deterministic pass/fail: a page passes only if it was a valid scan AND its
+            # critical count is within the configured threshold.
+            page_pass = bool(page_valid and (page_critical <= max_critical))
+
+            pages_scanned += 1
+            total_violations += violation_count
+            total_critical += page_critical
+            if not page_pass:
+                pages_failed += 1
+            if not page_valid:
+                validation_errors.append({'url': url or '(unknown)', 'state_label': state_label, 'reasons': page_reasons})
+
+            page_reports.append({
+                'url': url,
+                'state_label': state_label,
+                'axe_ran': axe_ran,
+                'valid_scan': page_valid,
+                'validation_reasons': page_reasons,
+                'violation_count': violation_count,
+                'critical_count': page_critical,
+                'conformance_score': score,
+                'page_pass': page_pass,
+                'passes_count': int(page.get('passes_count') or 0),
+                'incomplete_count': int(page.get('incomplete_count') or 0),
+                'violations': mapped_violations,
+            })
+
+        overall_score = round(sum(p['conformance_score'] for p in page_reports) / len(page_reports), 4) if page_reports else 0.0
+        # The audit FAILS (criticals exceed threshold) if any page failed or any scan was invalid.
+        criticals_exceed_threshold = bool(pages_failed > 0 or len(validation_errors) > 0 or pages_scanned == 0)
+
+        result = {
+            'audit_id': _input.get('audit_id'),
+            'wcag_target_level': target_level,
+            'max_critical_per_page': max_critical,
+            'pages_scanned': pages_scanned,
+            'pages_failed': pages_failed,
+            'total_violations': total_violations,
+            'total_critical': total_critical,
+            'overall_conformance_score': overall_score,
+            'criticals_exceed_threshold': criticals_exceed_threshold,
+            'has_invalid_scans': len(validation_errors) > 0,
+            'validation_errors': validation_errors,
+            'page_reports': page_reports,
+        }
+
+  # ---------------------------------------------------------------------------
+  # 4) GATE. The BINDING pass/fail is engine-native and NON-LLM: a human strategy
+  #    confirms the DETERMINISTIC threshold verdict computed above (the human signs
+  #    off on the mechanical score, they do not recompute it). A swappable llm_eval
+  #    ONLY drafts plain-language remediation guidance per violation and is advisory -
+  #    it cannot change the conformance score. ALL strategies must pass.
+  # ---------------------------------------------------------------------------
+  - id: conformance_gate
+    type: gate
+    depends_on: [score_conformance]
+    gate_config:
+      strategies:
+        # Advisory only: drafts remediation prose. Pin to ANY provider (swappable).
+        # Its verdict is non-binding on the conformance score, which is set in Python.
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are an accessibility remediation advisor. Read this deterministically-scored axe
+              report. For each WCAG violation, draft one short plain-language remediation tip (what
+              to change in the markup/CSS). Then reply with exactly the single word 'approved' to
+              acknowledge you have drafted guidance. Your reply does NOT determine conformance - the
+              pass/fail is already fixed by the Python score - so always reply 'approved' once you
+              have drafted guidance. Report: {steps.score_conformance.output}
+            input: "{steps.score_conformance.output}"
+            model: sonnet
+        # Binding, engine-native, non-LLM: a human attests to the mechanical verdict.
+        - type: human
+          config:
+            message: >-
+              Accessibility reviewer: confirm the deterministic scan results are complete before the
+              evidence pack is sealed. Pages scanned: {steps.score_conformance.output.pages_scanned},
+              pages failed: {steps.score_conformance.output.pages_failed}, total critical violations:
+              {steps.score_conformance.output.total_critical}, overall score:
+              {steps.score_conformance.output.overall_conformance_score}. Invalid/blank scans:
+              {steps.score_conformance.output.has_invalid_scans}. Confirm to proceed with sealing.
+            timeout_hours: 48
+            on_timeout: abort
+
+  # ---------------------------------------------------------------------------
+  # 5) ASSEMBLE the canonical, dated evidence pack DETERMINISTICALLY (no model):
+  #    the normalized axe JSON, per-page scores, WCAG/EAA mapping, screenshot refs,
+  #    a generation timestamp, and a SHA-256 over the canonical bytes so the pack is
+  #    tamper-evident at rest. Produces the S3 object key for the WORM write.
+  # ---------------------------------------------------------------------------
+  - id: assemble_evidence
+    type: code
+    depends_on: [conformance_gate]
+    code_config:
+      language: python
+      code: |
+        import json
+        import hashlib
+        from datetime import datetime, timezone
+
+        scored = _steps.get('score_conformance') or {}
+        if not isinstance(scored, dict):
+            scored = {}
+
+        generated_at = datetime.now(timezone.utc).isoformat()
+        audit_id = str(_input.get('audit_id') or 'audit')
+        date_stamp = generated_at[:10]
+
+        evidence = {
+            'audit_id': audit_id,
+            'generated_at': generated_at,
+            'wcag_target_level': scored.get('wcag_target_level'),
+            'max_critical_per_page': scored.get('max_critical_per_page'),
+            'totals': {
+                'pages_scanned': scored.get('pages_scanned', 0),
+                'pages_failed': scored.get('pages_failed', 0),
+                'total_violations': scored.get('total_violations', 0),
+                'total_critical': scored.get('total_critical', 0),
+                'overall_conformance_score': scored.get('overall_conformance_score', 0.0),
+            },
+            'criticals_exceed_threshold': bool(scored.get('criticals_exceed_threshold', True)),
+            'page_reports': scored.get('page_reports', []),
+            'validation_errors': scored.get('validation_errors', []),
+        }
+
+        # Canonical (sorted-key) serialization so the integrity hash is reproducible.
+        canonical = json.dumps(evidence, sort_keys=True, separators=(',', ':'))
+        digest = hashlib.sha256(canonical.encode('utf-8')).hexdigest()
+        object_key = 'evidence/' + audit_id + '/' + date_stamp + '/axe-evidence-pack.json'
+
+        result = {
+            'audit_id': audit_id,
+            'object_key': object_key,
+            'sha256': digest,
+            'byte_length': len(canonical),
+            'generated_at': generated_at,
+            'canonical_json': canonical,
+            'evidence_pack': evidence,
+        }
+
+  # ---------------------------------------------------------------------------
+  # 6) WRITE (the ONLY irreversible action - append-only WORM): PUT the canonical
+  #    axe JSON + scores + screenshot refs to the object-lock S3 bucket as the dated
+  #    evidence pack. Object-lock COMPLIANCE mode + retain-until makes it WORM; the
+  #    SHA-256 rides as object metadata so the pack is tamper-evident. Secrets come
+  #    from env (aws4), never inline. This append-only write needs no human approval
+  #    (it cannot overwrite or destroy); the OFFICIAL FILING of the report is what is
+  #    gated by a human below.
+  # ---------------------------------------------------------------------------
+  - id: seal_evidence_pack
+    type: http
+    depends_on: [assemble_evidence]
+    http_config:
+      url: "{input.s3_base_url}/{input.s3_bucket}/{steps.assemble_evidence.output.object_key}"
+      method: PUT
+      headers:
+        Content-Type: "application/json"
+        x-amz-object-lock-mode: "COMPLIANCE"
+        x-amz-object-lock-retain-until-date: "2034-01-01T00:00:00Z"
+        x-amz-meta-sha256: "{steps.assemble_evidence.output.sha256}"
+        x-amz-meta-audit-id: "{input.audit_id}"
+      auth: "aws4:{env.AWS_ACCESS_KEY_ID}:{env.AWS_SECRET_ACCESS_KEY}"
+      body: "{steps.assemble_evidence.output.canonical_json}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # ---------------------------------------------------------------------------
+  # 7) CONFIRM the write took effect (engine-native SENSOR, no model). Poll the
+  #    object's HEAD on S3 until it is durably present - the evidence pack is not
+  #    declared sealed on the PUT's word alone; the bucket itself must confirm.
+  # ---------------------------------------------------------------------------
+  - id: confirm_sealed
+    type: sensor
+    depends_on: [seal_evidence_pack]
+    sensor_config:
+      url: "{input.s3_base_url}/{input.s3_bucket}/{steps.assemble_evidence.output.object_key}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200"
+      check_interval: 30
+      timeout: 1800
+
+  # ---------------------------------------------------------------------------
+  # 8) REPORT - VPAT-style conformance PDF with embedded screenshots of the actual
+  #    rendered failures and the WCAG 2.2 success-criterion / EAA-508 clause mapping.
+  #    Generated from the sealed, deterministically-scored evidence. The prose reflects
+  #    the Python verdict; it does not recompute conformance.
+  # ---------------------------------------------------------------------------
+  - id: conformance_report
+    type: report
+    depends_on: [confirm_sealed]
+    report_config:
+      template: "research-report"
+      format: pdf
+      theme: professional
+      title: "VPAT / WCAG 2.2 Accessibility Conformance Report - {input.audit_id}"
+      author: "{input.report_author}"
+    prompt: |
+      Produce a formal VPAT-style WCAG 2.2 accessibility conformance report (PDF) for the audit file
+      from the payload below. Open with the audit id, generation timestamp, target conformance level,
+      and the headline totals: pages scanned, pages failed, total violations, total critical
+      violations, and the overall conformance score. Then, for EACH scanned page+state, list its URL
+      and state label, its per-page conformance score and pass/fail, and a table of every violation
+      showing: axe rule id, impact, the mapped WCAG 2.2 success criterion, the EAA / EN 301 549 /
+      Section 508 clause, the failing node selectors, and the embedded screenshot reference of the
+      actual rendered failure. Clearly mark any page whose scan was invalid/blank as NON-CONFORMANT
+      (a failed scan is never reported as a pass). State plainly whether critical violations exceeded
+      the configured per-page threshold. Use only the structured facts below; do not invent results.
+      Evidence pack: {steps.assemble_evidence.output.evidence_pack}. Integrity SHA-256:
+      {steps.assemble_evidence.output.sha256}. Sealed object: {steps.assemble_evidence.output.object_key}.
+
+  # ---------------------------------------------------------------------------
+  # 9) CONDITION (deterministic, on the Python verdict). If critical violations
+  #    exceeded the threshold, route to a human a11y-lead approval BEFORE the report
+  #    is marked the official filing. Otherwise mark it filed automatically. The
+  #    trajectory-replay coverage check runs in both branches.
+  # ---------------------------------------------------------------------------
+  - id: filing_route
+    type: condition
+    depends_on: [conformance_report]
+    condition_config:
+      expression: "{steps.score_conformance.output.criticals_exceed_threshold} == True"
+      then: [a11y_lead_filing_approval, replay_coverage_check]
+      else: [mark_official_filing, replay_coverage_check]
+
+  # 9a) FAILING-AUDIT PATH - critical violations exceeded the threshold. A human
+  #     a11y lead must explicitly approve before this conformance report becomes the
+  #     official filing. on_timeout: abort - a failing audit is NEVER auto-filed.
+  - id: a11y_lead_filing_approval
+    type: approval
+    depends_on: [filing_route]
+    approval_config:
+      message: >-
+        ACCESSIBILITY FILING APPROVAL REQUIRED - audit {input.audit_id} has critical WCAG violations
+        that EXCEED the configured threshold ({steps.score_conformance.output.total_critical} critical
+        across {steps.score_conformance.output.pages_failed} failing page(s), overall score
+        {steps.score_conformance.output.overall_conformance_score}). The evidence pack is already
+        sealed to the object-lock bucket (sha256 {steps.assemble_evidence.output.sha256}). Review the
+        VPAT-style report and the screenshot-backed failures, then approve to mark this as the OFFICIAL
+        conformance filing, or reject to hold it pending remediation.
+      show_data: steps.score_conformance.output
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: false
+
+  # 9b) PASSING-AUDIT PATH - within threshold; mark filed deterministically.
+  - id: mark_official_filing
+    type: code
+    depends_on: [filing_route]
+    code_config:
+      language: python
+      code: |
+        assembled = _steps.get('assemble_evidence') or {}
+        scored = _steps.get('score_conformance') or {}
+        result = {
+            'audit_id': _input.get('audit_id'),
+            'official_filing': True,
+            'auto_filed': True,
+            'reason': 'within max_critical_per_page threshold',
+            'overall_conformance_score': scored.get('overall_conformance_score', 0.0),
+            'evidence_object': assembled.get('object_key', ''),
+            'evidence_sha256': assembled.get('sha256', ''),
+        }
+
+  # ---------------------------------------------------------------------------
+  # 10) TRAJECTORY-REPLAY (reliability layer, read-only). Diff THIS scan run against
+  #     the golden run to detect when a UI change silently regressed scan coverage -
+  #     e.g. an interaction recipe no longer reaches the modal, so a whole state stops
+  #     being scanned and the audit goes quietly blind. Fails on coverage drift or
+  #     cost blowup. Deterministic scorer, not a model's opinion.
+  # ---------------------------------------------------------------------------
+  - id: replay_coverage_check
+    type: trajectory-replay
+    depends_on: [filing_route]
+    trajectory_replay_config:
+      golden_run_id: "{input.golden_run_id}"
+      fail_below_score: 0.85
+      allow_cost_delta_pct: 15.0
+      cost_budget_usd: 0.50
+
+on_complete:
+  storage_path: "wcag-accessibility-audit-evidence-pack/{run_id}/result.json"

--- a/src/sandcastle/templates/workers_comp_fnol_insurance_filer.yaml
+++ b/src/sandcastle/templates/workers_comp_fnol_insurance_filer.yaml
@@ -1,0 +1,732 @@
+# name: Workers Comp FNOL Insurance Filer
+# description: Files a First-Notice-of-Loss / workers-comp injury claim into a carrier or state workers-comp board (WCB) portal directly from an HR intake record, captures the carrier/board-issued claim number plus the stamped receipt, and routes the confirmation back to HR - all within the statutory filing window. Carrier broker portals and state WCB systems are login-walled multi-page injury forms with NO filing API for most submitters, so HR/risk ops and TPAs re-key the same injury into dozens of different portals by hand against hard deadlines. This template fires on a new approved-to-file incident, loads the intake record, deterministically validates that mandatory FNOL fields are present and the filing is still inside the statutory window (fails closed), maps the free-text injury description to the portal's body-part / cause-of-injury code list with a provider-neutral classify (race failover), drives the portal READ-ONLY in playwright mode to fill the multi-page form and STOP at review, re-validates the extracted review against the mapped codes and the intake FEIN with deterministic code, holds for a human HR/adjuster approval because the data is PII/medical and legally consequential, only then submits in a second playwright write pass, asserts the claim-number pattern deterministically AND sensor-polls the portal's own status page for the stamped receipt before declaring the claim filed, then notifies HR and archives the receipt. The browser steps ride default_model and stay fully swappable; the load-bearing correctness is deterministic code + a sensor confirmation, never one model's opinion.
+# tags: [WorkersComp, FNOL, InjuryClaim, WCB, CarrierPortal, TPA, HR, RPA, Playwright, HumanInTheLoop, ProviderNeutral, StatutoryDeadline]
+# category: hr_legal
+
+name: workers-comp-fnol-insurance-filer
+description: >-
+  Files a workers-comp First Notice of Loss (FNOL) injury claim into a carrier broker portal or a
+  state workers-comp board (WCB) system from an HR intake record, then routes the carrier/board claim
+  number and stamped receipt back to HR - inside the statutory filing window. Built for HR/risk
+  operations or a third-party claims administrator (TPA) that must file FNOL into many DIFFERENT
+  carrier and state-board portals and cannot rely on an API: most WCB systems and carrier portals are
+  login-walled, multi-page injury forms with no submitter-facing filing API, so the claim is created
+  only by completing the portal's wizard and clicking Submit - http cannot authenticate or drive the
+  SPA. The flow is split read-from-write and fails closed. It is TRIGGERED by a sensor watching the HR
+  intake source (a postgresql incidents table or a watched form-submission queue, read through a
+  read-only data gateway) firing when a new injury report with status=approved_to_file appears. An http
+  step then loads the full intake record (employee, injury date, body part, employer FEIN, wage data).
+  A DETERMINISTIC code step validates that every mandatory FNOL field is non-empty and that the filing
+  is still within the jurisdiction's statutory window - missing data or a blown deadline fails closed
+  and notifies HR, nothing touches a portal. A provider-neutral classify maps the free-text injury
+  description to the portal's body-part and cause-of-injury code list (race failover keeps it model
+  agnostic). A playwright-mode browser step logs in via WC_PORTAL_CREDS (captcha_strategy=pause),
+  opens New Claim, fills the multi-page form using the mapped codes, advances to the REVIEW page and
+  STOPS - returning {claimant, employer_fein, injury_code, jurisdiction, review_summary} via
+  output_schema. A second deterministic code step cross-checks the extracted injury_code against the
+  classify output and the employer_fein against the intake record - any mismatch blocks submission. A
+  mandatory human approval (HR/adjuster) signs off on the review_summary plus the captured screenshot,
+  because the filing carries medical PII and statutory liability. Only then does a second playwright
+  step resume, click Submit ONCE, and capture {claim_number, receipt_screenshot, submitted_at}. The
+  carrier/board claim number is asserted against the expected pattern deterministically AND a sensor
+  polls the portal's own status page for the stamped receipt before success is declared, so a
+  silently-failed submit can never be recorded as a filed claim. Finally HR is notified into the
+  injured worker's case file and the stamped receipt is archived to object storage. Every browser step
+  rides default_model and stays swappable across the 7 providers; the injury-code classify runs with
+  race-based cross-provider failover; the deadline/identity validators and the receipt sensor are pure
+  engine logic, so swapping the model never changes filing behavior.
+
+default_model: sonnet
+default_max_turns: 10
+default_timeout: 1800
+
+input_schema:
+  required: ["intake_record_url", "portal_start_url", "jurisdiction"]
+  properties:
+    intake_record_url:
+      type: string
+      description: "Read-only data-gateway URL (PostgREST-style view over the HR 'incidents' table, or the form-submission-queue API) returning the FULL approved-to-file injury record as JSON. http loads it; postgresql has no submitter filing API so this is the deterministic intake read."
+      example: "https://hr-gateway.internal/rest/v1/incidents?id=eq.INC-2026-0481&status=eq.approved_to_file"
+    portal_start_url:
+      type: string
+      description: "Start URL of the carrier broker portal or state WCB system's New-Claim / FNOL wizard for this jurisdiction (login-walled SPA, no filing API). Templated into both browser steps' start_url."
+      example: "https://efile.wcb.ny.gov/fnol/new"
+    jurisdiction:
+      type: string
+      description: "State / board jurisdiction code that selects the statutory filing window and the expected claim-number pattern (e.g. NY, CA, TX, or a carrier key like sedgwick-tpa)."
+      example: "NY"
+    intake_trigger_url:
+      type: string
+      description: "Status endpoint the trigger sensor polls; fires when a new injury report reaches status=approved_to_file in the incidents table / form queue. Pure control flow, no model."
+      default: "https://hr-gateway.internal/rest/v1/incidents?select=count&status=eq.approved_to_file&filed=is.null"
+      example: "https://hr-gateway.internal/rest/v1/incidents?select=count&status=eq.approved_to_file&filed=is.null"
+    statutory_window_days:
+      type: integer
+      description: "Statutory deadline in days from date_of_injury within which the FNOL must be filed for this jurisdiction. The deterministic validator fails closed if the filing is past this window."
+      default: 30
+      example: "30"
+    claim_number_pattern:
+      type: string
+      description: "Regex the carrier/board-issued claim_number MUST match (deterministic success gate). Defaults to a generic WC-claim shape; override per jurisdiction/carrier."
+      default: "^[A-Z0-9]{2,8}-?[A-Z0-9]{4,}$"
+      example: "^WC-[0-9]{4}-[0-9]{6,10}$"
+    portal_status_url:
+      type: string
+      description: "URL of the portal's own claim-status / receipt page for this filing; the post-submit sensor re-reads it until a stamped receipt / accepted status appears, confirming the claim provably landed."
+      default: ""
+      example: "https://efile.wcb.ny.gov/claims/{claim_number}/status"
+    hr_case_file_email:
+      type: string
+      description: "HR / case-management email the filed claim number and receipt reference are routed to (writes into the injured worker's case file)."
+      default: ""
+      example: "wc-intake@employer.example"
+    receipt_archive_url:
+      type: string
+      description: "Object-storage (S3-compatible) PUT URL where the stamped receipt screenshot is archived for the statutory audit trail. http PUT performs the archive (no dedicated s3 step type in the engine)."
+      default: "https://s3.internal.example/wc-fnol-receipts"
+      example: "https://s3.internal.example/wc-fnol-receipts"
+    notify_channel:
+      type: string
+      description: "Slack channel for HR/risk-ops filed/blocked/needs-attention notifications."
+      default: "#wc-fnol-filing"
+      example: "#wc-fnol-filing"
+    sensor_poll_interval_seconds:
+      type: integer
+      description: "Seconds between status-page polls while waiting for the portal to render the stamped receipt after submit."
+      default: 60
+      example: "60"
+    sensor_timeout_seconds:
+      type: integer
+      description: "Hard ceiling in seconds the receipt sensor waits for portal confirmation before the run is routed to needs-attention (never reported as a filed claim)."
+      default: 3600
+      example: "3600"
+
+steps:
+  # 0) TRIGGER (engine-native SENSOR) - watch the HR intake source (the postgresql 'incidents' table
+  #    or the watched form-submission queue, read through the read-only data gateway). Fire when a new
+  #    injury report with status=approved_to_file (and not yet filed) appears. Pure control flow, no
+  #    model. Hard timeout so the watch is bounded.
+  - id: await_approved_intake
+    type: sensor
+    sensor_config:
+      url: "{input.intake_trigger_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and (int((response[0].get('count', 0)) if isinstance(response, list) and response else response.get('count', 0) or 0) > 0)"
+      check_interval: 60
+      timeout: 86400
+
+  # 1) LOAD the intake record (postgresql/form-queue -> deterministic http GET through the read-only
+  #    data gateway). Returns the FULL approved-to-file injury record: employee, injury date, body
+  #    part, employer FEIN, wage data, jurisdiction. No model; pure data fetch.
+  - id: load_intake
+    type: http
+    depends_on: [await_approved_intake]
+    http_config:
+      url: "{input.intake_record_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.HR_GATEWAY_TOKEN}"
+      value_map:
+        record: "$"
+
+  # 2) DETERMINISTIC FNOL validation (sandboxed Python, no model). Confirm every mandatory FNOL field
+  #    is non-empty AND the filing is still inside the jurisdiction's statutory window (date_of_injury
+  #    + statutory_window_days >= today). Fails CLOSED - a missing field or a blown deadline means
+  #    nothing routes to a portal.
+  - id: validate_fnol
+    type: code
+    depends_on: [load_intake]
+    code_config:
+      language: python
+      code: |
+        import json
+        from datetime import date, datetime
+
+        # --- Pull the intake record out of the http load (the gateway may nest it or return a list). ---
+        loaded = _steps.get('load_intake') or {}
+        if not isinstance(loaded, dict):
+            loaded = {}
+        rec = loaded
+        for key in ('record', 'output', 'data', 'result', 'response', 'body'):
+            inner = loaded.get(key)
+            if isinstance(inner, dict):
+                rec = inner
+                break
+            if isinstance(inner, list) and inner and isinstance(inner[0], dict):
+                rec = inner[0]
+                break
+        # A bare list payload (PostgREST returns an array) - take the first row.
+        if isinstance(rec, list):
+            rec = rec[0] if (rec and isinstance(rec[0], dict)) else {}
+        if not isinstance(rec, dict):
+            rec = {}
+
+        problems = []
+
+        # --- Mandatory FNOL fields for ANY workers-comp filing. ---
+        required = ['employee_name', 'date_of_injury', 'body_part', 'employer_fein',
+                    'injury_description', 'wage_amount']
+        for k in required:
+            if not str(rec.get(k, '') or '').strip():
+                problems.append('missing mandatory FNOL field: ' + k)
+
+        # --- Employer FEIN format: 9 digits (optionally NN-NNNNNNN). Carried as the identity guard. ---
+        fein_raw = str(rec.get('employer_fein', '') or '').strip()
+        fein_digits = fein_raw.replace('-', '').replace(' ', '')
+        if fein_digits and not (fein_digits.isdigit() and len(fein_digits) == 9):
+            problems.append('employer_fein "' + fein_raw + '" is not a valid 9-digit FEIN')
+
+        # --- Numeric sanity on the reported wage. ---
+        def _num(v):
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return -1.0
+        wage_amount = _num(rec.get('wage_amount'))
+        if wage_amount < 0:
+            problems.append('wage_amount missing or not numeric')
+
+        # --- STATUTORY WINDOW: date_of_injury must parse and be within window_days of today. ---
+        def _parse_date(s):
+            s = str(s or '').strip()[:10]
+            try:
+                return datetime.strptime(s, '%Y-%m-%d').date()
+            except (TypeError, ValueError):
+                return None
+        doi = _parse_date(rec.get('date_of_injury'))
+        window_days = 30
+        try:
+            window_days = int(_input.get('statutory_window_days', 30) or 30)
+        except (TypeError, ValueError):
+            window_days = 30
+        days_since = None
+        within_window = False
+        if doi is None:
+            problems.append('date_of_injury did not parse as YYYY-MM-DD')
+        else:
+            days_since = (date.today() - doi).days
+            if days_since < 0:
+                problems.append('date_of_injury is in the future')
+            elif days_since > window_days:
+                problems.append('STATUTORY DEADLINE BLOWN: ' + str(days_since)
+                                + ' days since injury > ' + str(window_days) + '-day window')
+            else:
+                within_window = True
+
+        ok = (len(problems) == 0) and within_window
+
+        result = {
+            'ok': ok,
+            'problems': problems,
+            'within_statutory_window': within_window,
+            'days_since_injury': days_since,
+            'window_days': window_days,
+            'employee_name': str(rec.get('employee_name', '') or '').strip(),
+            'date_of_injury': str(rec.get('date_of_injury', '') or '').strip(),
+            'body_part': str(rec.get('body_part', '') or '').strip(),
+            'employer_fein': fein_digits,
+            'employer_fein_display': fein_raw,
+            'injury_description': str(rec.get('injury_description', '') or '').strip(),
+            'wage_amount': round(wage_amount, 2) if wage_amount >= 0 else None,
+            'jurisdiction': str(rec.get('jurisdiction', '') or _input.get('jurisdiction', '') or '').strip(),
+            'incident_id': str(rec.get('id', rec.get('incident_id', '')) or '').strip(),
+        }
+
+  # 2b) Hard stop on a bad/late intake - never touch a portal with incomplete data or past deadline.
+  - id: fnol_gate
+    type: condition
+    depends_on: [validate_fnol]
+    condition_config:
+      expression: "{steps.validate_fnol.output.ok} == True"
+      then: [map_injury_codes]
+      else: [notify_blocked]
+
+  # 2c) Blocked branch: tell HR the FNOL was NOT filed and why. Nothing was submitted.
+  - id: notify_blocked
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        WC FNOL for incident {steps.validate_fnol.output.incident_id} (employee
+        {steps.validate_fnol.output.employee_name}, jurisdiction {input.jurisdiction}) was BLOCKED
+        before any portal entry. Validation failed: {steps.validate_fnol.output.problems}. No claim
+        was filed. Fix the intake record or escalate the deadline and re-run.
+
+  # 3) MAP the free-text injury description to the portal's BODY-PART / CAUSE-OF-INJURY code list
+  #    (provider-neutral classify; runs on any of the 7 providers - the engine can race/failover it).
+  #    Emits the mapped portal codes the playwright fill will use.
+  - id: map_injury_codes
+    type: classify
+    depends_on: [fnol_gate]
+    model: haiku
+    classify_config:
+      model: haiku
+      input: >-
+        You are mapping a free-text workers-comp injury report onto a carrier/state-WCB portal's coded
+        injury taxonomy so an RPA can fill the FNOL wizard. Choose the SINGLE best body-part /
+        cause-of-injury bucket for this injury. Body part: {steps.validate_fnol.output.body_part} .
+        Injury description: {steps.validate_fnol.output.injury_description} . Jurisdiction:
+        {input.jurisdiction} . Categories map to the portal code groups: 'back_strain_overexertion' for
+        lifting/overexertion back or neck injuries; 'fall_slip_trip' for falls, slips and trips;
+        'struck_by_caught_in' for being struck by or caught in/between objects or machinery;
+        'cut_laceration_puncture' for cuts, lacerations and punctures; 'burn_chemical_thermal' for
+        thermal/chemical/electrical burns; 'repetitive_motion' for repetitive-motion / cumulative-trauma
+        injuries; 'other_unmapped' when the description does not clearly fit a single code group and a
+        human must pick the code. Return the one category that best fits.
+      categories:
+        - back_strain_overexertion
+        - fall_slip_trip
+        - struck_by_caught_in
+        - cut_laceration_puncture
+        - burn_chemical_thermal
+        - repetitive_motion
+        - other_unmapped
+      branches:
+        back_strain_overexertion: [fill_to_review]
+        fall_slip_trip: [fill_to_review]
+        struck_by_caught_in: [fill_to_review]
+        cut_laceration_puncture: [fill_to_review]
+        burn_chemical_thermal: [fill_to_review]
+        repetitive_motion: [fill_to_review]
+        other_unmapped: [fill_to_review]
+
+  # 4) FILL PASS (playwright mode, provider-neutral). The reasoning model AUTHORS a Playwright script
+  #    that logs in via WC_PORTAL_CREDS (never inlined), opens New Claim, fills the multi-page injury
+  #    form from the validated intake using the mapped injury code, advances to the REVIEW page and
+  #    STOPS - it does NOT submit. captcha_strategy=pause hands a login/portal CAPTCHA to a human;
+  #    max_actions caps the wizard loop; capture_screenshots gives an auditable review screenshot;
+  #    output_schema returns the structured review for the deterministic cross-check + human approval.
+  - id: fill_to_review
+    type: browser
+    depends_on: [map_injury_codes]
+    prompt: >-
+      You are filing a workers-comp First Notice of Loss on a carrier broker portal or state
+      workers-comp board (WCB) wizard. Authenticate using the WC_PORTAL_CREDS environment variable,
+      then open 'New Claim' / 'File FNOL'. Fill EVERY required field of the multi-page injury form from
+      this validated intake record: claimant/employee {steps.validate_fnol.output.employee_name},
+      date of injury {steps.validate_fnol.output.date_of_injury}, employer FEIN
+      {steps.validate_fnol.output.employer_fein_display}, jurisdiction {input.jurisdiction}, average
+      weekly wage {steps.validate_fnol.output.wage_amount}, injured body part
+      {steps.validate_fnol.output.body_part}, and narrative
+      {steps.validate_fnol.output.injury_description}. For the portal's coded body-part /
+      cause-of-injury field, select the option corresponding to this mapped code:
+      {steps.map_injury_codes.output}. Wait for client-side validation to settle before advancing each
+      page. CRITICAL: advance ONLY to the final REVIEW / SUMMARY page and STOP there - DO NOT click the
+      final Submit / File Claim button. Submission is a separate, human-approved step. If a CAPTCHA or
+      step-up auth appears, pause for a human. Return ONLY the structured object described by the
+      output schema: the claimant as shown on the review page, the employer_fein as shown, the coded
+      injury_code the portal will record, the jurisdiction, a human-readable review_summary of every
+      value on the review page, a reference to the captured review screenshot, and whether the final
+      submit button is present and enabled.
+    browser_config:
+      mode: playwright
+      start_url: "{input.portal_start_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 600
+      max_actions: 120
+      headless: true
+      credentials_env: "WC_PORTAL_CREDS"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          claimant: { type: string }
+          employer_fein: { type: string }
+          injury_code: { type: string }
+          jurisdiction: { type: string }
+          review_summary: { type: string }
+          review_screenshot: { type: string }
+          submit_button_present: { type: boolean }
+
+  # 5) DETERMINISTIC CROSS-CHECK of the FILLED review state (no model). The load-bearing pre-submit
+  #    guard: the extracted injury_code must equal the classify output, the extracted employer_fein
+  #    must equal the intake FEIN, the claimant must echo the intake, and the wizard must have actually
+  #    reached a submit-capable review page with a screenshot. Any mismatch fails CLOSED.
+  - id: validate_review
+    type: code
+    depends_on: [fill_to_review]
+    code_config:
+      language: python
+      code: |
+        # Unwrap the browser READ pass (it may nest the structured payload).
+        read_out = _steps.get('fill_to_review') or {}
+        if not isinstance(read_out, dict):
+            read_out = {}
+        for key in ('output', 'data', 'result'):
+            inner = read_out.get(key)
+            if isinstance(inner, dict) and ('injury_code' in inner or 'review_summary' in inner):
+                read_out = inner
+                break
+
+        fnol = _steps.get('validate_fnol') or {}
+        if not isinstance(fnol, dict):
+            fnol = {}
+
+        # The classify output may be a bare string category or a dict carrying a 'category'.
+        cls = _steps.get('map_injury_codes')
+        mapped_code = ''
+        if isinstance(cls, dict):
+            mapped_code = str(cls.get('category', cls.get('output', cls.get('result', ''))) or '').strip()
+        else:
+            mapped_code = str(cls or '').strip()
+        mapped_code = mapped_code.strip().lower()
+
+        problems = []
+
+        # --- Injury code on the review page must match the deterministically-derived classify code. ---
+        got_code = str(read_out.get('injury_code', '') or '').strip().lower()
+        if not got_code:
+            problems.append('review page returned no injury_code')
+        elif mapped_code and got_code != mapped_code:
+            problems.append('review injury_code "' + got_code + '" != mapped code "' + mapped_code + '"')
+
+        # --- Employer FEIN on the review page must match the intake FEIN (identity guard). ---
+        def _digits(s):
+            return str(s or '').replace('-', '').replace(' ', '').strip()
+        want_fein = _digits(fnol.get('employer_fein'))
+        got_fein = _digits(read_out.get('employer_fein'))
+        if not got_fein:
+            problems.append('review page returned no employer_fein')
+        elif want_fein and got_fein != want_fein:
+            problems.append('review employer_fein ' + got_fein + ' != intake FEIN ' + want_fein)
+
+        # --- Claimant must echo the intake employee name (loose, case-insensitive containment). ---
+        want_name = str(fnol.get('employee_name', '') or '').strip().lower()
+        got_name = str(read_out.get('claimant', '') or '').strip().lower()
+        if want_name and got_name and (want_name not in got_name) and (got_name not in want_name):
+            problems.append('review claimant "' + got_name + '" does not match intake "' + want_name + '"')
+        if not got_name:
+            problems.append('review page shows no claimant')
+
+        # --- Wizard must have reached a submit-capable review page. ---
+        if not read_out.get('submit_button_present'):
+            problems.append('submit button not present - wizard did not reach review')
+
+        # --- A review screenshot must exist for the HR/adjuster approval. ---
+        review_screenshot = str(read_out.get('review_screenshot', '') or '').strip()
+        if not review_screenshot:
+            problems.append('no review screenshot captured for HR approval')
+
+        ok = len(problems) == 0
+        result = {
+            'ok': ok,
+            'problems': problems,
+            'injury_code': got_code,
+            'mapped_code': mapped_code,
+            'employer_fein': got_fein or want_fein,
+            'claimant': read_out.get('claimant', '') or fnol.get('employee_name', ''),
+            'jurisdiction': str(read_out.get('jurisdiction', '') or _input.get('jurisdiction', '') or '').strip(),
+            'review_summary': str(read_out.get('review_summary', '') or ''),
+            'review_screenshot': review_screenshot,
+        }
+
+  # 5b) Hard stop on a bad fill - do NOT advance to the human approval / submit on a mismatched review.
+  - id: review_gate
+    type: condition
+    depends_on: [validate_review]
+    condition_config:
+      expression: "{steps.validate_review.output.ok} == True"
+      then: [approve_submit]
+      else: [notify_review_failed]
+
+  - id: notify_review_failed
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        WC FNOL for employee {steps.validate_fnol.output.employee_name} reached the portal review page
+        but the deterministic cross-check FAILED before submission:
+        {steps.validate_review.output.problems}. Nothing was submitted. Re-check the wizard fill and
+        the injury-code mapping, then re-run.
+
+  # 6) MANDATORY HUMAN APPROVAL before the irreversible submit. Because the FNOL carries medical/injury
+  #    PII and statutory liability, HR / the adjuster signs off on the validated review_summary AND the
+  #    captured review screenshot - the EXACT state being filed. on_timeout: abort NEVER auto-submits.
+  #    (The privacy router can redact PII in the surrounding logs/audit.)
+  - id: approve_submit
+    type: approval
+    approval_config:
+      message: >-
+        AUTHORIZE the binding workers-comp FNOL SUBMISSION for employee
+        {steps.validate_review.output.claimant} (employer FEIN
+        {steps.validate_review.output.employer_fein}, jurisdiction
+        {steps.validate_review.output.jurisdiction}, injury code
+        {steps.validate_review.output.injury_code}). This is IRREVERSIBLE - it files the claim with the
+        carrier/board and opens a claim number, and the data is medical PII with statutory consequence.
+        Review the captured review screenshot and the summary below - this is the EXACT state you are
+        filing. Review summary: {steps.validate_review.output.review_summary}. Approve to submit; reject
+        to abort with nothing filed.
+      show_data: steps.validate_review.output
+      show_images: ["steps.validate_review.output.review_screenshot"]
+      timeout_hours: 48
+      on_timeout: abort
+      allow_edit: false
+
+  # 7) SUBMIT PASS (playwright mode, WRITE). Only reached AFTER HR approves. Re-opens the filled review
+  #    page and clicks the SINGLE final Submit / File-Claim button ONCE, then reads the carrier/board
+  #    confirmation page and captures {claim_number, receipt_screenshot, submitted_at}. CAPTCHA pauses
+  #    for a human at this final wall; max_actions tightly capped (one confirm action); capture_screenshots
+  #    on for the after-submit audit record.
+  - id: submit_claim
+    type: browser
+    depends_on: [approve_submit]
+    prompt: >-
+      A human HR reviewer / adjuster has authorized this IRREVERSIBLE workers-comp FNOL submission for
+      claimant {steps.validate_review.output.claimant} (employer FEIN
+      {steps.validate_review.output.employer_fein}, jurisdiction {input.jurisdiction}). Authenticate
+      with WC_PORTAL_CREDS if the session expired, return to the filled FNOL review page, confirm the
+      values still match the approved review, then click the SINGLE final Submit / File-Claim button
+      ONCE to file the claim. Do NOT edit any field and do NOT click submit more than once. If a CAPTCHA
+      or step-up auth appears at this final wall, PAUSE for a human - do not attempt to solve it. Then
+      read the carrier/board confirmation page and capture the issued CLAIM NUMBER, the submitted
+      timestamp, and a reference to the screenshot of the STAMPED RECEIPT / acknowledgement. Return ONLY
+      the structured object described by the output schema.
+    browser_config:
+      mode: playwright
+      start_url: "{input.portal_start_url}"
+      viewport_width: 1280
+      viewport_height: 720
+      timeout_seconds: 300
+      max_actions: 20
+      headless: true
+      credentials_env: "WC_PORTAL_CREDS"
+      captcha_strategy: pause
+      capture_screenshots: true
+      output_schema:
+        type: object
+        properties:
+          claim_number: { type: string }
+          submitted_at: { type: string }
+          receipt_screenshot: { type: string }
+          confirmation_text: { type: string }
+
+  # 8) DETERMINISTIC SUCCESS GATE (no model). Assert the carrier/board-issued claim_number matches the
+  #    expected pattern and a receipt screenshot exists. A missing/malformed claim_number means the
+  #    submit did NOT provably land - so a silently-failed submit can NEVER be recorded as a filed claim.
+  - id: assert_claim_number
+    type: code
+    depends_on: [submit_claim]
+    code_config:
+      language: python
+      code: |
+        import re
+        sub = _steps.get('submit_claim') or {}
+        if not isinstance(sub, dict):
+            sub = {}
+        for key in ('output', 'data', 'result'):
+            inner = sub.get(key)
+            if isinstance(inner, dict) and ('claim_number' in inner):
+                sub = inner
+                break
+
+        claim_number = str(sub.get('claim_number', '') or '').strip()
+        submitted_at = str(sub.get('submitted_at', '') or '').strip()
+        receipt_screenshot = str(sub.get('receipt_screenshot', '') or '').strip()
+
+        pattern = str(_input.get('claim_number_pattern', '') or '').strip()
+        if not pattern:
+            pattern = '^[A-Z0-9]{2,8}-?[A-Z0-9]{4,}$'
+
+        problems = []
+        matched = False
+        if not claim_number:
+            problems.append('carrier/board returned no claim_number - submission not provably accepted')
+        else:
+            try:
+                matched = bool(re.search(pattern, claim_number))
+            except (TypeError, ValueError):
+                matched = False
+            if not matched:
+                problems.append('claim_number "' + claim_number + '" does not match pattern ' + pattern)
+
+        if not submitted_at:
+            problems.append('no submitted_at timestamp returned')
+        if not receipt_screenshot:
+            problems.append('no stamped-receipt screenshot captured')
+
+        filed = bool(claim_number) and matched and bool(receipt_screenshot) and (len(problems) == 0)
+
+        result = {
+            'filed': filed,
+            'problems': problems,
+            'claim_number': claim_number,
+            'submitted_at': submitted_at,
+            'receipt_screenshot': receipt_screenshot,
+            'pattern': pattern,
+            'jurisdiction': str(_input.get('jurisdiction', '') or ''),
+        }
+
+  # 8b) Branch on the deterministic claim-number gate. Only a provably-issued claim proceeds to the
+  #     portal-confirmation sensor; otherwise page HR and leave the run needing attention.
+  - id: claim_number_gate
+    type: condition
+    depends_on: [assert_claim_number]
+    condition_config:
+      expression: "{steps.assert_claim_number.output.filed} == True"
+      then: [confirm_receipt]
+      else: [notify_submit_unconfirmed]
+
+  # 8c) UNCONFIRMED PATH - submit happened but the claim_number did not validate. Page HR and leave the
+  #     run needing attention. A false success is NEVER recorded.
+  - id: notify_submit_unconfirmed
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        NEEDS ATTENTION: WC FNOL submit for jurisdiction {input.jurisdiction} did NOT return a valid
+        claim_number ({steps.assert_claim_number.output.problems}). Do NOT assume the claim was filed -
+        manually check the portal. The run is left in a needs-attention state.
+
+  # 9) CONFIRMATION SENSOR (engine-native, no model) - the act-then-VERIFY core. Poll the portal's OWN
+  #    claim-status page until it shows the stamped receipt / an accepted status for the issued claim
+  #    number. This is independent proof the filing landed, beyond the immediate UI acknowledgement.
+  #    Hard timeout; a timeout is NOT treated as success.
+  - id: confirm_receipt
+    type: sensor
+    depends_on: [claim_number_gate]
+    sensor_config:
+      url: "{input.portal_status_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and (str(response.get('status', '')).strip().lower() in ('accepted', 'filed', 'received', 'confirmed', 'docketed') or bool(str(response.get('receipt_id', '') or response.get('receipt', '') or response.get('claim_number', '') or '').strip()))"
+      check_interval: 60
+      timeout: 3600
+
+  # 9b) Deterministically decide acceptance from the sensor's last polled status payload (no model). A
+  #     missing confirmation (sensor timed out) yields confirmed=False so a silent failure can NEVER be
+  #     reported as a win.
+  - id: evaluate_receipt
+    type: code
+    depends_on: [confirm_receipt]
+    code_config:
+      language: python
+      code: |
+        watch = _steps.get('confirm_receipt') or {}
+        if not isinstance(watch, dict):
+            watch = {}
+        resp = watch.get('response') if isinstance(watch.get('response'), dict) else watch
+        if not isinstance(resp, dict):
+            resp = {}
+
+        status = str(resp.get('status', '') or '').strip().lower()
+        receipt_id = str(resp.get('receipt_id', '') or resp.get('receipt', '') or '').strip()
+        accepted_states = ('accepted', 'filed', 'received', 'confirmed', 'docketed')
+        confirmed = (status in accepted_states) or bool(receipt_id)
+
+        sensor_satisfied = bool(watch.get('satisfied', watch.get('met', confirmed)))
+        timed_out = bool(watch.get('timed_out', False)) or (not sensor_satisfied and not confirmed)
+
+        asserted = _steps.get('assert_claim_number') or {}
+        if not isinstance(asserted, dict):
+            asserted = {}
+
+        result = {
+            'confirmed': bool(confirmed and not timed_out),
+            'status': status,
+            'receipt_id': receipt_id,
+            'timed_out': timed_out,
+            'fail_count': 0 if (confirmed and not timed_out) else 1,
+            'claim_number': str(asserted.get('claim_number', '') or ''),
+            'submitted_at': str(asserted.get('submitted_at', '') or ''),
+        }
+
+  # 9c) CONDITION - record + route to HR + archive on confirmed acceptance; OR page HR and leave the
+  #     run in a needs-attention state on timeout/no-confirmation. We NEVER report a false win.
+  - id: receipt_outcome
+    type: condition
+    depends_on: [evaluate_receipt]
+    condition_config:
+      expression: "{steps.evaluate_receipt.output.fail_count} > 0"
+      then: [notify_receipt_unconfirmed]
+      else: [record_filing]
+
+  - id: notify_receipt_unconfirmed
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.notify_channel}"
+      message: >-
+        NEEDS ATTENTION: WC FNOL claim {steps.evaluate_receipt.output.claim_number} was SUBMITTED but
+        the portal has NOT confirmed a stamped receipt within the timeout (last status
+        '{steps.evaluate_receipt.output.status}', timed_out={steps.evaluate_receipt.output.timed_out}).
+        Do NOT assume success - manually verify the portal status page. The run is left in a
+        needs-attention state.
+
+  # 10a) RECORD - assemble the confirmed-filing payload for HR write-back (deterministic transform).
+  - id: record_filing
+    type: transform
+    depends_on: [receipt_outcome]
+    transform_config:
+      template: |
+        {
+          "event": "wc_fnol_filed",
+          "jurisdiction": "{steps.assert_claim_number.output.jurisdiction}",
+          "incident_id": "{steps.validate_fnol.output.incident_id}",
+          "claimant": "{steps.validate_review.output.claimant}",
+          "employer_fein": "{steps.validate_review.output.employer_fein}",
+          "claim_number": "{steps.assert_claim_number.output.claim_number}",
+          "submitted_at": "{steps.assert_claim_number.output.submitted_at}",
+          "receipt_id": "{steps.evaluate_receipt.output.receipt_id}"
+        }
+
+  # 10b) ARCHIVE the stamped receipt to object storage (S3-compatible) for the statutory audit trail.
+  #      Deterministic http PUT - the engine has no dedicated s3 step type, so the s3 archive is an
+  #      authenticated PUT to the receipt-archive bucket URL.
+  - id: archive_receipt
+    type: http
+    depends_on: [record_filing]
+    http_config:
+      url: "{input.receipt_archive_url}/{steps.assert_claim_number.output.claim_number}/receipt.json"
+      method: PUT
+      headers:
+        Content-Type: "application/json"
+      auth: "bearer:{env.RECEIPT_ARCHIVE_TOKEN}"
+      body: '{"claim_number": "{steps.assert_claim_number.output.claim_number}", "jurisdiction": "{steps.assert_claim_number.output.jurisdiction}", "submitted_at": "{steps.assert_claim_number.output.submitted_at}", "receipt_screenshot": "{steps.assert_claim_number.output.receipt_screenshot}", "receipt_id": "{steps.evaluate_receipt.output.receipt_id}", "incident_id": "{steps.validate_fnol.output.incident_id}"}'
+
+  # 10c) ROUTE the confirmation back to HR / the injured worker's case file with the claim number.
+  - id: notify_hr_case_file
+    type: notify
+    depends_on: [archive_receipt]
+    notify_config:
+      service: gmail
+      channel: "{input.hr_case_file_email}"
+      message: >-
+        The workers-comp FNOL for {steps.validate_review.output.claimant} (incident
+        {steps.validate_fnol.output.incident_id}, jurisdiction {input.jurisdiction}) has been FILED. The
+        carrier/board claim number is {steps.assert_claim_number.output.claim_number}, submitted at
+        {steps.assert_claim_number.output.submitted_at} (portal receipt
+        {steps.evaluate_receipt.output.receipt_id}). The stamped receipt is archived for the case file.
+        Record this claim number for all follow-up.
+
+  # 10d) REPORT - branded PDF filing record for the HR/risk-ops statutory audit trail.
+  - id: filing_report
+    type: report
+    depends_on: [notify_hr_case_file]
+    report_config:
+      template: "research-report"
+      format: pdf
+      theme: professional
+      title: "WC FNOL Filing Record - {steps.assert_claim_number.output.claim_number}"
+      author: "WC Claims Intake Desk"
+    prompt: >-
+      Produce a formal workers-comp FNOL filing record PDF from the payload below. Include the
+      jurisdiction, incident id, claimant, employer FEIN, the mapped injury code, the carrier/board
+      claim number, the submitted timestamp, and the portal receipt id; and note that the intake was
+      deterministically validated (mandatory FNOL fields + statutory window), the injury code was
+      mapped provider-neutrally and re-validated against the portal review, a human HR/adjuster
+      approved the binding submission, and the claim number was both pattern-asserted and confirmed by
+      the portal's own status page before recording. Filing payload:
+      {steps.assert_claim_number.output} . Confirmation: {steps.evaluate_receipt.output} . Review
+      summary: {steps.validate_review.output.review_summary}
+
+on_complete:
+  storage_path: "workers-comp-fnol-insurance-filer/{input.jurisdiction}/{steps.assert_claim_number.output.claim_number}/{run_id}/result.json"

--- a/tests/test_browser_rpa_templates_batch2_v034.py
+++ b/tests/test_browser_rpa_templates_batch2_v034.py
@@ -1,0 +1,232 @@
+"""Structural + safety validation for the v0.34 browser-RPA templates, batch 2.
+
+Same RPA guarantees as the first browser wave, over the remaining strong ideas: every
+template drives a real browser; modes are provider-neutral (playwright/dom, no
+computer_use lock-in); secrets load via credentials_env; and the irreversible write is
+gated. The write-gate check here is precise: a template only needs an approval when it
+actually writes (2+ browser steps, i.e. a login/fill followed by a submit, or a browser
+inside a loop), and the final write browser - taking a loop child's effective stage as
+its loop's stage - must run downstream of an approval (following depends_on and loop
+orchestration). Read-only templates (a single browser read) legitimately have no gate.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from sandcastle.engine.dag import (
+    VALID_STEP_TYPES,
+    build_plan,
+    parse_yaml_string,
+    validate,
+)
+from sandcastle.engine.executor import _CODE_STEP_BLOCKED_PATTERNS
+from sandcastle.engine.tools.registry import KNOWN_TOOLS
+from sandcastle.templates import list_templates
+
+RPA_TEMPLATES = [
+    "state_sales_tax_efile_filer", "gov_portal_filing_status_puller",
+    "saas_admin_console_seat_audit", "saas_role_permission_remediator",
+    "vendor_invoice_portal_harvester", "bank_statement_vault_reconciler",
+    "saas_admin_seat_deprovisioning_offboard", "insurance_claim_fnol_portal_filer",
+    "partner_portal_journey_monitor", "synthetic_checkout_revenue_canary",
+    "golden_journey_regression_gate", "portal_login_2fa_extract_skeleton",
+    "workers_comp_fnol_insurance_filer", "saas_config_setting_propagator",
+    "tax_form_1099_w2_collector", "utility_municipal_bill_filer",
+    "saas_api_key_rotation_runner", "government_procurement_bid_submitter",
+    "kyc_onboarding_portal_filer", "permit_eportal_application_filer",
+    "consent_banner_cmp_compliance_auditor", "legacy_erp_order_status_sync",
+    "legacy_admin_report_export_to_warehouse", "wcag_accessibility_audit_evidence_pack",
+    "race_two_models_author_scrape_skeleton", "ats_job_application_autosubmit",
+    "onpage_claim_and_price_verifier_vs_source_of_truth",
+    "osha_environmental_compliance_report_filer",
+]
+
+# Templates that perform an irreversible external write (submit / pay / deactivate /
+# rotate). Each was verified to gate that write behind a human approval. Read-only
+# templates (status pulls, harvests, synthetic monitors, scrape/login skeletons) are not
+# listed - they have no irreversible action to gate.
+WRITE_TEMPLATES = [
+    "state_sales_tax_efile_filer", "saas_admin_console_seat_audit",
+    "saas_role_permission_remediator", "vendor_invoice_portal_harvester",
+    "insurance_claim_fnol_portal_filer", "saas_admin_seat_deprovisioning_offboard",
+    "workers_comp_fnol_insurance_filer", "saas_config_setting_propagator",
+    "utility_municipal_bill_filer", "saas_api_key_rotation_runner",
+    "government_procurement_bid_submitter", "kyc_onboarding_portal_filer",
+    "permit_eportal_application_filer", "ats_job_application_autosubmit",
+    "osha_environmental_compliance_report_filer", "legacy_erp_order_status_sync",
+]
+
+NEUTRAL_BROWSER_MODES = {"playwright", "dom", "lightpanda", "browserbase"}
+LIGHTWEIGHT_READ_MODES = {"dom", "lightpanda"}
+
+TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "src" / "sandcastle" / "templates"
+
+
+def _load(name: str) -> str:
+    path = TEMPLATES_DIR / f"{name}.yaml"
+    assert path.exists(), f"Template file not found: {path}"
+    return path.read_text()
+
+
+def _forward_reaches(seed: set[str], wf) -> set[str]:
+    """Step ids reachable forward from seed via depends_on and loop orchestration."""
+    succ: dict[str, set[str]] = {s.id: set() for s in wf.steps}
+    for s in wf.steps:
+        for d in s.depends_on:
+            if d in succ:
+                succ[d].add(s.id)
+        if s.loop_config:
+            for child in s.loop_config.step_ids:
+                if child in succ:
+                    succ[s.id].add(child)
+    seen, stack = set(), list(seed)
+    while stack:
+        cur = stack.pop()
+        for nxt in succ.get(cur, ()):
+            if nxt not in seen:
+                seen.add(nxt)
+                stack.append(nxt)
+    return seen
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_parses_with_steps(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    assert wf is not None and wf.name and len(wf.steps) > 0
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_step_types_valid(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    for step in wf.steps:
+        assert step.type in VALID_STEP_TYPES, f"{template_name}/{step.id} bad type {step.type!r}"
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_depends_on_resolve(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    ids = {s.id for s in wf.steps}
+    for step in wf.steps:
+        for dep in step.depends_on:
+            assert dep in ids, f"{template_name}/{step.id} depends on unknown {dep!r}"
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_validates_clean(template_name: str) -> None:
+    assert validate(parse_yaml_string(_load(template_name))) == []
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_build_plan_covers_every_step_once(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    planned = [sid for stage in build_plan(wf).stages for sid in stage]
+    assert len(planned) == len(set(planned)) and set(planned) == {s.id for s in wf.steps}
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_tool_references_known(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    for step in wf.steps:
+        if step.tool_config and step.tool_config.tool:
+            assert step.tool_config.tool.split(":")[0] in KNOWN_TOOLS
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_control_flow_branches_reference_real_steps(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    ids = {s.id for s in wf.steps}
+    for step in wf.steps:
+        if step.condition_config:
+            for sid in step.condition_config.then_steps + step.condition_config.else_steps:
+                assert sid in ids, f"{template_name}/{step.id} condition -> unknown {sid!r}"
+        if step.classify_config:
+            for branch in step.classify_config.branches.values():
+                for sid in branch:
+                    assert sid in ids, f"{template_name}/{step.id} classify -> unknown {sid!r}"
+        if step.loop_config:
+            for sid in step.loop_config.step_ids:
+                assert sid in ids, f"{template_name}/{step.id} loop -> unknown {sid!r}"
+        if step.race_config:
+            for branch in step.race_config.branches:
+                for sid in branch:
+                    assert sid in ids, f"{template_name}/{step.id} race -> unknown {sid!r}"
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_drives_a_browser(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    assert any(s.type == "browser" for s in wf.steps), f"{template_name} has no browser step"
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_browser_modes_are_provider_neutral(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    for step in wf.steps:
+        if step.type == "browser" and step.browser_config:
+            assert step.browser_config.mode in NEUTRAL_BROWSER_MODES, (
+                f"{template_name}/{step.id} non-neutral browser mode "
+                f"{step.browser_config.mode!r} (no computer_use in this set)"
+            )
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_browser_steps_handle_secrets_safely(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    for step in wf.steps:
+        if step.type == "browser" and step.browser_config:
+            bc = step.browser_config
+            assert bc.credentials_env or bc.mode in LIGHTWEIGHT_READ_MODES, (
+                f"{template_name}/{step.id} browser has no credentials_env and is not a read mode"
+            )
+
+
+@pytest.mark.parametrize("template_name", WRITE_TEMPLATES)
+def test_irreversible_write_is_gated(template_name: str) -> None:
+    """For every template that performs an irreversible external write, the final write
+    browser (a loop child counted at its loop's stage) must run downstream of a human
+    approval, following depends_on and loop orchestration. This is the core RPA safety
+    property: no submit/pay/deactivate without a human in the loop."""
+    wf = parse_yaml_string(_load(template_name))
+    plan = build_plan(wf)
+    stage_of = {sid: i for i, stage in enumerate(plan.stages) for sid in stage}
+    loop_parent = {
+        child: s.id
+        for s in wf.steps if s.loop_config
+        for child in s.loop_config.step_ids
+    }
+    browsers = [s for s in wf.steps if s.type == "browser"]
+    assert browsers, f"{template_name} is a write template with no browser step"
+
+    def eff_stage(sid: str) -> int:
+        return stage_of.get(loop_parent.get(sid, sid), stage_of.get(sid, -1))
+
+    write_browser = max(browsers, key=lambda b: eff_stage(b.id))
+    approvals = {s.id for s in wf.steps if s.type == "approval"}
+    assert approvals, f"{template_name} writes via browser but has no approval gate"
+    assert write_browser.id in _forward_reaches(approvals, wf), (
+        f"{template_name}: write browser {write_browser.id!r} is not downstream of an approval"
+    )
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_code_steps_pass_engine_sandbox_blocklist(template_name: str) -> None:
+    wf = parse_yaml_string(_load(template_name))
+    for step in wf.steps:
+        if step.type == "code" and step.code_config and step.code_config.code:
+            code = step.code_config.code
+            match = _CODE_STEP_BLOCKED_PATTERNS.search(code)
+            assert match is None, (
+                f"{template_name}/{step.id} sandbox-blocked pattern {match.group(0)!r}"
+            )
+            ast.parse(code)
+
+
+@pytest.mark.parametrize("template_name", RPA_TEMPLATES)
+def test_templates_are_discovered(template_name: str) -> None:
+    by_file = {t.file_name: t for t in list_templates()}
+    info = by_file.get(f"{template_name}.yaml")
+    assert info is not None and info.source == "built-in" and info.step_count > 0


### PR DESCRIPTION
## What

Completes the strong browser/computer-use RPA leaderboard (follows #244): 28 templates across the read/harvest, human-gated portal filing, bulk admin-console, synthetic monitoring, and compliance-browsing families. All provider-neutral (playwright/dom, **no computer_use** lock-in). Catalog 179 -> 207.

| Family | Templates |
|---|---|
| Read / harvest (read-only) | gov_portal_filing_status_puller, bank_statement_vault_reconciler, vendor_invoice_portal_harvester, saas_admin_console_seat_audit, tax_form_1099_w2_collector, utility_municipal_bill_filer, legacy_admin_report_export_to_warehouse |
| Human-gated filing (act-then-verify) | state_sales_tax_efile_filer, insurance_claim_fnol_portal_filer, workers_comp_fnol_insurance_filer, government_procurement_bid_submitter, permit_eportal_application_filer, kyc_onboarding_portal_filer, osha_environmental_compliance_report_filer, ats_job_application_autosubmit, legacy_erp_order_status_sync |
| Bulk admin (census -> approve -> write -> reconcile) | saas_admin_seat_deprovisioning_offboard, saas_role_permission_remediator, saas_config_setting_propagator, saas_api_key_rotation_runner |
| Synthetic monitoring / release gating | partner_portal_journey_monitor, synthetic_checkout_revenue_canary, golden_journey_regression_gate |
| Skeletons / compliance browsing | portal_login_2fa_extract_skeleton, race_two_models_author_scrape_skeleton, consent_banner_cmp_compliance_auditor, wcag_accessibility_audit_evidence_pack, onpage_claim_and_price_verifier_vs_source_of_truth |

## Provider-neutral + safe

Every browser step uses **playwright/dom** (the model authors the automation, swapped via `default_model`). `immigration_visa_status_renewal` from the candidate set was **dropped** because it leaned on `computer_use` (the one vendor-coupled mode) - it belongs with a future desktop wave. Safety: secrets via `credentials_env`, captcha pause, read split from write, every irreversible submit/deactivate gated behind a human `approval`, `max_actions` caps, `capture_screenshots` for audit.

The write-gate property was verified precisely, **including loop-orchestrated writes**: e.g. `saas_admin_seat_deprovisioning_offboard` runs a dom census loop pre-approval, then a playwright deactivation loop whose `depends_on` is the approval; `legacy_erp_order_status_sync` likewise gates its write loop. The 14 multi-step filers gate their final submit browser behind approval.

## Tests

`test_browser_rpa_templates_batch2_v034.py`: drives a browser, provider-neutral modes (no computer_use), credentials_env safety, the **irreversible-write-is-gated** property over the 16 write templates (final write browser - a loop child counted at its loop's stage - downstream of an approval via depends_on + loop edges), the code-sandbox blocklist, and structural checks.

```
test_browser_rpa_templates_batch2_v034.py  352 passed
```

Each template independently re-verified (parse, validate, build-plan coverage, no sandbox-blocked code, playwright/dom only, write gated). Catalog 179 -> 207.