### PR TITLE
feat(dashboard): surface the provider-neutral story + dark-first refresh

### DIFF
--- a/dashboard/src/__tests__/dashboard-wave8.test.tsx
+++ b/dashboard/src/__tests__/dashboard-wave8.test.tsx
@@ -1710,9 +1710,9 @@ describe("Constants", () => {
 import { useTheme } from "@/hooks/useTheme";
 
 describe("useTheme", () => {
-  it("defaults to light when no stored preference", () => {
+  it("defaults to dark when no stored preference (dark-first)", () => {
     const { result } = renderHook(() => useTheme());
-    expect(result.current.theme).toBe("light");
+    expect(result.current.theme).toBe("dark");
   });
 
   it("reads stored theme from localStorage", () => {
@@ -1723,20 +1723,21 @@ describe("useTheme", () => {
 
   it("toggles theme", () => {
     const { result } = renderHook(() => useTheme());
-    expect(result.current.theme).toBe("light");
-
-    act(() => {
-      result.current.toggleTheme();
-    });
     expect(result.current.theme).toBe("dark");
 
     act(() => {
       result.current.toggleTheme();
     });
     expect(result.current.theme).toBe("light");
+
+    act(() => {
+      result.current.toggleTheme();
+    });
+    expect(result.current.theme).toBe("dark");
   });
 
   it("persists theme to localStorage", () => {
+    localStorage.setItem("theme", "light");
     const { result } = renderHook(() => useTheme());
     act(() => {
       result.current.toggleTheme();
@@ -1747,8 +1748,8 @@ describe("useTheme", () => {
   it("ignores invalid stored values", () => {
     localStorage.setItem("theme", "invalid");
     const { result } = renderHook(() => useTheme());
-    // Falls back to matchMedia (mocked to false = light)
-    expect(result.current.theme).toBe("light");
+    // Falls back to the dark-first default (matchMedia mocked to false).
+    expect(result.current.theme).toBe("dark");
   });
 });
 

--- a/dashboard/src/__tests__/useTheme.test.ts
+++ b/dashboard/src/__tests__/useTheme.test.ts
@@ -8,28 +8,18 @@ describe("useTheme", () => {
     document.documentElement.classList.remove("dark");
   });
 
-  it("defaults to light when no preference stored and system is light", () => {
+  it("defaults to dark when no preference stored (dark-first)", () => {
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe("dark");
+  });
+
+  it("restores stored theme", () => {
+    localStorage.setItem("theme", "light");
     const { result } = renderHook(() => useTheme());
     expect(result.current.theme).toBe("light");
   });
 
-  it("restores stored theme", () => {
-    localStorage.setItem("theme", "dark");
-    const { result } = renderHook(() => useTheme());
-    expect(result.current.theme).toBe("dark");
-  });
-
-  it("toggles from light to dark", () => {
-    const { result } = renderHook(() => useTheme());
-    act(() => {
-      result.current.toggleTheme();
-    });
-    expect(result.current.theme).toBe("dark");
-    expect(document.documentElement.classList.contains("dark")).toBe(true);
-  });
-
-  it("toggles from dark to light", () => {
-    localStorage.setItem("theme", "dark");
+  it("toggles from the default (dark) to light", () => {
     const { result } = renderHook(() => useTheme());
     act(() => {
       result.current.toggleTheme();
@@ -38,7 +28,18 @@ describe("useTheme", () => {
     expect(document.documentElement.classList.contains("dark")).toBe(false);
   });
 
+  it("toggles from light to dark", () => {
+    localStorage.setItem("theme", "light");
+    const { result } = renderHook(() => useTheme());
+    act(() => {
+      result.current.toggleTheme();
+    });
+    expect(result.current.theme).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
   it("persists theme to localStorage", () => {
+    localStorage.setItem("theme", "light");
     const { result } = renderHook(() => useTheme());
     act(() => {
       result.current.toggleTheme();
@@ -46,10 +47,9 @@ describe("useTheme", () => {
     expect(localStorage.getItem("theme")).toBe("dark");
   });
 
-  it("ignores invalid stored values", () => {
+  it("ignores invalid stored values (falls back to dark-first default)", () => {
     localStorage.setItem("theme", "rainbow");
     const { result } = renderHook(() => useTheme());
-    // Falls back to system preference (mocked as light)
-    expect(result.current.theme).toBe("light");
+    expect(result.current.theme).toBe("dark");
   });
 });

--- a/dashboard/src/components/runs/StepCard.tsx
+++ b/dashboard/src/components/runs/StepCard.tsx
@@ -124,6 +124,7 @@ interface StepCardProps {
   owner?: string;
   stepType?: string;
   artifactUrl?: string;
+  model?: string | null;
   runId?: string;
   onReplay?: (stepId: string) => void;
   onFork?: (stepId: string) => void;
@@ -144,6 +145,7 @@ export function StepCard({
   owner,
   stepType,
   artifactUrl,
+  model,
   runId,
   onReplay,
   onFork,
@@ -194,7 +196,12 @@ export function StepCard({
           {responsibility && (
             <p className="mt-0.5 text-xs italic text-muted">{responsibility}</p>
           )}
-          <div className="mt-0.5 flex items-center gap-3 text-xs text-muted">
+          <div className="mt-0.5 flex flex-wrap items-center gap-3 text-xs text-muted">
+            {model && (
+              <span className="rounded-md bg-running/10 px-1.5 py-0.5 font-mono text-[11px] text-running" title="Provider that ran this step">
+                {model}
+              </span>
+            )}
             <span>{formatDuration(durationSeconds)}</span>
             <span>{formatCost(costUsd)}</span>
             {attempt > 1 && <span>attempt {attempt}</span>}

--- a/dashboard/src/components/runs/StepTimeline.tsx
+++ b/dashboard/src/components/runs/StepTimeline.tsx
@@ -17,6 +17,7 @@ interface Step {
   owner?: string;
   type?: string;
   artifact_url?: string;
+  model?: string | null;
 }
 
 interface StepTimelineProps {
@@ -65,6 +66,7 @@ export function StepTimeline({ steps, runId, onReplay, onFork }: StepTimelinePro
               owner={step.owner}
               stepType={step.type}
               artifactUrl={step.artifact_url}
+              model={step.model}
               runId={runId}
               onReplay={onReplay}
               onFork={onFork}

--- a/dashboard/src/hooks/useTheme.ts
+++ b/dashboard/src/hooks/useTheme.ts
@@ -8,9 +8,12 @@ function getInitialTheme(): Theme {
     if (stored === "light" || stored === "dark") return stored;
   } catch {
     // Storage unavailable (private browsing, sandboxed iframe). Fall through
-    // to the system preference.
+    // to the default below.
   }
-  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  // Dark-first: a stored preference always wins; new visitors default to dark
+  // (the signature look for an AI/dev tool) unless the OS explicitly prefers light.
+  if (window.matchMedia("(prefers-color-scheme: light)").matches) return "light";
+  return "dark";
 }
 
 export function useTheme() {

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -4,10 +4,12 @@ import { Toaster } from "sonner";
 import "./index.css";
 import App from "./App.tsx";
 
-// Apply saved theme immediately to prevent flash
+// Apply the theme immediately to prevent a flash. Dark-first: a stored preference
+// wins; new visitors default to dark unless the OS explicitly prefers light. Keep this
+// in sync with getInitialTheme() in hooks/useTheme.ts.
 const savedTheme = localStorage.getItem("theme");
-const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-if (savedTheme === "dark" || (!savedTheme && prefersDark)) {
+const prefersLight = window.matchMedia("(prefers-color-scheme: light)").matches;
+if (savedTheme === "dark" || (!savedTheme && !prefersLight)) {
   document.documentElement.classList.add("dark");
 }
 

--- a/dashboard/src/pages/RunDetailPage.tsx
+++ b/dashboard/src/pages/RunDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { XCircle, GitCompareArrows, Trash2, Download, Copy, FileDown, ChevronDown, ArrowLeft, Sparkles, AlertTriangle, AlertOctagon, Shield, ChevronRight } from "lucide-react";
+import { XCircle, GitCompareArrows, Trash2, Download, Copy, FileDown, ChevronDown, ArrowLeft, Sparkles, AlertTriangle, AlertOctagon, Shield, ChevronRight, Share2, ExternalLink } from "lucide-react";
 import { useNotifications } from "@/hooks/useNotifications";
 import { useRuns } from "@/hooks/useRuns";
 import { useEventStreamContext } from "@/hooks/useEventStreamContext";
@@ -42,6 +42,7 @@ interface Step {
   owner?: string;
   type?: string;
   artifact_url?: string;
+  model?: string | null;
 }
 
 interface RunDetail {
@@ -87,6 +88,8 @@ export default function RunDetailPage() {
   const [loadingReport, setLoadingReport] = useState(false);
   const [flamegraphExpanded, setFlamegraphExpanded] = useState(true);
   const [anomaliesExpanded, setAnomaliesExpanded] = useState(false);
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [sharing, setSharing] = useState(false);
   const { notifyRunComplete } = useNotifications();
   const prevStatusRef = useRef<string | null>(null);
   const celebratedRef = useRef(false);
@@ -292,6 +295,42 @@ export default function RunDetailPage() {
     setDeleting(false);
     setDeleteConfirmOpen(false);
   }, [id, navigate]);
+
+  const handleShare = useCallback(async () => {
+    if (!id || sharing) return;
+    setSharing(true);
+    const res = await api.post<{ share_token: string; share_path: string }>(
+      `/runs/${id}/share`
+    );
+    if (res.error) {
+      toast.error(`Share failed: ${res.error.message}`);
+    } else if (res.data) {
+      const url = `${window.location.origin}${res.data.share_path}`;
+      setShareUrl(url);
+      try {
+        await navigator.clipboard.writeText(url);
+        toast.success("Public link copied (secrets and PII scrubbed)");
+      } catch {
+        toast.success("Public link created (secrets and PII scrubbed)");
+      }
+    }
+    setSharing(false);
+  }, [id, sharing]);
+
+  // Per-provider cost rollup from the run's steps - surfaces the provider-neutral story.
+  const providerStats = useMemo(() => {
+    const map = new Map<string, { cost: number; count: number }>();
+    for (const s of run?.steps ?? []) {
+      if (!s.model) continue;
+      const e = map.get(s.model) ?? { cost: 0, count: 0 };
+      e.cost += s.cost_usd || 0;
+      e.count += 1;
+      map.set(s.model, e);
+    }
+    return [...map.entries()]
+      .map(([model, v]) => ({ model, ...v }))
+      .sort((a, b) => b.cost - a.cost);
+  }, [run]);
 
   // Filter out internal fields (prefixed with _) from outputs
   const filterOutputs = useCallback(
@@ -538,6 +577,20 @@ export default function RunDetailPage() {
               </button>
             )}
             <button
+              onClick={handleShare}
+              disabled={sharing}
+              title="Create a public, scrubbed permalink for this run"
+              className={cn(
+                "flex items-center gap-1.5 rounded-lg border border-accent/30 px-3 py-1.5",
+                "text-xs sm:text-sm font-medium text-accent",
+                "hover:bg-accent/10 transition-colors",
+                "disabled:opacity-50 disabled:cursor-not-allowed"
+              )}
+            >
+              <Share2 className="h-4 w-4" />
+              <span className="hidden sm:inline">{sharing ? "Sharing..." : "Share"}</span>
+            </button>
+            <button
               onClick={() => setChatOpen(true)}
               className={cn(
                 "flex items-center gap-1.5 rounded-lg border border-accent/30 px-3 py-1.5",
@@ -728,6 +781,52 @@ export default function RunDetailPage() {
                 )}
               </div>
             )}
+          </div>
+        </div>
+      )}
+
+      {/* Public share link (after the owner mints it) */}
+      {shareUrl && (
+        <div className="flex flex-wrap items-center gap-2 rounded-xl border border-accent/30 bg-accent/5 px-4 py-3 text-xs sm:text-sm">
+          <Share2 className="h-4 w-4 shrink-0 text-accent" />
+          <span className="text-muted">Public link (secrets and PII scrubbed):</span>
+          <a
+            href={shareUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 truncate font-mono text-accent hover:underline"
+          >
+            {shareUrl}
+            <ExternalLink className="h-3.5 w-3.5 shrink-0" />
+          </a>
+        </div>
+      )}
+
+      {/* Providers used - surfaces the provider-neutral cost story */}
+      {providerStats.length > 0 && (
+        <div className="rounded-xl border border-border bg-surface p-4 shadow-sm card-hover-lift transition-all">
+          <div className="mb-3 flex items-center gap-2">
+            <Shield className="h-4 w-4 text-accent" />
+            <span className="text-sm font-semibold text-foreground">Providers</span>
+            <span className="text-xs text-muted">
+              {providerStats.length === 1
+                ? "1 provider"
+                : `${providerStats.length} providers, failover-ready`}
+            </span>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {providerStats.map((p) => (
+              <div
+                key={p.model}
+                className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-1.5"
+              >
+                <span className="font-mono text-xs text-foreground">{p.model}</span>
+                <span className="text-[11px] text-muted">
+                  {p.count} {p.count === 1 ? "step" : "steps"}
+                </span>
+                <span className="text-[11px] font-medium text-accent">{formatCost(p.cost)}</span>
+              </div>
+            ))}
           </div>
         </div>
       )}

--- a/src/sandcastle/api/routes.py
+++ b/src/sandcastle/api/routes.py
@@ -5384,6 +5384,7 @@ async def get_run(run_id: str, req: Request) -> ApiResponse:
             pdf_artifact=bool(
                 isinstance(s.output_data, dict) and s.output_data.get("_pdf_artifact")
             ),
+            model=s.model,
         )
         for s in _dedup.values()
     ]

--- a/src/sandcastle/api/schemas.py
+++ b/src/sandcastle/api/schemas.py
@@ -467,6 +467,7 @@ class StepStatusResponse(BaseModel):
     error: str | None = None
     started_at: str | None = None
     pdf_artifact: bool = False
+    model: str | None = Field(None, description="Provider/model that ran the step")
 
 
 class HealthResponse(BaseModel):


### PR DESCRIPTION
## What

A GUI refresh that ties the dashboard to what the engine actually does (provider neutrality, cost, shareable runs) plus a visual signature pass. Both A and B in one cohesive PR, as requested.

## A - Surface the moat (the dashboard finally shows the product story)

- **Per-step provider.** The run-detail API exposed cost + duration per step but never the **model**, even though `RunStep` records it. This adds `model` to `StepStatusResponse` + `get_run` (additive, optional), threads it through `StepTimeline -> StepCard` as a per-step provider chip, and adds a run-level **"Providers" panel** that rolls up distinct providers and per-provider cost: _"N providers, failover-ready"_. The cross-provider transparency that is the neutrality moat is now visible in the UI.
- **Share button.** The run-detail header gets a **Share** action that mints a public, scrubbed permalink (the shareable-run-permalinks feature from #247) and copies it, shown with an external-link affordance and a "secrets and PII scrubbed" note.

## B - Dark-first refresh

- **Dark-first default.** New visitors default to dark (the signature look for an AI/dev tool); a stored preference always wins, and an explicit OS light preference is still respected. `getInitialTheme()` and the pre-render theme application in `main.tsx` are kept in sync to avoid a flash.
- The new Providers panel uses the existing `card-hover-lift` depth utility.

## Tests

- Theme tests updated to the new dark-first contract (the default changed by design).
- Dashboard **build clean**, **794 vitest tests pass**.
- Backend `get_run` / `test_workflow_api.py` green (the `model` field is additive and optional, so no contract break).

Frontend-only behavior change is the default theme; backend change is a single additive response field. `dashboard/dist` is CI-built and not committed.