### PR TITLE
feat(api): shareable run permalinks - public, scrubbed, Loom-for-workflows

### DIFF
--- a/alembic/versions/013_share_token.py
+++ b/alembic/versions/013_share_token.py
@@ -1,0 +1,29 @@
+"""Add a public share_token to runs for shareable run permalinks.
+
+Revision ID: 013
+Revises: 012
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "013"
+down_revision: str | None = "012"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("runs", sa.Column("share_token", sa.String(64), nullable=True))
+    op.create_index(
+        "ix_runs_share_token", "runs", ["share_token"], unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_runs_share_token", table_name="runs")
+    op.drop_column("runs", "share_token")

--- a/src/sandcastle/__main__.py
+++ b/src/sandcastle/__main__.py
@@ -1190,6 +1190,34 @@ def _cmd_cancel(args: argparse.Namespace) -> None:
     print(f"Cancelled run {args.run_id}")
 
 
+def _cmd_share(args: argparse.Namespace) -> None:
+    """Mint (or revoke) a public, scrubbed share permalink for a run."""
+    _validate_run_id(args.run_id)
+    client = _get_client(args)
+    base = getattr(client, "_base_url", "")
+    revoke = getattr(args, "revoke", False)
+    try:
+        if revoke:
+            resp = client._client.delete(f"/api/runs/{args.run_id}/share")
+        else:
+            resp = client._client.post(f"/api/runs/{args.run_id}/share")
+    except Exception as exc:
+        print(_format_cli_error(exc), file=sys.stderr)
+        sys.exit(1)
+
+    if resp.status_code >= 400:
+        print(f"Error: HTTP {resp.status_code}: {resp.text[:200]}", file=sys.stderr)
+        sys.exit(1)
+
+    if revoke:
+        print(_color("Share link revoked.", _C.GREEN))
+        return
+
+    data = resp.json().get("data", {})
+    print(_color(f"Public run link: {base}{data.get('share_path', '')}", _C.GREEN))
+    print(_color("Secrets and PII are scrubbed on the public page.", _C.GRAY))
+
+
 def _cmd_logs(args: argparse.Namespace) -> None:
     """Stream SSE events for a run."""
     _validate_run_id(args.run_id)
@@ -4571,6 +4599,16 @@ def _build_parser() -> argparse.ArgumentParser:
     p_cancel.add_argument("run_id", help="Run ID to cancel")
     _add_connection_args(p_cancel)
 
+    # --- share ---
+    p_share = subparsers.add_parser(
+        "share", help="Mint a public, scrubbed permalink for a run (or --revoke it)"
+    )
+    p_share.add_argument("run_id", help="Run ID to share")
+    p_share.add_argument(
+        "--revoke", action="store_true", help="Revoke the run's public share link"
+    )
+    _add_connection_args(p_share)
+
     # --- logs ---
     p_logs = subparsers.add_parser("logs", help="Stream run events (SSE)")
     p_logs.add_argument("run_id", help="Run ID to stream")
@@ -4989,6 +5027,7 @@ def main() -> None:
         "run": _cmd_run,
         "status": _cmd_status,
         "cancel": _cmd_cancel,
+        "share": _cmd_share,
         "logs": _cmd_logs,
         "ls": _cmd_ls,
         "worker": _cmd_worker,

--- a/src/sandcastle/api/auth.py
+++ b/src/sandcastle/api/auth.py
@@ -27,8 +27,9 @@ PUBLIC_PATHS = {
     "/api/redoc", "/.well-known/agent.json",
 }
 
-# Path prefixes that don't require authentication
-PUBLIC_PREFIXES = ("/api/templates",)
+# Path prefixes that don't require authentication. "/api/r/" serves public, scrubbed
+# shareable run permalinks (the run owner opts in by minting a token).
+PUBLIC_PREFIXES = ("/api/templates", "/api/r/")
 
 # Path suffixes that don't require authentication (e.g. workflow API spec)
 PUBLIC_SUFFIXES = ("/spec",)

--- a/src/sandcastle/api/routes.py
+++ b/src/sandcastle/api/routes.py
@@ -5916,6 +5916,108 @@ async def list_runs(
     )
 
 
+# --- Shareable run permalinks ---
+
+
+@router.post("/runs/{run_id}/share")
+async def share_run(run_id: str, req: Request) -> ApiResponse:
+    """Mint a public, scrubbed share permalink for a run (owner only).
+
+    Returns the relative share path /api/r/{token}. The token is stable across calls so
+    re-sharing the same run returns the same link.
+    """
+    import secrets as _secrets
+
+    tenant_id = get_tenant_id(req)
+    try:
+        run_uuid = uuid.UUID(run_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail=ApiResponse(
+                error=ErrorResponse(code="INVALID_ID", message="Invalid run ID format")
+            ).model_dump(),
+        )
+
+    async with async_session() as session:
+        stmt = select(Run).where(Run.id == run_uuid)
+        stmt = _apply_tenant_filter(stmt, tenant_id, Run.tenant_id)
+        run = (await session.execute(stmt)).scalar_one_or_none()
+        if not run:
+            raise HTTPException(
+                status_code=404,
+                detail=ApiResponse(
+                    error=ErrorResponse(code="NOT_FOUND", message=f"Run '{run_id}' not found")
+                ).model_dump(),
+            )
+        if not run.share_token:
+            run.share_token = _secrets.token_urlsafe(24)
+            await session.commit()
+        token = run.share_token
+
+    return ApiResponse(data={"share_token": token, "share_path": f"/api/r/{token}"})
+
+
+@router.delete("/runs/{run_id}/share")
+async def unshare_run(run_id: str, req: Request) -> ApiResponse:
+    """Revoke a run's public share permalink (owner only)."""
+    tenant_id = get_tenant_id(req)
+    try:
+        run_uuid = uuid.UUID(run_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail=ApiResponse(
+                error=ErrorResponse(code="INVALID_ID", message="Invalid run ID format")
+            ).model_dump(),
+        )
+    async with async_session() as session:
+        stmt = select(Run).where(Run.id == run_uuid)
+        stmt = _apply_tenant_filter(stmt, tenant_id, Run.tenant_id)
+        run = (await session.execute(stmt)).scalar_one_or_none()
+        if not run:
+            raise HTTPException(
+                status_code=404,
+                detail=ApiResponse(
+                    error=ErrorResponse(code="NOT_FOUND", message=f"Run '{run_id}' not found")
+                ).model_dump(),
+            )
+        run.share_token = None
+        await session.commit()
+    return ApiResponse(data={"revoked": True})
+
+
+@router.get("/r/{token}")
+async def view_shared_run(token: str, req: Request) -> Response:
+    """Public, auth-bypassed view of a shared run as a self-contained, scrubbed HTML page.
+
+    Secrets and PII are redacted before rendering (redact-by-default). The page is only
+    reachable when the owner has minted a token via POST /runs/{id}/share.
+    """
+    from sandcastle.api.share import render_run_page
+
+    if not token or len(token) > 128:
+        raise HTTPException(status_code=404, detail="Not found")
+
+    async with async_session() as session:
+        stmt = (
+            select(Run)
+            .options(selectinload(Run.steps))
+            .where(Run.share_token == token)
+        )
+        run = (await session.execute(stmt)).scalar_one_or_none()
+
+    if not run:
+        return Response(
+            content="<!doctype html><title>Not found</title><h1>This run link is not available.</h1>",
+            media_type="text/html",
+            status_code=404,
+        )
+
+    html = render_run_page(run)
+    return Response(content=html, media_type="text/html", status_code=200)
+
+
 # --- Cancel ---
 
 

--- a/src/sandcastle/api/share.py
+++ b/src/sandcastle/api/share.py
@@ -1,0 +1,143 @@
+"""Shareable run permalinks: redact a finished run and render it as a public page.
+
+A run owner mints a token; the public page at /api/r/{token} shows the run's workflow,
+per-step provider/cost/duration (the cross-provider transparency that is the selling
+point), and each step's output - with secrets and PII scrubbed first. Redaction is
+redact-by-default: every string in every step output passes through the secret scrubber,
+a supplementary high-confidence secret filter, and the PII router before it is rendered.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from sandcastle.engine.dag import ReportConfig
+from sandcastle.engine.generator import _scrub_secrets
+from sandcastle.engine.privacy import PII_PATTERNS, PrivacyConfig, PrivacyRouter
+from sandcastle.engine.report import render_report_html
+
+# PII router covering every built-in entity (email/phone/ssn/cc/ip/iban/dob).
+_PUB_PRIVACY = PrivacyRouter(
+    PrivacyConfig(enabled=True, entities=list(PII_PATTERNS.keys()))
+)
+
+# Supplementary high-confidence secret shapes the generic scrubber may miss. These are
+# deliberately conservative (clear token shapes) to avoid over-redacting real content.
+_SECRET_PATTERNS = [
+    re.compile(r"\b(?:ghp_|gho_|ghu_|ghs_|glpat-|xox[baprs]-|AKIA|ASIA|AIza|sk-|sk_live_|sk_test_|pk_live_|rk_live_)[A-Za-z0-9_\-]{8,}"),
+    re.compile(r"\beyJ[A-Za-z0-9_\-]{6,}\.[A-Za-z0-9_\-]{6,}\.[A-Za-z0-9_\-]{6,}"),  # JWT
+    re.compile(r"(?i)\b(?:bearer|authorization|api[_-]?key|access[_-]?token|secret|password|passwd|client[_-]?secret)\b\s*[:=]\s*[^\s\"']{6,}"),
+    re.compile(r"[a-zA-Z][a-zA-Z0-9+.\-]*://[^\s:@/]+:[^\s:@/]+@"),  # creds in a URL
+]
+
+_MAX_OUTPUT_CHARS = 3000
+
+
+def _redact_str(text: str) -> str:
+    out = _scrub_secrets(text)
+    for pat in _SECRET_PATTERNS:
+        out = pat.sub("[REDACTED]", out)
+    out, _ = _PUB_PRIVACY.scrub(out)
+    return out
+
+
+def redact_public(value: Any) -> Any:
+    """Recursively redact secrets + PII from any JSON-able value for public display."""
+    if isinstance(value, str):
+        return _redact_str(value)
+    if isinstance(value, dict):
+        return {k: redact_public(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [redact_public(v) for v in value]
+    return value
+
+
+def _enum_str(value: Any) -> str:
+    return getattr(value, "value", None) or getattr(value, "name", None) or str(value)
+
+
+def _fmt_output(output: Any) -> str:
+    if output is None or output == "" or output == {} or output == []:
+        return "_(no output)_"
+    redacted = redact_public(output)
+    text = redacted if isinstance(redacted, str) else json.dumps(redacted, indent=2, default=str)
+    if len(text) > _MAX_OUTPUT_CHARS:
+        text = text[:_MAX_OUTPUT_CHARS] + "\n... (truncated)"
+    return f"```\n{text}\n```"
+
+
+def run_to_markdown(run: Any) -> str:
+    """Compose a public markdown page from a finished Run and its steps (redacted)."""
+    steps = list(getattr(run, "steps", []) or [])
+    steps.sort(key=lambda s: (getattr(s, "started_at", None) or 0, str(getattr(s, "step_id", ""))))
+
+    status = _enum_str(run.status)
+    cost = float(getattr(run, "total_cost_usd", 0.0) or 0.0)
+    started = getattr(run, "started_at", "") or ""
+    completed = getattr(run, "completed_at", "") or ""
+    providers = sorted({str(s.model) for s in steps if getattr(s, "model", None)})
+
+    lines: list[str] = []
+    lines.append(f"# {run.workflow_name}")
+    lines.append("")
+    lines.append(
+        f"**Status:** {status}  |  **Cost:** ${cost:.4f}  |  "
+        f"**Started:** {started}  |  **Finished:** {completed}"
+    )
+    if providers:
+        plural = "providers" if len(providers) > 1 else "provider"
+        lines.append("")
+        lines.append(f"Ran across {len(providers)} {plural}: " + ", ".join(f"`{p}`" for p in providers))
+    if getattr(run, "error", None):
+        lines.append("")
+        lines.append(f"**Error:** {_redact_str(str(run.error))}")
+
+    lines.append("")
+    lines.append(f"## Steps ({len(steps)})")
+    lines.append("")
+    lines.append("| # | Step | Provider | Status | Cost | Duration |")
+    lines.append("|---|------|----------|--------|------|----------|")
+    for i, s in enumerate(steps, 1):
+        lines.append(
+            f"| {i} | {getattr(s, 'step_id', '')} | `{getattr(s, 'model', '') or '-'}` | "
+            f"{_enum_str(getattr(s, 'status', ''))} | "
+            f"${float(getattr(s, 'cost_usd', 0.0) or 0.0):.4f} | "
+            f"{float(getattr(s, 'duration_seconds', 0.0) or 0.0):.2f}s |"
+        )
+
+    lines.append("")
+    lines.append("## Step outputs")
+    for s in steps:
+        lines.append("")
+        lines.append(f"### {getattr(s, 'step_id', '')}  -  model `{getattr(s, 'model', '') or '-'}`")
+        if getattr(s, "error", None):
+            lines.append(f"**Error:** {_redact_str(str(s.error))}")
+        lines.append(_fmt_output(getattr(s, "output_data", None)))
+
+    lines.append("")
+    lines.append("## Run this yourself")
+    lines.append("")
+    lines.append("```")
+    lines.append("pip install sandcastle-ai")
+    lines.append(f"sandcastle run --local {run.workflow_name}")
+    lines.append("```")
+    lines.append("")
+    lines.append("_Reproducible and provider-neutral. Shared from Sandcastle._")
+    return "\n".join(lines)
+
+
+def render_run_page(run: Any) -> str:
+    """Render a finished run as a self-contained, scrubbed public HTML page."""
+    markdown = run_to_markdown(run)
+    config = ReportConfig(
+        format="html",
+        theme="professional",
+        title=str(run.workflow_name),
+        subtitle="Sandcastle run",
+        author="Sandcastle",
+        include_toc=False,
+        include_page_numbers=False,
+    )
+    return render_report_html(markdown, config, {"title": str(run.workflow_name)})

--- a/src/sandcastle/models/db.py
+++ b/src/sandcastle/models/db.py
@@ -115,6 +115,11 @@ class Run(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )
+    # Public share token: when set, the run is viewable at /api/r/{share_token} with
+    # secrets and PII scrubbed. None means private (the default).
+    share_token: Mapped[str | None] = mapped_column(
+        String(64), nullable=True, unique=True, index=True
+    )
 
     steps: Mapped[list[RunStep]] = relationship(
         back_populates="run", cascade="all, delete-orphan", foreign_keys="RunStep.run_id"

--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -1,0 +1,129 @@
+"""Tests for shareable run permalinks - the public page must never leak secrets or PII.
+
+The redaction gate is the load-bearing safety control: a finished run is published to a
+public, auth-bypassed URL, so every string in every step output has to pass through the
+secret scrubber and the PII router first. These tests prove the gate removes a battery of
+secret shapes and PII while keeping benign content, that the rendered HTML page never
+contains a planted secret, and that the public route only serves shared runs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import types
+import uuid
+
+import pytest
+
+from sandcastle.api.share import redact_public, render_run_page
+
+SECRETS = [
+    "sk-ABC123def456ghi789jkl",        # OpenAI-style key
+    "ghp_AbC123dEf456GhI789jKl0",       # GitHub PAT
+    "AKIAIOSFODNN7EXAMPLE",             # AWS access key id
+    "ya29.A0ARrdaM-SECRETtoken123456",  # Google OAuth (via bearer assignment)
+    "eyJhbGciOi.eyJzdWIiOiJ.SflKxwRJSMe",  # JWT
+]
+PII = ["victim@example.com", "555-123-4567", "123-45-6789"]
+
+
+def test_redact_removes_secrets_and_pii_keeps_benign():
+    payload = {
+        "openai_key": "sk-ABC123def456ghi789jkl",
+        "github": "ghp_AbC123dEf456GhI789jKl0",
+        "aws": "AKIAIOSFODNN7EXAMPLE",
+        "authorization": "Bearer ya29.A0ARrdaM-SECRETtoken123456",
+        "jwt": "eyJhbGciOi.eyJzdWIiOiJ.SflKxwRJSMe",
+        "password=": "password=hunter2supersecret",
+        "db_url": "postgres://dbuser:dbpass@host:5432/app",
+        "nested": [{"email": "victim@example.com"}, "call 555-123-4567", "ssn 123-45-6789"],
+        "benign": "Rolled back deploy abc123, error rate recovered.",
+    }
+    blob = json.dumps(redact_public(payload))
+    for secret in SECRETS + ["hunter2supersecret", "dbuser:dbpass@host"]:
+        assert secret not in blob, f"secret leaked: {secret}"
+    for pii in PII:
+        assert pii not in blob, f"PII leaked: {pii}"
+    assert "Rolled back deploy" in blob, "benign content should be preserved"
+
+
+def test_redact_handles_primitives_and_none():
+    assert redact_public(42) == 42
+    assert redact_public(None) is None
+    assert redact_public(True) is True
+    assert redact_public(["a@b.com", 7]) == ["[EMAIL]", 7]
+
+
+def _fake_run(output):
+    step = types.SimpleNamespace(
+        step_id="diagnose", status="completed", model="google/gemini-2.5-pro",
+        cost_usd=0.012, duration_seconds=1.4, started_at=1, error=None, output_data=output,
+    )
+    return types.SimpleNamespace(
+        workflow_name="closed-loop-autoremediator", status="completed",
+        total_cost_usd=0.012, started_at="t0", completed_at="t1", error=None, steps=[step],
+    )
+
+
+def test_rendered_page_is_html_and_leak_free():
+    run = _fake_run({"fix": "rollback", "leaked": "sk-ABC123def456ghi789jkl", "to": "victim@example.com"})
+    html = render_run_page(run)
+    assert "<html" in html.lower() and len(html) > 1000
+    assert "closed-loop-autoremediator" in html           # workflow shown
+    assert "gemini-2.5-pro" in html                        # provider transparency
+    assert "sk-ABC123def456ghi789jkl" not in html          # secret scrubbed
+    assert "victim@example.com" not in html                # PII scrubbed
+    assert "Run this yourself" in html                     # viral loop CTA
+
+
+# ----------------------------------------------------------------------------
+# Route-level: the public page only serves shared runs and stays leak-free.
+# ----------------------------------------------------------------------------
+
+def _seed_shared_run(token: str, secret_in_output: str) -> None:
+    from sandcastle.models.db import Run, RunStatus, RunStep, StepStatus, async_session, init_db
+
+    async def _seed():
+        await init_db()
+        run_id = uuid.uuid4()
+        async with async_session() as session:
+            session.add(Run(
+                id=run_id, workflow_name="shared-wf", status=RunStatus.COMPLETED,
+                total_cost_usd=0.05, share_token=token,
+            ))
+            session.add(RunStep(
+                id=uuid.uuid4(), run_id=run_id, step_id="s1", parallel_index=None,
+                status=StepStatus.COMPLETED, model="sonnet", cost_usd=0.05,
+                duration_seconds=2.0, output_data={"note": "ok", "key": secret_in_output},
+            ))
+            await session.commit()
+
+    asyncio.run(_seed())
+
+
+def test_public_route_serves_shared_run_without_leaking():
+    from fastapi.testclient import TestClient
+
+    from sandcastle.main import app
+
+    token = "pubtoken_test_123"
+    _seed_shared_run(token, "sk-ROUTELEAK999shouldNotAppear")
+    client = TestClient(app)
+
+    resp = client.get(f"/api/r/{token}")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers.get("content-type", "")
+    body = resp.text
+    assert "shared-wf" in body
+    assert "sk-ROUTELEAK999shouldNotAppear" not in body, "route leaked a secret"
+
+
+def test_public_route_unknown_token_is_404():
+    from fastapi.testclient import TestClient
+
+    from sandcastle.main import app
+
+    client = TestClient(app)
+    resp = client.get("/api/r/this-token-does-not-exist")
+    assert resp.status_code == 404


### PR DESCRIPTION
## What

The next "trust + distribution" build from the bold-ideas sweep. Turns the orchestrator's most viral artifact - a finished run with per-step **provider, cost, and audit trail** - into a public distribution surface.

```
$ sandcastle share <run_id>
Public run link: http://host/api/r/Xy7...   (secrets and PII scrubbed)
```

The owner mints a token; the run becomes viewable at a public, auth-bypassed URL showing the workflow, a per-step **provider/cost/duration** table (the cross-provider transparency no single vendor exposes), each step's output, and a **"Run this yourself"** CTA that deep-links into `sandcastle run --local`. The run, not the template, becomes the unit of distribution.

## How (read-only over persisted rows, no provider SDK)

- **`models/db.py`** + **`alembic/013`**: a nullable, unique, indexed `share_token` on `Run`.
- **`api/share.py`** - the load-bearing **safety gate**. `redact_public()` recursively scrubs every string in every step output through `generator._scrub_secrets` + supplementary high-confidence secret shapes (bearer / JWT / key-prefixes like `ghp_`/`AKIA`/`sk-` / credential-URLs) + the PII router (`engine/privacy`, all 7 entities), then composes markdown and renders it with `engine/report.render_report_html`. **Redact-by-default**; raw run input is never published.
- **`api/routes.py`**: `POST /runs/{id}/share` (owner mints, tenant-scoped), `DELETE` to revoke, `GET /r/{token}` public (`auth.py` PUBLIC_PREFIXES += `/api/r/`) returning scrubbed HTML.
- **`__main__.py`**: `sandcastle share <run_id>` / `--revoke`.

## Security is the whole point

A public, auth-bypassed page of run data is an external publish - so the scrub gate is the control that matters. `test_share.py` proves:
- the gate strips a battery of secret shapes (OpenAI/GitHub/AWS keys, bearer, JWT, `password=`, db creds) **and** PII (email/phone/ssn) while keeping benign content;
- the rendered HTML **never** contains a planted secret or PII;
- the public route serves **only** shared runs (unknown token -> 404), with a route-level leak assertion on a seeded run.

```
tests/test_share.py  5 passed
tests/test_workflow_api.py + test_cli_local_run.py  green ; migration 013 chains to 012
```

Additive: the column is nullable (private by default), the routes are new, the public prefix is scoped to `/api/r/`. The provider-bakeoff-leaderboard (next) reuses this share surface for replayable receipts.