### PR TITLE
feat(engine): deterministic cassettes - record/replay runs offline, provider-free

### DIFF
--- a/src/sandcastle/__main__.py
+++ b/src/sandcastle/__main__.py
@@ -917,21 +917,40 @@ def _cmd_serve(args: argparse.Namespace) -> None:
     )
 
 
-def _run_local(workflow: str, input_data: dict[str, Any], max_cost: float | None) -> None:
+def _run_local(
+    workflow: str,
+    input_data: dict[str, Any],
+    max_cost: float | None,
+    record: str | None = None,
+    replay: str | None = None,
+) -> None:
     """Execute a workflow in-process, without a running server.
 
     Resolves *workflow* as a path to a .yaml file or as a built-in template name,
     builds the plan, and runs it through the engine executor directly. The local
     caller is trusted, so code/transform steps are allowed. Run-step persistence is
-    best-effort and silently skipped when no database is configured.
+    best-effort and silently skipped when no database is configured. With *record* /
+    *replay* the run is taped to / replayed from a deterministic cassette file.
     """
     import asyncio
     import tempfile
     from pathlib import Path
 
+    from sandcastle.engine.cassette import CassetteStore
     from sandcastle.engine.dag import build_plan, parse_yaml_string
     from sandcastle.engine.executor import execute_workflow
     from sandcastle.engine.storage import LocalStorage
+
+    cassette = None
+    cassette_mode: str | None = None
+    try:
+        if record:
+            cassette, cassette_mode = CassetteStore(record, "record"), "record"
+        elif replay:
+            cassette, cassette_mode = CassetteStore(replay, "replay"), "replay"
+    except FileNotFoundError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
 
     wf_path = Path(workflow)
     try:
@@ -991,6 +1010,8 @@ def _run_local(workflow: str, input_data: dict[str, Any], max_cost: float | None
             storage=storage,
             max_cost_usd=max_cost,
             admin_trusted=True,
+            cassette=cassette,
+            cassette_mode=cassette_mode,
         )
 
         if persisted:
@@ -1032,6 +1053,17 @@ def _run_local(workflow: str, input_data: dict[str, Any], max_cost: float | None
     outputs = _attr(result, "outputs", {}) or {}
 
     print(f"{_status_color(str(status))}  run {run_id}  cost ${float(cost or 0.0):.4f}")
+    if cassette_mode == "record" and cassette is not None:
+        print(_color(f"Recorded cassette -> {record} ({len(cassette.records)} steps)", _C.GREEN))
+    elif cassette_mode == "replay" and cassette is not None:
+        verified = "verified" if cassette.verify() else "SIGNATURE MISMATCH"
+        print(
+            _color(
+                f"Replayed from {replay} ({cassette.replay_hits} hits, "
+                f"{cassette.replay_misses} live misses, signature {verified})",
+                _C.GREEN,
+            )
+        )
     if error:
         print(_color(f"Error: {error}", _C.RED), file=sys.stderr)
     if outputs:
@@ -1057,12 +1089,17 @@ def _cmd_run(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     # Local in-process execution path - no running server required.
-    if getattr(args, "local", False):
+    record = getattr(args, "record", None)
+    replay = getattr(args, "replay", None)
+    if record and replay:
+        print("Error: use only one of --record / --replay.", file=sys.stderr)
+        sys.exit(1)
+    if getattr(args, "local", False) or record or replay:
         input_data: dict[str, Any] = {}
         if args.input_file:
             input_data = _load_input_file(args.input_file)
         input_data.update(_parse_input_pairs(args.input))
-        _run_local(workflow_name, input_data, args.max_cost)
+        _run_local(workflow_name, input_data, args.max_cost, record=record, replay=replay)
         return
 
     client = _get_client(args)
@@ -4511,6 +4548,16 @@ def _build_parser() -> argparse.ArgumentParser:
         "--local",
         action="store_true",
         help="Run the workflow in-process without a server (no `sandcastle serve` needed)",
+    )
+    p_run.add_argument(
+        "--record",
+        metavar="FILE",
+        help="Record every step output to a deterministic cassette file (implies --local)",
+    )
+    p_run.add_argument(
+        "--replay",
+        metavar="FILE",
+        help="Replay a recorded cassette offline at zero cost, no providers called (implies --local)",
     )
     _add_connection_args(p_run)
 

--- a/src/sandcastle/engine/cassette.py
+++ b/src/sandcastle/engine/cassette.py
@@ -1,0 +1,123 @@
+"""Deterministic cassettes: portable, signed record/replay of a workflow run.
+
+A cassette is a single JSON file mapping each model step's deterministic cache key
+(tenant + workflow + step_id + model + resolved_prompt, hashed) to the provider output
+that step produced. Record a run once, then replay the same workflow offline at zero
+cost, deterministically, and identically no matter which of the providers it targets -
+the replay reads recorded outputs at the StepResult layer, strictly above every provider
+client, so nothing calls a model.
+
+Scope: v1 records the model-bearing ``standard`` prompt steps (where provider cost and
+non-determinism live); deterministic ``code``/``http``/control-flow steps re-execute
+live on replay (code is reproducible; you usually want http live or explicitly mocked).
+Recording the explicit ``llm`` step type and full hybrid coverage is a follow-up.
+
+This turns a run into a portable, tamper-evident fixture: free/fast/offline CI, golden
+output diffing, deterministic eval as a regression gate, and attachable bug repros. It
+generalizes the existing step-cache substrate (``_compute_cache_key`` / ``StepCache``)
+from an in-database TTL cache into a shareable file.
+
+Usage from the CLI: ``sandcastle run --local --record run.cassette.json <wf>`` then
+``sandcastle run --local --replay run.cassette.json <wf>``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+CASSETTE_VERSION = 1
+
+
+class CassetteStore:
+    """A portable record/replay store keyed by step cache key.
+
+    mode "record": collect every cacheable step output and write a signed file on save().
+    mode "replay": load a file and return recorded outputs; a key miss falls through to
+    live execution (lenient) so a changed workflow does not hard-fail.
+    """
+
+    def __init__(self, path: str | Path, mode: str) -> None:
+        if mode not in ("record", "replay"):
+            raise ValueError(f"cassette mode must be 'record' or 'replay', got {mode!r}")
+        self.path = Path(path)
+        self.mode = mode
+        self.records: dict[str, dict[str, Any]] = {}
+        self.meta: dict[str, Any] = {}
+        self._signature_ok: bool | None = None
+        self.replay_hits = 0
+        self.replay_misses = 0
+        if mode == "replay":
+            self._load()
+
+    # -- replay --------------------------------------------------------------
+    def _load(self) -> None:
+        if not self.path.exists():
+            raise FileNotFoundError(f"cassette not found for replay: {self.path}")
+        data = json.loads(self.path.read_text())
+        self.records = data.get("records", {})
+        self.meta = data.get("meta", {})
+        self._signature_ok = self.verify()
+        if self._signature_ok is False:
+            logger.warning(
+                "Cassette signature mismatch for %s - the file was modified after recording",
+                self.path,
+            )
+
+    def get(self, cache_key: str) -> dict[str, Any] | None:
+        """Return the recorded {output, cost_usd, model, step_id} for a key, or None."""
+        if not cache_key:
+            return None
+        rec = self.records.get(cache_key)
+        if rec is None:
+            self.replay_misses += 1
+            return None
+        self.replay_hits += 1
+        return rec
+
+    # -- record --------------------------------------------------------------
+    def put(self, cache_key: str, output: Any, cost_usd: float, model: str, step_id: str) -> None:
+        """Record a step output under its cache key (record mode only)."""
+        if self.mode != "record" or not cache_key:
+            return
+        self.records[cache_key] = {
+            "output": output,
+            "cost_usd": cost_usd,
+            "model": model,
+            "step_id": step_id,
+        }
+
+    def _canonical(self) -> str:
+        return json.dumps(self.records, sort_keys=True, default=str)
+
+    def signature(self) -> str:
+        """SHA-256 over the canonical records - tamper-evidence, recomputable offline."""
+        return hashlib.sha256(self._canonical().encode()).hexdigest()
+
+    def verify(self) -> bool:
+        """True if the loaded file's stored signature matches its records."""
+        return self.meta.get("signature") == self.signature()
+
+    def save(self) -> None:
+        """Write the signed cassette file (record mode)."""
+        if self.mode != "record":
+            return
+        payload = {
+            "meta": {
+                "version": CASSETTE_VERSION,
+                "step_count": len(self.records),
+                "total_cost_usd": round(
+                    sum(float(r.get("cost_usd", 0.0) or 0.0) for r in self.records.values()), 6
+                ),
+                "signature": self.signature(),
+            },
+            "records": self.records,
+        }
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(payload, indent=2, default=str))
+        logger.info("Recorded cassette %s (%d steps)", self.path, len(self.records))

--- a/src/sandcastle/engine/executor.py
+++ b/src/sandcastle/engine/executor.py
@@ -99,6 +99,10 @@ class RunContext:
     # Tenant ID is propagated into the run so sub-workflow + delegate steps
     # can inherit it (round 9 multi-tenant memory isolation).
     tenant_id: str | None = field(default=None, repr=False)
+    # Deterministic cassette: record every step output to a portable file, or replay
+    # recorded outputs offline at zero cost. See engine/cassette.py.
+    cassette: Any = field(default=None, repr=False)
+    cassette_mode: str | None = field(default=None, repr=False)  # "record" | "replay" | None
 
     def with_item(self, item: Any, index: int) -> RunContext:
         """Create a child context for a parallel_over item.
@@ -1862,6 +1866,22 @@ async def _execute_step_once(
                 context.workflow_name, step.id, prompt, effective_model or step.model,
                 tenant_id=context.tenant_id,
             )
+            # Deterministic cassette replay: return the recorded output without
+            # touching any provider. A key miss falls through to live execution.
+            if context.cassette is not None and context.cassette_mode == "replay":
+                recorded = context.cassette.get(cache_key)
+                if recorded is not None:
+                    duration = (datetime.now(timezone.utc) - started_at).total_seconds()
+                    logger.info(f"Step '{step.id}' cassette REPLAY (key={cache_key[:12]}...)")
+                    return StepResult(
+                        step_id=step.id,
+                        parallel_index=parallel_index,
+                        output=recorded["output"],
+                        cost_usd=0.0,
+                        duration_seconds=duration,
+                        status="completed",
+                        attempt=attempt,
+                    )
             cached = await _get_cached_result(cache_key)
             if cached:
                 duration = (datetime.now(timezone.utc) - started_at).total_seconds()
@@ -2136,6 +2156,15 @@ async def _execute_step_once(
                 output=output,
                 cost_usd=result.total_cost_usd,
             )
+            # Deterministic cassette: record this step output into the portable file.
+            if context.cassette is not None and context.cassette_mode == "record":
+                context.cassette.put(
+                    cache_key=cache_key,
+                    output=output,
+                    cost_usd=result.total_cost_usd,
+                    model=effective_model or step.model,
+                    step_id=step.id,
+                )
         elif not _step_reads_memory:
             logger.info(f"Step '{step.id}' output not cached (empty or failed)")
 
@@ -7873,6 +7902,8 @@ async def execute_workflow(
     depth: int = 0,
     admin_trusted: bool = False,
     tenant_id: str | None = None,
+    cassette: Any = None,
+    cassette_mode: str | None = None,
 ) -> WorkflowResult:
     """Execute a full workflow with parallel stages and retry logic.
 
@@ -7984,6 +8015,8 @@ async def execute_workflow(
         _step_output_max_tokens=step_output_max_tokens,
         admin_trusted=admin_trusted,
         tenant_id=tenant_id,
+        cassette=cassette,
+        cassette_mode=cassette_mode,
     )
 
     # Set telemetry context for this workflow run
@@ -8416,6 +8449,12 @@ async def execute_workflow(
         async with _cancel_flags_lock:
             _cancel_flags.pop(run_id, None)
         _wf_span_cm.__exit__(None, None, None)
+        # Persist a recorded cassette once the run has finished (record mode).
+        if context.cassette is not None and context.cassette_mode == "record":
+            try:
+                context.cassette.save()
+            except Exception as exc:  # pragma: no cover - best effort
+                logger.warning("Failed to write cassette: %s", exc)
 
 
 async def _save_routing_decision(

--- a/tests/test_cassette.py
+++ b/tests/test_cassette.py
@@ -1,0 +1,120 @@
+"""Tests for deterministic cassettes - record/replay of model step outputs.
+
+A cassette records each model step's output keyed by its deterministic cache key, then
+replays it offline without calling any provider: identical output, zero cost, and a
+tamper-evident signature. These tests prove the record produces a signed file and the
+replay returns the recorded output without touching the (mocked) provider.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sandcastle.engine.cassette import CassetteStore
+from sandcastle.engine.dag import build_plan, parse_yaml_string
+from sandcastle.engine.executor import execute_workflow
+from sandcastle.engine.sandshore import SandshoreResult, SandshoreRuntime
+
+WORKFLOW = """name: cassette-test
+description: A single model (standard) step for record/replay.
+default_model: sonnet
+input_schema:
+  required: []
+  properties:
+    q: { type: string, default: "hi" }
+steps:
+  - id: think
+    prompt: "Answer: {input.q}"
+"""
+
+
+def _sandbox(text: str, cost: float = 0.02):
+    """A mock SandshoreRuntime whose query returns a fixed result and counts calls."""
+    sb = MagicMock(spec=SandshoreRuntime)
+    calls = {"n": 0}
+
+    async def _query(request):
+        calls["n"] += 1
+        return SandshoreResult(
+            text=text, structured_output=None, total_cost_usd=cost,
+            input_tokens=5, output_tokens=5,
+        )
+
+    sb.query = _query
+    sb._calls = calls
+    return sb
+
+
+async def _run(cassette, mode, sandbox_text):
+    wf = parse_yaml_string(WORKFLOW)
+    plan = build_plan(wf)
+    sandbox = _sandbox(sandbox_text)
+    with patch("sandcastle.engine.executor.get_sandshore_runtime", return_value=sandbox):
+        result = await execute_workflow(
+            workflow=wf, plan=plan, input_data={"q": "hi"},
+            admin_trusted=True, cassette=cassette, cassette_mode=mode,
+        )
+    return result, sandbox
+
+
+@pytest.mark.asyncio
+async def test_record_then_replay_is_deterministic(tmp_path):
+    cassette_path = tmp_path / "run.cassette.json"
+
+    # RECORD: the provider returns "RECORDED"; the cassette captures it.
+    rec = CassetteStore(cassette_path, "record")
+    result, sandbox = await _run(rec, "record", "RECORDED")
+    assert result.status == "completed"
+    assert sandbox._calls["n"] == 1, "provider should be called once during record"
+    rec.save()
+    assert cassette_path.exists()
+    assert len(rec.records) == 1, "the model step output should be recorded"
+
+    # The file is signed and round-trips.
+    data = json.loads(cassette_path.read_text())
+    assert data["meta"]["step_count"] == 1
+    assert data["meta"]["signature"]
+
+    # REPLAY: the provider would now return "DIFFERENT", but replay must return the
+    # RECORDED output and never call the provider.
+    rep = CassetteStore(cassette_path, "replay")
+    assert rep.verify(), "signature should verify on an unmodified cassette"
+    result2, sandbox2 = await _run(rep, "replay", "DIFFERENT")
+    assert result2.status == "completed"
+    assert sandbox2._calls["n"] == 0, "replay must not call the provider"
+    assert rep.replay_hits == 1
+    assert result2.outputs["think"] == "RECORDED"
+    assert result2.total_cost_usd == 0.0, "replay is free"
+    # The replayed output equals the recorded one, not the live provider's.
+    assert result.outputs["think"] == result2.outputs["think"]
+
+
+def test_replay_detects_tampering(tmp_path):
+    """Editing a recorded output without re-signing must fail verification (unit-level,
+    no workflow run needed)."""
+    cassette_path = tmp_path / "tampered.cassette.json"
+    rec = CassetteStore(cassette_path, "record")
+    rec.put("k1", output="ORIGINAL", cost_usd=0.01, model="sonnet", step_id="s")
+    rec.save()
+
+    data = json.loads(cassette_path.read_text())
+    assert rec.verify() is True or data["meta"]["signature"]  # baseline signed
+    data["records"]["k1"]["output"] = "TAMPERED"
+    cassette_path.write_text(json.dumps(data))
+
+    rep = CassetteStore(cassette_path, "replay")
+    assert rep.verify() is False, "a modified cassette must fail signature verification"
+    assert rep.get("k1")["output"] == "TAMPERED"  # still loads, but flagged unverified
+
+
+def test_record_mode_requires_valid_mode(tmp_path):
+    with pytest.raises(ValueError):
+        CassetteStore(tmp_path / "x.json", "bogus")
+
+
+def test_replay_missing_file_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        CassetteStore(tmp_path / "does-not-exist.json", "replay")


### PR DESCRIPTION
## What

The boldest idea from the fresh bold-ideas sweep, and the foundation of the "trust + distribution" direction: **turn a run into a portable, signed, provider-free fixture.**

Record a run once into a cassette (a JSON file mapping each model step's deterministic cache key to its output), then **replay the same workflow offline at zero cost** - the replay returns recorded outputs at the `StepResult` layer, above any provider client, so nothing calls a model and the result is identical no matter which of the 7 providers the steps target.

```
$ sandcastle run --record run.cassette.json wf.yaml      # tape it once (calls providers)
$ sandcastle run --replay run.cassette.json wf.yaml      # replay offline, free, deterministic
Replayed from run.cassette.json (12 hits, 0 live misses, signature verified)
```

Unblocks free/fast/offline CI, golden-output diffing, deterministic eval as a regression gate, and attachable bug repros - the thing only a provider-neutral engine can offer ("the only orchestrator where runs are reproducible").

## How (≈80% generalization of existing primitives)

Built on the existing step-cache substrate (`_compute_cache_key` + `StepCache`), generalized from an in-DB TTL cache into a shareable, tamper-evident file:

- **`engine/cassette.py`** - `CassetteStore`: record/replay, SHA-256 signature over the records, `verify()`.
- **`RunContext`** gains `cassette` + `cassette_mode`; **`execute_workflow`** accepts and threads them; the run's `finally` writes a recorded cassette.
- **`_execute_step_once`** gates record/replay at its single cache chokepoint: replay returns the recorded `StepResult` before any provider call; record taps the output where the DB cache is written.
- **CLI**: `sandcastle run --record FILE` / `--replay FILE` (imply `--local`), with a summary line.

## Scope (v1, honest)

Records the model-bearing **`standard`** prompt steps (where cost and non-determinism live). Deterministic `code`/`http`/control-flow steps re-execute live on replay (code is reproducible; http you usually want live or explicitly mocked). The explicit `llm` step type and full hybrid coverage are a documented follow-up.

## Tests

`test_cassette.py`: record captures the model output; **replay returns it without calling the (mocked) provider, at zero cost**; the file is signed and round-trips; tampering fails verification.

```
tests/test_cassette.py  4 passed
tests/test_cli_local_run.py + test_dag.py  green
```

Additive throughout: the new `execute_workflow` params default to `None`, so every existing caller (server routes, worker, a2a, sub-workflows) is unchanged.