### PR TITLE
fix(dashboard): recover from stale-deploy chunk misses (no more dead-end 'Connection error')

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ build_template.py
 :memory:*
 .coverage
 coverage*.json
+
+# autoresearch scratch output
+.autoresearch/

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,5 +1,5 @@
 import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
-import { Suspense, lazy } from "react";
+import { Suspense } from "react";
 import { Layout } from "@/components/layout/Layout";
 import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
 import { ErrorBoundary } from "@/components/shared/ErrorBoundary";
@@ -7,32 +7,35 @@ import { EventStreamProvider } from "@/components/providers/EventStreamProvider"
 import { useAuth } from "@/hooks/useAuth";
 import { AuthGate } from "@/components/auth/AuthGate";
 import { usePageTracking } from "@/hooks/usePageTracking";
+import { lazyWithRetry } from "@/lib/lazyWithRetry";
 
-// Lazy-loaded page components for code splitting
-const Overview = lazy(() => import("@/pages/Overview"));
-const Runs = lazy(() => import("@/pages/Runs"));
-const RunComparePage = lazy(() => import("@/pages/RunComparePage"));
-const RunDetailPage = lazy(() => import("@/pages/RunDetailPage"));
-const Workflows = lazy(() => import("@/pages/Workflows"));
-const WorkflowBuilderPage = lazy(() => import("@/pages/WorkflowBuilderPage"));
-const WorkflowDetailPage = lazy(() => import("@/pages/WorkflowDetailPage"));
-const ApprovalsPage = lazy(() => import("@/pages/ApprovalsPage"));
-const AutoPilotPage = lazy(() => import("@/pages/AutoPilotPage"));
-const ViolationsPage = lazy(() => import("@/pages/ViolationsPage"));
-const OptimizerPage = lazy(() => import("@/pages/OptimizerPage"));
-const Schedules = lazy(() => import("@/pages/Schedules"));
-const ScheduleMonitorPage = lazy(() => import("@/pages/ScheduleMonitorPage"));
-const DeadLetterPage = lazy(() => import("@/pages/DeadLetterPage"));
-const ApiKeysPage = lazy(() => import("@/pages/ApiKeysPage"));
-const SettingsPage = lazy(() => import("@/pages/SettingsPage"));
-const TemplatesPage = lazy(() => import("@/pages/TemplatesPage"));
-const IntegrationsPage = lazy(() => import("@/pages/IntegrationsPage"));
-const EvaluationsPage = lazy(() => import("@/pages/EvaluationsPage"));
-const EvolutionPage = lazy(() => import("@/pages/EvolutionPage"));
-const SystemHealthPage = lazy(() => import("@/pages/SystemHealthPage"));
-const CompliancePage = lazy(() => import("@/pages/CompliancePage"));
-const MemoryPage = lazy(() => import("@/pages/MemoryPage"));
-const Onboarding = lazy(() => import("@/pages/Onboarding"));
+// Lazy-loaded page components for code splitting. lazyWithRetry recovers from a
+// stale-deploy chunk miss (open tab + new deploy = 404 on the old hashed chunk)
+// by reloading once for the fresh index.html, instead of dead-ending the route.
+const Overview = lazyWithRetry(() => import("@/pages/Overview"), "overview");
+const Runs = lazyWithRetry(() => import("@/pages/Runs"), "runs");
+const RunComparePage = lazyWithRetry(() => import("@/pages/RunComparePage"), "run-compare");
+const RunDetailPage = lazyWithRetry(() => import("@/pages/RunDetailPage"), "run-detail");
+const Workflows = lazyWithRetry(() => import("@/pages/Workflows"), "workflows");
+const WorkflowBuilderPage = lazyWithRetry(() => import("@/pages/WorkflowBuilderPage"), "workflow-builder");
+const WorkflowDetailPage = lazyWithRetry(() => import("@/pages/WorkflowDetailPage"), "workflow-detail");
+const ApprovalsPage = lazyWithRetry(() => import("@/pages/ApprovalsPage"), "approvals");
+const AutoPilotPage = lazyWithRetry(() => import("@/pages/AutoPilotPage"), "autopilot");
+const ViolationsPage = lazyWithRetry(() => import("@/pages/ViolationsPage"), "violations");
+const OptimizerPage = lazyWithRetry(() => import("@/pages/OptimizerPage"), "optimizer");
+const Schedules = lazyWithRetry(() => import("@/pages/Schedules"), "schedules");
+const ScheduleMonitorPage = lazyWithRetry(() => import("@/pages/ScheduleMonitorPage"), "schedule-monitor");
+const DeadLetterPage = lazyWithRetry(() => import("@/pages/DeadLetterPage"), "dead-letter");
+const ApiKeysPage = lazyWithRetry(() => import("@/pages/ApiKeysPage"), "api-keys");
+const SettingsPage = lazyWithRetry(() => import("@/pages/SettingsPage"), "settings");
+const TemplatesPage = lazyWithRetry(() => import("@/pages/TemplatesPage"), "templates");
+const IntegrationsPage = lazyWithRetry(() => import("@/pages/IntegrationsPage"), "integrations");
+const EvaluationsPage = lazyWithRetry(() => import("@/pages/EvaluationsPage"), "evaluations");
+const EvolutionPage = lazyWithRetry(() => import("@/pages/EvolutionPage"), "evolution");
+const SystemHealthPage = lazyWithRetry(() => import("@/pages/SystemHealthPage"), "system-health");
+const CompliancePage = lazyWithRetry(() => import("@/pages/CompliancePage"), "compliance");
+const MemoryPage = lazyWithRetry(() => import("@/pages/MemoryPage"), "memory");
+const Onboarding = lazyWithRetry(() => import("@/pages/Onboarding"), "onboarding");
 
 /** Wrap a lazy-loaded page in a per-route error boundary so a crash in one
  *  page does not take down the entire app. */

--- a/dashboard/src/__tests__/ErrorBoundary.test.tsx
+++ b/dashboard/src/__tests__/ErrorBoundary.test.tsx
@@ -11,6 +11,18 @@ function GoodComponent(): React.ReactElement {
   return <div>Everything is fine</div>;
 }
 
+// Throws the exact shape a stale-deploy chunk miss produces.
+function ChunkBroken(): React.ReactElement {
+  throw new TypeError(
+    "Failed to fetch dynamically imported module: https://x/assets/TemplatesPage-abc.js"
+  );
+}
+
+// Throws a genuine network error (api call), not a chunk miss.
+function NetworkBroken(): React.ReactElement {
+  throw new TypeError("Failed to fetch");
+}
+
 describe("ErrorBoundary", () => {
   // Suppress React's error boundary console.error in tests
   let consoleError: ReturnType<typeof vi.spyOn>;
@@ -61,8 +73,56 @@ describe("ErrorBoundary", () => {
     expect(screen.getByText("Something went wrong")).toBeInTheDocument();
   });
 
+  it("shows an 'Update available' reload prompt for a stale-deploy chunk miss", () => {
+    render(
+      <ErrorBoundary>
+        <ChunkBroken />
+      </ErrorBoundary>
+    );
+    // Chunk misses must NOT read as a network/connection problem.
+    expect(screen.getByText("Update available")).toBeInTheDocument();
+    expect(screen.getByText("Reload")).toBeInTheDocument();
+    expect(screen.queryByText("Connection error")).not.toBeInTheDocument();
+    expect(screen.queryByText("Something went wrong")).not.toBeInTheDocument();
+  });
+
+  it("Reload button hard-reloads and clears the chunk-retry guards", () => {
+    const reload = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, reload },
+    });
+    window.sessionStorage.setItem("sc:chunk-reload:templates", "1");
+    window.sessionStorage.setItem("unrelated", "keep");
+
+    render(
+      <ErrorBoundary>
+        <ChunkBroken />
+      </ErrorBoundary>
+    );
+    fireEvent.click(screen.getByText("Reload"));
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(window.sessionStorage.getItem("sc:chunk-reload:templates")).toBeNull();
+    expect(window.sessionStorage.getItem("unrelated")).toBe("keep");
+  });
+
+  it("still shows 'Connection error' for a real network failure", () => {
+    render(
+      <ErrorBoundary>
+        <NetworkBroken />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText("Connection error")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Could not reach the server/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Update available")).not.toBeInTheDocument();
+  });
+
   // Clean up
   afterEach(() => {
     consoleError?.mockRestore();
+    window.sessionStorage.clear();
   });
 });

--- a/dashboard/src/__tests__/lazyWithRetry.test.tsx
+++ b/dashboard/src/__tests__/lazyWithRetry.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Suspense } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { lazyWithRetry, isChunkLoadError } from "@/lib/lazyWithRetry";
+import { ErrorBoundary } from "@/components/shared/ErrorBoundary";
+
+function chunkError(): TypeError {
+  return new TypeError(
+    "Failed to fetch dynamically imported module: https://x/assets/Foo-abc123.js"
+  );
+}
+
+describe("isChunkLoadError", () => {
+  it("matches the dynamic-import failure shapes across engines", () => {
+    expect(isChunkLoadError(chunkError())).toBe(true);
+    expect(
+      isChunkLoadError(new Error("error loading dynamically imported module"))
+    ).toBe(true);
+    expect(
+      isChunkLoadError(new Error("Importing a module script failed."))
+    ).toBe(true);
+    const named = new Error("whatever");
+    named.name = "ChunkLoadError";
+    expect(isChunkLoadError(named)).toBe(true);
+    // Vite's per-chunk CSS preload 404 rejects the same import.
+    expect(
+      isChunkLoadError(new Error("Unable to preload CSS for /assets/Foo-abc.css"))
+    ).toBe(true);
+  });
+
+  it("does NOT match a plain network fetch failure or generic errors", () => {
+    // The crucial distinction: a real api/network failure stays a network error.
+    expect(isChunkLoadError(new TypeError("Failed to fetch"))).toBe(false);
+    expect(isChunkLoadError(new Error("boom"))).toBe(false);
+    expect(isChunkLoadError("not an error")).toBe(false);
+    expect(isChunkLoadError(null)).toBe(false);
+    expect(isChunkLoadError(undefined)).toBe(false);
+  });
+});
+
+describe("lazyWithRetry", () => {
+  let reload: ReturnType<typeof vi.fn>;
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    reload = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, reload },
+    });
+    window.sessionStorage.clear();
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError?.mockRestore();
+    window.sessionStorage.clear();
+    // Restore online state in case a test stubbed it.
+    Object.defineProperty(navigator, "onLine", { configurable: true, value: true });
+  });
+
+  it("renders the component when the import succeeds and leaves no guard behind", async () => {
+    const Lazy = lazyWithRetry(
+      () => Promise.resolve({ default: () => <div>loaded ok</div> }),
+      "ok"
+    );
+    render(
+      <Suspense fallback={<div>loading</div>}>
+        <Lazy />
+      </Suspense>
+    );
+    await screen.findByText("loaded ok");
+    expect(reload).not.toHaveBeenCalled();
+    expect(window.sessionStorage.getItem("sc:chunk-reload:ok")).toBeNull();
+  });
+
+  it("reloads exactly once on a chunk miss and keeps the Suspense fallback up", async () => {
+    const Lazy = lazyWithRetry(() => Promise.reject(chunkError()), "miss");
+    render(
+      <ErrorBoundary>
+        <Suspense fallback={<div>loading</div>}>
+          <Lazy />
+        </Suspense>
+      </ErrorBoundary>
+    );
+    await waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+    // Guard set so a second failure won't loop.
+    expect(window.sessionStorage.getItem("sc:chunk-reload:miss")).toBe("1");
+    // The load-bearing line: the never-settling promise must keep the fallback
+    // up and NEVER flash the boundary. Give React real time to retry the thunk
+    // and propagate any throw - a single microtask flush would be too short to
+    // catch a regression where line returns `throw err` instead of the promise.
+    await new Promise((r) => setTimeout(r, 200));
+    expect(screen.queryByText("Update available")).toBeNull();
+    expect(screen.queryByText("Something went wrong")).toBeNull();
+    expect(screen.getByText("loading")).toBeInTheDocument();
+  });
+
+  it("clears the guard after a reload-recovered import finally succeeds", async () => {
+    // Simulate the recovery path: guard was set by the pre-reload attempt; on
+    // the fresh document the import now succeeds, so the guard must be cleared.
+    window.sessionStorage.setItem("sc:chunk-reload:recovered", "1");
+    const Lazy = lazyWithRetry(
+      () => Promise.resolve({ default: () => <div>recovered</div> }),
+      "recovered"
+    );
+    render(
+      <Suspense fallback={<div>loading</div>}>
+        <Lazy />
+      </Suspense>
+    );
+    await screen.findByText("recovered");
+    expect(window.sessionStorage.getItem("sc:chunk-reload:recovered")).toBeNull();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("does NOT auto-reload when sessionStorage cannot persist the guard (would loop)", async () => {
+    // Private mode / blocked storage: setItem throws so the guard is not durable.
+    // Auto-reloading here would loop forever, so we must surface to the boundary.
+    const setItem = vi
+      .spyOn(window.sessionStorage, "setItem")
+      .mockImplementation(() => {
+        throw new DOMException("QuotaExceededError");
+      });
+    const Lazy = lazyWithRetry(() => Promise.reject(chunkError()), "nostore");
+    render(
+      <ErrorBoundary>
+        <Suspense fallback={<div>loading</div>}>
+          <Lazy />
+        </Suspense>
+      </ErrorBoundary>
+    );
+    await screen.findByText("Update available");
+    expect(reload).not.toHaveBeenCalled();
+    setItem.mockRestore();
+  });
+
+  it("does NOT auto-reload when offline; it surfaces an offline-aware boundary", async () => {
+    Object.defineProperty(navigator, "onLine", { configurable: true, value: false });
+    const Lazy = lazyWithRetry(() => Promise.reject(chunkError()), "offline");
+    render(
+      <ErrorBoundary>
+        <Suspense fallback={<div>loading</div>}>
+          <Lazy />
+        </Suspense>
+      </ErrorBoundary>
+    );
+    // Offline: a reload would not bring the chunk back, so no auto-reload, and
+    // the message must not claim a deploy happened.
+    await screen.findByText("Couldn't load this page");
+    expect(reload).not.toHaveBeenCalled();
+    expect(screen.queryByText("Update available")).toBeNull();
+  });
+
+  it("does not reload twice: after the guard is set it rethrows to the boundary", async () => {
+    window.sessionStorage.setItem("sc:chunk-reload:already", "1");
+    const Lazy = lazyWithRetry(() => Promise.reject(chunkError()), "already");
+    render(
+      <ErrorBoundary>
+        <Suspense fallback={<div>loading</div>}>
+          <Lazy />
+        </Suspense>
+      </ErrorBoundary>
+    );
+    // Boundary classifies it as a chunk error and offers a manual reload.
+    await screen.findByText("Update available");
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("never auto-reloads on a non-chunk error; it surfaces to the boundary", async () => {
+    const Lazy = lazyWithRetry(() => Promise.reject(new Error("real bug")), "bug");
+    render(
+      <ErrorBoundary>
+        <Suspense fallback={<div>loading</div>}>
+          <Lazy />
+        </Suspense>
+      </ErrorBoundary>
+    );
+    await screen.findByText("Something went wrong");
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/src/components/shared/ErrorBoundary.tsx
+++ b/dashboard/src/components/shared/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
-import { AlertTriangle, RotateCcw } from "lucide-react";
+import { AlertTriangle, RotateCcw, Download } from "lucide-react";
+import { isChunkLoadError } from "@/lib/lazyWithRetry";
 
 interface Props {
   children: ReactNode;
@@ -12,20 +13,31 @@ interface State {
   hasError: boolean;
   error: Error | null;
   isNetworkError: boolean;
+  isChunkError: boolean;
+  isOffline: boolean;
 }
 
 /**
  * Error boundary that catches render errors in its subtree.
- * Distinguishes between network errors and application errors
- * to provide more helpful messages.
+ * Distinguishes between a stale-deploy chunk miss, a network error, and a
+ * generic application error so each gets an accurate, actionable message.
  */
 export class ErrorBoundary extends Component<Props, State> {
-  state: State = { hasError: false, error: null, isNetworkError: false };
+  state: State = { hasError: false, error: null, isNetworkError: false, isChunkError: false, isOffline: false };
 
   static getDerivedStateFromError(error: Error): State {
+    // A failed chunk import reads as a network error to the naive matcher, but
+    // the cure is "reload for the new build", not "check your connection".
+    // Classify it first so the user gets the right message.
+    const isChunkError = isChunkLoadError(error);
     const isNetworkError =
-      error.name === "TypeError" && /fetch|network|load/i.test(error.message);
-    return { hasError: true, error, isNetworkError };
+      !isChunkError &&
+      error.name === "TypeError" &&
+      /fetch|network|load/i.test(error.message);
+    // A chunk miss while offline is not a deploy - don't claim one. Compute it
+    // here so render() stays a pure function of state.
+    const isOffline = typeof navigator !== "undefined" && !navigator.onLine;
+    return { hasError: true, error, isNetworkError, isChunkError, isOffline };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
@@ -38,11 +50,58 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   handleReset = () => {
-    this.setState({ hasError: false, error: null, isNetworkError: false });
+    this.setState({ hasError: false, error: null, isNetworkError: false, isChunkError: false, isOffline: false });
+  };
+
+  handleHardReload = () => {
+    // Clear the one-shot reload guards so the fresh build is allowed to
+    // auto-retry its chunks again after this manual reload.
+    try {
+      const s = window.sessionStorage;
+      for (let i = s.length - 1; i >= 0; i--) {
+        const k = s.key(i);
+        if (k && k.startsWith("sc:chunk-reload:")) s.removeItem(k);
+      }
+    } catch {
+      /* storage unavailable - reload still works */
+    }
+    window.location.reload();
   };
 
   render() {
     if (this.state.hasError) {
+      // A stale-deploy chunk miss is recoverable by reloading the app; show
+      // that directly rather than the page-level fallback or a network error.
+      // When offline the same failure shape means "you're disconnected", not
+      // "a new version deployed" - don't assert a deploy that didn't happen.
+      if (this.state.isChunkError) {
+        const offline = this.state.isOffline;
+        return (
+          <div className="flex flex-col items-center justify-center py-24 gap-6">
+            <div className="flex items-center justify-center w-16 h-16 rounded-2xl bg-accent/10">
+              <Download className="w-8 h-8 text-accent" />
+            </div>
+            <div className="text-center space-y-2">
+              <h2 className="text-lg font-semibold text-foreground">
+                {offline ? "Couldn't load this page" : "Update available"}
+              </h2>
+              <p className="text-sm text-muted max-w-md">
+                {offline
+                  ? "You appear to be offline. Reconnect, then reload to try again."
+                  : "A newer version of the dashboard was just deployed. Reload to load the latest build."}
+              </p>
+            </div>
+            <button
+              onClick={this.handleHardReload}
+              className="flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground hover:bg-accent-hover transition-all duration-200"
+            >
+              <RotateCcw className="w-4 h-4" />
+              Reload
+            </button>
+          </div>
+        );
+      }
+
       if (this.props.fallback) return this.props.fallback;
 
       return (

--- a/dashboard/src/lib/lazyWithRetry.ts
+++ b/dashboard/src/lib/lazyWithRetry.ts
@@ -1,0 +1,123 @@
+import { lazy, type ComponentType, type LazyExoticComponent } from "react";
+
+/**
+ * True when an error is a failed dynamic-import / chunk fetch. This is the
+ * classic symptom of a fresh deploy: an open tab still references the old
+ * hashed asset name, the new deploy removed it, so the import 404s. Browsers
+ * surface this as a TypeError whose message mentions the module, or as a named
+ * ChunkLoadError. We keep the matcher broad across engines (Chrome/Firefox/
+ * Safari word it differently) and also cover Vite's per-chunk CSS preload
+ * failure ("Unable to preload CSS for ..."), which rejects the same import.
+ *
+ * Note: a plain "Failed to fetch" / "Load failed" (no "module"/"css" qualifier)
+ * is deliberately NOT matched - that is a real api/network failure and must stay
+ * a connection error, not a "reload for the new build" prompt.
+ */
+export function isChunkLoadError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const msg = err.message || "";
+  return (
+    err.name === "ChunkLoadError" ||
+    /failed to fetch dynamically imported module/i.test(msg) ||
+    /error loading dynamically imported module/i.test(msg) ||
+    /importing a module script failed/i.test(msg) ||
+    /unable to preload css/i.test(msg) ||
+    /dynamically imported module/i.test(msg)
+  );
+}
+
+/** sessionStorage that never throws (private mode, disabled storage, SSR). */
+function safeSession(): Storage | null {
+  try {
+    return typeof window !== "undefined" ? window.sessionStorage : null;
+  } catch {
+    return null;
+  }
+}
+
+function getFlag(key: string): boolean {
+  try {
+    return safeSession()?.getItem(key) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Set/clear the guard and report whether it actually persisted. Some browser
+ * modes (storage-partitioned iframes, "block all storage", Safari private mode)
+ * let getItem return null yet throw - or silently no-op - on setItem. We must
+ * know the guard is durable before trusting it to make the reload one-shot, so
+ * we read it back. A non-durable guard means the caller must NOT auto-reload
+ * (it would loop forever), so it returns false.
+ */
+function setFlag(key: string, value: boolean): boolean {
+  try {
+    const s = safeSession();
+    if (!s) return false;
+    if (value) s.setItem(key, "1");
+    else s.removeItem(key);
+    // Verify it stuck - this is what makes the one-shot guarantee real.
+    return value ? s.getItem(key) === "1" : s.getItem(key) === null;
+  } catch {
+    // Storage unavailable - report failure so the caller skips the auto-reload.
+    return false;
+  }
+}
+
+/**
+ * Decide whether to recover from a chunk miss by reloading once, and do it.
+ * Returns true if a reload was triggered (caller keeps the loading UI up),
+ * false if the reload was suppressed - in which case the caller should let the
+ * error reach the boundary for a bounded, manual recovery. Reload is suppressed
+ * when:
+ *   - the browser is known-offline (a reload would not bring the chunk back), or
+ *   - this route already auto-reloaded once this session (the guard is set), or
+ *   - the guard could not be durably persisted (auto-reload would loop forever).
+ */
+function tryChunkReload(guardKey: string): boolean {
+  const online = typeof navigator === "undefined" || navigator.onLine;
+  if (!online) return false;
+  if (getFlag(guardKey)) return false;
+  if (!setFlag(guardKey, true)) return false;
+  // Pull the fresh index.html + the new chunk hashes it points at.
+  window.location.reload();
+  return true;
+}
+
+/**
+ * Drop-in replacement for React.lazy that recovers from a stale-deploy chunk
+ * miss by reloading the page once to pull the fresh index.html, instead of
+ * dead-ending in the error boundary with a misleading "connection error".
+ *
+ * The reload is strictly one-shot and only fires when it can actually help
+ * (online, durable guard): if the chunk is still missing afterwards (a broken
+ * deploy) or recovery is impossible (offline, storage blocked), the error is
+ * rethrown so the boundary can show a real, actionable "Update available"
+ * card rather than reload-looping forever.
+ *
+ * @param factory the dynamic import, e.g. `() => import("@/pages/Foo")`
+ * @param key     stable route key used to namespace the reload guard
+ */
+export function lazyWithRetry<T extends ComponentType<unknown>>(
+  factory: () => Promise<{ default: T }>,
+  key: string,
+): LazyExoticComponent<T> {
+  const flag = `sc:chunk-reload:${key}`;
+  return lazy(async () => {
+    try {
+      const mod = await factory();
+      setFlag(flag, false); // loaded cleanly - clear any prior guard
+      return mod;
+    } catch (err) {
+      if (isChunkLoadError(err) && tryChunkReload(flag)) {
+        // Keep Suspense's fallback up during the reload instead of flashing the
+        // error boundary; this promise never settles before navigation.
+        return new Promise<{ default: T }>(() => {});
+      }
+      // Offline, already retried, storage blocked, or not a chunk error -
+      // let the boundary handle it.
+      throw err;
+    }
+  });
+}


### PR DESCRIPTION
## The bug

The live demo's **Template Hub** (and any lazy-loaded route) could show a full-page **"Connection error / Could not reach the server. Check your network connection and try again."** A clean browser load never reproduces it - demo mode works fine.

**Root cause** (confirmed by reproducing live + an adversarial review panel): after a redeploy, an already-open tab still holds a **stale `index.html` referencing the old hashed chunk names**. The new deploy removed them, so navigating to a not-yet-loaded route makes `import("@/pages/TemplatesPage")` **404** with a `TypeError: Failed to fetch dynamically imported module`. The error boundary's `/fetch|network|load/` matcher mislabels that as a network outage - with no recovery but a manual hard refresh. Our three rapid merges (#248/#249/#250) are exactly the redeploy burst that triggers it.

## The fix (two layers)

**1. `lazyWithRetry`** wraps all 24 lazy routes. On a chunk miss it reloads **once** to pull the fresh `index.html`, keeping the Suspense fallback up during navigation. The reload is strictly one-shot and only fires when it can actually help:
- guarded by a **read-back-verified** `sessionStorage` flag, so blocked / private-mode storage can't reload-loop;
- **suppressed when `navigator.onLine` is false** (an offline reload is pointless);
- otherwise the error is rethrown so the boundary handles it.

**2. `ErrorBoundary`** now classifies chunk/preload failures **first** and renders an **"Update available - reload for the latest build"** card (offline-aware: *"You appear to be offline"* when disconnected) with a Reload button that clears the guards. Real network `TypeError`s still correctly read as **"Connection error"**.

`isChunkLoadError` also covers Vite's `"Unable to preload CSS for ..."` reject (CSS preload 404s).

## Hardened by adversarial review

A 5-lens review panel ran before this PR; it confirmed and this commit fixes: storage-throws reload loop, offline misclassification, a vacuous "fallback stays" test, the CSS-preload false negative, and self-consistent staging of the new module.

## Tests
`lazyWithRetry.test.tsx` (9: success/clears-guard, one-shot reload with discriminating never-settle assertion, storage-blocked no-loop, offline no-reload, guard-set rethrow, non-chunk passthrough, cross-engine matcher) + 3 ErrorBoundary additions (chunk card, hard-reload clears guards, network stays "Connection error"). **Suite 806 green, tsc clean, build ok.**