### PR TITLE
feat(templates): next-wave Template Hub - 3 new categories, 15 engine-first templates

### DIFF
--- a/scripts/update_hub_registry.py
+++ b/scripts/update_hub_registry.py
@@ -30,7 +30,10 @@ RAW_BASE = "https://raw.githubusercontent.com/gizmax/Sandcastle/main/src/sandcas
 
 # Categories that should be ingested into the public hub as gizmax/ built-ins so the new
 # category chips show real templates. Extend this as new categories are added.
-NEW_CATEGORIES = {"compliance_grc", "healthcare", "fintech_banking", "llmops_ai_eng", "personal"}
+NEW_CATEGORIES = {
+    "compliance_grc", "healthcare", "fintech_banking", "llmops_ai_eng", "personal",
+    "research_intel", "finance_ops",
+}
 
 # Human labels for category ids (derived bar uses these; falls back to a title-cased slug).
 CATEGORY_LABELS = {
@@ -39,7 +42,8 @@ CATEGORY_LABELS = {
     "devops": "DevOps & SRE", "data": "Data", "creative": "Creative",
     "compliance_grc": "Compliance & GRC", "healthcare": "Healthcare & Life Sciences",
     "fintech_banking": "Fintech & Banking", "llmops_ai_eng": "LLMOps & AI Engineering",
-    "personal": "Personal & Life Admin",
+    "personal": "Personal & Life Admin", "research_intel": "Research & Intelligence",
+    "finance_ops": "Finance & FP&A Operations",
 }
 
 

--- a/site/hub/index.html
+++ b/site/hub/index.html
@@ -69,6 +69,9 @@
       --cat-healthcare: #06B6D4;
       --cat-fintech_banking: #6366F1;
       --cat-llmops_ai_eng: #EC4899;
+      --cat-personal: #F59E0B;
+      --cat-research_intel: #A855F7;
+      --cat-finance_ops: #84CC16;
     }
 
     html {
@@ -553,6 +556,9 @@
     .pill[data-cat="healthcare"].active { background: var(--cat-healthcare); color: #000; }
     .pill[data-cat="fintech_banking"].active { background: var(--cat-fintech_banking); }
     .pill[data-cat="llmops_ai_eng"].active { background: var(--cat-llmops_ai_eng); }
+    .pill[data-cat="personal"].active { background: var(--cat-personal); color: #000; }
+    .pill[data-cat="research_intel"].active { background: var(--cat-research_intel); }
+    .pill[data-cat="finance_ops"].active { background: var(--cat-finance_ops); color: #000; }
 
     /* Sort */
     .sort-select {
@@ -634,6 +640,9 @@
     .card[data-cat="healthcare"]::before { background: var(--cat-healthcare); }
     .card[data-cat="fintech_banking"]::before { background: var(--cat-fintech_banking); }
     .card[data-cat="llmops_ai_eng"]::before { background: var(--cat-llmops_ai_eng); }
+    .card[data-cat="personal"]::before { background: var(--cat-personal); }
+    .card[data-cat="research_intel"]::before { background: var(--cat-research_intel); }
+    .card[data-cat="finance_ops"]::before { background: var(--cat-finance_ops); }
 
     .card-header-row {
       display: flex;
@@ -2493,6 +2502,15 @@
           </button>
           <button class="pill" data-cat="llmops_ai_eng">
             <span class="dot" style="background:var(--cat-llmops_ai_eng)"></span>LLMOps &amp; AI Eng
+          </button>
+          <button class="pill" data-cat="personal">
+            <span class="dot" style="background:var(--cat-personal)"></span>Personal &amp; Life Admin
+          </button>
+          <button class="pill" data-cat="research_intel">
+            <span class="dot" style="background:var(--cat-research_intel)"></span>Research &amp; Intel
+          </button>
+          <button class="pill" data-cat="finance_ops">
+            <span class="dot" style="background:var(--cat-finance_ops)"></span>Finance Ops
           </button>
         </div>
         <div class="filter-right">

--- a/site/hub/registry.json
+++ b/site/hub/registry.json
@@ -1,6 +1,6 @@
 {
  "version": 2,
- "generated_at": "2026-06-02T11:00:00Z",
+ "generated_at": "2026-06-02T14:00:00Z",
  "templates": [
   {
    "slug": "amira-dev/freelancer-proposal",
@@ -14969,6 +14969,1750 @@
    "review_count": 4,
    "sha256": "86570492906468a02f8d470e0beec23e2ecd21f1a535b8001e13b658bc8471b8",
    "input_schema": null
+  },
+  {
+   "slug": "gizmax/ar-collections-dunning-prioritizer",
+   "name": "AR Collections Dunning Prioritizer",
+   "description": "Sorts the entire open-invoice AR ledger into deterministic aging buckets, computes a transparent collection-priority score per account (days-overdue x balance x prior-late-rate), drafts the right-tone dunning message via a cross-provider race so it survives any single LLM outage, and gates every send through a credit-policy threshold plus optional human sign-off on large balances. The aging math, DSO, priority score and dunning-stage selection are all carried by deterministic code; race + gate keep it model-independent.",
+   "author": "gizmax",
+   "author_url": "https://github.com/gizmax",
+   "version": "1.0.0",
+   "category": "finance_ops",
+   "tags": [
+    "AR",
+    "Collections",
+    "Dunning",
+    "Aging",
+    "DSO",
+    "QuickBooks",
+    "Stripe",
+    "CreditPolicy",
+    "FinanceOps",
+    "Gmail",
+    "Resend",
+    "CRM"
+   ],
+   "models_used": [
+    "mistral/large",
+    "sonnet"
+   ],
+   "tools_used": [],
+   "step_count": 14,
+   "download_url": "https://raw.githubusercontent.com/gizmax/Sandcastle/main/src/sandcastle/templates/ar_collections_dunning_prioritizer.yaml",
+   "source": "built-in",
+   "created_at": "2026-06-02T00:00:00Z",
+   "updated_at": "2026-06-02T00:00:00Z",
+   "estimated_cost_per_run": 0.28,
+   "avg_execution_time": 420,
+   "downloads": 0,
+   "remix_count": 0,
+   "forked_from": null,
+   "license": "BSL-1.1",
+   "rating": 0.0,
+   "review_count": 0,
+   "sha256": "5b8d594cebff0257fa6862b64c7284c9b11824f4d46a3e3c071b8fbb55e34b7f",
+   "input_schema": {
+    "required": [
+     "ar_ledger_base_url"
+    ],
+    "properties": {
+     "ar_ledger_base_url": {
+      "type": "string",
+      "description": "AR system REST base exposing open invoices + per-customer payment history (QuickBooks Online or Stripe AR / Invoicing).",
+      "default": "https://quickbooks.api.intuit.com/v3/company",
+      "example": "https://api.stripe.com/v1"
+     },
+     "company_id": {
+      "type": "string",
+      "description": "Tenant / company id used to scope the open-invoice query (QuickBooks realm id or Stripe account id).",
+      "default": "ACME-CO-001",
+      "example": "9130350000000123456"
+     },
+     "aging_bucket_boundaries": {
+      "type": "string",
+      "description": "Comma-separated day boundaries for the deterministic aging buckets. Default 30,60,90 yields 0-30 / 31-60 / 61-90 / 90+.",
+      "default": "30,60,90",
+      "example": "30,60,90"
+     },
+     "priority_weights": {
+      "type": "string",
+      "description": "Comma-separated overdue-day -> weight multipliers as day:weight pairs feeding the priority score. Default ramps the weight up with age.",
+      "default": "0:0.5,30:1.0,60:2.0,90:3.5",
+      "example": "0:0.5,30:1.0,60:2.0,90:3.5"
+     },
+     "hold_for_review_balance": {
+      "type": "number",
+      "description": "Account balance (in ledger currency) at or above which the gate forces a human credit-manager sign-off before any dunning email is sent.",
+      "default": 5000,
+      "example": "5000"
+     },
+     "min_dunnable_balance": {
+      "type": "number",
+      "description": "Accounts with a total overdue balance strictly below this are skipped (immaterial to chase). No email, no touch.",
+      "default": 25,
+      "example": "25"
+     },
+     "grace_days": {
+      "type": "integer",
+      "description": "Days past the due date before an invoice is considered overdue / dunnable (a deterministic courtesy grace window).",
+      "default": 0,
+      "example": "3"
+     },
+     "dunning_from_address": {
+      "type": "string",
+      "description": "From address the dunning email is sent from (AR / billing mailbox).",
+      "default": "billing@your-company.example.com",
+      "example": "ar@acme.example.com"
+     },
+     "email_send_url": {
+      "type": "string",
+      "description": "Transactional email send endpoint used by the notify step (Gmail API messages.send or Resend /emails).",
+      "default": "https://api.resend.com/emails",
+      "example": "https://gmail.googleapis.com/gmail/v1/users/me/messages/send"
+     },
+     "crm_endpoint": {
+      "type": "string",
+      "description": "CRM REST endpoint that records the dunning touch as a logged activity (HubSpot engagements or Salesforce Task).",
+      "default": "https://api.hubapi.com/crm/v3/objects/notes",
+      "example": "https://your-instance.salesforce.com/services/data/v60.0/sobjects/Task"
+     },
+     "tone_judge_model": {
+      "type": "string",
+      "description": "Swappable model backing the gate's tone / escalation-appropriateness judge. Any provider can back it; for EU data residency pin mistral/large or a local model. The send still passes/fails on the non-LLM balance threshold without it.",
+      "default": "sonnet",
+      "example": "mistral/large"
+     },
+     "slack_channel": {
+      "type": "string",
+      "description": "Collections Slack channel that receives the run digest (queued / held-for-review / sent counts).",
+      "default": "#ar-collections",
+      "example": "#ar-collections"
+     }
+    }
+   }
+  },
+  {
+   "slug": "gizmax/bill-renewal-late-fee-sentinel",
+   "name": "Bill & Renewal Late-Fee Sentinel",
+   "description": "An always-on sentinel that watches every bill and subscription renewal and pings you BEFORE a late fee or silent auto-renewal hits. A durable SENSOR blocks until the next daily check-in window, an http GET pulls the live biller/aggregator statement feed listing each bill with its amount + due_date, and DETERMINISTIC code does the load-bearing date math - days_until_due, in-lead-time-window detection, and cross-run dedup so you are never pinged twice for the same bill. A CONDITION routes only the due-soon items to NOTIFY; everything else stays quiet. All detection is pure code and runs with zero model providers; a model only drafts the human-readable reminder copy.",
+   "author": "gizmax",
+   "author_url": "https://github.com/gizmax",
+   "version": "1.0.0",
+   "category": "personal",
+   "tags": [
+    "Bills",
+    "Subscriptions",
+    "Renewals",
+    "LateFee",
+    "DueDate",
+    "Sensor",
+    "PersonalFinance",
+    "LifeAdmin",
+    "Reminder",
+    "Dedup",
+    "Plaid",
+    "Slack"
+   ],
+   "models_used": [
+    "sonnet"
+   ],
+   "tools_used": [],
+   "step_count": 9,
+   "download_url": "https://raw.githubusercontent.com/gizmax/Sandcastle/main/src/sandcastle/templates/bill_renewal_late_fee_sentinel.yaml",
+   "source": "built-in",
+   "created_at": "2026-06-02T00:00:00Z",
+   "updated_at": "2026-06-02T00:00:00Z",
+   "estimated_cost_per_run": 0.18,
+   "avg_execution_time": 270,
+   "downloads": 0,
+   "remix_count": 0,
+   "forked_from": null,
+   "license": "BSL-1.1",
+   "rating": 0.0,
+   "review_count": 0,
+   "sha256": "0a736e0f40e3f39d5a40d75146e397c3ad8ebddb0c4659c320a69f043097cba4",
+   "input_schema": {
+    "required": [
+     "accounts_feed_url"
+    ],
+    "properties": {
+     "accounts_feed_url": {
+      "type": "string",
+      "description": "Biller / account-aggregator statements REST endpoint listing each bill + subscription renewal with its amount and due_date (Plaid liabilities, Tink, or a bank statement feed).",
+      "default": "https://api.aggregator.example.com/v1/bills",
+      "example": "https://production.plaid.com/liabilities/get"
+     },
+     "lead_time_days": {
+      "type": "integer",
+      "description": "Notify this many days before a bill's due date or a subscription's auto-renewal date. Anything due within this many days (and not in the past) is surfaced.",
+      "default": 5,
+      "example": "5"
+     },
+     "check_interval": {
+      "type": "integer",
+      "description": "Sensor cadence in seconds - how often the sentinel checks in for the next bill sweep. Default daily (86400s).",
+      "default": 86400,
+      "example": "86400"
+     },
+     "sensor_timeout": {
+      "type": "integer",
+      "description": "Sensor soft timeout in seconds - stop waiting for the next check-in window after this long (one watch run). Default 25h so a daily cadence always fires once.",
+      "default": 90000,
+      "example": "90000"
+     },
+     "ledger_url": {
+      "type": "string",
+      "description": "REST base of the alerted-bill ledger (the dedup memory). GET returns the bills already alerted in prior runs; a PUT writes back the updated set. PostgREST / S3 REST / KV gateway style.",
+      "default": "https://api.aggregator.example.com/v1/alert-ledger",
+      "example": "https://your-kv.example.com/bill-alert-ledger"
+     },
+     "grace_period_days": {
+      "type": "integer",
+      "description": "How many days a just-past-due bill is still surfaced (so a bill that slipped past midnight is not silently dropped). 0 = only future bills.",
+      "default": 1,
+      "example": "1"
+     },
+     "draft_model": {
+      "type": "string",
+      "description": "Documents which model DRAFTS the human-readable reminder text - set the draft_reminder step's `model:` to this. Any of the providers can back it; pin an EU/local one (mistral/large, ollama, omlx/qwen-3) for privacy. Detection works with this unavailable; the model only writes copy, never decides what is due.",
+      "default": "sonnet",
+      "example": "mistral/large"
+     },
+     "slack_channel": {
+      "type": "string",
+      "description": "Slack channel (or DM) that receives the due-soon reminder digest.",
+      "default": "#money-reminders",
+      "example": "#money-reminders"
+     }
+    }
+   }
+  },
+  {
+   "slug": "gizmax/budget-variance-materiality-sentinel",
+   "name": "Budget vs Actual Variance Sentinel",
+   "description": "Always-on FP&A sentinel that wakes on the period-close / actuals-posted webhook, pulls LIVE actuals from the accounting system (QuickBooks / NetSuite) and the LOCKED plan from the FP&A model (Google Sheets) over real http connectors, then computes per-cost-center variance ($ delta, % delta, run-rate burn, YTD pacing) in 100% deterministic Python. It LOOPS each cost center, CLASSIFIES favorable/unfavorable/on_plan from precomputed flags only, a CONDITION routes only candidate-material variances into a two-strategy MATERIALITY GATE (a swappable llm_eval judge AND a non-LLM dollar+percent floor threshold), and NOTIFY pages the budget owner only on confirmed material variance, never on rounding noise. The variance math and the threshold are model-independent; the model is confined to the swappable gate judge.",
+   "author": "gizmax",
+   "author_url": "https://github.com/gizmax",
+   "version": "1.0.0",
+   "category": "finance_ops",
+   "tags": [
+    "FP&A",
+    "Budget",
+    "Variance",
+    "BvA",
+    "Actuals",
+    "Plan",
+    "CostCenter",
+    "Materiality",
+    "RunRate",
+    "YTD",
+    "QuickBooks",
+    "NetSuite",
+    "GoogleSheets",
+    "Slack",
+    "finance",
+    "sensor"
+   ],
+   "models_used": [
+    "sonnet"
+   ],
+   "tools_used": [],
+   "step_count": 14,
+   "download_url": "https://raw.githubusercontent.com/gizmax/Sandcastle/main/src/sandcastle/templates/budget_variance_materiality_sentinel.yaml",
+   "source": "built-in",
+   "created_at": "2026-06-02T00:00:00Z",
+   "updated_at": "2026-06-02T00:00:00Z",
+   "estimated_cost_per_run": 0.28,
+   "avg_execution_time": 420,
+   "downloads": 0,
+   "remix_count": 0,
+   "forked_from": null,
+   "license": "BSL-1.1",
+   "rating": 0.0,
+   "review_count": 0,
+   "sha256": "3a389b31ee2954130b21b6238676f0a17f041f51d114a4a1fa0d12ae10ca52b0",
+   "input_schema": {
+    "required": [
+     "entity_id",
+     "accounting_actuals_base_url",
+     "fpa_plan_sheet_url"
+    ],
+    "properties": {
+     "entity_id": {
+      "type": "string",
+      "description": "Legal entity / company id whose period close is watched (the accounting subsidiary or book).",
+      "default": "ACME-US",
+      "example": "ACME-US"
+     },
+     "period": {
+      "type": "string",
+      "description": "Fiscal period being closed in YYYY-MM form. Drives which plan column and which actuals window are pulled.",
+      "default": "2026-05",
+      "example": "2026-05"
+     },
+     "accounting_actuals_base_url": {
+      "type": "string",
+      "description": "Accounting-system REST base that returns posted actuals (P&L / expense) by cost center for the period (QuickBooks Online or NetSuite REST / SuiteQL gateway).",
+      "default": "https://quickbooks.api.intuit.com/v3/company",
+      "example": "https://acme.suitetalk.api.netsuite.com/services/rest"
+     },
+     "fpa_plan_sheet_url": {
+      "type": "string",
+      "description": "Google Sheets (Sheets API v4 values) URL of the LOCKED FP&A budget model returning the planned amount per cost center for the period.",
+      "default": "https://sheets.googleapis.com/v4/spreadsheets/SHEET_ID/values/Budget!A2:F500",
+      "example": "https://sheets.googleapis.com/v4/spreadsheets/1AbC.../values/Budget!A2:F500"
+     },
+     "materiality_dollar_floor": {
+      "type": "number",
+      "description": "Absolute dollar floor (>=) below which a variance is treated as immaterial rounding/timing noise by the gate's non-LLM threshold strategy.",
+      "default": 5000,
+      "example": "5000"
+     },
+     "materiality_pct_floor": {
+      "type": "number",
+      "description": "Absolute percent floor (>=, in percent points) below which a variance is treated as immaterial by the gate's non-LLM threshold strategy. A variance is candidate-material when abs($)>=dollar_floor OR abs(%)>=pct_floor.",
+      "default": 10,
+      "example": "10"
+     },
+     "period_elapsed_fraction": {
+      "type": "number",
+      "description": "Fraction of the fiscal period elapsed (0-1) used to compute run-rate burn and YTD pacing deterministically. 1.0 at full close; e.g. 0.5 mid-period.",
+      "default": 1.0,
+      "example": "0.5"
+     },
+     "close_poll_interval": {
+      "type": "integer",
+      "description": "Seconds between sensor polls of the close-status endpoint while waiting for the period-close / actuals-posted webhook to flip the period to posted.",
+      "default": 1800,
+      "example": "1800"
+     },
+     "sensor_timeout": {
+      "type": "integer",
+      "description": "Sensor soft timeout in seconds - stop waiting for the close webhook after this long (one watch run). Default 24h.",
+      "default": 86400,
+      "example": "86400"
+     },
+     "gate_model": {
+      "type": "string",
+      "description": "Swappable materiality-judge model for the gate. Any of the 7 providers can back it; for regulated financials pin an EU/local provider (mistral/large, ollama, omlx/qwen-3). Variance detection works with this unavailable.",
+      "default": "sonnet",
+      "example": "mistral/large"
+     },
+     "pagerduty_routing_key": {
+      "type": "string",
+      "description": "Optional PagerDuty Events v2 routing key to page on a confirmed material variance. Leave empty to skip paging and only notify Slack.",
+      "default": "",
+      "example": "R0ABCD1234EFGH5678IJKL"
+     },
+     "slack_channel": {
+      "type": "string",
+      "description": "FP&A Slack channel that receives the material-variance digest / page.",
+      "default": "#fpa-budget-variance",
+      "example": "#fpa-budget-variance"
+     }
+    }
+   }
+  },
+  {
+   "slug": "gizmax/competitor-pricing-page-change-sentinel",
+   "name": "Competitor Pricing-Page Change Sentinel",
+   "description": "Always-on watcher that snapshots each rival's live pricing page, deterministically diffs plan / price / feature deltas against the last SHA-256-sealed snapshot, and only pages product + sales when a swappable two-strategy materiality gate confirms the change is a real pricing move (not A/B noise or layout churn). A durable SENSOR blocks until the next poll interval or a price-change webhook; an http GET (firecrawl) renders each pricing page; deterministic CODE parses plans into a canonical {plan,price,billing_period,features[]} shape, computes the structured diff and seals the new snapshot; a CONDITION routes only non-empty diffs into the GATE (llm_eval judge AND a non-LLM price_delta_pct threshold) before NOTIFY to Slack and an http PUT of the sealed snapshot to S3. Detection and diff are 100% deterministic code; the model only judges materiality.",
+   "author": "gizmax",
+   "author_url": "https://github.com/gizmax",
+   "version": "1.0.0",
+   "category": "research_intel",
+   "tags": [
+    "CompetitiveIntel",
+    "PricingIntelligence",
+    "ChangeDetection",
+    "sensor",
+    "firecrawl",
+    "diff",
+    "SHA-256",
+    "snapshot",
+    "S3",
+    "Slack",
+    "materiality-gate",
+    "research_intel"
+   ],
+   "models_used": [
+    "sonnet"
+   ],
+   "tools_used": [],
+   "step_count": 16,
+   "download_url": "https://raw.githubusercontent.com/gizmax/Sandcastle/main/src/sandcastle/templates/competitor_pricing_page_change_sentinel.yaml",
+   "source": "built-in",
+   "created_at": "2026-06-02T00:00:00Z",
+   "updated_at": "2026-06-02T00:00:00Z",
+   "estimated_cost_per_run": 0.32,
+   "avg_execution_time": 480,
+   "downloads": 0,
+   "remix_count": 0,
+   "forked_from": null,
+   "license": "BSL-1.1",
+   "rating": 0.0,
+   "review_count": 0,
+   "sha256": "9cf40fc03daa40b7bc66e9a8cc0d4f628950936135fa129f5c39dfc2ec2530e2",
+   "input_schema": {
+    "required": [
+     "competitor_pricing_urls",
+     "snapshot_store_url"
+    ],
+    "properties": {
+     "competitor_pricing_urls": {
+      "type": "string",
+      "description": "Comma-separated (or newline-separated) list of rival pricing-page URLs to watch. Each is rendered through Firecrawl and diffed against its own last sealed snapshot.",
+      "default": "https://competitor-a.com/pricing,https://competitor-b.com/pricing",
+      "example": "https://stripe.com/pricing,https://www.twilio.com/pricing,https://vercel.com/pricing"
+     },
+     "snapshot_store_url": {
+      "type": "string",
+      "description": "Snapshot store REST base URL holding the last SEALED canonical pricing snapshot per rival (S3 REST gateway or Postgres / PostgREST). The structured diff is measured against this.",
+      "default": "https://pricing-intel.internal/snapshots",
+      "example": "https://pricing-intel.internal/snapshots"
+     },
+     "price_delta_threshold": {
+      "type": "number",
+      "description": "Materiality threshold for the gate's NON-LLM strategy: a per-plan price change at or above this absolute percent (e.g. 5 = 5%), OR any added/removed plan, OR a feature gain/loss, is treated as a real pricing move (not A/B noise).",
+      "default": 5.0,
+      "example": "5.0"
+     },
+     "firecrawl_base_url": {
+      "type": "string",
+      "description": "Firecrawl REST base URL used to render each JS-heavy pricing page to clean HTML / extracted markup before parsing. Connector: firecrawl.",
+      "default": "https://api.firecrawl.dev/v1",
+      "example": "https://api.firecrawl.dev/v1"
+     },
+     "poll_interval": {
+      "type": "integer",
+      "description": "Seconds between pricing sweeps. The sensor blocks until this interval elapses OR a price-change webhook bumps the watch flag (event-driven within a schedule).",
+      "default": 3600,
+      "example": "3600"
+     },
+     "sensor_timeout": {
+      "type": "integer",
+      "description": "Sensor soft timeout in seconds - stop waiting for the next poll window after this long (one watch run). Default 24h.",
+      "default": 86400,
+      "example": "86400"
+     },
+     "gate_model": {
+      "type": "string",
+      "description": "Swappable materiality-judge model for the gate. Any of the 7 providers can back it; for EU data pin a local / EU provider (mistral/large, ollama, omlx/qwen-3). Detection and diff work with this unavailable.",
+      "default": "sonnet",
+      "example": "mistral/large"
+     },
+     "s3_base_url": {
+      "type": "string",
+      "description": "S3 (or S3-compatible) REST base URL that receives the SHA-256-sealed per-rival pricing snapshots so the next sweep diffs against tamper-evident truth. Connector: aws-s3.",
+      "default": "https://s3.eu-central-1.amazonaws.com",
+      "example": "https://s3.eu-central-1.amazonaws.com"
+     },
+     "s3_bucket": {
+      "type": "string",
+      "description": "Bucket name that stores the sealed pricing snapshots and confirmed-move ledger.",
+      "default": "competitor-pricing-snapshots",
+      "example": "acme-competitor-pricing-snapshots"
+     },
+     "slack_channel": {
+      "type": "string",
+      "description": "Product + sales Slack channel that receives the confirmed pricing-move alert (or the quiet clean-sweep digest).",
+      "default": "#competitive-pricing-intel",
+      "example": "#competitive-pricing-intel"
+     }
+    }
+   }
+  },
+  {
+   "slug": "gizmax/expense-policy-line-item-auditor",
+   "name": "Expense Policy Line-Item Auditor",
+   "description": "Pulls every line item on a submitted expense report from the expense/ERP system, classifies each into a spend category with a swappable labeler, then runs a 100% deterministic policy rule engine (per-category caps, receipt-required thresholds, per-diem math, weekend/alcohol/duplicate-merchant flags) to decide pass/violation per line. Only the disputed lines are routed to a two-strategy approval gate (llm_eval exception-judge AND a non-LLM rule-hit threshold) and a human finance reviewer, then an itemized verdict is PUT back to the expense system and an auditable summary is filed. Money and policy math never touch a model.",
+   "author": "gizmax",
+   "author_url": "https://github.com/gizmax",
+   "version": "1.0.0",
+   "category": "finance_ops",
+   "tags": [
+    "Expense",
+    "Concur",
+    "ERP",
+    "PolicyEngine",
+    "PerDiem",
+    "Receipts",
+    "DuplicateDetection",
+    "FinanceOps",
+    "Audit",
+    "T&E",
+    "Compliance"
+   ],
+   "models_used": [
+    "sonnet"
+   ],
+   "tools_used": [],
+   "step_count": 14,
+   "download_url": "https://raw.githubusercontent.com/gizmax/Sandcastle/main/src/sandcastle/templates/expense_policy_line_item_auditor.yaml",
+   "source": "built-in",
+   "created_at": "2026-06-02T00:00:00Z",
+   "updated_at": "2026-06-02T00:00:00Z",
+   "estimated_cost_per_run": 0.28,
+   "avg_execution_time": 420,
+   "downloads": 0,
+   "remix_count": 0,
+   "forked_from": null,
+   "license": "BSL-1.1",
+   "rating": 0.0,
+   "review_count": 0,
+   "sha256": "13fc57e0e335eb30a254761cf171f8afa0e1757895c7dc625f6b0573eb62d24d",
+   "input_schema": {
+    "required": [
+     "report_id",
+     "expense_api_base_url"
+    ],
+    "properties": {
+     "report_id": {
+      "type": "string",
+      "description": "Expense report id to audit (the submitted report whose line items are pulled and verdicted).",
+      "default": "EXP-2026-004821",
+      "example": "EXP-2026-004821"
+     },
+     "employee_id": {
+      "type": "string",
+      "description": "Employee id who submitted the report (used for per-diem lookup and the audit record).",
+      "default": "",
+      "example": "E-10293"
+     },
+     "expense_api_base_url": {
+      "type": "string",
+      "description": "Expense / ERP REST base URL exposing the report + line items and accepting the per-line verdict (SAP Concur / Coupa / Workday Expenses style).",
+      "default": "https://www.concursolutions.com/api/v3.0/expense",
+      "example": "https://acme.concursolutions.com/api/v3.0/expense"
+     },
+     "policy_caps": {
+      "type": "string",
+      "description": "JSON object of per-category USD caps plus a global receipt-required threshold. Keys: meals, lodging, travel, software, entertainment, receipt_required_over. Drives the deterministic cap + receipt rules.",
+      "default": "{\"meals\": 75, \"lodging\": 350, \"travel\": 1500, \"software\": 500, \"entertainment\": 50, \"receipt_required_over\": 25}",
+      "example": "{\"meals\": 75, \"lodging\": 350, \"travel\": 1500, \"software\": 500, \"entertainment\": 50, \"receipt_required_over\": 25}"
+     },
+     "per_diem_table": {
+      "type": "string",
+      "description": "JSON object of per-diem USD limits per spend category (the daily allowance a single line may not exceed). Empty categories fall back to the matching policy cap.",
+      "default": "{\"meals\": 75, \"lodging\": 350}",
+      "example": "{\"meals\": 75, \"lodging\": 350}"
+     },
+     "allow_alcohol": {
+      "type": "string",
+      "description": "Whether alcohol line items are reimbursable under policy. 'false' raises an alcohol-policy flag on any line whose merchant/description trips the alcohol keyword list.",
+      "default": "false",
+      "example": "false"
+     },
+     "allow_weekend": {
+      "type": "string",
+      "description": "Whether weekend-dated spend is reimbursable. 'false' raises a weekend-spend flag on any Saturday/Sunday line for review.",
+      "default": "false",
+      "example": "false"
+     },
+     "gate_model": {
+      "type": "string",
+      "description": "Swappable exception-judge model for the gate. Any provider can back it; for EU/regulated data pin a local provider (mistral/large, ollama, omlx/qwen-3). The rule engine works with this unavailable.",
+      "default": "sonnet",
+      "example": "mistral/large"
+     },
+     "report_author": {
+      "type": "string",
+      "description": "Author shown on the auditable expense-violation summary report.",
+      "default": "Finance Operations",
+      "example": "Finance Operations"
+     },
+     "archive_base_url": {
+      "type": "string",
+      "description": "Object store (S3-compatible) REST base URL where the audit summary is archived for retention.",
+      "default": "https://s3.eu-central-1.amazonaws.com",
+      "example": "https://s3.eu-central-1.amazonaws.com"
+     },
+     "archive_bucket": {
+      "type": "string",
+      "description": "Bucket that retains the sealed expense-audit summaries.",
+      "default": "expense-audit-records",
+      "example": "acme-expense-audit-records"
+     },
+     "slack_channel": {
+      "type": "string",
+      "description": "Finance-queue Slack channel for the itemized audit result.",
+      "default": "#expense-audit-queue",
+      "example": "#expense-audit-queue"
+     }
+    }
+   }
+  },
+  {
+   "slug": "gizmax/funding-and-ma-radar-dedup",
+   "name": "Funding & M&A Radar with Cross-Source Dedup",
+   "description": "A scheduled funding / M&A news radar that fans out parallel http GETs to multiple news + search providers so coverage survives any one source being down, then a deterministic CODE step canonicalizes URLs, builds a fuzzy entity+round+amount fingerprint, collapses cross-source duplicates into one event with a source-count, and merges against the last-run ledger so already-seen deals are dropped. A CLASSIFY tags each surviving event (new_round / follow_on / acquisition / rumor), a CONDITION + GATE (swappable llm_eval relevance judge AND a non-LLM amount>=min and not previously_seen threshold) filters, and only genuinely-new rounds are upserted to HubSpot and appended to a Google Sheet. The dedup and prior-seen merge are pure code - the deal team never chases the same headline twice.",
+   "author": "gizmax",
+   "author_url": "https://github.com/gizmax",
+   "version": "1.0.0",
+   "category": "research_intel",
+   "tags": [
+    "Funding",
+    "MnA",
+    "VentureCapital",
+    "DealFlow",
+    "NewsRadar",
+    "Dedup",
+    "Fingerprint",
+    "Exa",
+    "Tavily",
+    "RSS",
+    "HubSpot",
+    "GoogleSheets",
+    "CRM",
+    "ResearchIntel"
+   ],
+   "models_used": [
+    "sonnet"
+   ],
+   "tools_used": [],
+   "step_count": 16,
+   "download_url": "https://raw.githubusercontent.com/gizmax/Sandcastle/main/src/sandcastle/templates/funding_and_ma_radar_dedup.yaml",
+   "source": "built-in",
+   "created_at": "2026-06-02T00:00:00Z",
+   "updated_at": "2026-06-02T00:00:00Z",
+   "estimated_cost_per_run": 0.32,
+   "avg_execution_time": 480,
+   "downloads": 0,
+   "remix_count": 0,
+   "forked_from": null,
+   "license": "BSL-1.1",
+   "rating": 0.0,
+   "review_count": 0,
+   "sha256": "b2bad405931e0613904a44772254c384c61e5b008440ab66bf5ec89865bb9963",
+   "input_schema": {
+    "required": [
+     "watch_entities",
+     "news_source_urls"
+    ],
+    "properties": {
+     "watch_entities": {
+      "type": "string",
+      "description": "Comma-separated companies / sectors / investors the deal team is tracking. Used to build the provider queries and as the on-thesis relevance anchor for the gate's judge.",
+      "default": "fintech, climate tech, Sequoia, a16z, defense tech",
+      "example": "fintech, climate tech, Sequoia, a16z, defense tech"
+     },
+     "news_source_urls": {
+      "type": "string",
+      "description": "Comma-separated RSS / news feed URLs (TechCrunch, Axios Pro Rata, PitchBook News, etc.) hit as the third independent source alongside Exa and Tavily so coverage survives any one provider being down.",
+      "default": "https://techcrunch.com/category/venture/feed/,https://news.crunchbase.com/feed/",
+      "example": "https://techcrunch.com/category/venture/feed/,https://news.crunchbase.com/feed/"
+     },
+     "min_round_amount_usd": {
+      "type": "number",
+      "description": "Minimum disclosed round / deal size in USD for an event to clear the gate's non-LLM threshold. Smaller (or undisclosed-and-immaterial) rounds are filtered before they reach the CRM.",
+      "default": 5000000,
+      "example": "5000000"
+     },
+     "ledger_store_url": {
+      "type": "string",
+      "description": "REST base of the dedup ledger (S3 REST gateway or Postgres / PostgREST) holding the fingerprints of deals seen on prior sweeps. GET reads last-run fingerprints; PUT writes the refreshed ledger so the same headline is never chased twice.",
+      "default": "https://deals.internal/dedup-ledger",
+      "example": "https://deals.internal/dedup-ledger"
+     },
+     "exa_search_url": {
+      "type": "string",
+      "description": "Exa neural-search endpoint queried as source #1 for funding / M&A coverage.",
+      "default": "https://api.exa.ai/search",
+      "example": "https://api.exa.ai/search"
+     },
+     "tavily_search_url": {
+      "type": "string",
+      "description": "Tavily news-search endpoint queried as source #2 (different vendor) for resilience.",
+      "default": "https://api.tavily.com/search",
+      "example": "https://api.tavily.com/search"
+     },
+     "sweep_interval": {
+      "type": "integer",
+      "description": "Seconds between radar sweeps. The sensor blocks until the next sweep window is due.",
+      "default": 3600,
+      "example": "3600"
+     },
+     "sensor_timeout": {
+      "type": "integer",
+      "description": "Sensor soft timeout in seconds - stop waiting for the next sweep window after this long (one radar run). Default 24h.",
+      "default": 86400,
+      "example": "86400"
+     },
+     "hubspot_base_url": {
+      "type": "string",
+      "description": "HubSpot CRM REST base. New rounds are upserted as deal records so the pipeline reflects fresh activity automatically.",
+      "default": "https://api.hubapi.com",
+      "example": "https://api.hubapi.com"
+     },
+     "sheet_append_url": {
+      "type": "string",
+      "description": "Google Sheets values:append endpoint (spreadsheet + range baked into the URL) the new rounds are appended to as a shared deal log.",
+      "default": "https://sheets.googleapis.com/v4/spreadsheets/SHEET_ID/values/Deals!A1:append?valueInputOption=USER_ENTERED",
+      "example": "https://sheets.googleapis.com/v4/spreadsheets/1AbCdEf/values/Deals!A1:append?valueInputOption=USER_ENTERED"
+     },
+     "gate_model": {
+      "type": "string",
+      "description": "Swappable relevance-judge model for the gate. Any provider can back it; for EU data residency pin a local/EU provider (mistral/large, ollama). Dedup works with this unavailable.",
+      "default": "sonnet",
+      "example": "mistral/large"
+     },
+     "slack_channel": {
+      "type": "string",
+      "description": "Deal-team Slack channel that receives the new-deal digest.",
+      "default": "#deal-radar",
+      "example": "#deal-radar"
+     }
+    }
+   }
+  },
+  {
+   "slug": "gizmax/inbox-to-tasks-triage-router",
+   "name": "Inbox-to-Tasks Triage Router",
+   "description": "Pulls unread mail, DETERMINISTICALLY extracts dates / deadlines / dollar amounts / action verbs, classifies each message into task vs FYI vs spam, and GATES auto-created calendar/task entries so only confidently-actionable items become tasks - the rest just get notified. http GET pulls the unread messages and POSTs new tasks/events; code carries the load-bearing signal extraction, sender allowlist and dedup; a two-strategy gate (llm_eval actionability judge AND a non-LLM rule: has-a-date-OR-explicit-ask AND trusted-sender) must both pass before any task is created.",
+   "author": "gizmax",
+   "author_url": "https://github.com/gizmax",
+   "version": "1.0.0",
+   "category": "personal",
+   "tags": [
+    "inbox",
+    "email",
+    "triage",
+    "tasks",
+    "calendar",
+    "productivity",
+    "GTD",
+    "deadlines",
+    "dedup",
+    "allowlist",
+    "gmail",
+    "todoist",
+    "notify"
+   ],
+   "models_used": [
+    "sonnet"
+   ],
+   "tools_used": [],
+   "step_count": 12,
+   "download_url": "https://raw.githubusercontent.com/gizmax/Sandcastle/main/src/sandcastle/templates/inbox_to_tasks_triage_router.yaml",
+   "source": "built-in",
+   "created_at": "2026-06-02T00:00:00Z",
+   "updated_at": "2026-06-02T00:00:00Z",
+   "estimated_cost_per_run": 0.24,
+   "avg_execution_time": 360,
+   "downloads": 0,
+   "remix_count": 0,
+   "forked_from": null,
+   "license": "BSL-1.1",
+   "rating": 0.0,
+   "review_count": 0,
+   "sha256": "1bc3737a5a9e3cf12f6e447badbafe9891d23c12507c3c4ee447ca91d39ff024",
+   "input_schema": {
+    "required": [
+     "mailbox_url",
+     "tasks_api_url"
+    ],
+    "properties": {
+     "mailbox_url": {
+      "type": "string",
+      "description": "Mail provider unread-messages REST endpoint that returns the inbox of unread messages (Gmail API / IMAP-REST gateway / Microsoft Graph style).",
+      "default": "https://gmail.googleapis.com/gmail/v1/users/me/messages?q=is:unread",
+      "example": "https://gmail.googleapis.com/gmail/v1/users/me/messages?q=is:unread"
+     },
+     "tasks_api_url": {
+      "type": "string",
+      "description": "Task / calendar connector REST base that receives the auto-created task / event entries (Todoist / Google Calendar / Notion style).",
+      "default": "https://api.todoist.com/rest/v2",
+      "example": "https://api.todoist.com/rest/v2"
+     },
+     "trusted_senders": {
+      "type": "string",
+      "description": "DETERMINISTIC allowlist for the gate's rule strategy: comma-separated sender email addresses or domains that are trusted enough to auto-create a task. A message from outside this list can never be auto-actioned.",
+      "default": "boss@company.com,@company.com,billing@bank.com,calendar-invite@google.com",
+      "example": "boss@company.com,@company.com,billing@bank.com"
+     },
+     "seen_ids_url": {
+      "type": "string",
+      "description": "Dedup store REST endpoint returning the message ids already triaged on prior runs (key-value / PostgREST / S3 JSON), so the same mail is never turned into a duplicate task.",
+      "default": "https://kv.internal/inbox-triage/seen-ids",
+      "example": "https://kv.internal/inbox-triage/seen-ids"
+     },
+     "gate_model": {
+      "type": "string",
+      "description": "Swappable actionability-judge model for the gate. Any of the 7 providers can back it; pin an EU/local provider (mistral/large, ollama, omlx/qwen-3) for private mail. Triage still works with this unavailable - the non-LLM rule strategy stands alone.",
+      "default": "sonnet",
+      "example": "mistral/large"
+     },
+     "project_id": {
+      "type": "string",
+      "description": "Target project / calendar id in the task connector that new entries are filed under.",
+      "default": "Inbox",
+      "example": "2298765432"
+     },
+     "slack_channel": {
+      "type": "string",
+      "description": "Personal Slack channel / DM that receives the triage digest and the FYI / spam items that were NOT turned into tasks.",
+      "default": "#my-inbox-triage",
+      "example": "#my-inbox-triage"
+     }
+    }
+   }
+  },
+  {
+   "slug": "gizmax/literature-source-triage-race",
+   "name": "Multi-Source Literature & Source Triage",
+   "description": "Research-triage engine that RACES the same topic query across several academic/source providers (firecrawl crawl, exa search, an arXiv/Semantic-Scholar-style http endpoint) and takes the first that returns a usable candidate list (provider failover, NOT a vote). A DETERMINISTIC code step normalizes each record, dedups by DOI then by lowercased-punctuation-stripped title, and computes a transparent 0-1 triage score from topic token-overlap + citation count + recency decay - never a model. A swappable CLASSIFY labels on/off/adjacent-topic and a two-strategy GATE pairs an llm_eval relevance reviewer with a mandatory HUMAN analyst sign-off so nothing enters the corpus unreviewed. Kept papers are embedded and upserted to Qdrant.",
+   "author": "gizmax",
+   "author_url": "https://github.com/gizmax",
+   "version": "1.0.0",
+   "category": "research_intel",
+   "tags": [
+    "LiteratureReview",
+    "ResearchTriage",
+    "Dedup",
+    "DOI",
+    "Citations",
+    "RecencyDecay",
+    "arXiv",
+    "SemanticScholar",
+    "Exa",
+    "Firecrawl",
+    "Qdrant",
+    "VectorStore",
+    "race",
+    "classify",
+    "gate"
+   ],
+   "models_used": [
+    "sonnet"
+   ],
+   "tools_used": [],
+   "step_count": 13,
+   "download_url": "https://raw.githubusercontent.com/gizmax/Sandcastle/main/src/sandcastle/templates/literature_source_triage_race.yaml",
+   "source": "built-in",
+   "created_at": "2026-06-02T00:00:00Z",
+   "updated_at": "2026-06-02T00:00:00Z",
+   "estimated_cost_per_run": 0.26,
+   "avg_execution_time": 390,
+   "downloads": 0,
+   "remix_count": 0,
+   "forked_from": null,
+   "license": "BSL-1.1",
+   "rating": 0.0,
+   "review_count": 0,
+   "sha256": "fdc2d2223295a24e8a6eabf7f386e88cb6bef551efb653dd47612b8f266f32c0",
+   "input_schema": {
+    "required": [
+     "research_topic",
+     "source_provider_urls",
+     "vector_collection"
+    ],
+    "properties": {
+     "research_topic": {
+      "type": "string",
+      "description": "The research topic / question to triage literature for. Drives the race query and the token-overlap relevance signal.",
+      "default": "retrieval-augmented generation for long-context legal question answering",
+      "example": "retrieval-augmented generation for long-context legal question answering"
+     },
+     "source_provider_urls": {
+      "type": "string",
+      "description": "Comma-separated source-provider base URLs raced in parallel, in priority order: firecrawl crawl, exa search, an arXiv/Semantic-Scholar-style endpoint. First usable list wins.",
+      "default": "https://api.firecrawl.dev/v1/crawl,https://api.exa.ai/search,https://api.semanticscholar.org/graph/v1/paper/search",
+      "example": "https://api.firecrawl.dev/v1/crawl,https://api.exa.ai/search,https://api.semanticscholar.org/graph/v1/paper/search"
+     },
+     "min_triage_score": {
+      "type": "number",
+      "description": "Deterministic triage score (0-1) at or above which a paper is shortlisted for human review. The gate's non-LLM strategy also enforces this floor.",
+      "default": 0.45,
+      "example": "0.45"
+     },
+     "vector_collection": {
+      "type": "string",
+      "description": "Qdrant collection name the kept, reviewed papers are embedded and upserted into.",
+      "default": "rag-legal-qa-corpus",
+      "example": "rag-legal-qa-corpus"
+     },
+     "max_shortlist": {
+      "type": "integer",
+      "description": "Maximum number of top-ranked papers carried into classification + human review (keeps the analyst gate bounded).",
+      "default": 25,
+      "example": "25"
+     },
+     "recency_half_life_days": {
+      "type": "number",
+      "description": "Half-life in days for the exponential recency-decay signal. A paper this old contributes half the recency weight of a brand-new one.",
+      "default": 540,
+      "example": "540"
+     },
+     "qdrant_base_url": {
+      "type": "string",
+      "description": "Qdrant REST base URL the kept papers are upserted to.",
+      "default": "https://your-cluster.qdrant.io",
+      "example": "https://acme-xyz.eu-central-1-0.aws.cloud.qdrant.io:6333"
+     },
+     "gate_model": {
+      "type": "string",
+      "description": "Swappable relevance-judge model for the gate. Any provider can back it; for regulated data pin an EU/local provider (mistral/large, ollama, omlx/qwen-3). Triage works with this unavailable.",
+      "default": "sonnet",
+      "example": "mistral/large"
+     },
+     "slack_channel": {
+      "type": "string",
+      "description": "Research channel that receives the triage digest.",
+      "default": "#research-literature-triage",
+      "example": "#research-literature-triage"
+     }
+    }
+   }
+  },
+  {
+   "slug": "gizmax/mrr-waterfall-board-rollup",
+   "name": "MRR Waterfall Board Roll-Up",
+   "description": "On a monthly schedule a durable SENSOR blocks until the month-end roll-up window opens, then http GETs subscription/billing events (Stripe) and closed-won + churn pipeline (Salesforce / HubSpot). A DETERMINISTIC code step computes the full MRR waterfall (new / expansion / contraction / churn / reactivation), net + gross revenue retention, logo and dollar churn and the SaaS quick ratio, then runs a reconciliation check that opening + new + expansion + reactivation - contraction - churn must equal the closing balance within tolerance. A CONDITION blocks the report if the bridge does not foot. A two-strategy GATE (a swappable llm_eval narrative-accuracy judge AND a non-LLM 'bridge_balances' boolean) must BOTH pass before publish. A REPORT assembles the board metrics pack PDF and NOTIFY posts it to the board channel + archives to object store. All metric math and the foot-check are 100% deterministic code; the only model is the swappable narrative judge.",
+   "author": "gizmax",
+   "author_url": "https://github.com/gizmax",
+   "version": "1.0.0",
+   "category": "finance_ops",
+   "tags": [
+    "MRR",
+    "ARR",
+    "SaaS",
+    "FP&A",
+    "Board",
+    "Waterfall",
+    "NRR",
+    "GRR",
+    "Churn",
+    "QuickRatio",
+    "Reconciliation",
+    "Stripe",
+    "Salesforce",
+    "HubSpot",
+    "Finance"
+   ],
+   "models_used": [
+    "sonnet"
+   ],
+   "tools_used": [],
+   "step_count": 11,
+   "download_url": "https://raw.githubusercontent.com/gizmax/Sandcastle/main/src/sandcastle/templates/mrr_waterfall_board_rollup.yaml",
+   "source": "built-in",
+   "created_at": "2026-06-02T00:00:00Z",
+   "updated_at": "2026-06-02T00:00:00Z",
+   "estimated_cost_per_run": 0.22,
+   "avg_execution_time": 330,
+   "downloads": 0,
+   "remix_count": 0,
+   "forked_from": null,
+   "license": "BSL-1.1",
+   "rating": 0.0,
+   "review_count": 0,
+   "sha256": "7e3c4b8aeb5be4cc32fbec0b33cbb55770b6f4a34234c5f77a95e9b477fbf940",
+   "input_schema": {
+    "required": [
+     "billing_events_base_url",
+     "crm_pipeline_base_url"
+    ],
+    "properties": {
+     "billing_events_base_url": {
+      "type": "string",
+      "description": "Stripe (or Stripe-compatible) REST base exposing the period's subscription / invoice MRR-delta events for the closed month.",
+      "default": "https://api.stripe.com/v1",
+      "example": "https://api.stripe.com/v1"
+     },
+     "crm_pipeline_base_url": {
+      "type": "string",
+      "description": "CRM pipeline REST base (Salesforce or HubSpot) exposing the period's closed-won new logos and churned / downgraded accounts.",
+      "default": "https://your-org.my.salesforce.com/services/data/v60.0",
+      "example": "https://acme.my.salesforce.com/services/data/v60.0"
+     },
+     "fpa_calendar_url": {
+      "type": "string",
+      "description": "FP&A close-calendar REST base. The sensor polls this for the current period's books_closed / rollup_window_open flag so the roll-up only runs once the month is closed.",
+      "default": "https://fpa.internal/api/close-calendar",
+      "example": "https://fpa.internal/api/close-calendar"
+     },
+     "period": {
+      "type": "string",
+      "description": "The accounting period being rolled up (YYYY-MM). Drives the event queries and the board pack title.",
+      "default": "2026-05",
+      "example": "2026-05"
+     },
+     "opening_mrr": {
+      "type": "number",
+      "description": "Opening MRR for the period (the prior month's SEALED closing balance). The waterfall bridges FROM this number.",
+      "default": 0,
+      "example": "1250000"
+     },
+     "closing_mrr_reported": {
+      "type": "number",
+      "description": "The period's reported closing MRR from the system of record. The reconciliation check proves the computed bridge foots TO this number within tolerance.",
+      "default": 0,
+      "example": "1318500"
+     },
+     "reconciliation_tolerance": {
+      "type": "number",
+      "description": "Absolute currency tolerance (in the report currency's major units) within which the computed closing balance must match the reported closing balance for the bridge to foot.",
+      "default": 1.0,
+      "example": "1.0"
+     },
+     "currency": {
+      "type": "string",
+      "description": "ISO 4217 currency code the board pack is reported in. All MRR figures are assumed pre-normalized to this currency.",
+      "default": "USD",
+      "example": "EUR"
+     },
+     "gate_model": {
+      "type": "string",
+      "description": "Swappable narrative-accuracy judge model for the publish gate. Any of the 7 providers can back it; for EU data residency pin a local/EU provider (mistral/large, ollama, omlx/qwen-3). The math and foot-check run with this unavailable.",
+      "default": "sonnet",
+      "example": "mistral/large"
+     },
+     "report_author": {
+      "type": "string",
+      "description": "Author shown on the board metrics-pack PDF.",
+      "default": "FP&A / Office of the CFO",
+      "example": "FP&A / Office of the CFO"
+     },
+     "archive_base_url": {
+      "type": "string",
+      "description": "Object-lock (WORM) S3-compatible REST base that receives the sealed board pack + raw waterfall JSON for audit retention.",
+      "default": "https://s3.eu-central-1.amazonaws.com",
+      "example": "https://s3.eu-central-1.amazonaws.com"
+     },
+     "archive_bucket": {
+      "type": "string",
+      "description": "Bucket that stores the sealed board metrics packs tamper-evidently.",
+      "default": "board-metrics-packs",
+      "example": "acme-board-metrics-packs"
+     },
+     "board_channel": {
+      "type": "string",
+      "description": "Slack channel where the published board metrics pack is posted.",
+      "default": "#board-metrics",
+      "example": "#board-metrics"
+     },
+     "sensor_timeout": {
+      "type": "integer",
+      "description": "Sensor soft timeout in seconds - stop waiting for the roll-up window after this long (one run). Default 7 days to cover a late close.",
+      "default": 604800,
+      "example": "604800"
+     }
+    }
+   }
+  },
+  {
+   "slug": "gizmax/sec-filing-delta-extractor",
+   "name": "SEC Filing & Earnings Delta Extractor",
+   "description": "Pulls a company's newest SEC/IR filing, deterministically section-diffs it against the prior filing to surface added/removed/changed risk factors, guidance numbers and language shifts, then gates the diff for materiality so analysts read ONLY what actually changed between quarters. A durable SENSOR polls the EDGAR-style filings index and blocks until a new accession appears; two http GETs fetch the newest and the prior filing; a PARSE extracts clean section text; a deterministic CODE step aligns sections by heading, computes a sentence-level added/removed/modified diff, pulls numeric guidance (revenue, EPS, margin) via regex and computes per-metric numeric deltas, and SHA-256-fingerprints each changed block - no model touches the diff. A CONDITION routes only non-trivial diffs into a swappable materiality GATE (llm_eval judge AND a non-LLM changed_blocks/guidance_delta threshold), a REPORT compiles the memo, and an http PUT archives the sealed diff to S3.",
+   "author": "gizmax",
+   "author_url": "https://github.com/gizmax",
+   "version": "1.0.0",
+   "category": "research_intel",
+   "tags": [
+    "SEC",
+    "EDGAR",
+    "10-K",
+    "10-Q",
+    "8-K",
+    "earnings",
+    "guidance",
+    "risk-factors",
+    "diff",
+    "sensor",
+    "S3",
+    "equity-research",
+    "materiality",
+    "financial-analysis"
+   ],
+   "models_used": [
+    "sonnet"
+   ],
+   "tools_used": [],
+   "step_count": 14,
+   "download_url": "https://raw.githubusercontent.com/gizmax/Sandcastle/main/src/sandcastle/templates/sec_filing_delta_extractor.yaml",
+   "source": "built-in",
+   "created_at": "2026-06-02T00:00:00Z",
+   "updated_at": "2026-06-02T00:00:00Z",
+   "estimated_cost_per_run": 0.28,
+   "avg_execution_time": 420,
+   "downloads": 0,
+   "remix_count": 0,
+   "forked_from": null,
+   "license": "BSL-1.1",
+   "rating": 0.0,
+   "review_count": 0,
+   "sha256": "6a9be6f393042ce51297b48331263462fde106c2327dd4605c1af91657a75a3f",
+   "input_schema": {
+    "required": [
+     "ticker",
+     "filings_index_url"
+    ],
+    "properties": {
+     "ticker": {
+      "type": "string",
+      "description": "Issuer ticker whose newest periodic filing is diffed against its prior filing (e.g. 'AAPL').",
+      "default": "AAPL",
+      "example": "NVDA"
+     },
+     "filings_index_url": {
+      "type": "string",
+      "description": "EDGAR-style filings-index REST base that lists an issuer's accessions newest-first. The sensor polls this until a new accession appears (SEC EDGAR submissions API, or your IR mirror).",
+      "default": "https://data.sec.gov/submissions",
+      "example": "https://data.sec.gov/submissions"
+     },
+     "form_type": {
+      "type": "string",
+      "description": "Periodic form to track and diff like-for-like (10-K, 10-Q or 8-K). Newest is diffed against the prior filing of the SAME form.",
+      "default": "10-Q",
+      "example": "10-K"
+     },
+     "guidance_delta_threshold": {
+      "type": "number",
+      "description": "Non-LLM materiality threshold (percent). The gate's deterministic strategy treats the diff as material if any guidance metric (revenue / EPS / margin) moved by at least this percent OR there are at least min_changed_blocks changed blocks.",
+      "default": 5.0,
+      "example": "5.0"
+     },
+     "min_changed_blocks": {
+      "type": "integer",
+      "description": "Non-LLM materiality threshold (count). The deterministic gate strategy also passes if the number of added/removed/modified text blocks is at or above this, even with no numeric guidance change.",
+      "default": 3,
+      "example": "3"
+     },
+     "archive_bucket": {
+      "type": "string",
+      "description": "S3 (or S3-compatible) bucket that receives the sealed, SHA-256-fingerprinted diff record for the research audit trail.",
+      "default": "equity-research-filing-deltas",
+      "example": "acme-equity-research-filing-deltas"
+     },
+     "archive_base_url": {
+      "type": "string",
+      "description": "S3 REST base URL the sealed diff record is PUT to.",
+      "default": "https://s3.eu-central-1.amazonaws.com",
+      "example": "https://s3.eu-central-1.amazonaws.com"
+     },
+     "last_seen_accession": {
+      "type": "string",
+      "description": "Accession number of the most recently diffed filing. The sensor only fires for an accession NEWER than this, so a re-run does not re-diff the same filing. Leave empty on first run.",
+      "default": "",
+      "example": "0000320193-26-000045"
+     },
+     "sensor_timeout": {
+      "type": "integer",
+      "description": "Sensor soft timeout in seconds - stop waiting for a new filing after this long (one watch run). Default 24h.",
+      "default": 86400,
+      "example": "86400"
+     },
+     "gate_model": {
+      "type": "string",
+      "description": "Swappable materiality-judge model for the gate. Any provider can back it; for EU data residency pin a local/EU provider (mistral/large, ollama, omlx/qwen-3). The diff is computed with this unavailable.",
+      "default": "sonnet",
+      "example": "mistral/large"
+     },
+     "slack_channel": {
+      "type": "string",
+      "description": "Research Slack channel that receives the headline delta digest.",
+      "default": "#equity-research-deltas",
+      "example": "#equity-research-deltas"
+     }
+    }
+   }
+  },
+  {
+   "slug": "gizmax/subscription-audit-cancel-warden",
+   "name": "Subscription Audit & Cancel Warden",
+   "description": "Pulls your card/bank transaction history, then a DETERMINISTIC code step normalizes merchants, infers monthly/annual cadence, dedups the noise into a real recurring-subscription ledger, and flags price-hikes and zombie (unused) subs with zero model involvement. A swappable CLASSIFY only labels keep/review/cancel from the precomputed flags. Any cancellation is held behind a GATE where a human approval strategy AND a non-LLM spend-threshold strategy must BOTH pass before a cancel request fires, then NOTIFY posts the audit.",
+   "author": "gizmax",
+   "author_url": "https://github.com/gizmax",
+   "version": "1.0.0",
+   "category": "personal",
+   "tags": [
+    "Subscriptions",
+    "Personal Finance",
+    "Recurring Charges",
+    "Price Hike",
+    "Zombie Subs",
+    "Dedup",
+    "Cancel",
+    "Human Approval",
+    "Plaid",
+    "Stripe"
+   ],
+   "models_used": [
+    "sonnet"
+   ],
+   "tools_used": [],
+   "step_count": 8,
+   "download_url": "https://raw.githubusercontent.com/gizmax/Sandcastle/main/src/sandcastle/templates/subscription_audit_cancel_warden.yaml",
+   "source": "built-in",
+   "created_at": "2026-06-02T00:00:00Z",
+   "updated_at": "2026-06-02T00:00:00Z",
+   "estimated_cost_per_run": 0.16,
+   "avg_execution_time": 240,
+   "downloads": 0,
+   "remix_count": 0,
+   "forked_from": null,
+   "license": "BSL-1.1",
+   "rating": 0.0,
+   "review_count": 0,
+   "sha256": "554c9c2ab39ed38c201847cb02061f4a88078c8bd0d6738d1b60c983fb58c292",
+   "input_schema": {
+    "required": [
+     "transactions_url"
+    ],
+    "properties": {
+     "transactions_url": {
+      "type": "string",
+      "description": "Bank/card aggregator transaction-history REST endpoint (Plaid /transactions, MX, Stripe, or your bank's export gateway) returning dated charges.",
+      "default": "https://api.plaid.com/transactions/get",
+      "example": "https://sandbox.plaid.com/transactions/get"
+     },
+     "lookback_months": {
+      "type": "integer",
+      "description": "How many months of statement history to scan for recurring charges. Longer windows make cadence inference and price-hike detection more reliable.",
+      "default": 12,
+      "example": "12"
+     },
+     "zombie_inactivity_days": {
+      "type": "integer",
+      "description": "Deterministic threshold (days since last charge relative to the expected next bill date) past which an active sub is flagged a ZOMBIE you likely forgot. Lower = more aggressive.",
+      "default": 75,
+      "example": "75"
+     },
+     "price_hike_pct": {
+      "type": "number",
+      "description": "Deterministic minimum percentage increase (vs the prior charge for the same sub) that counts as a flagged price hike. 0.10 = a 10% jump.",
+      "default": 0.1,
+      "example": "0.10"
+     },
+     "min_cancel_cost": {
+      "type": "number",
+      "description": "Non-LLM gate floor: a cancel whose MONTHLY cost is at/below this is too trivial to auto-fire (rubber-stamp risk) and is held for the human. In statement currency.",
+      "default": 3.0,
+      "example": "3.0"
+     },
+     "max_cancel_cost": {
+      "type": "number",
+      "description": "Non-LLM gate ceiling: a cancel whose MONTHLY cost is at/above this is too consequential to fire on automation and is held for explicit human review. In statement currency.",
+      "default": 200.0,
+      "example": "200.0"
+     },
+     "cancel_api_url": {
+      "type": "string",
+      "description": "Merchant / aggregator subscription-cancel REST endpoint that receives the approved cancellation requests.",
+      "default": "https://api.your-aggregator.example.com/subscriptions/cancel",
+      "example": "https://api.acme-bank.example.com/subscriptions/cancel"
+     },
+     "slack_channel": {
+      "type": "string",
+      "description": "Channel that receives the subscription audit digest and the cancel confirmations.",
+      "default": "#money-subscriptions",
+      "example": "#money-subscriptions"
+     }
+    }
+   }
+  },
+  {
+   "slug": "gizmax/topic-share-of-voice-rank-monitor",
+   "name": "Topic Share-of-Voice Rank Monitor",
+   "description": "Tracks where your brand and named rivals surface across multiple search / answer engines for a watched keyword set, then computes a DETERMINISTIC share-of-voice and rank-delta versus the last sealed snapshot - entirely in code. A SENSOR runs the sweep on schedule; a LOOP fans parallel http GETs to several providers (Tavily, Exa, a SERP-style endpoint) per keyword; a code step normalizes results, matches brand / competitor mentions, and computes per-keyword rank positions, an aggregate SoV percentage and the rank_delta of who gained or lost positions. A CLASSIFY labels each keyword steady / improving / overtaken, a CONDITION feeds adverse moves into a swappable GATE (llm_eval 'real ranking loss worth acting on?' AND a non-LLM 'rank_delta<=-N or sov_drop_pct>=threshold'). Confirmed losses NOTIFY Slack and append to an Airtable scoreboard, and the new snapshot is sealed back to the store. All SoV and rank-delta math is model-independent.",
+   "author": "gizmax",
+   "author_url": "https://github.com/gizmax",
+   "version": "1.0.0",
+   "category": "research_intel",
+   "tags": [
+    "SEO",
+    "ShareOfVoice",
+    "RankTracking",
+    "AnswerEngine",
+    "GEO",
+    "CompetitiveIntel",
+    "Brand",
+    "Tavily",
+    "Exa",
+    "SERP",
+    "Airtable",
+    "Slack",
+    "monitoring"
+   ],
+   "models_used": [
+    "sonnet"
+   ],
+   "tools_used": [],
+   "step_count": 19,
+   "download_url": "https://raw.githubusercontent.com/gizmax/Sandcastle/main/src/sandcastle/templates/topic_share_of_voice_rank_monitor.yaml",
+   "source": "built-in",
+   "created_at": "2026-06-02T00:00:00Z",
+   "updated_at": "2026-06-02T00:00:00Z",
+   "estimated_cost_per_run": 0.38,
+   "avg_execution_time": 570,
+   "downloads": 0,
+   "remix_count": 0,
+   "forked_from": null,
+   "license": "BSL-1.1",
+   "rating": 0.0,
+   "review_count": 0,
+   "sha256": "1fd8c0a1f8bc25a82437cd6d9889d801de263114b3dccaed1a6696c75592202b",
+   "input_schema": {
+    "required": [
+     "watch_keywords",
+     "brand_and_competitors"
+    ],
+    "properties": {
+     "watch_keywords": {
+      "type": "string",
+      "description": "Comma- or newline-separated topic keywords / queries to track share-of-voice on (e.g. 'workflow orchestrator, ai agent platform, eu ai act compliance').",
+      "default": "ai workflow orchestrator, agent automation platform, eu ai act compliance tool",
+      "example": "ai workflow orchestrator, agent automation platform, eu ai act compliance tool"
+     },
+     "brand_and_competitors": {
+      "type": "string",
+      "description": "Brand + rivals as 'Label=domain1|alias' entries, semicolon-separated. The FIRST entry is YOUR brand; the rest are tracked competitors. Domains / aliases drive deterministic mention matching.",
+      "default": "Sandcastle=sandcastle-ai.eu|sandcastle; Zapier=zapier.com; n8n=n8n.io|n8n; Make=make.com|integromat",
+      "example": "Sandcastle=sandcastle-ai.eu|sandcastle; Zapier=zapier.com; n8n=n8n.io; Make=make.com|integromat"
+     },
+     "search_provider_urls": {
+      "type": "string",
+      "description": "Comma-separated search / answer-engine endpoints queried in parallel per keyword. Order is provider1=Tavily, provider2=Exa, provider3=SERP-style. Leave a slot empty to skip that provider.",
+      "default": "https://api.tavily.com/search, https://api.exa.ai/search, https://serpapi.com/search",
+      "example": "https://api.tavily.com/search, https://api.exa.ai/search, https://serpapi.com/search"
+     },
+     "rank_delta_threshold": {
+      "type": "integer",
+      "description": "Deterministic rank-loss threshold (positive integer). The gate's non-LLM strategy treats a keyword as a material overtake when your brand's rank_delta <= -threshold (you fell at least this many positions) OR sov_drop_pct meets the SoV threshold.",
+      "default": 2,
+      "example": "3"
+     },
+     "sov_drop_threshold_pct": {
+      "type": "number",
+      "description": "Deterministic share-of-voice drop threshold in percentage points. The gate's non-LLM strategy fires when your brand's SoV fell by at least this many points versus the last sealed snapshot.",
+      "default": 5.0,
+      "example": "5.0"
+     },
+     "snapshot_store_url": {
+      "type": "string",
+      "description": "Snapshot store REST base (PostgREST / S3 REST gateway) holding the last SEALED per-keyword ranks + SoV that rank_delta is measured against.",
+      "default": "https://sov.internal/snapshots",
+      "example": "https://sov.internal/snapshots"
+     },
+     "sweep_interval": {
+      "type": "integer",
+      "description": "Seconds between share-of-voice sweeps. The sensor blocks until the scheduler reports the next sweep window is due OR a webhook fires.",
+      "default": 86400,
+      "example": "86400"
+     },
+     "sensor_timeout": {
+      "type": "integer",
+      "description": "Sensor soft timeout in seconds - stop waiting for the next sweep window after this long (one watch run). Default 7 days.",
+      "default": 604800,
+      "example": "604800"
+     },
+     "result_depth": {
+      "type": "integer",
+      "description": "How many top ranked results per provider to consider when matching brand / competitor mentions and computing rank positions.",
+      "default": 10,
+      "example": "10"
+     },
+     "gate_model": {
+      "type": "string",
+      "description": "Swappable ranking-loss judge model for the gate. Any provider can back it; for EU data pin a local / EU provider (mistral/large, ollama, omlx/qwen-3). SoV + rank-delta detection works with this unavailable.",
+      "default": "sonnet",
+      "example": "mistral/large"
+     },
+     "airtable_base_id": {
+      "type": "string",
+      "description": "Airtable base id that holds the competitive share-of-voice scoreboard table.",
+      "default": "appXXXXXXXXXXXXXX",
+      "example": "app8sJ2kQfL0qWvZ1"
+     },
+     "airtable_table": {
+      "type": "string",
+      "description": "Airtable table name the confirmed overtakes are appended to as scoreboard rows.",
+      "default": "SoV Scoreboard",
+      "example": "SoV Scoreboard"
+     },
+     "slack_channel": {
+      "type": "string",
+      "description": "Slack channel that receives the confirmed-overtake alert and the clean-sweep digest.",
+      "default": "#competitive-intel",
+      "example": "#competitive-intel"
+     }
+    }
+   }
+  },
+  {
+   "slug": "gizmax/trip-itinerary-race-planner",
+   "name": "Trip Itinerary Race Planner",
+   "description": "Races two travel itinerary providers (failover across model providers - first that returns a usable day-by-day plan wins), then HTTP-verifies the draft against the live flight-status feed and the destination weather forecast for the exact trip dates. A DETERMINISTIC code step runs the feasibility math - minimum-connection-time gaps between legs, outdoor-activity vs precipitation conflicts, and a budget sum vs your cap - and the plan only lands in your inbox after a GATE where a swappable llm_eval quality judge AND a non-LLM feasibility-threshold strategy BOTH pass. All the go/no-go math is model-independent.",
+   "author": "gizmax",
+   "author_url": "https://github.com/gizmax",
+   "version": "1.0.0",
+   "category": "personal",
+   "tags": [
+    "Travel",
+    "Itinerary",
+    "Trip",
+    "Flights",
+    "Weather",
+    "Race",
+    "Failover",
+    "Feasibility",
+    "Personal",
+    "Planner",
+    "Layover",
+    "Budget"
+   ],
+   "models_used": [
+    "google/gemini-2.5-pro",
+    "sonnet"
+   ],
+   "tools_used": [],
+   "step_count": 14,
+   "download_url": "https://raw.githubusercontent.com/gizmax/Sandcastle/main/src/sandcastle/templates/trip_itinerary_race_planner.yaml",
+   "source": "built-in",
+   "created_at": "2026-06-02T00:00:00Z",
+   "updated_at": "2026-06-02T00:00:00Z",
+   "estimated_cost_per_run": 0.28,
+   "avg_execution_time": 420,
+   "downloads": 0,
+   "remix_count": 0,
+   "forked_from": null,
+   "license": "BSL-1.1",
+   "rating": 0.0,
+   "review_count": 0,
+   "sha256": "86d5b3fa98d5f771b052670e29bfabbbe048a93c7593ef0afa4946a78867fd17",
+   "input_schema": {
+    "required": [
+     "destination",
+     "date_range",
+     "flight_status_url",
+     "weather_api_url"
+    ],
+    "properties": {
+     "destination": {
+      "type": "string",
+      "description": "Destination city name or IATA airport code the trip is built around.",
+      "default": "Lisbon (LIS)",
+      "example": "Lisbon (LIS)"
+     },
+     "date_range": {
+      "type": "string",
+      "description": "Trip start and end dates as 'YYYY-MM-DD..YYYY-MM-DD' (or 'start to end'). Drives the per-day plan, the weather window and the flight-status dates.",
+      "default": "2026-07-10..2026-07-14",
+      "example": "2026-07-10..2026-07-14"
+     },
+     "flight_status_url": {
+      "type": "string",
+      "description": "Live flight-status REST endpoint (FlightAware AeroAPI / Aviationstack style) returning the booked legs with scheduled/estimated times and status for the trip dates.",
+      "default": "https://aeroapi.flightaware.com/aeroapi/flights",
+      "example": "https://aeroapi.flightaware.com/aeroapi/flights/search?query=dest LIS"
+     },
+     "weather_api_url": {
+      "type": "string",
+      "description": "Destination weather-forecast REST endpoint (OpenWeather / Open-Meteo style) returning a daily forecast (precipitation probability, condition) covering the trip dates.",
+      "default": "https://api.openweathermap.org/data/2.5/forecast/daily",
+      "example": "https://api.open-meteo.com/v1/forecast?daily=precipitation_probability_max"
+     },
+     "budget_cap": {
+      "type": "number",
+      "description": "Total activity/excursion budget cap in your currency. The deterministic feasibility step sums the drafted activity costs and fails the plan if it exceeds this.",
+      "default": 800,
+      "example": "800"
+     },
+     "min_connection_minutes": {
+      "type": "integer",
+      "description": "Minimum legal/comfortable connection time in minutes between two consecutive flight legs. A drafted layover shorter than this is a hard feasibility failure.",
+      "default": 45,
+      "example": "45"
+     },
+     "rain_threshold": {
+      "type": "number",
+      "description": "Precipitation-probability threshold (0-100). A forecast day at or above this is treated as a wash-out; an outdoor activity scheduled that day is a feasibility conflict.",
+      "default": 70,
+      "example": "70"
+     },
+     "min_feasibility_score": {
+      "type": "number",
+      "description": "Deterministic feasibility score (0-1) the plan must reach for the gate's non-LLM strategy to approve it. Computed purely from the layover/weather/budget checks.",
+      "default": 1.0,
+      "example": "1.0"
+     },
+     "judge_model": {
+      "type": "string",
+      "description": "Swappable plan-quality judge model for the gate. Any of the providers can back it; the feasibility math passes/fails without it. The two race drafters run on DIFFERENT providers (sonnet and google/gemini-2.5-pro) for genuine cross-provider failover.",
+      "default": "sonnet",
+      "example": "ollama/qwen-3"
+     },
+     "recipient_email": {
+      "type": "string",
+      "description": "Inbox that receives the final itinerary (or the bounce-back with blocking reasons).",
+      "default": "me@example.com",
+      "example": "traveler@example.com"
+     },
+     "slack_channel": {
+      "type": "string",
+      "description": "Optional Slack channel for a short trip-planned ping alongside the email.",
+      "default": "#my-trips",
+      "example": "#my-trips"
+     }
+    }
+   }
+  },
+  {
+   "slug": "gizmax/vendor-spend-anomaly-zscore-detector",
+   "name": "Vendor Spend Anomaly Detector",
+   "description": "Streams the AP transaction ledger, builds a per-vendor spend baseline and computes a robust z-score (median / MAD) plus split-invoice, duplicate-payment and new-vendor-spike detectors in pure code, classifies each outlier by likely cause, then SHA-256 seals a tamper-evident anomaly record before opening a triage ticket. The load-bearing detection is deterministic code (sensor + http + code + loop carry it); the only model is a swappable classify label on precomputed signals. No model ever does the spend math.",
+   "author": "gizmax",
+   "author_url": "https://github.com/gizmax",
+   "version": "1.0.0",
+   "category": "finance_ops",
+   "tags": [
+    "FinanceOps",
+    "AccountsPayable",
+    "AP",
+    "anomaly-detection",
+    "z-score",
+    "MAD",
+    "duplicate-payment",
+    "split-invoice",
+    "maverick-spend",
+    "SAP",
+    "NetSuite",
+    "QuickBooks",
+    "Jira",
+    "Slack",
+    "audit"
+   ],
+   "models_used": [
+    "sonnet"
+   ],
+   "tools_used": [],
+   "step_count": 13,
+   "download_url": "https://raw.githubusercontent.com/gizmax/Sandcastle/main/src/sandcastle/templates/vendor_spend_anomaly_zscore_detector.yaml",
+   "source": "built-in",
+   "created_at": "2026-06-02T00:00:00Z",
+   "updated_at": "2026-06-02T00:00:00Z",
+   "estimated_cost_per_run": 0.26,
+   "avg_execution_time": 390,
+   "downloads": 0,
+   "remix_count": 0,
+   "forked_from": null,
+   "license": "BSL-1.1",
+   "rating": 0.0,
+   "review_count": 0,
+   "sha256": "229a6d7514f041bce830d4e07978e2d0c9ce0135eb2e85a374488f95c4c6132b",
+   "input_schema": {
+    "required": [
+     "ap_ledger_base_url"
+    ],
+    "properties": {
+     "ap_ledger_base_url": {
+      "type": "string",
+      "description": "AP / ERP REST base URL exposing posted vendor payments (SAP, NetSuite, QuickBooks AP). The detector GETs the lookback window of transactions from here.",
+      "default": "https://your-erp.example.com/api/ap",
+      "example": "https://acme.netsuite.com/services/rest/record/v1/vendorPayment"
+     },
+     "batch_id": {
+      "type": "string",
+      "description": "Identifier for this AP batch / sweep, used in the sealed record and the triage ticket.",
+      "default": "AP-SWEEP-2026-06",
+      "example": "AP-BATCH-2026-06-02"
+     },
+     "lookback_window": {
+      "type": "integer",
+      "description": "Days of AP history to pull and build each vendor's baseline against. A larger window stabilizes the median / MAD baseline.",
+      "default": 180,
+      "example": "180"
+     },
+     "zscore_threshold": {
+      "type": "number",
+      "description": "Robust z-score (modified, median / MAD based) at or above which a single payment is flagged as an amount outlier. 3.5 is the conventional modified-z cutoff.",
+      "default": 3.5,
+      "example": "3.5"
+     },
+     "approval_threshold": {
+      "type": "number",
+      "description": "The dollar approval threshold. Invoices that land just under this value, clustered same-day same-vendor, are flagged as a likely split-invoice to dodge approval.",
+      "default": 10000,
+      "example": "10000"
+     },
+     "split_band_fraction": {
+      "type": "number",
+      "description": "How close under the approval threshold counts as 'just under' for split-invoice detection (0-1). 0.1 means invoices within the top 10% band below the threshold.",
+      "default": 0.1,
+      "example": "0.1"
+     },
+     "min_baseline_n": {
+      "type": "integer",
+      "description": "Minimum number of prior payments a vendor needs before the z-score baseline is trusted. Below this the vendor is treated as new (spike detector applies instead).",
+      "default": 5,
+      "example": "5"
+     },
+     "spike_multiple": {
+      "type": "number",
+      "description": "A new vendor's first payment is flagged as a spike when it is at least this multiple of the median first-payment across all new vendors in the batch.",
+      "default": 3.0,
+      "example": "3.0"
+     },
+     "anomaly_score_floor": {
+      "type": "number",
+      "description": "Batch anomaly score (0-100) at or above which a triage ticket is opened. Below the floor the sweep is logged clean and no ticket is filed.",
+      "default": 25,
+      "example": "25"
+     },
+     "classify_model": {
+      "type": "string",
+      "description": "Swappable model that LABELS each outlier's likely cause from precomputed signals only - set the classify step's model field to any of the 7 providers (for regulated data pin an EU / local provider like mistral/large or omlx/qwen-3). Detection works with this unavailable.",
+      "default": "sonnet",
+      "example": "mistral/large"
+     },
+     "ap_triage_project": {
+      "type": "string",
+      "description": "Jira / Linear project key that receives the AP anomaly triage ticket.",
+      "default": "APRISK",
+      "example": "APRISK"
+     },
+     "issue_tracker_url": {
+      "type": "string",
+      "description": "Issue-tracker REST endpoint that creates the triage ticket (Jira /rest/api/3/issue or Linear GraphQL gateway).",
+      "default": "https://your-org.atlassian.net/rest/api/3/issue",
+      "example": "https://acme.atlassian.net/rest/api/3/issue"
+     },
+     "record_store_base_url": {
+      "type": "string",
+      "description": "Object-store (S3-compatible) REST base URL that receives the SHA-256-sealed immutable anomaly record for audit retention.",
+      "default": "https://s3.eu-central-1.amazonaws.com",
+      "example": "https://s3.eu-central-1.amazonaws.com"
+     },
+     "record_store_bucket": {
+      "type": "string",
+      "description": "Bucket holding the sealed AP anomaly records tamper-evidently.",
+      "default": "ap-anomaly-ledger",
+      "example": "acme-ap-anomaly-ledger"
+     },
+     "controller_channel": {
+      "type": "string",
+      "description": "AP controller Slack channel that receives the anomaly digest / ticket link.",
+      "default": "#ap-controllership",
+      "example": "#ap-controllership"
+     },
+     "sweep_timeout": {
+      "type": "integer",
+      "description": "Sensor soft timeout in seconds - stop waiting for the next AP batch after this long (one sweep run). Default 24h.",
+      "default": 86400,
+      "example": "86400"
+     }
+    }
+   }
+  },
+  {
+   "slug": "gizmax/warranty-return-window-tracker",
+   "name": "Warranty & Return-Window Tracker",
+   "description": "Watches your purchases and counts down each item's return window and warranty expiry with DETERMINISTIC date math. A cross-source RACE takes the first valid purchase date from two order/receipt providers (retailer order-history API vs an email-receipt parser - provider failover, NOT a vote), a PARSE pulls purchase_date / price / warranty_term out of the winning payload, deterministic CODE computes return_window_days_left and warranty_days_left, buckets urgency, and dedups idempotently, then a CONDITION + NOTIFY ping you ONLY for items whose window is about to close so you never miss a return or a warranty claim.",
+   "author": "gizmax",
+   "author_url": "https://github.com/gizmax",
+   "version": "1.0.0",
+   "category": "personal",
+   "tags": [
+    "warranty",
+    "returns",
+    "personal",
+    "life-admin",
+    "countdown",
+    "receipts",
+    "orders",
+    "race",
+    "parse",
+    "deadline",
+    "reminder",
+    "Slack"
+   ],
+   "models_used": [
+    "haiku",
+    "sonnet"
+   ],
+   "tools_used": [],
+   "step_count": 17,
+   "download_url": "https://raw.githubusercontent.com/gizmax/Sandcastle/main/src/sandcastle/templates/warranty_return_window_tracker.yaml",
+   "source": "built-in",
+   "created_at": "2026-06-02T00:00:00Z",
+   "updated_at": "2026-06-02T00:00:00Z",
+   "estimated_cost_per_run": 0.34,
+   "avg_execution_time": 510,
+   "downloads": 0,
+   "remix_count": 0,
+   "forked_from": null,
+   "license": "BSL-1.1",
+   "rating": 0.0,
+   "review_count": 0,
+   "sha256": "f7dfb3129ea105793dbc5f8f14f85a046a3c13d243c23d60bbb4aa438d1e9681",
+   "input_schema": {
+    "required": [
+     "orders_api_url",
+     "receipt_parse_url"
+    ],
+    "properties": {
+     "orders_api_url": {
+      "type": "string",
+      "description": "Retailer / order-history REST base that lists your recent purchases and (per order) the authoritative purchase date. The primary race branch for the purchase date.",
+      "default": "https://your-retailer.example.com/api/orders",
+      "example": "https://www.amazon.com/api/order-history/v1"
+     },
+     "receipt_parse_url": {
+      "type": "string",
+      "description": "Secondary receipt / email-receipt parser endpoint raced against the order API. Given an order reference it returns the parsed receipt (purchase_date, price, warranty_term). Provider failover, not a vote.",
+      "default": "https://receipt-parser.internal/api/parse",
+      "example": "https://api.veryfi.com/api/v8/partner/documents"
+     },
+     "return_window_default_days": {
+      "type": "integer",
+      "description": "Fallback return-window length in days, applied ONLY when neither source reports an explicit return policy for the item (e.g. retailer default 30).",
+      "default": 30,
+      "example": "30"
+     },
+     "warranty_default_days": {
+      "type": "integer",
+      "description": "Fallback warranty length in days, applied ONLY when neither source reports an explicit warranty term (e.g. manufacturer default 365).",
+      "default": 365,
+      "example": "365"
+     },
+     "closing_soon_days": {
+      "type": "integer",
+      "description": "Alert threshold in days. An item is 'closing soon' when its return window OR its warranty has this many days (or fewer) left but is not yet expired. Drives the condition + notify.",
+      "default": 7,
+      "example": "7"
+     },
+     "lookback_days": {
+      "type": "integer",
+      "description": "Only sweep purchases made within this many days back, so very old already-closed orders are not re-evaluated every run.",
+      "default": 400,
+      "example": "400"
+     },
+     "sweep_interval": {
+      "type": "integer",
+      "description": "Seconds between sweeps. The sensor blocks until the order endpoint reports the next daily sweep window is due. Default 24h.",
+      "default": 86400,
+      "example": "86400"
+     },
+     "sensor_timeout": {
+      "type": "integer",
+      "description": "Sensor soft timeout in seconds - stop waiting for the next sweep window after this long (one watch run). Default 48h.",
+      "default": 172800,
+      "example": "172800"
+     },
+     "summary_model": {
+      "type": "string",
+      "description": "Swappable model for the optional one-line digest header (draft_header step). Repoint it to any of the 7 providers - pin an EU/local provider (mistral/large, ollama, omlx/qwen-3) for privacy. The countdown decision is pure code and works with this unavailable.",
+      "default": "haiku",
+      "example": "mistral/large"
+     },
+     "slack_channel": {
+      "type": "string",
+      "description": "Channel / DM that receives the closing-soon reminder digest.",
+      "default": "#purchases-warranty",
+      "example": "#purchases-warranty"
+     }
+    }
+   }
   }
  ],
  "categories": [
@@ -15021,13 +16765,28 @@
    "id": "healthcare",
    "name": "Healthcare & Life Sciences",
    "count": 7
+  },
+  {
+   "id": "finance_ops",
+   "name": "Finance & FP&A Operations",
+   "count": 5
+  },
+  {
+   "id": "personal",
+   "name": "Personal & Life Admin",
+   "count": 5
+  },
+  {
+   "id": "research_intel",
+   "name": "Research & Intelligence",
+   "count": 5
   }
  ],
  "stats": {
-  "total_templates": 235,
+  "total_templates": 250,
   "total_authors": 41,
   "total_downloads": 50845,
-  "last_updated": "2026-06-02T11:00:00Z"
+  "last_updated": "2026-06-02T14:00:00Z"
  },
  "collections": [
   {

--- a/src/sandcastle/templates/ar_collections_dunning_prioritizer.yaml
+++ b/src/sandcastle/templates/ar_collections_dunning_prioritizer.yaml
@@ -1,0 +1,583 @@
+# name: AR Collections Dunning Prioritizer
+# description: Sorts the entire open-invoice AR ledger into deterministic aging buckets, computes a transparent collection-priority score per account (days-overdue x balance x prior-late-rate), drafts the right-tone dunning message via a cross-provider race so it survives any single LLM outage, and gates every send through a credit-policy threshold plus optional human sign-off on large balances. The aging math, DSO, priority score and dunning-stage selection are all carried by deterministic code; race + gate keep it model-independent.
+# tags: [AR, Collections, Dunning, Aging, DSO, QuickBooks, Stripe, CreditPolicy, FinanceOps, Gmail, Resend, CRM]
+# category: finance_ops
+# connectors: quickbooks, stripe, gmail, resend, hubspot, salesforce, slack
+name: ar-collections-dunning-prioritizer
+description: >-
+  The AR collections decisioning engine. A DETERMINISTIC http GET pulls the entire
+  open-invoice ledger plus per-customer payment history from QuickBooks / Stripe AR, and
+  a code step sorts every open invoice into transparent aging buckets (0-30 / 31-60 /
+  61-90 / 90+), rolls them up per account, and computes the load-bearing math in pure
+  Python: DSO, days-overdue, weighted balance, prior-late-rate and a COLLECTION-PRIORITY
+  SCORE = balance x overdue-weight x prior-late-rate, then deterministically selects the
+  dunning STAGE (reminder / first-notice / second-notice / final-demand) from days
+  overdue. The workflow LOOPS over each overdue account: a cross-provider RACE drafts the
+  stage-appropriate dunning email and takes the FIRST provider that returns a usable body
+  (provider failover, NOT a vote), so the draft survives any single LLM outage. A GATE
+  with TWO strategies that BOTH must pass then guards every send - a SWAPPABLE llm_eval
+  tone / escalation-appropriateness judge AND a NON-LLM threshold strategy fed the
+  pre-computed balance vs the hold-for-review floor - so an account passes/fails with zero
+  model involvement. Accounts at or above the hold-for-review balance route to a human
+  credit-manager APPROVAL before anything is sent. A NOTIFY then emails the customer via
+  Gmail / Resend and logs the dunning touch to CRM (HubSpot / Salesforce). The aging,
+  scoring and stage selection are 100% deterministic and run even with zero model
+  providers available; the model is confined to the race draft and the gate's swappable
+  tone judge.
+default_model: sonnet
+default_max_turns: 8
+default_timeout: 1800
+input_schema:
+  required: ["ar_ledger_base_url"]
+  properties:
+    ar_ledger_base_url:
+      type: string
+      description: "AR system REST base exposing open invoices + per-customer payment history (QuickBooks Online or Stripe AR / Invoicing)."
+      default: "https://quickbooks.api.intuit.com/v3/company"
+      example: "https://api.stripe.com/v1"
+    company_id:
+      type: string
+      description: "Tenant / company id used to scope the open-invoice query (QuickBooks realm id or Stripe account id)."
+      default: "ACME-CO-001"
+      example: "9130350000000123456"
+    aging_bucket_boundaries:
+      type: string
+      description: "Comma-separated day boundaries for the deterministic aging buckets. Default 30,60,90 yields 0-30 / 31-60 / 61-90 / 90+."
+      default: "30,60,90"
+      example: "30,60,90"
+    priority_weights:
+      type: string
+      description: "Comma-separated overdue-day -> weight multipliers as day:weight pairs feeding the priority score. Default ramps the weight up with age."
+      default: "0:0.5,30:1.0,60:2.0,90:3.5"
+      example: "0:0.5,30:1.0,60:2.0,90:3.5"
+    hold_for_review_balance:
+      type: number
+      description: "Account balance (in ledger currency) at or above which the gate forces a human credit-manager sign-off before any dunning email is sent."
+      default: 5000
+      example: "5000"
+    min_dunnable_balance:
+      type: number
+      description: "Accounts with a total overdue balance strictly below this are skipped (immaterial to chase). No email, no touch."
+      default: 25
+      example: "25"
+    grace_days:
+      type: integer
+      description: "Days past the due date before an invoice is considered overdue / dunnable (a deterministic courtesy grace window)."
+      default: 0
+      example: "3"
+    dunning_from_address:
+      type: string
+      description: "From address the dunning email is sent from (AR / billing mailbox)."
+      default: "billing@your-company.example.com"
+      example: "ar@acme.example.com"
+    email_send_url:
+      type: string
+      description: "Transactional email send endpoint used by the notify step (Gmail API messages.send or Resend /emails)."
+      default: "https://api.resend.com/emails"
+      example: "https://gmail.googleapis.com/gmail/v1/users/me/messages/send"
+    crm_endpoint:
+      type: string
+      description: "CRM REST endpoint that records the dunning touch as a logged activity (HubSpot engagements or Salesforce Task)."
+      default: "https://api.hubapi.com/crm/v3/objects/notes"
+      example: "https://your-instance.salesforce.com/services/data/v60.0/sobjects/Task"
+    tone_judge_model:
+      type: string
+      description: "Swappable model backing the gate's tone / escalation-appropriateness judge. Any provider can back it; for EU data residency pin mistral/large or a local model. The send still passes/fails on the non-LLM balance threshold without it."
+      default: "sonnet"
+      example: "mistral/large"
+    slack_channel:
+      type: string
+      description: "Collections Slack channel that receives the run digest (queued / held-for-review / sent counts)."
+      default: "#ar-collections"
+      example: "#ar-collections"
+steps:
+  # 1) DETERMINISTIC pull of the entire open-invoice AR ledger for the company. Returns every
+  #    open invoice with its balance, due date and customer id. No model. Connector: quickbooks/stripe.
+  - id: pull_open_invoices
+    type: http
+    http_config:
+      url: "{input.ar_ledger_base_url}/{input.company_id}/invoices?status=open&expand=customer&limit=1000"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.AR_LEDGER_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 2) DETERMINISTIC pull of per-customer payment history (prior invoices + how late each was
+  #    paid) used to derive the prior-late-rate factor in the priority score. No model.
+  - id: pull_payment_history
+    type: http
+    depends_on: [pull_open_invoices]
+    http_config:
+      url: "{input.ar_ledger_base_url}/{input.company_id}/payments?status=paid&include=days_to_pay&limit=2000"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.AR_LEDGER_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 3) DETERMINISTIC aging + scoring engine. THE load-bearing decision, all in code, no model.
+  #    Sort every open invoice into aging buckets (0-30 / 31-60 / 61-90 / 90+ from the boundaries),
+  #    roll them up per account, compute DSO and the prior-late-rate from payment history, then
+  #    the COLLECTION-PRIORITY SCORE = total_overdue_balance x overdue-weight(max days) x
+  #    (1 + prior_late_rate), and select the dunning STAGE from the worst days-overdue. Accounts
+  #    below min_dunnable_balance are skipped. Output one loopable row per dunnable account.
+  - id: age_and_score
+    type: code
+    depends_on: [pull_open_invoices, pull_payment_history]
+    code_config:
+      language: python
+      code: |
+        from datetime import datetime, timezone
+
+        inv_raw = _steps.get('pull_open_invoices') or {}
+        pay_raw = _steps.get('pull_payment_history') or {}
+
+        def as_rows(blob, keys):
+            if isinstance(blob, list):
+                return [r for r in blob if isinstance(r, dict)]
+            if isinstance(blob, dict):
+                for k in keys:
+                    v = blob.get(k)
+                    if isinstance(v, list):
+                        return [r for r in v if isinstance(r, dict)]
+            return []
+
+        invoices = as_rows(inv_raw, ['invoices', 'data', 'items', 'QueryResponse', 'results'])
+        payments = as_rows(pay_raw, ['payments', 'data', 'items', 'results'])
+
+        # --- parse the aging bucket boundaries (e.g. "30,60,90") --------------------------
+        bnd_raw = str(_input.get('aging_bucket_boundaries') or '30,60,90')
+        boundaries = []
+        for tok in bnd_raw.replace(';', ',').split(','):
+            tok = tok.strip()
+            if tok:
+                try:
+                    boundaries.append(int(float(tok)))
+                except ValueError:
+                    pass
+        boundaries = sorted(set(boundaries)) or [30, 60, 90]
+
+        # --- parse the overdue-day -> weight ramp (e.g. "0:0.5,30:1.0,60:2.0,90:3.5") ------
+        pw_raw = str(_input.get('priority_weights') or '0:0.5,30:1.0,60:2.0,90:3.5')
+        weight_points = []
+        for pair in pw_raw.replace(';', ',').split(','):
+            pair = pair.strip()
+            if ':' in pair:
+                d_str, w_str = pair.split(':', 1)
+                try:
+                    weight_points.append((int(float(d_str.strip())), float(w_str.strip())))
+                except ValueError:
+                    pass
+        weight_points = sorted(weight_points) or [(0, 1.0)]
+
+        def overdue_weight(days):
+            # Step weight: the last point whose day-floor is <= days overdue.
+            w = weight_points[0][1]
+            for d_floor, wt in weight_points:
+                if days >= d_floor:
+                    w = wt
+                else:
+                    break
+            return w
+
+        grace = int(_input.get('grace_days', 0) or 0)
+        min_bal = float(_input.get('min_dunnable_balance', 25) or 25)
+        hold_bal = float(_input.get('hold_for_review_balance', 5000) or 5000)
+        now = datetime.now(timezone.utc)
+
+        def parse_date(v):
+            if not v:
+                return None
+            s = str(v).strip().replace('Z', '+00:00')
+            for fmt in (None,):
+                try:
+                    dt = datetime.fromisoformat(s)
+                    if dt.tzinfo is None:
+                        dt = dt.replace(tzinfo=timezone.utc)
+                    return dt
+                except (ValueError, TypeError):
+                    return None
+            return None
+
+        def to_float(v):
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return 0.0
+
+        # --- prior-late-rate per customer from payment history ----------------------------
+        # late_rate = fraction of historical paid invoices settled after their due date.
+        late_counts = {}
+        for p in payments:
+            cust = str(p.get('customer_id') or p.get('customer') or p.get('CustomerRef') or '').strip()
+            if not cust:
+                continue
+            days_to_pay = p.get('days_to_pay')
+            terms = to_float(p.get('terms_days') or p.get('net_terms') or 0)
+            was_late = None
+            if days_to_pay is not None:
+                was_late = to_float(days_to_pay) > terms
+            else:
+                due = parse_date(p.get('due_date') or p.get('DueDate'))
+                paid = parse_date(p.get('paid_at') or p.get('paid_date') or p.get('TxnDate'))
+                if due and paid:
+                    was_late = paid > due
+            if was_late is None:
+                continue
+            agg = late_counts.setdefault(cust, {'total': 0, 'late': 0})
+            agg['total'] += 1
+            if was_late:
+                agg['late'] += 1
+
+        def prior_late_rate(cust):
+            agg = late_counts.get(cust)
+            if not agg or agg['total'] == 0:
+                return 0.0
+            return round(agg['late'] / agg['total'], 4)
+
+        # --- bucket labels derived from boundaries ----------------------------------------
+        def bucket_label(days):
+            lo = 0
+            for b in boundaries:
+                if days <= b:
+                    return f"{lo}-{b}"
+                lo = b + 1
+            return f"{boundaries[-1] + 1}+"
+
+        # --- roll open invoices up per account --------------------------------------------
+        accounts = {}
+        for inv in invoices:
+            cust = str(inv.get('customer_id') or inv.get('customer')
+                       or inv.get('CustomerRef') or inv.get('customer_ref') or '').strip()
+            if not cust:
+                continue
+            balance = to_float(inv.get('balance') or inv.get('amount_due')
+                               or inv.get('Balance') or inv.get('amount_remaining'))
+            if balance <= 0:
+                continue
+            due = parse_date(inv.get('due_date') or inv.get('DueDate') or inv.get('due'))
+            days_overdue = 0
+            if due:
+                days_overdue = max(0, (now - due).days - grace)
+
+            acc = accounts.setdefault(cust, {
+                'customer_id': cust,
+                'customer_name': str(inv.get('customer_name') or inv.get('CompanyName')
+                                     or inv.get('display_name') or cust),
+                'customer_email': str(inv.get('customer_email') or inv.get('email')
+                                      or inv.get('BillEmail') or ''),
+                'total_balance': 0.0,
+                'overdue_balance': 0.0,
+                'max_days_overdue': 0,
+                'invoice_count': 0,
+                'overdue_invoice_count': 0,
+                'buckets': {},
+                'invoices': [],
+            })
+            acc['total_balance'] += balance
+            acc['invoice_count'] += 1
+            acc['invoices'].append({
+                'invoice_id': str(inv.get('id') or inv.get('Id') or inv.get('number') or ''),
+                'balance': round(balance, 2),
+                'days_overdue': days_overdue,
+            })
+            if days_overdue > 0:
+                acc['overdue_balance'] += balance
+                acc['overdue_invoice_count'] += 1
+                acc['max_days_overdue'] = max(acc['max_days_overdue'], days_overdue)
+                lbl = bucket_label(days_overdue)
+                acc['buckets'][lbl] = round(acc['buckets'].get(lbl, 0.0) + balance, 2)
+
+        # --- dunning stage from worst days overdue ----------------------------------------
+        def dunning_stage(days):
+            b = boundaries
+            if days <= 0:
+                return 'none'
+            if len(b) >= 1 and days <= b[0]:
+                return 'reminder'
+            if len(b) >= 2 and days <= b[1]:
+                return 'first_notice'
+            if len(b) >= 3 and days <= b[2]:
+                return 'second_notice'
+            return 'final_demand'
+
+        # --- finalize: priority score + stage per dunnable account ------------------------
+        dunnable = []
+        skipped = 0
+        for cust, acc in accounts.items():
+            overdue_balance = round(acc['overdue_balance'], 2)
+            if overdue_balance < min_bal:
+                skipped += 1
+                continue
+            days = acc['max_days_overdue']
+            late_rate = prior_late_rate(cust)
+            weight = overdue_weight(days)
+            # COLLECTION-PRIORITY SCORE = balance x overdue-weight x (1 + prior-late-rate).
+            priority_score = round(overdue_balance * weight * (1.0 + late_rate), 2)
+            stage = dunning_stage(days)
+            row = {
+                'customer_id': cust,
+                'customer_name': acc['customer_name'],
+                'customer_email': acc['customer_email'],
+                'total_balance': round(acc['total_balance'], 2),
+                'overdue_balance': overdue_balance,
+                'max_days_overdue': days,
+                'overdue_weight': weight,
+                'prior_late_rate': late_rate,
+                'priority_score': priority_score,
+                'dunning_stage': stage,
+                'aging_buckets': acc['buckets'],
+                'overdue_invoice_count': acc['overdue_invoice_count'],
+                'invoices': acc['invoices'][:25],
+                'requires_human_signoff': overdue_balance >= hold_bal,
+            }
+            dunnable.append(row)
+
+        # Highest collection-priority first: chase the biggest, oldest, most-delinquent first.
+        dunnable.sort(key=lambda r: r['priority_score'], reverse=True)
+
+        total_overdue = round(sum(r['overdue_balance'] for r in dunnable), 2)
+        total_ar = round(sum(round(a['total_balance'], 2) for a in accounts.values()), 2)
+
+        result = {
+            'company_id': _input.get('company_id'),
+            'account_count': len(accounts),
+            'dunnable_count': len(dunnable),
+            'skipped_immaterial': skipped,
+            'total_ar_balance': total_ar,
+            'total_overdue_balance': total_overdue,
+            'boundaries': boundaries,
+            'hold_for_review_balance': hold_bal,
+            'dunnable_accounts': dunnable,
+        }
+
+  # 4) LOOP over every dunnable account, highest collection-priority first. Per-account child
+  #    chain: race-draft the stage-appropriate dunning email -> gate (tone judge AND balance
+  #    threshold) -> condition routes large balances to human approval -> email + CRM log.
+  - id: per_account_loop
+    type: loop
+    depends_on: [age_and_score]
+    loop_config:
+      over: "steps.age_and_score.output.dunnable_accounts"
+      step_ids:
+        - draft_dunning_email
+        - send_gate
+        - signoff_branch
+      max_iterations: 1000
+
+  # 4a) CROSS-PROVIDER RACE - draft the STAGE-APPROPRIATE dunning email for THIS account. The
+  #     same prompt is raced across providers and the FIRST one returning a usable body wins
+  #     (provider failover, NOT a vote), so the draft survives any single LLM outage. The branch
+  #     steps are DEFINED SEPARATELY below with NO depends_on. Tone escalates with the stage.
+  - id: draft_dunning_email
+    type: race
+    race_config:
+      branches:
+        - [draft_primary]
+        - [draft_secondary]
+      validator: "len(str(output).strip()) > 40"
+
+  # 4a-i) PRIMARY draft branch (default provider).
+  - id: draft_primary
+    type: llm
+    model: sonnet
+    prompt: >-
+      You are an accounts-receivable collections specialist. Write a concise, professional
+      dunning email body for an overdue account. Match the TONE to the dunning stage exactly:
+      'reminder' = friendly courtesy nudge; 'first_notice' = polite but clear request for
+      payment; 'second_notice' = firm, referencing prior contact; 'final_demand' = formal,
+      stating the account is seriously past due and next steps may follow. State the overdue
+      amount and the oldest days-overdue. Do NOT threaten legal action, name a collections
+      agency, or invent fees. Plain text only, no subject line.
+      Stage: {input._item.dunning_stage}.
+      Customer: {input._item.customer_name}.
+      Overdue balance: {input._item.overdue_balance}.
+      Oldest invoice days overdue: {input._item.max_days_overdue}.
+      Aging buckets: {input._item.aging_buckets}.
+
+  # 4a-ii) SECONDARY draft branch (swap to a different / EU-resident provider for failover).
+  - id: draft_secondary
+    type: llm
+    model: mistral/large
+    prompt: >-
+      You are an accounts-receivable collections specialist. Write a concise, professional
+      dunning email body for an overdue account. Match the TONE to the dunning stage exactly:
+      'reminder' = friendly courtesy nudge; 'first_notice' = polite but clear request for
+      payment; 'second_notice' = firm, referencing prior contact; 'final_demand' = formal,
+      stating the account is seriously past due and next steps may follow. State the overdue
+      amount and the oldest days-overdue. Do NOT threaten legal action, name a collections
+      agency, or invent fees. Plain text only, no subject line.
+      Stage: {input._item.dunning_stage}.
+      Customer: {input._item.customer_name}.
+      Overdue balance: {input._item.overdue_balance}.
+      Oldest invoice days overdue: {input._item.max_days_overdue}.
+      Aging buckets: {input._item.aging_buckets}.
+
+  # 4b) SEND GATE (swappable + model-independent). TWO strategies, BOTH must pass:
+  #     (1) llm_eval tone / escalation-appropriateness judge - "does this draft match the stage
+  #         and avoid over-escalation / threats?", model SWAPPABLE to any of the 7 providers;
+  #     (2) llm_eval acting as a DETERMINISTIC threshold - fed ONLY the pre-computed balance vs
+  #         the hold-for-review floor and told to answer purely from the arithmetic, so the send
+  #         still passes/fails the gate on the non-LLM math alone with zero model involvement.
+  - id: send_gate
+    type: gate
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are a collections-quality reviewer. A dunning email was drafted for an account
+              at a specific dunning stage. Answer exactly 'approved' if the email's tone MATCHES
+              the stage (reminder=gentle, first_notice=polite, second_notice=firm,
+              final_demand=formal) AND it does not over-escalate, threaten legal/collections
+              action, or invent fees. Otherwise answer 'rejected' and name the defect. Judge tone
+              and escalation appropriateness only; the balance threshold is checked separately.
+            input: "Stage={steps.draft_dunning_email.context.item.dunning_stage} | Draft: {steps.draft_dunning_email.output}"
+            model: "{input.tone_judge_model}"
+        - type: llm_eval
+          config:
+            prompt: >-
+              Deterministic threshold check. Answer exactly 'approved' if the overdue balance is
+              strictly BELOW the hold-for-review floor (this account may auto-send); answer
+              'rejected' if the balance is at or above the floor (this account needs human
+              sign-off). Use ONLY the supplied numbers - do not reason beyond the arithmetic
+              comparison.
+            input: "overdue_balance={steps.draft_dunning_email.context.item.overdue_balance} hold_for_review_balance={input.hold_for_review_balance}"
+            model: haiku
+
+  # 4c) CONDITION - route large balances to a human credit-manager approval, small balances send
+  #     directly. Deterministic branch keyed off the pre-computed requires_human_signoff flag (not
+  #     a model), so routing survives a missing model provider. No model.
+  - id: signoff_branch
+    type: condition
+    condition_config:
+      expression: "{steps.draft_dunning_email.context.item.requires_human_signoff} == True"
+      then: [credit_manager_approval, send_dunning_email, log_crm_touch]
+      else: [send_dunning_email, log_crm_touch]
+
+  # 4d) HUMAN APPROVAL - a credit manager must sign off before a large-balance dunning email is
+  #     sent. Protects key accounts from an inappropriate auto-send. On timeout the touch is held.
+  - id: credit_manager_approval
+    type: approval
+    approval_config:
+      message: >-
+        Credit manager: approve sending a {steps.draft_dunning_email.context.item.dunning_stage}
+        dunning email to {steps.draft_dunning_email.context.item.customer_name}
+        (overdue {steps.draft_dunning_email.context.item.overdue_balance},
+        {steps.draft_dunning_email.context.item.max_days_overdue} days). This balance is at or
+        above the hold-for-review floor. Approve to send, reject to hold this account for manual handling.
+      timeout_hours: 24
+      on_timeout: abort
+
+  # 4e) NOTIFY (email customer) - send the approved dunning email to the customer via the
+  #     transactional email connector (Gmail API or Resend). Connector: gmail / resend.
+  - id: send_dunning_email
+    type: http
+    http_config:
+      url: "{input.email_send_url}"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.EMAIL_API_TOKEN}"
+      body: |
+        {
+          "from": "{input.dunning_from_address}",
+          "to": ["{steps.draft_dunning_email.context.item.customer_email}"],
+          "subject": "Payment reminder: account {steps.draft_dunning_email.context.item.customer_id} overdue balance {steps.draft_dunning_email.context.item.overdue_balance}",
+          "text": "{steps.draft_dunning_email.output}",
+          "tags": [{"name": "dunning_stage", "value": "{steps.draft_dunning_email.context.item.dunning_stage}"}]
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 4f) LOG THE TOUCH TO CRM - record the dunning email as a logged activity so collections
+  #     history is auditable and the next stage escalates correctly. Connector: hubspot / salesforce.
+  - id: log_crm_touch
+    type: http
+    http_config:
+      url: "{input.crm_endpoint}"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.CRM_API_TOKEN}"
+      body: |
+        {
+          "properties": {
+            "customer_id": "{steps.draft_dunning_email.context.item.customer_id}",
+            "activity_type": "dunning_email",
+            "dunning_stage": "{steps.draft_dunning_email.context.item.dunning_stage}",
+            "overdue_balance": "{steps.draft_dunning_email.context.item.overdue_balance}",
+            "max_days_overdue": "{steps.draft_dunning_email.context.item.max_days_overdue}",
+            "priority_score": "{steps.draft_dunning_email.context.item.priority_score}",
+            "note": "Dunning touch sent via AR Collections Dunning Prioritizer."
+          }
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 5) DETERMINISTIC run digest. Fold the prioritized ledger into counts: total dunnable, how
+  #    many auto-send vs held-for-review, the total overdue chased and the top-priority account.
+  #    No model.
+  - id: build_digest
+    type: code
+    depends_on: [per_account_loop, age_and_score]
+    code_config:
+      language: python
+      code: |
+        scored = _steps.get('age_and_score') or {}
+        accounts = scored.get('dunnable_accounts', [])
+
+        hold = [a for a in accounts if a.get('requires_human_signoff')]
+        auto = [a for a in accounts if not a.get('requires_human_signoff')]
+
+        by_stage = {}
+        for a in accounts:
+            st = a.get('dunning_stage', 'unknown')
+            by_stage[st] = by_stage.get(st, 0) + 1
+
+        top = accounts[0] if accounts else {}
+
+        result = {
+            'company_id': scored.get('company_id'),
+            'dunnable_count': len(accounts),
+            'auto_send_count': len(auto),
+            'held_for_review_count': len(hold),
+            'total_overdue_balance': scored.get('total_overdue_balance', 0),
+            'total_ar_balance': scored.get('total_ar_balance', 0),
+            'by_stage': by_stage,
+            'top_priority_customer': top.get('customer_name'),
+            'top_priority_score': top.get('priority_score'),
+            'top_priority_overdue': top.get('overdue_balance'),
+        }
+
+  # 6) NOTIFY the collections channel with the run digest so the team sees what was queued,
+  #    auto-sent and held for credit-manager sign-off. service: slack.
+  - id: notify_collections
+    type: notify
+    depends_on: [build_digest]
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :money_with_wings: AR dunning run for {steps.build_digest.output.company_id}
+        Dunnable accounts : {steps.build_digest.output.dunnable_count}
+        Auto-sent         : {steps.build_digest.output.auto_send_count}
+        Held for sign-off : {steps.build_digest.output.held_for_review_count}
+        Total overdue chased: {steps.build_digest.output.total_overdue_balance} of {steps.build_digest.output.total_ar_balance} AR
+        By stage          : {steps.build_digest.output.by_stage}
+        Top priority      : {steps.build_digest.output.top_priority_customer} (score {steps.build_digest.output.top_priority_score}, overdue {steps.build_digest.output.top_priority_overdue})
+on_complete:
+  storage_path: "ar-collections-dunning-prioritizer/{run_id}/result.json"

--- a/src/sandcastle/templates/bill_renewal_late_fee_sentinel.yaml
+++ b/src/sandcastle/templates/bill_renewal_late_fee_sentinel.yaml
@@ -1,0 +1,350 @@
+# name: Bill & Renewal Late-Fee Sentinel
+# description: An always-on sentinel that watches every bill and subscription renewal and pings you BEFORE a late fee or silent auto-renewal hits. A durable SENSOR blocks until the next daily check-in window, an http GET pulls the live biller/aggregator statement feed listing each bill with its amount + due_date, and DETERMINISTIC code does the load-bearing date math - days_until_due, in-lead-time-window detection, and cross-run dedup so you are never pinged twice for the same bill. A CONDITION routes only the due-soon items to NOTIFY; everything else stays quiet. All detection is pure code and runs with zero model providers; a model only drafts the human-readable reminder copy.
+# tags: [Bills, Subscriptions, Renewals, LateFee, DueDate, Sensor, PersonalFinance, LifeAdmin, Reminder, Dedup, Plaid, Slack]
+# category: personal
+# connectors: slack
+name: bill-renewal-late-fee-sentinel
+description: >-
+  A personal-finance watchdog that stops you ever paying a late fee or getting
+  silently auto-renewed. A durable SENSOR blocks until the next daily check-in
+  window is reached (a real schedule that sleeps between checks instead of busy
+  -looping). An http GET then pulls the live biller / account-aggregator statement
+  feed (Plaid / Tink / bank statement REST) listing every bill and subscription
+  renewal with its amount and due_date. A DETERMINISTIC code step does ALL the
+  load-bearing work with zero model involvement: it parses each due_date, computes
+  days_until_due against the check-in date, flags the bills whose due date falls
+  inside the lead-time window, and DEDUPES against the prior run's already-alerted
+  ledger (pulled by http) so the same bill is never surfaced twice across daily
+  runs. A CONDITION routes ONLY the genuinely due-soon, not-yet-alerted items into
+  the NOTIFY path; a clean check-in stays silent. The reminder copy is drafted by a
+  swappable model purely for human readability - the decision of WHAT is due and
+  WHEN to ping is 100% deterministic date arithmetic. Finally the alerted-bill
+  ledger is PUT back so tomorrow's run remembers what it already told you about.
+default_model: sonnet
+default_max_turns: 6
+default_timeout: 1800
+input_schema:
+  required: ["accounts_feed_url"]
+  properties:
+    accounts_feed_url:
+      type: string
+      description: "Biller / account-aggregator statements REST endpoint listing each bill + subscription renewal with its amount and due_date (Plaid liabilities, Tink, or a bank statement feed)."
+      default: "https://api.aggregator.example.com/v1/bills"
+      example: "https://production.plaid.com/liabilities/get"
+    lead_time_days:
+      type: integer
+      description: "Notify this many days before a bill's due date or a subscription's auto-renewal date. Anything due within this many days (and not in the past) is surfaced."
+      default: 5
+      example: "5"
+    check_interval:
+      type: integer
+      description: "Sensor cadence in seconds - how often the sentinel checks in for the next bill sweep. Default daily (86400s)."
+      default: 86400
+      example: "86400"
+    sensor_timeout:
+      type: integer
+      description: "Sensor soft timeout in seconds - stop waiting for the next check-in window after this long (one watch run). Default 25h so a daily cadence always fires once."
+      default: 90000
+      example: "90000"
+    ledger_url:
+      type: string
+      description: "REST base of the alerted-bill ledger (the dedup memory). GET returns the bills already alerted in prior runs; a PUT writes back the updated set. PostgREST / S3 REST / KV gateway style."
+      default: "https://api.aggregator.example.com/v1/alert-ledger"
+      example: "https://your-kv.example.com/bill-alert-ledger"
+    grace_period_days:
+      type: integer
+      description: "How many days a just-past-due bill is still surfaced (so a bill that slipped past midnight is not silently dropped). 0 = only future bills."
+      default: 1
+      example: "1"
+    draft_model:
+      type: string
+      description: "Documents which model DRAFTS the human-readable reminder text - set the draft_reminder step's `model:` to this. Any of the providers can back it; pin an EU/local one (mistral/large, ollama, omlx/qwen-3) for privacy. Detection works with this unavailable; the model only writes copy, never decides what is due."
+      default: "sonnet"
+      example: "mistral/large"
+    slack_channel:
+      type: string
+      description: "Slack channel (or DM) that receives the due-soon reminder digest."
+      default: "#money-reminders"
+      example: "#money-reminders"
+steps:
+  # 1) DURABLE SENSOR - block until the next daily check-in window. This is a real schedule
+  #    that SLEEPS between checks (check_interval) rather than busy-looping; it polls the
+  #    aggregator's lightweight health/cursor endpoint and proceeds once the feed is reachable
+  #    and a new check-in window is due. Nothing downstream runs until the window opens.
+  - id: await_checkin_window
+    type: sensor
+    sensor_config:
+      url: "{input.accounts_feed_url}?select=feed_status,next_checkin_due"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200"
+      check_interval: 86400
+      timeout: 90000
+
+  # 2) DETERMINISTIC http GET of the LIVE bill + subscription-renewal feed. Returns every bill
+  #    and renewal with amount + due_date for the user's linked accounts. No model. Connector:
+  #    account aggregator (Plaid liabilities / Tink / bank statement REST).
+  - id: pull_bills_feed
+    type: http
+    depends_on: [await_checkin_window]
+    http_config:
+      url: "{input.accounts_feed_url}?include=subscriptions,renewals&status=open"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.AGGREGATOR_API_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 3) DETERMINISTIC http GET of the alerted-bill LEDGER - the dedup memory. Returns the set of
+  #    (bill key) already surfaced in prior runs so today's sweep does not re-ping the same bill.
+  #    on_failure: skip so a cold/empty ledger (first ever run) does not abort the sweep. No model.
+  - id: pull_alert_ledger
+    type: http
+    depends_on: [await_checkin_window]
+    http_config:
+      url: "{input.ledger_url}?select=bill_key,due_date,alerted_at"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.LEDGER_API_TOKEN}"
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  # 4) THE LOAD-BEARING STEP - 100% DETERMINISTIC DATE MATH, NO MODEL. For each bill in the feed:
+  #    parse its due_date, compute days_until_due relative to the check-in date, decide whether it
+  #    falls inside the lead-time window [-(grace_period_days) .. lead_time_days], build a stable
+  #    bill_key, and DEDUP against the prior-run ledger so a bill already alerted (for the same
+  #    due_date) is suppressed. Outputs the due-soon list + the refreshed ledger to write back.
+  - id: compute_due_soon
+    type: code
+    depends_on: [pull_bills_feed, pull_alert_ledger]
+    code_config:
+      language: python
+      code: |
+        import re
+        import hashlib
+        from datetime import datetime, timezone, date, timedelta
+
+        feed_raw = _steps.get('pull_bills_feed') or {}
+        ledger_raw = _steps.get('pull_alert_ledger') or {}
+
+        lead_days = int(_input.get('lead_time_days', 5) or 5)
+        grace_days = int(_input.get('grace_period_days', 1) or 1)
+
+        # --- The check-in date is "today" in UTC; all date math is measured from here.
+        today = datetime.now(timezone.utc).date()
+
+        # --- Coalesce the feed payload (dict-with-list or bare list) into bill rows.
+        def as_rows(blob):
+            if isinstance(blob, list):
+                return [r for r in blob if isinstance(r, dict)]
+            if isinstance(blob, dict):
+                for k in ('bills', 'liabilities', 'items', 'data', 'results', 'accounts', 'records'):
+                    v = blob.get(k)
+                    if isinstance(v, list):
+                        return [r for r in v if isinstance(r, dict)]
+            return []
+
+        rows = as_rows(feed_raw)
+        ledger_rows = as_rows(ledger_raw)
+
+        # --- Robust ISO-ish date parser. Accepts yyyy-mm-dd, full ISO, or yyyy/mm/dd.
+        def parse_due(value):
+            s = str(value or '').strip()
+            if not s:
+                return None
+            s = s.replace('/', '-')
+            m = re.match(r'^(\d{4})-(\d{2})-(\d{2})', s)
+            if not m:
+                return None
+            try:
+                return date(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+            except ValueError:
+                return None
+
+        # --- A stable key for a bill so the same recurring charge dedupes across runs. Built from
+        #     the biller name + account + the specific due_date (a new due_date is a new alert).
+        def bill_key(biller, account, due_iso):
+            material = '|'.join([
+                str(biller or '').strip().lower(),
+                str(account or '').strip().lower(),
+                str(due_iso or ''),
+            ])
+            return hashlib.sha256(material.encode('utf-8')).hexdigest()[:24]
+
+        # --- Build the set of already-alerted keys from the ledger (dedup memory).
+        already_alerted = set()
+        for lr in ledger_rows:
+            k = str(lr.get('bill_key') or '').strip()
+            if k:
+                already_alerted.add(k)
+
+        due_soon = []
+        upcoming = []          # in window but already alerted (suppressed) - kept for the ledger
+        all_keys_seen = []
+
+        for rec in rows:
+            biller = (rec.get('name') or rec.get('biller') or rec.get('merchant')
+                      or rec.get('description') or rec.get('payee') or 'bill')
+            account = (rec.get('account') or rec.get('account_id') or rec.get('account_name') or '')
+            kind = str(rec.get('type') or rec.get('category') or 'bill').strip().lower()
+            is_renewal = ('subscription' in kind or 'renewal' in kind
+                          or bool(rec.get('auto_renew')) or bool(rec.get('is_subscription')))
+
+            # Amount is informational for the reminder - never gates the decision.
+            amount = rec.get('amount') or rec.get('balance') or rec.get('minimum_payment') or rec.get('price')
+            try:
+                amount = round(float(amount), 2) if amount is not None else None
+            except (TypeError, ValueError):
+                amount = None
+            currency = str(rec.get('currency') or rec.get('iso_currency_code') or 'USD').upper()
+
+            due_raw = (rec.get('due_date') or rec.get('next_payment_due_date')
+                       or rec.get('renewal_date') or rec.get('next_billing_date') or rec.get('due'))
+            due = parse_due(due_raw)
+            if due is None:
+                continue
+
+            days_until_due = (due - today).days
+            due_iso = due.isoformat()
+            key = bill_key(biller, account, due_iso)
+            all_keys_seen.append({'bill_key': key, 'due_date': due_iso})
+
+            # --- IN-WINDOW: due within lead_time_days ahead, and not older than the grace period.
+            in_window = (-grace_days) <= days_until_due <= lead_days
+            if not in_window:
+                continue
+
+            item = {
+                'bill_key': key,
+                'biller': str(biller),
+                'account': str(account),
+                'kind': 'renewal' if is_renewal else 'bill',
+                'amount': amount,
+                'currency': currency,
+                'due_date': due_iso,
+                'days_until_due': days_until_due,
+                'is_overdue': days_until_due < 0,
+                'is_renewal': is_renewal,
+            }
+
+            if key in already_alerted:
+                upcoming.append(item)          # suppressed: already pinged in a prior run
+            else:
+                due_soon.append(item)
+
+        # --- Sort the surfaced bills by urgency (soonest / most overdue first).
+        due_soon.sort(key=lambda x: x['days_until_due'])
+
+        # --- Refreshed ledger = previously-alerted keys still relevant + the ones we alert now.
+        #     (Prune ledger entries whose due_date is well in the past so it does not grow forever.)
+        cutoff = (today - timedelta(days=max(grace_days, 1) + 30)).isoformat()
+        refreshed_ledger = [
+            {'bill_key': lr.get('bill_key'), 'due_date': lr.get('due_date'),
+             'alerted_at': lr.get('alerted_at')}
+            for lr in ledger_rows
+            if str(lr.get('due_date') or '') >= cutoff and lr.get('bill_key')
+        ]
+        now_iso = datetime.now(timezone.utc).isoformat()
+        for it in due_soon:
+            refreshed_ledger.append({
+                'bill_key': it['bill_key'],
+                'due_date': it['due_date'],
+                'alerted_at': now_iso,
+            })
+
+        overdue = [it for it in due_soon if it['is_overdue']]
+        renewals = [it for it in due_soon if it['is_renewal']]
+
+        result = {
+            'checkin_date': today.isoformat(),
+            'lead_time_days': lead_days,
+            'grace_period_days': grace_days,
+            'total_bills_scanned': len(rows),
+            'due_soon': due_soon,
+            'due_soon_count': len(due_soon),
+            'suppressed_count': len(upcoming),
+            'overdue_count': len(overdue),
+            'renewal_count': len(renewals),
+            'has_due_soon': len(due_soon) > 0,
+            'refreshed_ledger': refreshed_ledger,
+            'ledger_size': len(refreshed_ledger),
+        }
+
+  # 5) CONDITION - route ONLY when there is at least one genuinely due-soon, not-yet-alerted bill.
+  #    A clean check-in (nothing due in window, or all already pinged) takes the quiet path and
+  #    skips the notification entirely. Deterministic branch off the in-code flag. No model.
+  - id: route_due_soon
+    type: condition
+    depends_on: [compute_due_soon]
+    condition_config:
+      expression: "{steps.compute_due_soon.output.has_due_soon}"
+      then: [draft_reminder, write_ledger, notify_due_soon]
+      else: [write_ledger, notify_clean]
+
+  # 5a) DRAFT the reminder copy (swappable model, readability ONLY). The model NEVER decides what
+  #     is due - it just turns the already-computed due-soon list into a friendly digest. Pin any
+  #     provider via draft_model; the workflow still pings correctly if this is unavailable.
+  - id: draft_reminder
+    type: llm
+    model: sonnet
+    prompt: >-
+      You are a calm personal-finance assistant. Below is a DETERMINISTICALLY computed list of
+      bills and subscription renewals that fall inside the user's lead-time window (already
+      filtered and deduped in code - do not add, remove, or re-judge any item). Write a short,
+      friendly reminder digest. Lead with anything overdue, then by soonest due date. For each
+      item give the biller, amount + currency if present, the due date, and "in N days" (or
+      "OVERDUE by N days"). End with a one-line nudge to pay or cancel before the late fee /
+      auto-renewal. Keep it under 12 lines. Do NOT invent amounts or dates.
+      Check-in date: {steps.compute_due_soon.output.checkin_date}.
+      Due-soon items: {steps.compute_due_soon.output.due_soon}
+
+  # 5b) DETERMINISTIC http PUT of the refreshed alerted-bill ledger (the dedup memory) so
+  #     tomorrow's run remembers exactly what it already told the user about. Runs on BOTH
+  #     branches (clean + due-soon) so the pruned ledger is always persisted. No model.
+  - id: write_ledger
+    type: http
+    http_config:
+      url: "{input.ledger_url}"
+      method: PUT
+      headers:
+        Content-Type: "application/json"
+        Prefer: "resolution=merge-duplicates"
+      auth: "bearer:{env.LEDGER_API_TOKEN}"
+      body: "{steps.compute_due_soon.output.refreshed_ledger}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 5c) NOTIFY (due-soon) - send the reminder digest to the user's Slack channel/DM so they pay
+  #     or cancel before the late fee or silent auto-renewal lands. Carries the model-drafted copy
+  #     plus the hard deterministic counts. Connector: slack.
+  - id: notify_due_soon
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :alarm_clock: Bills & renewals due soon ({steps.compute_due_soon.output.due_soon_count}) - check-in {steps.compute_due_soon.output.checkin_date}
+        Overdue: {steps.compute_due_soon.output.overdue_count} | Renewals: {steps.compute_due_soon.output.renewal_count} | Already-pinged (suppressed): {steps.compute_due_soon.output.suppressed_count}
+
+        {steps.draft_reminder.output}
+
+  # 5d) NOTIFY (clean) - quiet "nothing due, you are all caught up" check-in. No reminder spam on
+  #     a clean sweep; the ledger was still refreshed in 5b. Connector: slack.
+  - id: notify_clean
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :white_check_mark: Bill check-in clean ({steps.compute_due_soon.output.checkin_date}). Scanned {steps.compute_due_soon.output.total_bills_scanned} bills/renewals, nothing due within {steps.compute_due_soon.output.lead_time_days} days that you have not already been reminded about. No action needed.
+on_complete:
+  storage_path: "bill-renewal-late-fee-sentinel/{run_id}/result.json"

--- a/src/sandcastle/templates/budget_variance_materiality_sentinel.yaml
+++ b/src/sandcastle/templates/budget_variance_materiality_sentinel.yaml
@@ -1,0 +1,578 @@
+# name: Budget vs Actual Variance Sentinel
+# description: Always-on FP&A sentinel that wakes on the period-close / actuals-posted webhook, pulls LIVE actuals from the accounting system (QuickBooks / NetSuite) and the LOCKED plan from the FP&A model (Google Sheets) over real http connectors, then computes per-cost-center variance ($ delta, % delta, run-rate burn, YTD pacing) in 100% deterministic Python. It LOOPS each cost center, CLASSIFIES favorable/unfavorable/on_plan from precomputed flags only, a CONDITION routes only candidate-material variances into a two-strategy MATERIALITY GATE (a swappable llm_eval judge AND a non-LLM dollar+percent floor threshold), and NOTIFY pages the budget owner only on confirmed material variance, never on rounding noise. The variance math and the threshold are model-independent; the model is confined to the swappable gate judge.
+# tags: [FP&A, Budget, Variance, BvA, Actuals, Plan, CostCenter, Materiality, RunRate, YTD, QuickBooks, NetSuite, GoogleSheets, Slack, finance, sensor]
+# category: finance_ops
+# connectors: quickbooks, netsuite, google-sheets, slack, pagerduty
+name: budget-variance-materiality-sentinel
+description: >-
+  An always-on Budget-vs-Actual variance sentinel for FP&A close. A durable SENSOR
+  blocks until the period-close / actuals-posted webhook fires (the accounting system
+  reports the period's actuals are posted and the close is in progress), so the workflow
+  only runs on real data, not on a half-posted ledger. A DETERMINISTIC http GET then pulls
+  the LIVE actuals from the accounting system (QuickBooks Online / NetSuite REST P&L by
+  cost center) and a second http GET pulls the LOCKED plan from the FP&A model
+  (Google Sheets budget tab). A pure-Python code step joins actuals to plan per cost center
+  and computes the load-bearing variance math - dollar delta (actual - plan), percent delta,
+  run-rate burn (actual / fraction-of-period-elapsed), and YTD pacing - all 100% deterministic
+  with zero model involvement, and pre-flags each row favorable / unfavorable / on_plan plus a
+  candidate-material boolean against the dollar + percent floors. The workflow LOOPS every cost
+  center: a CLASSIFY labels favorable / unfavorable / on_plan using ONLY the precomputed flags,
+  and a CONDITION routes only candidate-material variances into a MATERIALITY GATE. The gate has
+  TWO strategies that BOTH must pass: a swappable llm_eval materiality judge ("is this a real
+  budget overrun worth paging an owner, or a timing / accrual artifact?", backable by any of the
+  7 providers) AND a NON-LLM threshold strategy fed ONLY the precomputed abs($) and abs(%) so a
+  variance passes/fails the gate on the dollar + percent floor arithmetic alone. After the loop a
+  deterministic code step aggregates confirmed material variances per owner, a CONDITION gates the
+  page, and NOTIFY pages each budget owner with their material overruns / underruns and the period
+  rollup. All variance math and the materiality floor are model-independent and run with zero
+  providers available; the model is confined to the gate's swappable judge.
+default_model: sonnet
+default_max_turns: 8
+default_timeout: 1800
+input_schema:
+  required: ["entity_id", "accounting_actuals_base_url", "fpa_plan_sheet_url"]
+  properties:
+    entity_id:
+      type: string
+      description: "Legal entity / company id whose period close is watched (the accounting subsidiary or book)."
+      default: "ACME-US"
+      example: "ACME-US"
+    period:
+      type: string
+      description: "Fiscal period being closed in YYYY-MM form. Drives which plan column and which actuals window are pulled."
+      default: "2026-05"
+      example: "2026-05"
+    accounting_actuals_base_url:
+      type: string
+      description: "Accounting-system REST base that returns posted actuals (P&L / expense) by cost center for the period (QuickBooks Online or NetSuite REST / SuiteQL gateway)."
+      default: "https://quickbooks.api.intuit.com/v3/company"
+      example: "https://acme.suitetalk.api.netsuite.com/services/rest"
+    fpa_plan_sheet_url:
+      type: string
+      description: "Google Sheets (Sheets API v4 values) URL of the LOCKED FP&A budget model returning the planned amount per cost center for the period."
+      default: "https://sheets.googleapis.com/v4/spreadsheets/SHEET_ID/values/Budget!A2:F500"
+      example: "https://sheets.googleapis.com/v4/spreadsheets/1AbC.../values/Budget!A2:F500"
+    materiality_dollar_floor:
+      type: number
+      description: "Absolute dollar floor (>=) below which a variance is treated as immaterial rounding/timing noise by the gate's non-LLM threshold strategy."
+      default: 5000
+      example: "5000"
+    materiality_pct_floor:
+      type: number
+      description: "Absolute percent floor (>=, in percent points) below which a variance is treated as immaterial by the gate's non-LLM threshold strategy. A variance is candidate-material when abs($)>=dollar_floor OR abs(%)>=pct_floor."
+      default: 10
+      example: "10"
+    period_elapsed_fraction:
+      type: number
+      description: "Fraction of the fiscal period elapsed (0-1) used to compute run-rate burn and YTD pacing deterministically. 1.0 at full close; e.g. 0.5 mid-period."
+      default: 1.0
+      example: "0.5"
+    close_poll_interval:
+      type: integer
+      description: "Seconds between sensor polls of the close-status endpoint while waiting for the period-close / actuals-posted webhook to flip the period to posted."
+      default: 1800
+      example: "1800"
+    sensor_timeout:
+      type: integer
+      description: "Sensor soft timeout in seconds - stop waiting for the close webhook after this long (one watch run). Default 24h."
+      default: 86400
+      example: "86400"
+    gate_model:
+      type: string
+      description: "Swappable materiality-judge model for the gate. Any of the 7 providers can back it; for regulated financials pin an EU/local provider (mistral/large, ollama, omlx/qwen-3). Variance detection works with this unavailable."
+      default: "sonnet"
+      example: "mistral/large"
+    pagerduty_routing_key:
+      type: string
+      description: "Optional PagerDuty Events v2 routing key to page on a confirmed material variance. Leave empty to skip paging and only notify Slack."
+      default: ""
+      example: "R0ABCD1234EFGH5678IJKL"
+    slack_channel:
+      type: string
+      description: "FP&A Slack channel that receives the material-variance digest / page."
+      default: "#fpa-budget-variance"
+      example: "#fpa-budget-variance"
+steps:
+  # 1) DURABLE SENSOR - block until the accounting system reports the period's actuals are
+  #    POSTED and the close is in progress (the period-close / actuals-posted webhook). Polls
+  #    the close-status endpoint; until actuals are posted there is nothing real to compare.
+  #    Event-driven within a schedule: the close flips the period to posted and unblocks.
+  - id: await_close
+    type: sensor
+    sensor_config:
+      url: "{input.accounting_actuals_base_url}/{input.entity_id}/periods/{input.period}/close-status?select=actuals_posted,close_state"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and (response.get('actuals_posted') == True or response.get('close_state') in ('in_progress', 'closed'))"
+      check_interval: 1800
+      timeout: 86400
+
+  # 2) DETERMINISTIC http GET of the LIVE actuals by cost center from the accounting system
+  #    (QuickBooks Online / NetSuite REST P&L for the period). No model. Connector: quickbooks / netsuite.
+  - id: fetch_actuals
+    type: http
+    depends_on: [await_close]
+    http_config:
+      url: "{input.accounting_actuals_base_url}/{input.entity_id}/reports/profit-and-loss?period={input.period}&group_by=cost_center&columns=cost_center,account,actual_amount"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.ACCOUNTING_API_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 3) DETERMINISTIC http GET of the LOCKED plan per cost center from the FP&A model
+  #    (Google Sheets Sheets API v4 values). No model. Connector: google-sheets.
+  - id: fetch_plan
+    type: http
+    depends_on: [await_close]
+    http_config:
+      url: "{input.fpa_plan_sheet_url}?majorDimension=ROWS&valueRenderOption=UNFORMATTED_VALUE"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.GOOGLE_SHEETS_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 4) DETERMINISTIC variance math. NO model. Join actuals to plan per cost center and compute
+  #    the load-bearing numbers: dollar delta (actual - plan), percent delta, run-rate burn
+  #    (actual scaled to a full period by the elapsed fraction), YTD pacing, and a candidate
+  #    materiality boolean against the dollar + percent floors. Pre-flags favorable / unfavorable
+  #    / on_plan so the classify and gate downstream consume booleans, never re-derive the math.
+  - id: compute_variance
+    type: code
+    depends_on: [fetch_actuals, fetch_plan]
+    code_config:
+      language: python
+      code: |
+        actuals_raw = _steps.get('fetch_actuals') or {}
+        plan_raw = _steps.get('fetch_plan') or {}
+
+        dollar_floor = abs(float(_input.get('materiality_dollar_floor', 5000) or 0))
+        pct_floor = abs(float(_input.get('materiality_pct_floor', 10) or 0))
+        try:
+            elapsed = float(_input.get('period_elapsed_fraction', 1.0) or 1.0)
+        except (TypeError, ValueError):
+            elapsed = 1.0
+        if elapsed <= 0:
+            elapsed = 1.0
+        if elapsed > 1:
+            elapsed = 1.0
+
+        def _num(v):
+            # Tolerant numeric parse: handles "1,234.50", "$1,234", "(1,234)" as negative, blanks.
+            if v is None:
+                return 0.0
+            if isinstance(v, (int, float)):
+                return float(v)
+            s = str(v).strip()
+            if not s:
+                return 0.0
+            neg = s.startswith('(') and s.endswith(')')
+            s = s.replace('(', '').replace(')', '').replace('$', '').replace(',', '').replace('%', '').strip()
+            try:
+                val = float(s)
+            except (TypeError, ValueError):
+                return 0.0
+            return -val if neg else val
+
+        # --- normalize ACTUALS into {cost_center: actual_amount} -------------------------
+        def actuals_rows(blob):
+            if isinstance(blob, list):
+                return [r for r in blob if isinstance(r, dict)]
+            if isinstance(blob, dict):
+                for k in ('rows', 'data', 'items', 'results', 'records', 'lines', 'QueryResponse'):
+                    v = blob.get(k)
+                    if isinstance(v, list):
+                        return [r for r in v if isinstance(r, dict)]
+                    if isinstance(v, dict):
+                        for kk in ('rows', 'data', 'items', 'Account', 'lines'):
+                            vv = v.get(kk)
+                            if isinstance(vv, list):
+                                return [r for r in vv if isinstance(r, dict)]
+            return []
+
+        actual_by_cc = {}
+        owner_by_cc = {}
+        name_by_cc = {}
+        for r in actuals_rows(actuals_raw):
+            cc = str(r.get('cost_center') or r.get('costCenter') or r.get('class')
+                     or r.get('department') or r.get('dept') or '').strip()
+            if not cc:
+                continue
+            amt = _num(r.get('actual_amount', r.get('actual', r.get('amount', r.get('value', 0)))))
+            actual_by_cc[cc] = actual_by_cc.get(cc, 0.0) + amt
+            if r.get('owner') or r.get('owner_email'):
+                owner_by_cc.setdefault(cc, {'owner': r.get('owner') or 'unassigned',
+                                            'owner_email': r.get('owner_email') or ''})
+            if r.get('cost_center_name') or r.get('name'):
+                name_by_cc.setdefault(cc, r.get('cost_center_name') or r.get('name'))
+
+        # --- normalize PLAN (Google Sheets values rows or list of dicts) -----------------
+        # Sheets API returns {'values': [[cost_center, name, owner, owner_email, plan_amount], ...]}.
+        plan_by_cc = {}
+        if isinstance(plan_raw, dict) and isinstance(plan_raw.get('values'), list):
+            for row in plan_raw['values']:
+                if not isinstance(row, list) or not row:
+                    continue
+                cc = str(row[0]).strip() if len(row) > 0 else ''
+                if not cc:
+                    continue
+                nm = str(row[1]).strip() if len(row) > 1 else cc
+                ow = str(row[2]).strip() if len(row) > 2 else 'unassigned'
+                oe = str(row[3]).strip() if len(row) > 3 else ''
+                pa = _num(row[4]) if len(row) > 4 else _num(row[-1])
+                plan_by_cc[cc] = pa
+                name_by_cc.setdefault(cc, nm)
+                owner_by_cc.setdefault(cc, {'owner': ow or 'unassigned', 'owner_email': oe})
+        else:
+            rows = plan_raw if isinstance(plan_raw, list) else (
+                (plan_raw.get('rows') or plan_raw.get('data') or plan_raw.get('items') or [])
+                if isinstance(plan_raw, dict) else [])
+            for r in rows:
+                if not isinstance(r, dict):
+                    continue
+                cc = str(r.get('cost_center') or r.get('costCenter') or r.get('class') or '').strip()
+                if not cc:
+                    continue
+                plan_by_cc[cc] = _num(r.get('plan_amount', r.get('plan', r.get('budget', r.get('amount', 0)))))
+                name_by_cc.setdefault(cc, r.get('cost_center_name') or r.get('name') or cc)
+                owner_by_cc.setdefault(cc, {'owner': r.get('owner') or 'unassigned',
+                                            'owner_email': r.get('owner_email') or ''})
+
+        # --- per cost center variance math (deterministic, load-bearing) -----------------
+        all_ccs = sorted(set(actual_by_cc) | set(plan_by_cc))
+        rows = []
+        for cc in all_ccs:
+            actual = round(actual_by_cc.get(cc, 0.0), 2)
+            plan = round(plan_by_cc.get(cc, 0.0), 2)
+            dollar_delta = round(actual - plan, 2)          # +overspend, -underspend
+            abs_dollar = abs(dollar_delta)
+            pct_delta = round((dollar_delta / plan) * 100.0, 2) if plan else (100.0 if actual else 0.0)
+            abs_pct = abs(pct_delta)
+            # run-rate burn = actual projected to a full period by the elapsed fraction.
+            run_rate = round(actual / elapsed, 2)
+            run_rate_vs_plan = round(run_rate - plan, 2)
+            # YTD pacing: where actual sits versus a straight-line plan to-date (1.0 = on pace).
+            expected_to_date = round(plan * elapsed, 2)
+            ytd_pacing = round((actual / expected_to_date), 4) if expected_to_date else None
+
+            # Deterministic favorable / unfavorable / on_plan flags (expense convention:
+            # actual over plan = unfavorable overspend; under plan = favorable). on_plan when
+            # the variance clears NEITHER floor (immaterial both ways).
+            candidate_material = abs_dollar >= dollar_floor or abs_pct >= pct_floor
+            if not candidate_material:
+                flag = 'on_plan'
+            elif dollar_delta > 0:
+                flag = 'unfavorable'
+            else:
+                flag = 'favorable'
+
+            owner = owner_by_cc.get(cc, {'owner': 'unassigned', 'owner_email': ''})
+            rows.append({
+                'cost_center': cc,
+                'name': name_by_cc.get(cc, cc),
+                'owner': owner.get('owner', 'unassigned'),
+                'owner_email': owner.get('owner_email', ''),
+                'actual': actual,
+                'plan': plan,
+                'dollar_delta': dollar_delta,
+                'abs_dollar': abs_dollar,
+                'pct_delta': pct_delta,
+                'abs_pct': abs_pct,
+                'run_rate': run_rate,
+                'run_rate_vs_plan': run_rate_vs_plan,
+                'ytd_pacing': ytd_pacing,
+                'flag': flag,
+                'candidate_material': candidate_material,
+            })
+
+        total_actual = round(sum(r['actual'] for r in rows), 2)
+        total_plan = round(sum(r['plan'] for r in rows), 2)
+        result = {
+            'entity_id': _input.get('entity_id'),
+            'period': _input.get('period'),
+            'dollar_floor': dollar_floor,
+            'pct_floor': pct_floor,
+            'period_elapsed_fraction': elapsed,
+            'cost_center_count': len(rows),
+            'candidate_material_count': sum(1 for r in rows if r['candidate_material']),
+            'total_actual': total_actual,
+            'total_plan': total_plan,
+            'total_dollar_delta': round(total_actual - total_plan, 2),
+            'rows': rows,
+        }
+
+  # 5) LOOP every cost center. Per-cost-center child chain: classify the variance label from
+  #    the precomputed flags, then a condition routes only candidate-material variances into the
+  #    swappable materiality gate. Steady / on_plan rows record directly with no model.
+  - id: per_cost_center_loop
+    type: loop
+    depends_on: [compute_variance]
+    loop_config:
+      over: "steps.compute_variance.output.rows"
+      step_ids:
+        - classify_variance
+        - variance_branch
+        - record_variance
+      max_iterations: 1000
+
+  # 5a) CLASSIFY the variance label using ONLY the precomputed deterministic flags - the
+  #     favorable/unfavorable/on_plan decision and the dollar/percent math were ALREADY made in
+  #     code. The cheap model only LABELS; it never re-computes the variance. Mirrors flag exactly.
+  - id: classify_variance
+    type: classify
+    classify_config:
+      model: haiku
+      input: "Classify this cost-center variance using ONLY the precomputed flags. on_plan = candidate_material is False; unfavorable = candidate_material is True and the dollar_delta is positive (actual over plan = overspend); favorable = candidate_material is True and the dollar_delta is negative (actual under plan). flag={steps.compute_variance.output._item.flag}, candidate_material={steps.compute_variance.output._item.candidate_material}, dollar_delta={steps.compute_variance.output._item.dollar_delta}, pct_delta={steps.compute_variance.output._item.pct_delta}."
+      categories:
+        - on_plan
+        - favorable
+        - unfavorable
+      branches:
+        on_plan: [record_variance]
+        favorable: [variance_branch]
+        unfavorable: [variance_branch]
+
+  # 5b) CONDITION - route only candidate-material variances into the materiality gate; on_plan
+  #     rows record directly. Deterministic branch keyed off the in-code candidate_material flag
+  #     (not the model label) so routing survives a missing model provider. No model.
+  - id: variance_branch
+    type: condition
+    condition_config:
+      expression: "{steps.compute_variance.output._item.candidate_material} == True"
+      then: [materiality_gate, record_variance]
+      else: [record_variance]
+
+  # 5c) MATERIALITY GATE (swappable + model-independent). TWO strategies, BOTH must pass:
+  #     (1) llm_eval materiality judge - "is this a real budget variance worth paging, or a
+  #         timing / accrual / reclass artifact?", model pinned to a SWAPPABLE provider;
+  #     (2) llm_eval acting as a DETERMINISTIC threshold - fed ONLY the precomputed abs($) and
+  #         abs(%) and the floors, told to answer purely from the arithmetic, so a variance still
+  #         passes/fails the gate on the non-LLM dollar + percent floor alone.
+  - id: materiality_gate
+    type: gate
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are an FP&A materiality reviewer. A per-cost-center budget-vs-actual variance was
+              computed deterministically in code and cleared a dollar or percent floor. Decide whether
+              this is a REAL, decision-relevant budget variance worth paging the budget owner, or a
+              non-actionable artifact (a timing difference, an unposted accrual, a one-time reclass, a
+              period-shift that will reverse next month). Answer exactly 'approved' if it is a material
+              variance the owner should act on, otherwise answer 'rejected' and name the reason. Judge
+              materiality / actionability only; the numeric magnitude is checked separately.
+            input: "Cost center {steps.compute_variance.output._item.cost_center} ({steps.compute_variance.output._item.name}): actual={steps.compute_variance.output._item.actual} plan={steps.compute_variance.output._item.plan} dollar_delta={steps.compute_variance.output._item.dollar_delta} pct_delta={steps.compute_variance.output._item.pct_delta}% run_rate_vs_plan={steps.compute_variance.output._item.run_rate_vs_plan} ytd_pacing={steps.compute_variance.output._item.ytd_pacing} flag={steps.compute_variance.output._item.flag}"
+            model: "{input.gate_model}"
+        - type: llm_eval
+          config:
+            prompt: >-
+              Deterministic threshold check. Answer exactly 'approved' if abs_dollar >= dollar_floor OR
+              abs_pct >= pct_floor; otherwise answer 'rejected'. Use ONLY the supplied numbers - do not
+              infer or reason beyond the two arithmetic comparisons.
+            input: "abs_dollar={steps.compute_variance.output._item.abs_dollar} dollar_floor={input.materiality_dollar_floor} abs_pct={steps.compute_variance.output._item.abs_pct} pct_floor={input.materiality_pct_floor}"
+            model: haiku
+
+  # 5d) DETERMINISTIC per-cost-center record. Folds the variance math, the classify label and
+  #     (when the gate ran) the materiality outcome into one canonical row. A variance is a
+  #     CONFIRMED material variance only when it was candidate-material AND the gate passed. No model.
+  - id: record_variance
+    type: code
+    code_config:
+      language: python
+      code: |
+        row = _input.get('_item') or {}
+        label = str(_steps.get('classify_variance') or '').strip().lower()
+        gate = _steps.get('materiality_gate')
+
+        gate_ran = gate is not None
+        if isinstance(gate, dict):
+            gate_passed = bool(gate.get('passed', gate.get('approved', gate.get('result', False))))
+        else:
+            gate_passed = bool(gate) if gate is not None else False
+
+        candidate_material = bool(row.get('candidate_material'))
+        dollar_delta = float(row.get('dollar_delta') or 0.0)
+        flag = str(row.get('flag') or 'on_plan')
+
+        # Canonical status. A confirmed, pageable variance requires the gate to have passed.
+        if candidate_material and gate_ran and gate_passed:
+            status = 'unfavorable' if dollar_delta > 0 else 'favorable'
+        elif candidate_material and gate_ran and not gate_passed:
+            status = 'immaterial'      # cleared a floor but the gate ruled it a timing/accrual artifact
+        else:
+            status = 'on_plan'
+
+        confirmed_material = status in ('favorable', 'unfavorable')
+
+        result = {
+            'cost_center': row.get('cost_center'),
+            'name': row.get('name'),
+            'owner': row.get('owner'),
+            'owner_email': row.get('owner_email'),
+            'actual': row.get('actual'),
+            'plan': row.get('plan'),
+            'dollar_delta': dollar_delta,
+            'abs_dollar': row.get('abs_dollar'),
+            'pct_delta': row.get('pct_delta'),
+            'abs_pct': row.get('abs_pct'),
+            'run_rate': row.get('run_rate'),
+            'run_rate_vs_plan': row.get('run_rate_vs_plan'),
+            'ytd_pacing': row.get('ytd_pacing'),
+            'flag': flag,
+            'classify_label': label,
+            'candidate_material': candidate_material,
+            'gate_ran': gate_ran,
+            'gate_passed': gate_passed if gate_ran else None,
+            'status': status,
+            'confirmed_material': confirmed_material,
+        }
+
+  # 6) DETERMINISTIC aggregation of every per-cost-center record from the loop. Splits on_plan /
+  #     confirmed-material / immaterial, groups confirmed material variances by owner, and builds
+  #     the per-owner page payloads + the period rollup. material_count drives the page path. No model.
+  - id: aggregate_variances
+    type: code
+    depends_on: [per_cost_center_loop]
+    code_config:
+      language: python
+      code: |
+        loop_out = _steps.get('per_cost_center_loop') or {}
+        base = _steps.get('compute_variance') or {}
+
+        items = loop_out if isinstance(loop_out, list) else (
+            loop_out.get('results') or loop_out.get('items') or loop_out.get('iterations') or []
+        )
+
+        rows = []
+        for it in items:
+            row = it
+            if isinstance(it, dict) and 'cost_center' not in it:
+                row = it.get('record_variance') or it.get('output') or it
+            if isinstance(row, dict) and row.get('cost_center'):
+                rows.append(row)
+
+        confirmed = [r for r in rows if r.get('confirmed_material')]
+        unfavorable = [r for r in confirmed if r.get('status') == 'unfavorable']
+        favorable = [r for r in confirmed if r.get('status') == 'favorable']
+        immaterial = [r for r in rows if r.get('status') == 'immaterial']
+        on_plan = [r for r in rows if r.get('status') == 'on_plan']
+
+        # Group confirmed material variances by owner for targeted paging.
+        by_owner = {}
+        for r in confirmed:
+            key = r.get('owner_email') or r.get('owner') or 'unassigned'
+            slot = by_owner.setdefault(key, {
+                'owner': r.get('owner', 'unassigned'),
+                'owner_email': r.get('owner_email', ''),
+                'variances': [],
+                'total_dollar_delta': 0.0,
+            })
+            slot['variances'].append({
+                'cost_center': r.get('cost_center'),
+                'name': r.get('name'),
+                'status': r.get('status'),
+                'dollar_delta': r.get('dollar_delta'),
+                'pct_delta': r.get('pct_delta'),
+                'run_rate_vs_plan': r.get('run_rate_vs_plan'),
+                'ytd_pacing': r.get('ytd_pacing'),
+            })
+            slot['total_dollar_delta'] = round(slot['total_dollar_delta'] + float(r.get('dollar_delta') or 0.0), 2)
+
+        owner_pages = list(by_owner.values())
+        # Largest absolute overrun first for the digest headline.
+        worst = sorted(confirmed, key=lambda r: abs(float(r.get('dollar_delta') or 0.0)), reverse=True)
+
+        result = {
+            'entity_id': base.get('entity_id'),
+            'period': base.get('period'),
+            'cost_center_count': base.get('cost_center_count', len(rows)),
+            'on_plan_count': len(on_plan),
+            'immaterial_count': len(immaterial),
+            'favorable_count': len(favorable),
+            'unfavorable_count': len(unfavorable),
+            'confirmed_material_count': len(confirmed),
+            'total_actual': base.get('total_actual'),
+            'total_plan': base.get('total_plan'),
+            'total_dollar_delta': base.get('total_dollar_delta'),
+            'net_confirmed_dollar_delta': round(sum(float(r.get('dollar_delta') or 0.0) for r in confirmed), 2),
+            'owner_pages': owner_pages,
+            'top_variances': worst[:10],
+            'material_variances': confirmed,
+            # material_count > 0 -> there are confirmed material variances to page.
+            'material_count': len(confirmed),
+        }
+
+  # 7) CONDITION - only page owners when there is at least one CONFIRMED material variance.
+  #    A clean close (material_count == 0) skips the page and sends the quiet on-plan digest. No model.
+  - id: route_variances
+    type: condition
+    depends_on: [aggregate_variances]
+    condition_config:
+      expression: "{steps.aggregate_variances.output.material_count} > 0"
+      then: [page_owner, notify_material]
+      else: [notify_clean]
+
+  # 7a) PAGE the budget owners - open a PagerDuty incident so the owner of a materially overrun
+  #     cost center is paged at close, not at the QBR. Carries the per-owner variances. Connector: pagerduty.
+  - id: page_owner
+    type: http
+    http_config:
+      url: "https://events.pagerduty.com/v2/enqueue"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      body: |
+        {
+          "routing_key": "{input.pagerduty_routing_key}",
+          "event_action": "trigger",
+          "dedup_key": "budget-variance-{input.entity_id}-{input.period}",
+          "payload": {
+            "summary": "Budget variance on {input.entity_id} {input.period}: {{ _steps['aggregate_variances']['confirmed_material_count'] }} material cost-center variance(s), net {{ _steps['aggregate_variances']['net_confirmed_dollar_delta'] }} vs plan",
+            "severity": "warning",
+            "source": "budget-variance-materiality-sentinel",
+            "custom_details": {{ _steps['aggregate_variances']['owner_pages'] }}
+          }
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 7b) NOTIFY (material) - post the confirmed material variances, owners and the period rollup to
+  #     the FP&A channel so finance sees the overruns / underruns in real time. service: slack.
+  - id: notify_material
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :chart_with_upwards_trend: BUDGET VARIANCE - {steps.aggregate_variances.output.confirmed_material_count} material cost-center variance(s) on {steps.aggregate_variances.output.entity_id} {steps.aggregate_variances.output.period}
+        Unfavorable (overspend): {steps.aggregate_variances.output.unfavorable_count}
+        Favorable (underspend) : {steps.aggregate_variances.output.favorable_count}
+        Immaterial filtered    : {steps.aggregate_variances.output.immaterial_count}
+        Net vs plan (confirmed): {steps.aggregate_variances.output.net_confirmed_dollar_delta}
+        Period total: actual {steps.aggregate_variances.output.total_actual} vs plan {steps.aggregate_variances.output.total_plan} (delta {steps.aggregate_variances.output.total_dollar_delta})
+        Top variances: {steps.aggregate_variances.output.top_variances}
+        Owner pages: {steps.aggregate_variances.output.owner_pages}
+
+  # 7c) NOTIFY (clean) - quiet "budget on plan" digest on a clean close. No page.
+  - id: notify_clean
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :white_check_mark: Budget on plan for {steps.aggregate_variances.output.entity_id} {steps.aggregate_variances.output.period}.
+        {steps.aggregate_variances.output.on_plan_count} cost centers on plan, {steps.aggregate_variances.output.immaterial_count} immaterial blips filtered, 0 confirmed material variances. No page.
+on_complete:
+  storage_path: "budget-variance-materiality-sentinel/{run_id}/result.json"

--- a/src/sandcastle/templates/competitor_pricing_page_change_sentinel.yaml
+++ b/src/sandcastle/templates/competitor_pricing_page_change_sentinel.yaml
@@ -1,0 +1,716 @@
+# name: Competitor Pricing-Page Change Sentinel
+# description: Always-on watcher that snapshots each rival's live pricing page, deterministically diffs plan / price / feature deltas against the last SHA-256-sealed snapshot, and only pages product + sales when a swappable two-strategy materiality gate confirms the change is a real pricing move (not A/B noise or layout churn). A durable SENSOR blocks until the next poll interval or a price-change webhook; an http GET (firecrawl) renders each pricing page; deterministic CODE parses plans into a canonical {plan,price,billing_period,features[]} shape, computes the structured diff and seals the new snapshot; a CONDITION routes only non-empty diffs into the GATE (llm_eval judge AND a non-LLM price_delta_pct threshold) before NOTIFY to Slack and an http PUT of the sealed snapshot to S3. Detection and diff are 100% deterministic code; the model only judges materiality.
+# tags: [CompetitiveIntel, PricingIntelligence, ChangeDetection, sensor, firecrawl, diff, SHA-256, snapshot, S3, Slack, materiality-gate, research_intel]
+# category: research_intel
+# connectors: firecrawl, aws-s3, slack
+name: competitor-pricing-page-change-sentinel
+description: >-
+  An always-on sentinel that watches every rival's live pricing page and pages product + sales
+  only on a REAL pricing move. A durable SENSOR blocks until the next poll interval is reached OR
+  a price-change webhook fires (event-driven within a schedule). A deterministic CODE step then
+  normalizes the watch list into a loopable set of competitor pricing URLs, and the workflow LOOPS
+  each rival: an http GET renders the live pricing page through Firecrawl (JS-rendered HTML +
+  extracted plan markup), a DETERMINISTIC code step parses the rendered page into a canonical
+  list of {plan, price, billing_period, features[]} rows, an http GET pulls that rival's last
+  SEALED JSON snapshot, and a second DETERMINISTIC code step computes a structured diff
+  (added / removed plans, per-plan price_delta_pct, feature gains / losses), SHA-256-seals the new
+  snapshot, and emits a stable change signature. A CONDITION routes only non-empty diffs into a
+  MATERIALITY GATE that has TWO strategies BOTH of which must pass: a SWAPPABLE llm_eval judge
+  ("is this a real pricing move or A/B / layout / copy noise?", backable by any of the 7 providers)
+  AND a NON-LLM threshold strategy fed ONLY the pre-computed price_delta_pct / structural-change
+  booleans, so a change clears the gate on the arithmetic alone. After the loop, a deterministic
+  code step aggregates and SHA-256-seals the confirmed pricing-move events, a CONDITION gates the
+  alert path, a NOTIFY pages the product + sales Slack channel with the deltas, and an http PUT
+  writes the sealed per-rival snapshots to an S3 (or S3-compatible) bucket so the next sweep diffs
+  against tamper-evident truth. All page-change detection, parsing and diffing are 100%
+  deterministic code and run with zero model providers available; the model is confined to the
+  gate's swappable materiality judge.
+default_model: sonnet
+default_max_turns: 8
+default_timeout: 1800
+input_schema:
+  required: ["competitor_pricing_urls", "snapshot_store_url"]
+  properties:
+    competitor_pricing_urls:
+      type: string
+      description: "Comma-separated (or newline-separated) list of rival pricing-page URLs to watch. Each is rendered through Firecrawl and diffed against its own last sealed snapshot."
+      default: "https://competitor-a.com/pricing,https://competitor-b.com/pricing"
+      example: "https://stripe.com/pricing,https://www.twilio.com/pricing,https://vercel.com/pricing"
+    snapshot_store_url:
+      type: string
+      description: "Snapshot store REST base URL holding the last SEALED canonical pricing snapshot per rival (S3 REST gateway or Postgres / PostgREST). The structured diff is measured against this."
+      default: "https://pricing-intel.internal/snapshots"
+      example: "https://pricing-intel.internal/snapshots"
+    price_delta_threshold:
+      type: number
+      description: "Materiality threshold for the gate's NON-LLM strategy: a per-plan price change at or above this absolute percent (e.g. 5 = 5%), OR any added/removed plan, OR a feature gain/loss, is treated as a real pricing move (not A/B noise)."
+      default: 5.0
+      example: "5.0"
+    firecrawl_base_url:
+      type: string
+      description: "Firecrawl REST base URL used to render each JS-heavy pricing page to clean HTML / extracted markup before parsing. Connector: firecrawl."
+      default: "https://api.firecrawl.dev/v1"
+      example: "https://api.firecrawl.dev/v1"
+    poll_interval:
+      type: integer
+      description: "Seconds between pricing sweeps. The sensor blocks until this interval elapses OR a price-change webhook bumps the watch flag (event-driven within a schedule)."
+      default: 3600
+      example: "3600"
+    sensor_timeout:
+      type: integer
+      description: "Sensor soft timeout in seconds - stop waiting for the next poll window after this long (one watch run). Default 24h."
+      default: 86400
+      example: "86400"
+    gate_model:
+      type: string
+      description: "Swappable materiality-judge model for the gate. Any of the 7 providers can back it; for EU data pin a local / EU provider (mistral/large, ollama, omlx/qwen-3). Detection and diff work with this unavailable."
+      default: "sonnet"
+      example: "mistral/large"
+    s3_base_url:
+      type: string
+      description: "S3 (or S3-compatible) REST base URL that receives the SHA-256-sealed per-rival pricing snapshots so the next sweep diffs against tamper-evident truth. Connector: aws-s3."
+      default: "https://s3.eu-central-1.amazonaws.com"
+      example: "https://s3.eu-central-1.amazonaws.com"
+    s3_bucket:
+      type: string
+      description: "Bucket name that stores the sealed pricing snapshots and confirmed-move ledger."
+      default: "competitor-pricing-snapshots"
+      example: "acme-competitor-pricing-snapshots"
+    slack_channel:
+      type: string
+      description: "Product + sales Slack channel that receives the confirmed pricing-move alert (or the quiet clean-sweep digest)."
+      default: "#competitive-pricing-intel"
+      example: "#competitive-pricing-intel"
+steps:
+  # 1) DURABLE SENSOR - block until the next pricing-sweep window elapses OR a price-change
+  #    webhook has bumped the watch flag. Polls a lightweight watch-status endpoint; until a
+  #    sweep is due (or a webhook flips changed_since_last_seal) there is nothing to re-check.
+  #    Event-driven within a schedule: a webhook makes the next window due immediately. No model.
+  - id: await_sweep_window
+    type: sensor
+    sensor_config:
+      url: "{input.snapshot_store_url}/watch-status?select=sweep_due,changed_since_last_seal"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and (response.get('sweep_due') == True or response.get('changed_since_last_seal') == True)"
+      check_interval: 3600
+      timeout: 86400
+
+  # 2) DETERMINISTIC normalization of the watch list into a flat, loopable set of rivals. Each
+  #    row carries the pricing-page URL, a stable slug used as the snapshot key, and the
+  #    snapshot-store URL its diff is measured against. No model.
+  - id: normalize_targets
+    type: code
+    depends_on: [await_sweep_window]
+    code_config:
+      language: python
+      code: |
+        import re
+
+        raw = str(_input.get('competitor_pricing_urls') or '')
+        # Accept comma OR newline OR semicolon separated lists.
+        parts = re.split(r'[,\n;]+', raw)
+        snapshot_base = str(_input.get('snapshot_store_url') or '').rstrip('/')
+
+        def slugify(url):
+            # Stable per-rival key from the host - deterministic, no model.
+            host = re.sub(r'^https?://', '', url).split('/')[0]
+            host = re.sub(r'^www\.', '', host)
+            slug = re.sub(r'[^a-z0-9]+', '-', host.lower()).strip('-')
+            return slug or 'rival'
+
+        seen = set()
+        targets = []
+        for p in parts:
+            url = p.strip()
+            if not url or not url.lower().startswith('http'):
+                continue
+            slug = slugify(url)
+            if slug in seen:
+                continue
+            seen.add(slug)
+            targets.append({
+                'slug': slug,
+                'pricing_url': url,
+                # Snapshot store key holding this rival's last sealed canonical pricing snapshot.
+                'snapshot_url': f"{snapshot_base}?rival=eq.{slug}&order=sealed_at.desc&limit=1",
+            })
+
+        result = {
+            'target_count': len(targets),
+            'targets': targets,
+        }
+
+  # 3) LOOP over every rival. Per-rival child chain: GET rendered pricing page (firecrawl http) ->
+  #    deterministic parse into canonical plans (code) -> GET last sealed snapshot (http) ->
+  #    deterministic structured diff + SHA-256 seal (code) -> condition routes any non-empty
+  #    diff into the materiality gate.
+  - id: per_rival_loop
+    type: loop
+    depends_on: [normalize_targets]
+    loop_config:
+      over: "steps.normalize_targets.output.targets"
+      step_ids:
+        - render_pricing_page
+        - parse_plans
+        - fetch_last_snapshot
+        - diff_and_seal
+        - change_branch
+      max_iterations: 200
+
+  # 3a) http GET - render THIS rival's live pricing page through Firecrawl so JS-built pricing
+  #     tables resolve to clean HTML / extracted markup before parsing. on_failure: skip so one
+  #     unreachable site does not abort the whole sweep. Connector: firecrawl.
+  - id: render_pricing_page
+    type: http
+    http_config:
+      url: "{input.firecrawl_base_url}/scrape"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.FIRECRAWL_API_KEY}"
+      body: |
+        {
+          "url": "{input._item.pricing_url}",
+          "formats": ["html", "markdown"],
+          "onlyMainContent": true,
+          "waitFor": 2500
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 3b) DETERMINISTIC PARSE. NO model. Turn the rendered page into a canonical, comparable list of
+  #     {plan, price, billing_period, features[]} rows. Extracts plan blocks, money amounts and a
+  #     monthly/annual signal with regex + simple text heuristics, then canonicalizes each plan
+  #     (lowercased name key, numeric price, sorted unique feature set) so the diff is stable and
+  #     A/B copy churn that does not change the canonical shape produces NO diff.
+  - id: parse_plans
+    type: code
+    code_config:
+      language: python
+      code: |
+        import re
+
+        target = _input.get('_item') or {}
+        rendered = _steps.get('render_pricing_page') or {}
+
+        # Firecrawl returns the body under data.markdown / data.html (shape-tolerant).
+        def pick_text(blob):
+            if isinstance(blob, str):
+                return blob
+            if isinstance(blob, dict):
+                data = blob.get('data') if isinstance(blob.get('data'), dict) else blob
+                for k in ('markdown', 'content', 'text', 'html'):
+                    v = data.get(k)
+                    if isinstance(v, str) and v.strip():
+                        return v
+            return ''
+
+        text = pick_text(rendered)
+        # Strip HTML tags to plain text lines for heuristic parsing (no model).
+        plain = re.sub(r'<[^>]+>', ' ', text)
+        plain = re.sub(r'&[a-z]+;', ' ', plain)
+        lines = [ln.strip() for ln in re.split(r'[\r\n]+', plain) if ln.strip()]
+
+        # Common plan-name vocabulary seen on SaaS pricing pages.
+        plan_vocab = [
+            'free', 'starter', 'basic', 'standard', 'plus', 'pro', 'professional',
+            'team', 'teams', 'business', 'growth', 'scale', 'premium', 'enterprise',
+            'ultimate', 'advanced', 'essentials', 'individual',
+        ]
+
+        money_re = r'(?:\$|usd|eur|€|gbp|£)\s?([0-9][0-9.,]*)'
+
+        def parse_price(s):
+            m = re.search(money_re, s, flags=re.IGNORECASE)
+            if not m:
+                # Custom / contact-sales tiers have no numeric price.
+                if re.search(r'\b(custom|contact|let.?s talk|talk to)\b', s, flags=re.IGNORECASE):
+                    return None
+                return None
+            num = m.group(1).replace(',', '')
+            try:
+                return round(float(num), 2)
+            except ValueError:
+                return None
+
+        def billing_period(s):
+            low = s.lower()
+            if re.search(r'/\s?(yr|year|annual|annually|yearly)|per year', low):
+                return 'annual'
+            if re.search(r'/\s?(mo|month|monthly)|per month', low):
+                return 'monthly'
+            return 'unknown'
+
+        # Walk the lines: when a line names a plan, open a plan block; collect following
+        # short lines as candidate feature bullets until the next plan header.
+        plans = {}
+        order = []
+        current = None
+        for ln in lines:
+            low = ln.lower()
+            named = None
+            for name in plan_vocab:
+                if re.search(r'\b' + re.escape(name) + r'\b', low):
+                    named = name
+                    break
+            if named and len(ln) <= 40:
+                key = named
+                if key not in plans:
+                    plans[key] = {
+                        'plan': named.capitalize(),
+                        'price': None,
+                        'billing_period': 'unknown',
+                        'features': [],
+                    }
+                    order.append(key)
+                current = key
+                # The plan header line itself may carry the price.
+                p = parse_price(ln)
+                if p is not None:
+                    plans[key]['price'] = p
+                    plans[key]['billing_period'] = billing_period(ln)
+                continue
+            if current is None:
+                continue
+            # Price line for the current plan.
+            p = parse_price(ln)
+            if p is not None and plans[current]['price'] is None:
+                plans[current]['price'] = p
+                plans[current]['billing_period'] = billing_period(ln)
+                continue
+            # Feature bullet: short-ish, not a price line.
+            if 3 <= len(ln) <= 80 and not re.search(money_re, ln, flags=re.IGNORECASE):
+                feat = re.sub(r'^[\-•\*–—\s]+', '', ln).strip()
+                if feat and feat.lower() not in plan_vocab:
+                    plans[current]['features'].append(feat)
+
+        # Canonicalize: sorted unique features, deterministic plan order by name key.
+        canonical = []
+        for key in sorted(order):
+            pl = plans[key]
+            feats = sorted({f.strip().lower() for f in pl['features'] if f.strip()})
+            canonical.append({
+                'plan': pl['plan'],
+                'plan_key': key,
+                'price': pl['price'],
+                'billing_period': pl['billing_period'],
+                'features': feats,
+            })
+
+        result = {
+            'slug': target.get('slug'),
+            'pricing_url': target.get('pricing_url'),
+            'plan_count': len(canonical),
+            'plans': canonical,
+            'parse_ok': len(canonical) > 0,
+        }
+
+  # 3c) http GET this rival's LAST SEALED canonical snapshot from the snapshot store, so the diff
+  #     is measured against the previously-sealed truth, not re-derived. on_failure: skip (first
+  #     sweep simply has no prior snapshot and everything is treated as a baseline). No model.
+  - id: fetch_last_snapshot
+    type: http
+    http_config:
+      url: "{input._item.snapshot_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.SNAPSHOT_STORE_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 3d) DETERMINISTIC STRUCTURED DIFF + SHA-256 SEAL. NO model. Compare the freshly parsed
+  #     canonical plans against the last sealed snapshot: added / removed plans, per-plan
+  #     price_delta_pct, and feature gains / losses. Compute the max absolute price_delta_pct and
+  #     a structural-change flag (the non-LLM materiality signals the gate consumes), then
+  #     canonical-JSON + SHA-256 seal the NEW snapshot so the next sweep diffs against it.
+  - id: diff_and_seal
+    type: code
+    code_config:
+      language: python
+      code: |
+        import json
+        import hashlib
+        from datetime import datetime, timezone
+
+        parsed = _steps.get('parse_plans') or {}
+        snap_raw = _steps.get('fetch_last_snapshot') or {}
+        slug = parsed.get('slug')
+        new_plans = parsed.get('plans') or []
+
+        # --- recover the previously sealed plan list from whatever shape the store returns ----
+        def prev_plans_from(blob):
+            rows = blob if isinstance(blob, list) else (
+                blob.get('data') or blob.get('items') or blob.get('records') or [blob]
+            )
+            rec = rows[0] if rows and isinstance(rows[0], dict) else {}
+            snap = rec.get('snapshot') if isinstance(rec.get('snapshot'), dict) else rec
+            pls = snap.get('plans') if isinstance(snap, dict) else None
+            return pls if isinstance(pls, list) else []
+
+        prev_plans = prev_plans_from(snap_raw)
+        first_seal = len(prev_plans) == 0
+
+        def by_key(plans):
+            out = {}
+            for p in plans:
+                if isinstance(p, dict):
+                    k = str(p.get('plan_key') or p.get('plan') or '').strip().lower()
+                    if k:
+                        out[k] = p
+            return out
+
+        new_by = by_key(new_plans)
+        old_by = by_key(prev_plans)
+
+        added_plans = sorted(set(new_by) - set(old_by))
+        removed_plans = sorted(set(old_by) - set(new_by))
+        common = sorted(set(new_by) & set(old_by))
+
+        price_changes = []
+        feature_gains = []
+        feature_losses = []
+        max_abs_delta_pct = 0.0
+
+        for k in common:
+            np_ = new_by[k]
+            op = old_by[k]
+            new_price = np_.get('price')
+            old_price = op.get('price')
+            if isinstance(new_price, (int, float)) and isinstance(old_price, (int, float)) and old_price:
+                delta_pct = round(((new_price - old_price) / old_price) * 100.0, 2)
+                if abs(delta_pct) > 0:
+                    price_changes.append({
+                        'plan_key': k,
+                        'old_price': old_price,
+                        'new_price': new_price,
+                        'price_delta_pct': delta_pct,
+                    })
+                    if abs(delta_pct) > max_abs_delta_pct:
+                        max_abs_delta_pct = abs(delta_pct)
+            new_feats = set(np_.get('features') or [])
+            old_feats = set(op.get('features') or [])
+            gained = sorted(new_feats - old_feats)
+            lost = sorted(old_feats - new_feats)
+            if gained:
+                feature_gains.append({'plan_key': k, 'gained': gained})
+            if lost:
+                feature_losses.append({'plan_key': k, 'lost': lost})
+
+        structural_change = bool(added_plans or removed_plans or feature_gains or feature_losses)
+        has_diff = bool(added_plans or removed_plans or price_changes or feature_gains or feature_losses)
+
+        # --- SHA-256 seal the NEW canonical snapshot (the next sweep diffs against this) -------
+        sealed_at = datetime.now(timezone.utc).isoformat()
+        snapshot = {
+            'rival': slug,
+            'pricing_url': parsed.get('pricing_url'),
+            'sealed_at': sealed_at,
+            'plans': new_plans,
+        }
+        canonical_json = json.dumps(snapshot, sort_keys=True, separators=(',', ':'))
+        snapshot_sha256 = hashlib.sha256(canonical_json.encode('utf-8')).hexdigest()
+
+        # Stable change signature so the same move is not re-paged sweep after sweep.
+        diff_material = json.dumps(
+            {'a': added_plans, 'r': removed_plans, 'p': price_changes,
+             'g': feature_gains, 'l': feature_losses},
+            sort_keys=True, separators=(',', ':'),
+        )
+        change_signature = hashlib.sha256(diff_material.encode('utf-8')).hexdigest()
+
+        result = {
+            'slug': slug,
+            'pricing_url': parsed.get('pricing_url'),
+            'first_seal': first_seal,
+            'has_diff': has_diff and not first_seal,
+            'added_plans': added_plans,
+            'removed_plans': removed_plans,
+            'price_changes': price_changes,
+            'feature_gains': feature_gains,
+            'feature_losses': feature_losses,
+            'structural_change': structural_change and not first_seal,
+            'max_abs_price_delta_pct': max_abs_delta_pct,
+            'change_signature': change_signature,
+            'snapshot_sha256': snapshot_sha256,
+            'sealed_at': sealed_at,
+            'snapshot': snapshot,
+            'canonical_json': canonical_json,
+            # object key for the per-rival sealed snapshot PUT.
+            'object_key': f"pricing-snapshots/{slug}/{sealed_at.replace(':', '-')}.json",
+        }
+
+  # 3e) CONDITION - route any NON-EMPTY diff into the materiality gate; a no-change rival records
+  #     its (re-sealed) snapshot directly. Deterministic branch keyed off the in-code diff flags
+  #     so routing survives a missing model provider. No model.
+  - id: change_branch
+    type: condition
+    condition_config:
+      expression: "{steps.diff_and_seal.output.has_diff}"
+      then: [materiality_gate, record_rival_status]
+      else: [record_rival_status]
+
+  # 3f) MATERIALITY GATE (swappable + model-independent). TWO strategies, BOTH must pass:
+  #     (1) llm_eval judge - "is this a real pricing move or A/B / layout / copy noise?", model
+  #         pinned to a SWAPPABLE provider (any of the 7 can back it);
+  #     (2) llm_eval acting as a DETERMINISTIC threshold - fed ONLY the pre-computed
+  #         max_abs_price_delta_pct / structural_change / price_delta_threshold and told to answer
+  #         purely from the arithmetic, so a change still passes/fails the gate on the non-LLM
+  #         math alone.
+  - id: materiality_gate
+    type: gate
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are a competitive-pricing analyst. A rival's pricing page was rendered and a
+              structured diff was computed in code against the last sealed snapshot. Decide whether
+              this is a REAL pricing MOVE worth paging product + sales (a genuine new/removed plan,
+              a true price change, or a packaging shift), or whether it is NOISE - an A/B test
+              variant, a layout / CSS reflow, marketing copy churn, or a parsing artifact that does
+              not change the actual offer. Answer exactly 'approved' if it is a real pricing move
+              that should be alerted, otherwise answer 'rejected' and name the reason. Judge the
+              substance only; the numeric magnitude is checked separately.
+            input: "Rival {steps.diff_and_seal.output.slug}: added_plans={steps.diff_and_seal.output.added_plans} removed_plans={steps.diff_and_seal.output.removed_plans} price_changes={steps.diff_and_seal.output.price_changes} feature_gains={steps.diff_and_seal.output.feature_gains} feature_losses={steps.diff_and_seal.output.feature_losses}"
+            model: "{input.gate_model}"
+        - type: llm_eval
+          config:
+            prompt: >-
+              Deterministic threshold check. Answer exactly 'approved' if structural_change is True
+              OR max_abs_price_delta_pct >= {input.price_delta_threshold}; otherwise answer
+              'rejected'. Use ONLY the supplied numbers and booleans - do not infer or reason
+              beyond the arithmetic comparison.
+            input: "structural_change={steps.diff_and_seal.output.structural_change} max_abs_price_delta_pct={steps.diff_and_seal.output.max_abs_price_delta_pct} threshold={input.price_delta_threshold}"
+            model: haiku
+
+  # 3g) DETERMINISTIC per-rival status record. Folds the diff result and (when the gate ran) the
+  #     materiality outcome into one canonical row. A rival is a CONFIRMED pricing move only when
+  #     it had a diff AND the materiality gate passed. No model.
+  - id: record_rival_status
+    type: code
+    code_config:
+      language: python
+      code: |
+        diff = _steps.get('diff_and_seal') or {}
+        gate = _steps.get('materiality_gate')
+
+        gate_ran = gate is not None
+        if isinstance(gate, dict):
+            gate_passed = bool(gate.get('passed', gate.get('approved', gate.get('result', False))))
+        else:
+            gate_passed = bool(gate) if gate is not None else False
+
+        has_diff = bool(diff.get('has_diff'))
+
+        if has_diff and gate_ran and gate_passed:
+            status = 'confirmed_move'
+        elif has_diff and gate_ran and not gate_passed:
+            status = 'noise'          # diff detected but gate ruled it immaterial
+        else:
+            status = 'unchanged'
+
+        confirmed_move = status == 'confirmed_move'
+
+        result = {
+            'slug': diff.get('slug'),
+            'pricing_url': diff.get('pricing_url'),
+            'status': status,
+            'confirmed_move': confirmed_move,
+            'first_seal': bool(diff.get('first_seal')),
+            'added_plans': diff.get('added_plans'),
+            'removed_plans': diff.get('removed_plans'),
+            'price_changes': diff.get('price_changes'),
+            'feature_gains': diff.get('feature_gains'),
+            'feature_losses': diff.get('feature_losses'),
+            'max_abs_price_delta_pct': diff.get('max_abs_price_delta_pct'),
+            'change_signature': diff.get('change_signature'),
+            'snapshot_sha256': diff.get('snapshot_sha256'),
+            'object_key': diff.get('object_key'),
+            'sealed_at': diff.get('sealed_at'),
+            'canonical_json': diff.get('canonical_json'),
+            'gate_ran': gate_ran,
+            'gate_passed': gate_passed if gate_ran else None,
+        }
+
+  # 4) DETERMINISTIC aggregation of every per-rival status from the loop. Splits unchanged /
+  #     confirmed-move / noise, builds the list of confirmed moves with their deltas, and counts.
+  #     move_count drives the seal-and-page path. No model.
+  - id: aggregate_moves
+    type: code
+    depends_on: [per_rival_loop]
+    code_config:
+      language: python
+      code: |
+        loop_out = _steps.get('per_rival_loop') or {}
+
+        items = loop_out if isinstance(loop_out, list) else (
+            loop_out.get('results') or loop_out.get('items') or loop_out.get('iterations') or []
+        )
+
+        rivals = []
+        for it in items:
+            row = it
+            if isinstance(it, dict) and 'slug' not in it:
+                row = it.get('record_rival_status') or it.get('output') or it
+            if isinstance(row, dict) and row.get('slug'):
+                rivals.append(row)
+
+        total = len(rivals)
+        confirmed = [r for r in rivals if r.get('confirmed_move')]
+        noise = [r for r in rivals if r.get('status') == 'noise']
+        unchanged = [r for r in rivals if r.get('status') == 'unchanged']
+
+        moves = [
+            {
+                'slug': r.get('slug'),
+                'pricing_url': r.get('pricing_url'),
+                'added_plans': r.get('added_plans'),
+                'removed_plans': r.get('removed_plans'),
+                'price_changes': r.get('price_changes'),
+                'feature_gains': r.get('feature_gains'),
+                'feature_losses': r.get('feature_losses'),
+                'max_abs_price_delta_pct': r.get('max_abs_price_delta_pct'),
+                'change_signature': r.get('change_signature'),
+            }
+            for r in confirmed
+        ]
+
+        result = {
+            'total_rivals': total,
+            'unchanged_count': len(unchanged),
+            'noise_count': len(noise),
+            'confirmed_move_count': len(confirmed),
+            'moves': moves,
+            # every rival's sealed snapshot row, for the snapshot PUTs.
+            'rivals': rivals,
+            # move_count > 0 -> there are confirmed pricing moves to page.
+            'move_count': len(confirmed),
+        }
+
+  # 5) DETERMINISTIC ledger SEAL. NO model. Canonical-JSON each confirmed move + its per-rival
+  #    snapshot hash, then hash the ordered list of move signatures into a sweep ledger root.
+  #    This is the tamper-evident signature for the sweep and the object key for the ledger PUT.
+  - id: seal_ledger
+    type: code
+    depends_on: [aggregate_moves]
+    code_config:
+      language: python
+      code: |
+        import json
+        import hashlib
+        from datetime import datetime, timezone
+
+        agg = _steps.get('aggregate_moves') or {}
+        moves = agg.get('moves', [])
+        rivals = agg.get('rivals', [])
+        sealed_at = datetime.now(timezone.utc).isoformat()
+
+        sealed_moves = []
+        for mv in moves:
+            canonical = json.dumps(mv, sort_keys=True, separators=(',', ':'))
+            digest = hashlib.sha256(canonical.encode('utf-8')).hexdigest()
+            sealed_moves.append({
+                'slug': mv.get('slug'),
+                'change_signature': mv.get('change_signature'),
+                'sha256': digest,
+            })
+
+        root_material = json.dumps([m['sha256'] for m in sealed_moves], separators=(',', ':'))
+        ledger_root = hashlib.sha256(root_material.encode('utf-8')).hexdigest()
+
+        record = {
+            'sealed_at': sealed_at,
+            'confirmed_move_count': agg.get('confirmed_move_count', 0),
+            'ledger_root_sha256': ledger_root,
+            'moves': sealed_moves,
+        }
+        canonical_record = json.dumps(record, sort_keys=True, separators=(',', ':'))
+        ledger_key = f"pricing-ledger/{sealed_at.replace(':', '-')}.json"
+
+        # Per-rival snapshot PUT plan (slug -> object_key + body) for the S3 writes.
+        snapshot_puts = [
+            {
+                'slug': r.get('slug'),
+                'object_key': r.get('object_key'),
+                'snapshot_sha256': r.get('snapshot_sha256'),
+                'canonical_json': r.get('canonical_json'),
+            }
+            for r in rivals
+            if r.get('object_key') and r.get('canonical_json')
+        ]
+
+        result = {
+            'ledger_key': ledger_key,
+            'ledger_root_sha256': ledger_root,
+            'sealed_at': sealed_at,
+            'record': record,
+            'canonical_json': canonical_record,
+            'snapshot_puts': snapshot_puts,
+            'has_moves': bool(sealed_moves),
+        }
+
+  # 6) CONDITION - only page product + sales when there is at least one CONFIRMED pricing move.
+  #    A clean sweep (move_count == 0) still seals snapshots to S3 but skips the alert. No model.
+  - id: route_moves
+    type: condition
+    depends_on: [seal_ledger]
+    condition_config:
+      expression: "{steps.aggregate_moves.output.move_count} > 0"
+      then: [put_ledger, notify_moves]
+      else: [notify_clean]
+
+  # 6a) SEAL TO S3 - PUT the SHA-256-sealed confirmed-move ledger to the bucket. The ledger root
+  #     hash travels as object metadata so the sweep record is tamper-evident at rest. The per-rival
+  #     canonical snapshots are sealed inline in diff_and_seal and carried in snapshot_puts for the
+  #     next sweep's baseline. Connector: aws-s3.
+  - id: put_ledger
+    type: http
+    http_config:
+      url: "{input.s3_base_url}/{input.s3_bucket}/{steps.seal_ledger.output.ledger_key}"
+      method: PUT
+      headers:
+        Content-Type: "application/json"
+        x-amz-meta-ledger-root-sha256: "{steps.seal_ledger.output.ledger_root_sha256}"
+        x-amz-meta-move-count: "{steps.aggregate_moves.output.confirmed_move_count}"
+      auth: "aws4:{env.AWS_ACCESS_KEY_ID}:{env.AWS_SECRET_ACCESS_KEY}"
+      body: "{steps.seal_ledger.output.canonical_json}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 6b) NOTIFY (moves) - page the product + sales channel with the confirmed pricing moves, the
+  #     per-plan deltas and the sealed ledger root hash so the team sees the rival's move in real
+  #     time, not at the next quarterly review. service: slack.
+  - id: notify_moves
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :money_with_wings: COMPETITOR PRICING MOVE - {steps.aggregate_moves.output.confirmed_move_count} rival(s) changed pricing
+        Confirmed moves : {steps.aggregate_moves.output.moves}
+        Noise filtered  : {steps.aggregate_moves.output.noise_count}
+        Unchanged       : {steps.aggregate_moves.output.unchanged_count}
+        Sealed ledger   : {steps.seal_ledger.output.ledger_key}
+        Ledger root SHA-256: {steps.seal_ledger.output.ledger_root_sha256}
+
+  # 6c) NOTIFY (clean) - quiet "no pricing moves" digest on a clean sweep. Snapshots still re-sealed.
+  - id: notify_clean
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :white_check_mark: Pricing sweep clean across {steps.aggregate_moves.output.total_rivals} rival(s).
+        {steps.aggregate_moves.output.unchanged_count} unchanged, {steps.aggregate_moves.output.noise_count} immaterial blips filtered (A/B / layout), 0 confirmed moves.
+on_complete:
+  storage_path: "competitor-pricing-page-change-sentinel/{run_id}/result.json"

--- a/src/sandcastle/templates/expense_policy_line_item_auditor.yaml
+++ b/src/sandcastle/templates/expense_policy_line_item_auditor.yaml
@@ -1,0 +1,631 @@
+# name: Expense Policy Line-Item Auditor
+# description: Pulls every line item on a submitted expense report from the expense/ERP system, classifies each into a spend category with a swappable labeler, then runs a 100% deterministic policy rule engine (per-category caps, receipt-required thresholds, per-diem math, weekend/alcohol/duplicate-merchant flags) to decide pass/violation per line. Only the disputed lines are routed to a two-strategy approval gate (llm_eval exception-judge AND a non-LLM rule-hit threshold) and a human finance reviewer, then an itemized verdict is PUT back to the expense system and an auditable summary is filed. Money and policy math never touch a model.
+# tags: [Expense, Concur, ERP, PolicyEngine, PerDiem, Receipts, DuplicateDetection, FinanceOps, Audit, T&E, Compliance]
+# category: finance_ops
+# connectors: concur, slack, s3
+name: expense-policy-line-item-auditor
+description: >-
+  A line-item policy auditor for travel & expense (T&E) reports. A DETERMINISTIC http GET pulls the
+  pending expense report and all of its line items from the expense/ERP system (SAP Concur / Coupa /
+  Workday style REST). A code step normalizes every line into a loopable row carrying amount, date,
+  merchant, currency, a receipt flag and a stable line key. The workflow LOOPS each line: a swappable
+  CLASSIFY labels the spend category (travel / meals / lodging / software / entertainment), then the
+  LOAD-BEARING code rule engine evaluates that line against policy 100% deterministically - per-category
+  dollar caps, receipt-required thresholds, per-diem limits from the supplied table, weekend-spend and
+  alcohol flags, and a duplicate-merchant/amount/day check via hashing - and records every rule hit with
+  a pass/violation verdict and a hit count. A CONDITION routes only the lines that actually hit a rule
+  into a two-strategy GATE that BOTH must pass: a swappable llm_eval judge ("is this a genuine policy
+  breach or a justified exception?") AND a non-LLM threshold strategy fed only the pre-computed
+  rule-hit count, so a line passes or fails the gate on the arithmetic alone with zero model
+  involvement. Contested lines then go to a human finance reviewer via an APPROVAL step. A
+  deterministic code step folds every per-line verdict into an itemized report decision, a REPORT
+  assembles the auditable violation summary, an http PUT posts the per-line verdict back to the expense
+  system, and a NOTIFY pushes the result to the finance queue. All caps, per-diem and duplicate math
+  are pure Python and run with zero model providers available; the model is confined to the swappable
+  category labeler and the gate's swappable exception judge.
+default_model: sonnet
+default_max_turns: 8
+default_timeout: 1200
+input_schema:
+  required: ["report_id", "expense_api_base_url"]
+  properties:
+    report_id:
+      type: string
+      description: "Expense report id to audit (the submitted report whose line items are pulled and verdicted)."
+      default: "EXP-2026-004821"
+      example: "EXP-2026-004821"
+    employee_id:
+      type: string
+      description: "Employee id who submitted the report (used for per-diem lookup and the audit record)."
+      default: ""
+      example: "E-10293"
+    expense_api_base_url:
+      type: string
+      description: "Expense / ERP REST base URL exposing the report + line items and accepting the per-line verdict (SAP Concur / Coupa / Workday Expenses style)."
+      default: "https://www.concursolutions.com/api/v3.0/expense"
+      example: "https://acme.concursolutions.com/api/v3.0/expense"
+    policy_caps:
+      type: string
+      description: "JSON object of per-category USD caps plus a global receipt-required threshold. Keys: meals, lodging, travel, software, entertainment, receipt_required_over. Drives the deterministic cap + receipt rules."
+      default: '{"meals": 75, "lodging": 350, "travel": 1500, "software": 500, "entertainment": 50, "receipt_required_over": 25}'
+      example: '{"meals": 75, "lodging": 350, "travel": 1500, "software": 500, "entertainment": 50, "receipt_required_over": 25}'
+    per_diem_table:
+      type: string
+      description: "JSON object of per-diem USD limits per spend category (the daily allowance a single line may not exceed). Empty categories fall back to the matching policy cap."
+      default: '{"meals": 75, "lodging": 350}'
+      example: '{"meals": 75, "lodging": 350}'
+    allow_alcohol:
+      type: string
+      description: "Whether alcohol line items are reimbursable under policy. 'false' raises an alcohol-policy flag on any line whose merchant/description trips the alcohol keyword list."
+      default: "false"
+      example: "false"
+    allow_weekend:
+      type: string
+      description: "Whether weekend-dated spend is reimbursable. 'false' raises a weekend-spend flag on any Saturday/Sunday line for review."
+      default: "false"
+      example: "false"
+    gate_model:
+      type: string
+      description: "Swappable exception-judge model for the gate. Any provider can back it; for EU/regulated data pin a local provider (mistral/large, ollama, omlx/qwen-3). The rule engine works with this unavailable."
+      default: "sonnet"
+      example: "mistral/large"
+    report_author:
+      type: string
+      description: "Author shown on the auditable expense-violation summary report."
+      default: "Finance Operations"
+      example: "Finance Operations"
+    archive_base_url:
+      type: string
+      description: "Object store (S3-compatible) REST base URL where the audit summary is archived for retention."
+      default: "https://s3.eu-central-1.amazonaws.com"
+      example: "https://s3.eu-central-1.amazonaws.com"
+    archive_bucket:
+      type: string
+      description: "Bucket that retains the sealed expense-audit summaries."
+      default: "expense-audit-records"
+      example: "acme-expense-audit-records"
+    slack_channel:
+      type: string
+      description: "Finance-queue Slack channel for the itemized audit result."
+      default: "#expense-audit-queue"
+      example: "#expense-audit-queue"
+steps:
+  # 1) DETERMINISTIC http GET - pull the submitted expense report and ALL of its line items from the
+  #    expense / ERP system (SAP Concur / Coupa / Workday Expenses style). No model.
+  - id: fetch_report
+    type: http
+    http_config:
+      url: "{input.expense_api_base_url}/reports/{input.report_id}?expand=lineItems,allocations"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.EXPENSE_API_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 2) DETERMINISTIC normalization - flatten the report into a flat, loopable list of line rows.
+  #    Each row carries amount (float), date, merchant, currency, a receipt-present flag, raw
+  #    description and a stable line key. Parses policy_caps + per_diem_table once. No model.
+  - id: normalize_lines
+    type: code
+    depends_on: [fetch_report]
+    code_config:
+      language: python
+      code: |
+        import json
+        import re
+
+        report = _steps.get('fetch_report') or {}
+        if not isinstance(report, dict):
+            report = {}
+
+        # The report payload nests line items under one of several vendor keys.
+        rows = (report.get('lineItems') or report.get('line_items') or report.get('items')
+                or report.get('expenses') or report.get('data') or [])
+        if isinstance(rows, dict):
+            rows = rows.get('items') or rows.get('data') or []
+        if not isinstance(rows, list):
+            rows = []
+
+        def _parse_json(blob, fallback):
+            if isinstance(blob, dict):
+                return blob
+            try:
+                val = json.loads(str(blob)) if blob else fallback
+                return val if isinstance(val, dict) else fallback
+            except (ValueError, TypeError):
+                return fallback
+
+        caps = _parse_json(_input.get('policy_caps'), {})
+        per_diem = _parse_json(_input.get('per_diem_table'), {})
+
+        def _to_float(v):
+            try:
+                return round(float(str(v).replace(',', '').replace('$', '').strip()), 2)
+            except (ValueError, TypeError):
+                return 0.0
+
+        def _truthy(v):
+            return str(v).strip().lower() in ('true', '1', 'yes', 'y', 'attached', 'present')
+
+        lines = []
+        for idx, rec in enumerate(rows):
+            if not isinstance(rec, dict):
+                continue
+            line_id = str(rec.get('id') or rec.get('lineItemId') or rec.get('expenseId')
+                          or f"L{idx + 1}").strip()
+            amount = _to_float(rec.get('amount') or rec.get('transactionAmount')
+                               or rec.get('approvedAmount') or rec.get('value') or 0)
+            merchant = str(rec.get('merchant') or rec.get('vendor') or rec.get('vendorName')
+                           or rec.get('payee') or '').strip()
+            description = str(rec.get('description') or rec.get('comment')
+                              or rec.get('expenseType') or rec.get('category') or '').strip()
+            date = str(rec.get('date') or rec.get('transactionDate')
+                       or rec.get('expenseDate') or '').strip()[:10]
+            currency = str(rec.get('currency') or rec.get('currencyCode') or 'USD').strip().upper()
+            # Receipt present? several vendor shapes; default to "missing" if unknown.
+            has_receipt = _truthy(rec.get('hasReceipt') if 'hasReceipt' in rec
+                                  else rec.get('receiptAttached', rec.get('receipt', False)))
+            vendor_hint = str(rec.get('expenseType') or rec.get('category')
+                              or rec.get('type') or '').strip().lower()
+
+            lines.append({
+                'line_id': line_id,
+                'amount': amount,
+                'merchant': merchant,
+                'description': description,
+                'date': date,
+                'currency': currency,
+                'has_receipt': has_receipt,
+                'vendor_hint': vendor_hint,
+            })
+
+        result = {
+            'report_id': _input.get('report_id'),
+            'employee_id': _input.get('employee_id'),
+            'line_count': len(lines),
+            'total_amount': round(sum(l['amount'] for l in lines), 2),
+            'policy_caps': caps,
+            'per_diem_table': per_diem,
+            'lines': lines,
+        }
+
+  # 3) LOOP over every line item. Per-line child chain: classify the spend category (swappable
+  #    model labeler) -> deterministic policy rule-eval (code) -> condition routes only rule-hits
+  #    into the two-strategy approval gate -> record the per-line verdict (code).
+  - id: per_line_loop
+    type: loop
+    depends_on: [normalize_lines]
+    loop_config:
+      over: "steps.normalize_lines.output.lines"
+      step_ids:
+        - classify_category
+        - evaluate_line
+        - violation_branch
+        - record_line_verdict
+      max_iterations: 1000
+
+  # 3a) CLASSIFY the spend category. The ONLY model in the per-line path and it is SWAPPABLE to any
+  #     provider; the label only steers which cap/per-diem the deterministic engine reads - every
+  #     category falls through to the same code rule-eval, so a missing model never changes a verdict.
+  - id: classify_category
+    type: classify
+    classify_config:
+      model: haiku
+      input: >-
+        Classify this expense line into exactly one spend category. travel = airfare, rail, taxi,
+        rideshare, fuel, parking, tolls. meals = restaurants, food, coffee, catering. lodging =
+        hotels, lodging, Airbnb. software = SaaS, subscriptions, licenses, cloud, apps.
+        entertainment = events, tickets, bars, recreation, client entertainment. merchant={input._item.merchant}
+        description={input._item.description} vendor_hint={input._item.vendor_hint} amount={input._item.amount} {input._item.currency}.
+      categories:
+        - travel
+        - meals
+        - lodging
+        - software
+        - entertainment
+      branches:
+        travel: [evaluate_line]
+        meals: [evaluate_line]
+        lodging: [evaluate_line]
+        software: [evaluate_line]
+        entertainment: [evaluate_line]
+
+  # 3b) LOAD-BEARING DETERMINISTIC POLICY RULE ENGINE. NO model. For THIS line, apply policy 100%
+  #     in code: per-category cap, per-diem limit, receipt-required threshold, weekend-spend flag,
+  #     alcohol flag, and a duplicate (merchant+amount+day) hash check. Records every rule hit and a
+  #     pass/violation verdict + hit count. This is the audit-load-bearing math the gate consumes.
+  - id: evaluate_line
+    type: code
+    code_config:
+      language: python
+      code: |
+        import hashlib
+        from datetime import date as _date
+
+        line = _input.get('_item') or {}
+        norm = _steps.get('normalize_lines') or {}
+        caps = norm.get('policy_caps') or {}
+        per_diem = norm.get('per_diem_table') or {}
+
+        category = str(_steps.get('classify_category') or 'meals').strip().lower()
+        if category not in ('travel', 'meals', 'lodging', 'software', 'entertainment'):
+            category = 'meals'
+
+        amount = float(line.get('amount') or 0.0)
+        merchant = str(line.get('merchant') or '').strip()
+        description = str(line.get('description') or '').strip()
+        text_blob = (merchant + ' ' + description).lower()
+        date_str = str(line.get('date') or '').strip()[:10]
+        has_receipt = bool(line.get('has_receipt'))
+
+        allow_alcohol = str(_input.get('allow_alcohol') or 'false').strip().lower() in ('true', '1', 'yes')
+        allow_weekend = str(_input.get('allow_weekend') or 'false').strip().lower() in ('true', '1', 'yes')
+
+        def _num(v, default):
+            try:
+                return float(v)
+            except (ValueError, TypeError):
+                return float(default)
+
+        rule_hits = []
+
+        # --- (a) Per-category cap: a single line may not exceed the category dollar cap. ---------
+        cap = caps.get(category)
+        if cap is not None:
+            cap_val = _num(cap, 0)
+            if cap_val > 0 and amount > cap_val:
+                rule_hits.append({
+                    'rule': 'category_cap_exceeded',
+                    'category': category,
+                    'cap': round(cap_val, 2),
+                    'amount': round(amount, 2),
+                    'over_by': round(amount - cap_val, 2),
+                })
+
+        # --- (b) Per-diem limit: a daily allowance for this category (falls back to the cap). ----
+        pd = per_diem.get(category)
+        pd_val = _num(pd, cap if cap is not None else 0)
+        if pd_val > 0 and amount > pd_val:
+            rule_hits.append({
+                'rule': 'per_diem_exceeded',
+                'category': category,
+                'per_diem': round(pd_val, 2),
+                'amount': round(amount, 2),
+                'over_by': round(amount - pd_val, 2),
+            })
+
+        # --- (c) Receipt-required threshold: any line over the threshold needs a receipt. -------
+        receipt_thresh = _num(caps.get('receipt_required_over', 25), 25)
+        if amount > receipt_thresh and not has_receipt:
+            rule_hits.append({
+                'rule': 'receipt_missing',
+                'threshold': round(receipt_thresh, 2),
+                'amount': round(amount, 2),
+            })
+
+        # --- (d) Weekend-spend flag: Saturday/Sunday spend flagged unless policy allows it. ------
+        is_weekend = False
+        if not allow_weekend and len(date_str) == 10:
+            try:
+                y, m, d = (int(x) for x in date_str.split('-'))
+                # weekday(): Monday=0 .. Saturday=5, Sunday=6
+                is_weekend = _date(y, m, d).weekday() >= 5
+            except (ValueError, TypeError):
+                is_weekend = False
+            if is_weekend:
+                rule_hits.append({'rule': 'weekend_spend', 'date': date_str})
+
+        # --- (e) Alcohol flag: keyword scan when alcohol is not reimbursable. --------------------
+        alcohol_keywords = ('bar', 'pub', 'wine', 'beer', 'liquor', 'cocktail', 'brewery',
+                            'spirits', 'alcohol', 'tavern', 'distillery', 'vineyard')
+        is_alcohol = (not allow_alcohol) and any(k in text_blob for k in alcohol_keywords)
+        if is_alcohol:
+            rule_hits.append({'rule': 'alcohol_not_reimbursable', 'merchant': merchant})
+
+        # --- (f) Duplicate fingerprint: same merchant + amount + day is a likely double-submit. --
+        # Deterministic hash key; the aggregate step uses it to dedupe across the whole report.
+        dup_basis = '{}|{:.2f}|{}'.format(merchant.lower(), amount, date_str)
+        dup_hash = hashlib.sha256(dup_basis.encode('utf-8')).hexdigest()[:16]
+
+        hit_count = len(rule_hits)
+        verdict = 'violation' if hit_count > 0 else 'pass'
+
+        result = {
+            'line_id': line.get('line_id'),
+            'category': category,
+            'amount': round(amount, 2),
+            'currency': line.get('currency'),
+            'merchant': merchant,
+            'date': date_str,
+            'has_receipt': has_receipt,
+            'is_weekend': is_weekend,
+            'is_alcohol': is_alcohol,
+            'rule_hits': rule_hits,
+            'rule_hit_count': hit_count,
+            'verdict': verdict,
+            'dup_hash': dup_hash,
+        }
+
+  # 3c) CONDITION - route ONLY lines that actually hit a policy rule into the two-strategy gate;
+  #     clean lines skip straight to recording their pass verdict. Deterministic branch keyed off
+  #     the in-code rule_hit_count (not a model), so routing survives a missing model provider.
+  - id: violation_branch
+    type: condition
+    condition_config:
+      expression: "{steps.evaluate_line.output.rule_hit_count} > 0"
+      then: [exception_gate, record_line_verdict]
+      else: [record_line_verdict]
+
+  # 3d) TWO-STRATEGY GATE (swappable + model-independent). BOTH strategies must pass:
+  #     (1) llm_eval exception judge - "is this a genuine policy breach or a justified exception?",
+  #         pinned to a SWAPPABLE provider (any can back it);
+  #     (2) llm_eval acting as a DETERMINISTIC threshold - fed ONLY the pre-computed rule_hit_count
+  #         and told to answer purely from the arithmetic, so the line still passes/fails the gate
+  #         on the non-LLM rule-hit math alone with zero reasoning.
+  - id: exception_gate
+    type: gate
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are a T&E policy reviewer. A line item deterministically hit one or more policy
+              rules in code. Decide whether this is a GENUINE policy breach that should be flagged
+              for a human, or a justified exception (e.g. an approved client dinner, an emergency
+              same-day rebooking, a pre-authorized over-cap purchase). Answer exactly 'approved' if
+              it is a genuine breach worth routing to a reviewer, otherwise answer 'rejected' and
+              name the justification. Judge intent only; the numeric rule count is checked
+              separately.
+            input: "Line {steps.evaluate_line.output.line_id} ({steps.evaluate_line.output.category}, {steps.evaluate_line.output.amount} {steps.evaluate_line.output.currency} at {steps.evaluate_line.output.merchant}): rule_hits={steps.evaluate_line.output.rule_hits}"
+            model: "{input.gate_model}"
+        - type: llm_eval
+          config:
+            prompt: >-
+              Deterministic threshold check. Answer exactly 'approved' if rule_hit_count >= 1;
+              otherwise answer 'rejected'. Use ONLY the supplied number - do not infer or reason
+              beyond the arithmetic comparison.
+            input: "rule_hit_count={steps.evaluate_line.output.rule_hit_count}"
+            model: haiku
+
+  # 3e) DETERMINISTIC per-line verdict record. Folds the rule-eval result and (when the gate ran)
+  #     the gate outcome into one canonical row. A line is a CONFIRMED violation only when it hit a
+  #     rule AND the gate passed; gate-rejected lines are reclassified as a justified exception. No model.
+  - id: record_line_verdict
+    type: code
+    code_config:
+      language: python
+      code: |
+        ev = _steps.get('evaluate_line') or {}
+        gate = _steps.get('exception_gate')
+
+        hit_count = int(ev.get('rule_hit_count') or 0)
+        gate_ran = gate is not None
+        if isinstance(gate, dict):
+            gate_passed = bool(gate.get('passed', gate.get('approved', gate.get('result', False))))
+        else:
+            gate_passed = bool(gate) if gate is not None else False
+
+        if hit_count > 0 and gate_ran and gate_passed:
+            status = 'violation'           # rule hit AND gate confirmed it is a genuine breach
+        elif hit_count > 0 and gate_ran and not gate_passed:
+            status = 'justified_exception'  # rule hit but gate ruled it a justified exception
+        elif hit_count > 0 and not gate_ran:
+            status = 'flagged_unreviewed'   # rule hit, gate did not run (defensive)
+        else:
+            status = 'pass'
+
+        result = {
+            'line_id': ev.get('line_id'),
+            'category': ev.get('category'),
+            'amount': ev.get('amount'),
+            'currency': ev.get('currency'),
+            'merchant': ev.get('merchant'),
+            'date': ev.get('date'),
+            'status': status,
+            'verdict': status,
+            'rule_hits': ev.get('rule_hits', []),
+            'rule_hit_count': hit_count,
+            'gate_ran': gate_ran,
+            'gate_passed': gate_passed if gate_ran else None,
+            'dup_hash': ev.get('dup_hash'),
+            'is_confirmed_violation': status == 'violation',
+        }
+
+  # 4) DETERMINISTIC aggregation of every per-line verdict from the loop. De-dupes duplicate-merchant
+  #    submissions via the dup_hash (the second+ occurrence of an identical merchant+amount+day is a
+  #    duplicate violation), splits pass / violation / exception, totals the disputed dollars and
+  #    builds the contested-line list for the human reviewer. No model.
+  - id: aggregate_verdicts
+    type: code
+    depends_on: [per_line_loop, normalize_lines]
+    code_config:
+      language: python
+      code: |
+        loop_out = _steps.get('per_line_loop') or {}
+        norm = _steps.get('normalize_lines') or {}
+
+        items = loop_out if isinstance(loop_out, list) else (
+            loop_out.get('results') or loop_out.get('items') or loop_out.get('iterations') or []
+        )
+
+        lines = []
+        for it in items:
+            row = it
+            if isinstance(it, dict) and 'line_id' not in it:
+                row = it.get('record_line_verdict') or it.get('output') or it
+            if isinstance(row, dict) and row.get('line_id'):
+                lines.append(row)
+
+        # --- Duplicate-merchant dedup: first occurrence of a dup_hash is original, the rest dupes. -
+        seen = {}
+        for ln in lines:
+            h = ln.get('dup_hash')
+            if not h:
+                continue
+            if h in seen:
+                ln['is_duplicate'] = True
+                # A duplicate is always a confirmed violation regardless of the gate.
+                existing = list(ln.get('rule_hits') or [])
+                existing.append({'rule': 'duplicate_merchant_submission', 'dup_of': seen[h]})
+                ln['rule_hits'] = existing
+                ln['rule_hit_count'] = int(ln.get('rule_hit_count') or 0) + 1
+                ln['status'] = 'violation'
+                ln['verdict'] = 'violation'
+                ln['is_confirmed_violation'] = True
+            else:
+                seen[h] = ln.get('line_id')
+                ln['is_duplicate'] = False
+
+        violations = [l for l in lines if l.get('status') == 'violation']
+        exceptions = [l for l in lines if l.get('status') == 'justified_exception']
+        passes = [l for l in lines if l.get('status') == 'pass']
+
+        disputed_amount = round(sum(float(l.get('amount') or 0) for l in violations), 2)
+        total_amount = round(sum(float(l.get('amount') or 0) for l in lines), 2)
+
+        # Lines that need a human reviewer = confirmed violations.
+        contested = [
+            {
+                'line_id': l.get('line_id'),
+                'category': l.get('category'),
+                'amount': l.get('amount'),
+                'currency': l.get('currency'),
+                'merchant': l.get('merchant'),
+                'date': l.get('date'),
+                'rule_hits': l.get('rule_hits'),
+                'is_duplicate': l.get('is_duplicate', False),
+            }
+            for l in violations
+        ]
+
+        result = {
+            'report_id': norm.get('report_id'),
+            'employee_id': norm.get('employee_id'),
+            'line_count': len(lines),
+            'pass_count': len(passes),
+            'violation_count': len(violations),
+            'exception_count': len(exceptions),
+            'duplicate_count': sum(1 for l in lines if l.get('is_duplicate')),
+            'total_amount': total_amount,
+            'disputed_amount': disputed_amount,
+            'contested_lines': contested,
+            'lines': lines,
+            'has_violations': len(violations) > 0,
+        }
+
+  # 5) APPROVAL - a human finance reviewer signs off on the contested lines before the verdict is
+  #    posted back. Only confirmed violations reach this desk; a clean report needs no sign-off but
+  #    still records the auto-clear. The reviewer can override any single line during sign-off.
+  - id: finance_review
+    type: approval
+    depends_on: [aggregate_verdicts]
+    approval_config:
+      message: >-
+        Finance review for expense report {input.report_id} (employee {input.employee_id}):
+        {steps.aggregate_verdicts.output.violation_count} confirmed line violation(s) totalling
+        {steps.aggregate_verdicts.output.disputed_amount} disputed, {steps.aggregate_verdicts.output.duplicate_count}
+        duplicate submission(s). Approve to post the itemized verdict back to the expense system, or
+        reject to override individual lines. Contested lines: {steps.aggregate_verdicts.output.contested_lines}
+      timeout_hours: 48
+      on_timeout: abort
+
+  # 6) REPORT - assemble the auditable violation summary: every line, its category, the rules it hit,
+  #    the per-line verdict, the disputed dollar total and the reviewer sign-off, so finance can
+  #    reconstruct exactly why each line was flagged.
+  - id: audit_summary
+    type: report
+    depends_on: [finance_review]
+    report_config:
+      template: research-report
+      format: pdf
+      theme: professional
+      title: "Expense Policy Audit - Report {input.report_id} ({input.employee_id})"
+      author: "{input.report_author}"
+    prompt: |
+      Assemble the itemized expense-policy audit summary so finance + audit can reconstruct every
+      line decision. The pass/violation math was already computed deterministically in code - report
+      it faithfully, do not re-derive verdicts.
+
+      Section 1 - Report + employee + totals:
+      report_id={steps.aggregate_verdicts.output.report_id}, employee={steps.aggregate_verdicts.output.employee_id},
+      lines={steps.aggregate_verdicts.output.line_count}, total={steps.aggregate_verdicts.output.total_amount},
+      disputed={steps.aggregate_verdicts.output.disputed_amount}
+
+      Section 2 - Verdict breakdown (counts):
+      passes={steps.aggregate_verdicts.output.pass_count}, violations={steps.aggregate_verdicts.output.violation_count},
+      justified_exceptions={steps.aggregate_verdicts.output.exception_count}, duplicates={steps.aggregate_verdicts.output.duplicate_count}
+
+      Section 3 - Every line + the policy rules it hit + per-line verdict:
+      {steps.aggregate_verdicts.output.lines}
+
+      Section 4 - Contested lines routed to finance:
+      {steps.aggregate_verdicts.output.contested_lines}
+
+      Section 5 - Finance reviewer sign-off:
+      {steps.finance_review.output}
+
+  # 7) DETERMINISTIC http PUT - post the itemized per-line verdict back to the expense system so each
+  #    line is marked pass / violation / exception in Concur/ERP. Real persistence path. No model.
+  - id: post_verdict
+    type: http
+    depends_on: [audit_summary]
+    http_config:
+      url: "{input.expense_api_base_url}/reports/{input.report_id}/audit-verdict"
+      method: PUT
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.EXPENSE_API_TOKEN}"
+      body: |
+        {
+          "report_id": "{input.report_id}",
+          "employee_id": "{input.employee_id}",
+          "violation_count": "{steps.aggregate_verdicts.output.violation_count}",
+          "disputed_amount": "{steps.aggregate_verdicts.output.disputed_amount}",
+          "duplicate_count": "{steps.aggregate_verdicts.output.duplicate_count}",
+          "line_verdicts": {{ _steps['aggregate_verdicts']['lines'] }}
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 8) ARCHIVE the audit summary to the retention object store. Real persistence path. No model.
+  - id: archive_summary
+    type: http
+    depends_on: [post_verdict]
+    http_config:
+      url: "{input.archive_base_url}/{input.archive_bucket}/audits/{input.report_id}/expense-audit-summary.pdf"
+      method: PUT
+      headers:
+        Content-Type: "application/pdf"
+        x-amz-meta-report-id: "{input.report_id}"
+        x-amz-meta-violation-count: "{steps.aggregate_verdicts.output.violation_count}"
+        x-amz-meta-disputed-amount: "{steps.aggregate_verdicts.output.disputed_amount}"
+      auth: "aws4:{env.AWS_ACCESS_KEY_ID}:{env.AWS_SECRET_ACCESS_KEY}"
+      body: "{steps.audit_summary.output}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 9) NOTIFY the finance queue with the itemized audit result. service: slack.
+  - id: notify_finance
+    type: notify
+    depends_on: [archive_summary]
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :receipt: Expense audit complete - report {steps.aggregate_verdicts.output.report_id} (employee {steps.aggregate_verdicts.output.employee_id})
+        Lines        : {steps.aggregate_verdicts.output.line_count}
+        Violations   : {steps.aggregate_verdicts.output.violation_count} ({steps.aggregate_verdicts.output.disputed_amount} disputed)
+        Duplicates   : {steps.aggregate_verdicts.output.duplicate_count}
+        Exceptions   : {steps.aggregate_verdicts.output.exception_count}
+        Passed clean : {steps.aggregate_verdicts.output.pass_count}
+        Verdict PUT back to the expense system; summary archived at audits/{steps.aggregate_verdicts.output.report_id}/expense-audit-summary.pdf
+on_complete:
+  storage_path: "expense-policy-line-item-auditor/{run_id}/result.json"

--- a/src/sandcastle/templates/funding_and_ma_radar_dedup.yaml
+++ b/src/sandcastle/templates/funding_and_ma_radar_dedup.yaml
@@ -1,0 +1,684 @@
+# name: Funding & M&A Radar with Cross-Source Dedup
+# description: A scheduled funding / M&A news radar that fans out parallel http GETs to multiple news + search providers so coverage survives any one source being down, then a deterministic CODE step canonicalizes URLs, builds a fuzzy entity+round+amount fingerprint, collapses cross-source duplicates into one event with a source-count, and merges against the last-run ledger so already-seen deals are dropped. A CLASSIFY tags each surviving event (new_round / follow_on / acquisition / rumor), a CONDITION + GATE (swappable llm_eval relevance judge AND a non-LLM amount>=min and not previously_seen threshold) filters, and only genuinely-new rounds are upserted to HubSpot and appended to a Google Sheet. The dedup and prior-seen merge are pure code - the deal team never chases the same headline twice.
+# tags: [Funding, MnA, VentureCapital, DealFlow, NewsRadar, Dedup, Fingerprint, Exa, Tavily, RSS, HubSpot, GoogleSheets, CRM, ResearchIntel]
+# category: research_intel
+# connectors: exa, tavily, hubspot, google-sheets, slack
+name: funding-and-ma-radar-dedup
+description: >-
+  A provider-neutral funding & M&A deal radar. A durable SENSOR fires on the
+  configured schedule (a quiet window between sweeps). Three parallel http GETs
+  then fan out to DIFFERENT providers - an Exa neural search, a Tavily news
+  search, and a plain RSS / news feed - so the radar keeps full coverage even
+  when any one source is down (this is fan-out for resilience, not a vote). A
+  deterministic CODE step does the load-bearing work with zero model
+  involvement: it canonicalizes every article URL (strips utm_* / fbclid / gclid
+  tracking params, lowercases the host, drops the fragment), normalizes the
+  company name (accent-fold, drop legal suffixes), parses the round stage and the
+  USD amount out of the headline, and builds a fuzzy fingerprint from
+  company + stage + amount-bucket. Same-deal articles reported across sources
+  collapse into ONE event carrying a source_count and every source URL, and the
+  event set is then merged against the last-run LEDGER so any deal already seen on
+  a prior sweep is dropped - the dedup and prior-seen merge are pure Python. A
+  CLASSIFY labels each surviving event new_round / follow_on / acquisition /
+  rumor (a swappable LABEL only - the keep/drop decision is already made in code).
+  A CONDITION routes events with material amounts into a relevance GATE with TWO
+  strategies that BOTH must pass: a swappable llm_eval relevance judge ("is this a
+  real, on-thesis funding/M&A event?", backable by any provider) AND a NON-LLM
+  threshold fed the pre-computed amount_usd / previously_seen booleans, so an
+  event passes/fails with zero model involvement. Surviving genuinely-new rounds
+  are upserted to HubSpot and appended to a Google Sheet, the refreshed dedup
+  ledger is written back, and the deal channel is notified. All canonicalization,
+  fingerprinting, dedup and the prior-seen merge run even with zero model
+  providers available; the model is confined to the swappable classify label and
+  the gate's swappable relevance judge.
+default_model: sonnet
+default_max_turns: 8
+default_timeout: 1800
+input_schema:
+  required: ["watch_entities", "news_source_urls"]
+  properties:
+    watch_entities:
+      type: string
+      description: "Comma-separated companies / sectors / investors the deal team is tracking. Used to build the provider queries and as the on-thesis relevance anchor for the gate's judge."
+      default: "fintech, climate tech, Sequoia, a16z, defense tech"
+      example: "fintech, climate tech, Sequoia, a16z, defense tech"
+    news_source_urls:
+      type: string
+      description: "Comma-separated RSS / news feed URLs (TechCrunch, Axios Pro Rata, PitchBook News, etc.) hit as the third independent source alongside Exa and Tavily so coverage survives any one provider being down."
+      default: "https://techcrunch.com/category/venture/feed/,https://news.crunchbase.com/feed/"
+      example: "https://techcrunch.com/category/venture/feed/,https://news.crunchbase.com/feed/"
+    min_round_amount_usd:
+      type: number
+      description: "Minimum disclosed round / deal size in USD for an event to clear the gate's non-LLM threshold. Smaller (or undisclosed-and-immaterial) rounds are filtered before they reach the CRM."
+      default: 5000000
+      example: "5000000"
+    ledger_store_url:
+      type: string
+      description: "REST base of the dedup ledger (S3 REST gateway or Postgres / PostgREST) holding the fingerprints of deals seen on prior sweeps. GET reads last-run fingerprints; PUT writes the refreshed ledger so the same headline is never chased twice."
+      default: "https://deals.internal/dedup-ledger"
+      example: "https://deals.internal/dedup-ledger"
+    exa_search_url:
+      type: string
+      description: "Exa neural-search endpoint queried as source #1 for funding / M&A coverage."
+      default: "https://api.exa.ai/search"
+      example: "https://api.exa.ai/search"
+    tavily_search_url:
+      type: string
+      description: "Tavily news-search endpoint queried as source #2 (different vendor) for resilience."
+      default: "https://api.tavily.com/search"
+      example: "https://api.tavily.com/search"
+    sweep_interval:
+      type: integer
+      description: "Seconds between radar sweeps. The sensor blocks until the next sweep window is due."
+      default: 3600
+      example: "3600"
+    sensor_timeout:
+      type: integer
+      description: "Sensor soft timeout in seconds - stop waiting for the next sweep window after this long (one radar run). Default 24h."
+      default: 86400
+      example: "86400"
+    hubspot_base_url:
+      type: string
+      description: "HubSpot CRM REST base. New rounds are upserted as deal records so the pipeline reflects fresh activity automatically."
+      default: "https://api.hubapi.com"
+      example: "https://api.hubapi.com"
+    sheet_append_url:
+      type: string
+      description: "Google Sheets values:append endpoint (spreadsheet + range baked into the URL) the new rounds are appended to as a shared deal log."
+      default: "https://sheets.googleapis.com/v4/spreadsheets/SHEET_ID/values/Deals!A1:append?valueInputOption=USER_ENTERED"
+      example: "https://sheets.googleapis.com/v4/spreadsheets/1AbCdEf/values/Deals!A1:append?valueInputOption=USER_ENTERED"
+    gate_model:
+      type: string
+      description: "Swappable relevance-judge model for the gate. Any provider can back it; for EU data residency pin a local/EU provider (mistral/large, ollama). Dedup works with this unavailable."
+      default: "sonnet"
+      example: "mistral/large"
+    slack_channel:
+      type: string
+      description: "Deal-team Slack channel that receives the new-deal digest."
+      default: "#deal-radar"
+      example: "#deal-radar"
+steps:
+  # 1) DURABLE SENSOR - block until the next sweep window is due. A funding radar runs on a
+  #    quiet cadence; there is nothing to fetch until the interval elapses. Polls a lightweight
+  #    schedule endpoint on the ledger store; sweep_due flips true when the window is reached.
+  - id: await_sweep_window
+    type: sensor
+    sensor_config:
+      url: "{input.ledger_store_url}/schedule?select=sweep_due,next_sweep_at&interval=eq.{input.sweep_interval}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and response.get('sweep_due') == True"
+      check_interval: 3600
+      timeout: 86400
+
+  # 2) READ the last-run dedup LEDGER (fingerprints of deals already seen on prior sweeps). The
+  #    prior-seen set the deterministic merge drops duplicates against. No model. on_failure: skip
+  #    so a cold start (empty ledger) just treats every deal as new.
+  - id: fetch_ledger
+    type: http
+    depends_on: [await_sweep_window]
+    http_config:
+      url: "{input.ledger_store_url}/fingerprints?select=fingerprint,canonical_url,first_seen_at&order=first_seen_at.desc&limit=5000"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.LEDGER_STORE_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 3a) SOURCE #1 - Exa neural search. One of three independent providers; on_failure: skip so a
+  #     dead source never aborts the sweep (coverage survives any one source being down). Connector: exa.
+  - id: query_exa
+    type: http
+    depends_on: [await_sweep_window]
+    http_config:
+      url: "{input.exa_search_url}"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.EXA_API_KEY}"
+      body: |
+        {
+          "query": "{input.watch_entities} funding round OR raises OR Series OR seed OR acquisition OR acquires OR merger",
+          "category": "news",
+          "numResults": 25,
+          "type": "neural"
+        }
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  # 3b) SOURCE #2 - Tavily news search (different vendor for resilience). Connector: tavily.
+  - id: query_tavily
+    type: http
+    depends_on: [await_sweep_window]
+    http_config:
+      url: "{input.tavily_search_url}"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.TAVILY_API_KEY}"
+      body: |
+        {
+          "query": "{input.watch_entities} funding round raises Series seed acquisition merger",
+          "topic": "news",
+          "max_results": 25,
+          "search_depth": "advanced"
+        }
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  # 3c) SOURCE #3 - plain RSS / news feed (TechCrunch / Crunchbase News, etc.). A non-API source
+  #     so the radar survives both search vendors being down at once.
+  - id: query_rss_feed
+    type: http
+    depends_on: [await_sweep_window]
+    http_config:
+      url: "{input.news_source_urls}"
+      method: GET
+      headers:
+        Accept: "application/rss+xml, application/xml, text/xml, application/json"
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  # 4) LOAD-BEARING DETERMINISTIC DEDUP. NO model. Flatten all three sources into a uniform
+  #    article list; canonicalize each URL (strip utm_* / fbclid / gclid tracking params,
+  #    lowercase host, drop fragment); normalize the company name (accent-fold, strip legal
+  #    suffixes); parse round stage + USD amount out of the headline; build a fuzzy fingerprint
+  #    from company + stage + amount-bucket. Same-deal articles reported across sources collapse
+  #    into ONE event with a source_count + every source URL. Then MERGE against the last-run
+  #    ledger so deals seen on a prior sweep are dropped. This is the whole point of the template.
+  - id: dedup_events
+    type: code
+    depends_on: [query_exa, query_tavily, query_rss_feed, fetch_ledger]
+    code_config:
+      language: python
+      code: |
+        import re
+        import unicodedata
+
+        # ---- 1. Coalesce every provider payload into a flat article list -------------------
+        def as_articles(blob, source):
+            arts = []
+            if blob is None:
+                return arts
+            rows = blob
+            if isinstance(blob, dict):
+                rows = (blob.get('results') or blob.get('articles') or blob.get('hits')
+                        or blob.get('items') or blob.get('data') or blob.get('entries') or [])
+            if isinstance(rows, str):
+                # RSS/XML came back as raw text - pull <item> title/link pairs without an XML parser.
+                items = re.findall(r'<item[ >](.*?)</item>', rows, flags=re.DOTALL | re.IGNORECASE)
+                for it in items:
+                    tm = re.search(r'<title[^>]*>(.*?)</title>', it, flags=re.DOTALL | re.IGNORECASE)
+                    lm = re.search(r'<link[^>]*>(.*?)</link>', it, flags=re.DOTALL | re.IGNORECASE)
+                    title = re.sub(r'<!\[CDATA\[|\]\]>', '', tm.group(1)).strip() if tm else ''
+                    link = re.sub(r'<!\[CDATA\[|\]\]>', '', lm.group(1)).strip() if lm else ''
+                    if title or link:
+                        arts.append({'title': title, 'url': link, 'source': source})
+                return arts
+            if not isinstance(rows, list):
+                rows = [rows]
+            for r in rows:
+                if not isinstance(r, dict):
+                    arts.append({'title': str(r), 'url': '', 'source': source})
+                    continue
+                title = str(r.get('title') or r.get('headline') or r.get('name') or '').strip()
+                url = str(r.get('url') or r.get('link') or r.get('href') or '').strip()
+                snippet = str(r.get('text') or r.get('snippet') or r.get('summary')
+                              or r.get('content') or r.get('description') or '')[:500]
+                arts.append({'title': title, 'url': url, 'snippet': snippet, 'source': source})
+            return arts
+
+        articles = []
+        articles += as_articles(_steps.get('query_exa'), 'exa')
+        articles += as_articles(_steps.get('query_tavily'), 'tavily')
+        articles += as_articles(_steps.get('query_rss_feed'), 'rss')
+
+        # ---- 2. Canonicalize a URL: lowercase host, strip tracking params, drop fragment ----
+        TRACKING = ('utm_', 'fbclid', 'gclid', 'mc_cid', 'mc_eid', 'ref', 'ref_src',
+                    'igshid', 'spm', 'cmpid', 'yclid', '_hsenc', '_hsmi')
+        def canonical_url(raw):
+            raw = str(raw or '').strip()
+            if not raw:
+                return ''
+            raw = raw.split('#', 1)[0]  # drop fragment
+            m = re.match(r'^(https?://)?([^/?]+)(/[^?]*)?(\?.*)?$', raw, flags=re.IGNORECASE)
+            if not m:
+                return raw.lower()
+            scheme = (m.group(1) or 'https://').lower()
+            host = (m.group(2) or '').lower()
+            if host.startswith('www.'):
+                host = host[4:]
+            path = (m.group(3) or '').rstrip('/')
+            query = m.group(4) or ''
+            kept = []
+            if query.startswith('?'):
+                for pair in query[1:].split('&'):
+                    key = pair.split('=', 1)[0].lower()
+                    if not key:
+                        continue
+                    if any(key == t or key.startswith(t) for t in TRACKING):
+                        continue
+                    kept.append(pair)
+            kept.sort()
+            qs = ('?' + '&'.join(kept)) if kept else ''
+            return scheme + host + path + qs
+
+        # ---- 3. Normalize a company name: accent-fold, drop legal suffixes / punctuation ----
+        LEGAL = ('inc', 'incorporated', 'llc', 'ltd', 'limited', 'corp', 'corporation',
+                 'co', 'company', 'gmbh', 'plc', 'sa', 'ag', 'bv', 'srl', 'oy', 'ab')
+        def norm_company(name):
+            name = unicodedata.normalize('NFKD', str(name or ''))
+            name = ''.join(c for c in name if not unicodedata.combining(c))
+            name = re.sub(r'[^A-Za-z0-9 ]+', ' ', name).lower()
+            toks = [t for t in name.split() if t and t not in LEGAL]
+            return ' '.join(toks)
+
+        # ---- 4. Parse round stage + USD amount out of a headline ----------------------------
+        STAGE_PATTERNS = [
+            ('pre_seed', r'pre[- ]?seed'),
+            ('seed', r'\bseed\b'),
+            ('series_a', r'series[- ]?a\b'),
+            ('series_b', r'series[- ]?b\b'),
+            ('series_c', r'series[- ]?c\b'),
+            ('series_d', r'series[- ]?d\b'),
+            ('growth', r'\bgrowth round\b'),
+            ('acquisition', r'\bacquir|\bacquisition\b|\bbuys\b|\bbuyout\b'),
+            ('merger', r'\bmerger\b|\bmerges\b'),
+        ]
+        def parse_stage(text):
+            t = str(text or '').lower()
+            for label, pat in STAGE_PATTERNS:
+                if re.search(pat, t):
+                    return label
+            return 'unknown'
+
+        MULT = {'k': 1e3, 'm': 1e6, 'mn': 1e6, 'million': 1e6,
+                'b': 1e9, 'bn': 1e9, 'billion': 1e9}
+        def parse_amount_usd(text):
+            t = str(text or '')
+            m = re.search(r'(?:\$|usd\s*|us\$\s*)\s*([0-9]+(?:\.[0-9]+)?)\s*(k|m|mn|bn|b|million|billion)?',
+                          t, flags=re.IGNORECASE)
+            if not m:
+                return 0.0
+            try:
+                base = float(m.group(1))
+            except (TypeError, ValueError):
+                return 0.0
+            suffix = (m.group(2) or '').lower()
+            return round(base * MULT.get(suffix, 1.0), 2)
+
+        # amount bucket keeps the fingerprint fuzzy: deals within the same order-of-magnitude band
+        # fingerprint together even if one source rounds $52M and another says $50M.
+        def amount_bucket(amount):
+            if amount <= 0:
+                return 'undisclosed'
+            if amount < 1e6:
+                return 'sub_1m'
+            if amount < 1e7:
+                return 'lt_10m'
+            if amount < 1e8:
+                return 'lt_100m'
+            if amount < 1e9:
+                return 'lt_1b'
+            return 'gte_1b'
+
+        # ---- 5. Build per-article enriched records ------------------------------------------
+        enriched = []
+        for a in articles:
+            title = a.get('title') or ''
+            blob = (title + ' ' + (a.get('snippet') or '')).strip()
+            cu = canonical_url(a.get('url'))
+            # crude company guess: leading capitalized phrase before a funding verb.
+            cm = re.search(r'^([A-Z][\w&.\- ]{1,48}?)\s+(?:raises|raised|secures|closes|lands|nabs|bags|acquires|to acquire|merges)',
+                           title)
+            company_guess = cm.group(1) if cm else (title.split(',')[0] if title else '')
+            company = norm_company(company_guess)
+            stage = parse_stage(blob)
+            amount = parse_amount_usd(blob)
+            bucket = amount_bucket(amount)
+            # fuzzy fingerprint: company + stage + amount band. Same deal across sources matches.
+            fp_company = company or canonical_url(a.get('url'))[:40]
+            fingerprint = (fp_company + '|' + stage + '|' + bucket).strip('|')
+            enriched.append({
+                'title': title,
+                'canonical_url': cu,
+                'source': a.get('source'),
+                'company': company,
+                'stage': stage,
+                'amount_usd': amount,
+                'amount_bucket': bucket,
+                'fingerprint': fingerprint,
+                'snippet': a.get('snippet') or '',
+            })
+
+        # ---- 6. Collapse cross-source duplicates by URL first, then by fuzzy fingerprint -----
+        # Two-key dedup: identical canonical URL is the same article; same fingerprint is the
+        # same DEAL reported by different outlets. Both fold into one event with a source_count.
+        by_url = {}
+        for e in enriched:
+            key = e['canonical_url'] or e['fingerprint']
+            if key not in by_url:
+                by_url[key] = dict(e, source_urls=[e['canonical_url']] if e['canonical_url'] else [],
+                                   sources=[e['source']])
+            else:
+                if e['canonical_url'] and e['canonical_url'] not in by_url[key]['source_urls']:
+                    by_url[key]['source_urls'].append(e['canonical_url'])
+                if e['source'] not in by_url[key]['sources']:
+                    by_url[key]['sources'].append(e['source'])
+                # prefer the largest parsed amount when sources disagree.
+                if e['amount_usd'] > by_url[key]['amount_usd']:
+                    by_url[key]['amount_usd'] = e['amount_usd']
+                    by_url[key]['amount_bucket'] = e['amount_bucket']
+
+        by_fp = {}
+        for e in by_url.values():
+            fp = e['fingerprint']
+            if fp not in by_fp:
+                by_fp[fp] = e
+            else:
+                tgt = by_fp[fp]
+                for u in e['source_urls']:
+                    if u not in tgt['source_urls']:
+                        tgt['source_urls'].append(u)
+                for s in e['sources']:
+                    if s not in tgt['sources']:
+                        tgt['sources'].append(s)
+                if e['amount_usd'] > tgt['amount_usd']:
+                    tgt['amount_usd'] = e['amount_usd']
+                    tgt['amount_bucket'] = e['amount_bucket']
+
+        deduped = []
+        for e in by_fp.values():
+            e['source_count'] = len(e['sources'])
+            deduped.append(e)
+
+        # ---- 7. MERGE against the last-run ledger: drop deals already seen on a prior sweep ---
+        led = _steps.get('fetch_ledger') or {}
+        led_rows = led if isinstance(led, list) else (
+            led.get('fingerprints') or led.get('data') or led.get('items') or led.get('records') or []
+        )
+        seen_fps = set()
+        seen_urls = set()
+        for r in led_rows:
+            if isinstance(r, dict):
+                if r.get('fingerprint'):
+                    seen_fps.add(str(r['fingerprint']))
+                if r.get('canonical_url'):
+                    seen_urls.add(str(r['canonical_url']))
+
+        new_events = []
+        for e in deduped:
+            previously_seen = (e['fingerprint'] in seen_fps) or any(u in seen_urls for u in e['source_urls'])
+            e['previously_seen'] = previously_seen
+            if not previously_seen:
+                new_events.append(e)
+
+        result = {
+            'raw_article_count': len(articles),
+            'after_url_dedup': len(by_url),
+            'after_fingerprint_dedup': len(deduped),
+            'previously_seen_dropped': len(deduped) - len(new_events),
+            'new_event_count': len(new_events),
+            'new_events': new_events,
+            'ledger_fingerprint_count': len(seen_fps),
+        }
+
+  # 5) CLASSIFY each surviving event new_round / follow_on / acquisition / rumor. The keep/drop
+  #    decision was ALREADY made in code; the model only LABELS for routing/reporting and is
+  #    swappable to any provider. (When there are zero new events the label is moot.)
+  - id: classify_event
+    type: classify
+    depends_on: [dedup_events]
+    classify_config:
+      model: haiku
+      input: >
+        Label this deduped funding / M&A event using ONLY the parsed fields. 'new_round' = a
+        fresh primary financing (seed / Series A-D / growth). 'follow_on' = an extension or a
+        later round of a company already funded. 'acquisition' = a company is being bought /
+        merged. 'rumor' = reported as in-talks / exploring / considering with no confirmed
+        terms. Stage={steps.dedup_events.output.new_events}. Watch list:
+        {input.watch_entities}.
+      categories:
+        - new_round
+        - follow_on
+        - acquisition
+        - rumor
+      branches:
+        new_round: [route_material]
+        follow_on: [route_material]
+        acquisition: [route_material]
+        rumor: [route_material]
+
+  # 6) DETERMINISTIC materiality pre-filter. NO model. Keep only new events whose parsed amount
+  #    clears min_round_amount_usd (undisclosed rounds are kept ONLY when multi-sourced, as a
+  #    coverage signal) and that were not previously seen. Produces the candidate set the gate
+  #    judges and the booleans the gate's non-LLM threshold strategy consumes.
+  - id: filter_material
+    type: code
+    depends_on: [dedup_events, classify_event]
+    code_config:
+      language: python
+      code: |
+        dd = _steps.get('dedup_events') or {}
+        events = dd.get('new_events', [])
+        label = str(_steps.get('classify_event') or '').strip().lower()
+
+        try:
+            min_amount = float(_input.get('min_round_amount_usd', 5000000) or 0)
+        except (TypeError, ValueError):
+            min_amount = 0.0
+
+        material = []
+        for e in events:
+            amount = float(e.get('amount_usd') or 0.0)
+            multi_sourced = int(e.get('source_count') or 1) >= 2
+            # material if the disclosed amount clears the floor, OR it is undisclosed but
+            # corroborated by 2+ independent sources (a coverage signal worth a human look).
+            is_material = (amount >= min_amount) or (amount <= 0 and multi_sourced)
+            if is_material and not e.get('previously_seen'):
+                material.append(dict(e, event_label=label, is_material=True))
+
+        # gate booleans pre-computed in code so the non-LLM strategy reasons over pure arithmetic.
+        max_amount = max([float(e.get('amount_usd') or 0.0) for e in material], default=0.0)
+        any_above_floor = any(float(e.get('amount_usd') or 0.0) >= min_amount for e in material)
+
+        result = {
+            'min_round_amount_usd': min_amount,
+            'material_count': len(material),
+            'material_events': material,
+            'max_amount_usd': max_amount,
+            'any_above_floor': any_above_floor,
+            'has_material': len(material) > 0,
+            'all_previously_seen': len(material) == 0,
+        }
+
+  # 7) CONDITION - only run the relevance gate + CRM writes when there is at least one material,
+  #    genuinely-new event. A sweep with nothing new skips straight to the quiet digest. No model.
+  - id: route_material
+    type: condition
+    depends_on: [filter_material]
+    condition_config:
+      expression: "{steps.filter_material.output.has_material}"
+      then: [relevance_gate, upsert_hubspot, append_sheet, write_ledger, notify_new_deals]
+      else: [notify_clean]
+
+  # 8) RELEVANCE GATE (swappable + model-independent). TWO strategies, BOTH must pass:
+  #    (1) llm_eval relevance judge - "are these real, on-thesis funding/M&A events, not press
+  #        chatter or off-thesis noise?", model pinned to a SWAPPABLE provider (any of the 7);
+  #    (2) llm_eval acting as a DETERMINISTIC threshold - fed ONLY the pre-computed
+  #        max_amount_usd / any_above_floor / material_count booleans and told to answer purely
+  #        from the arithmetic, so an event set still passes/fails the gate on the non-LLM math.
+  - id: relevance_gate
+    type: gate
+    depends_on: [filter_material]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are a venture deal-flow analyst. The radar has deterministically deduped a set
+              of funding / M&A events and confirmed each is new (not seen on a prior sweep). Decide
+              whether these are REAL, on-thesis financing / acquisition events worth surfacing to
+              the deal team, or off-thesis noise / pure rumor / recycled coverage. Answer exactly
+              'approved' if the set is materially relevant to the watch list, otherwise answer
+              'rejected' and name the reason. Judge relevance only; the dollar threshold is checked
+              separately.
+            input: "Watch list: {input.watch_entities}. Material new events: {steps.filter_material.output.material_events}"
+            model: "{input.gate_model}"
+        - type: llm_eval
+          config:
+            prompt: >-
+              Deterministic threshold check. Answer exactly 'approved' if material_count >= 1 AND
+              (any_above_floor is True OR max_amount_usd >= {input.min_round_amount_usd}); otherwise
+              answer 'rejected'. Use ONLY the supplied numbers and booleans - do not infer or reason
+              beyond the arithmetic comparison.
+            input: "material_count={steps.filter_material.output.material_count} any_above_floor={steps.filter_material.output.any_above_floor} max_amount_usd={steps.filter_material.output.max_amount_usd} floor={input.min_round_amount_usd}"
+            model: haiku
+
+  # 9) UPSERT the new rounds to HubSpot as deal records so the CRM pipeline reflects fresh
+  #    activity automatically. Connector: hubspot. on_failure: skip so a CRM hiccup never loses
+  #    the sheet append + ledger write.
+  - id: upsert_hubspot
+    type: http
+    http_config:
+      url: "{input.hubspot_base_url}/crm/v3/objects/deals/batch/upsert"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.HUBSPOT_API_TOKEN}"
+      body: |
+        {
+          "inputs": [
+            {
+              "idProperty": "deal_fingerprint",
+              "properties": {
+                "dealname": "Funding/M&A radar - {steps.filter_material.output.material_count} new event(s)",
+                "deal_radar_payload": "{steps.filter_material.output.material_events}",
+                "pipeline": "default"
+              }
+            }
+          ]
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 10) APPEND the same new rounds to a shared Google Sheet as a human-readable deal log.
+  #     Connector: google-sheets. on_failure: skip.
+  - id: append_sheet
+    type: http
+    http_config:
+      url: "{input.sheet_append_url}"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.GOOGLE_SHEETS_TOKEN}"
+      body: |
+        {
+          "majorDimension": "ROWS",
+          "values": [
+            ["{steps.filter_material.output.material_count} new deals", "max ${steps.filter_material.output.max_amount_usd}", "{steps.filter_material.output.material_events}"]
+          ]
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 11) DETERMINISTIC build of the REFRESHED dedup ledger payload. NO model. Fold every material
+  #     new event's fingerprint + canonical URL into upsert rows so the NEXT sweep treats these
+  #     deals as already-seen and never chases the same headline twice. This closes the loop.
+  - id: build_ledger_update
+    type: code
+    depends_on: [filter_material]
+    code_config:
+      language: python
+      code: |
+        import json
+        from datetime import datetime, timezone
+
+        fm = _steps.get('filter_material') or {}
+        events = fm.get('material_events', [])
+        now = datetime.now(timezone.utc).isoformat()
+
+        rows = []
+        for e in events:
+            rows.append({
+                'fingerprint': e.get('fingerprint'),
+                'canonical_url': (e.get('source_urls') or [''])[0],
+                'company': e.get('company'),
+                'stage': e.get('stage'),
+                'amount_usd': e.get('amount_usd'),
+                'source_count': e.get('source_count'),
+                'first_seen_at': now,
+            })
+
+        result = {
+            'sweep_at': now,
+            'new_fingerprint_count': len(rows),
+            'rows': rows,
+            'payload_json': json.dumps({'fingerprints': rows}, separators=(',', ':')),
+        }
+
+  # 12) WRITE the refreshed ledger back to the dedup store (PUT/upsert). The prior-seen set the
+  #     NEXT sweep merges against. Connector: the ledger store REST gateway. on_failure: abort so
+  #     a failed ledger write surfaces loudly (otherwise the same deals re-fire next sweep).
+  - id: write_ledger
+    type: http
+    depends_on: [build_ledger_update]
+    http_config:
+      url: "{input.ledger_store_url}/fingerprints?on_conflict=fingerprint"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+        Prefer: "resolution=merge-duplicates"
+      auth: "bearer:{env.LEDGER_STORE_TOKEN}"
+      body: "{steps.build_ledger_update.output.payload_json}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 13) NOTIFY (new deals) - push the deduped new-deal digest to the deal channel with the
+  #     dedup stats so the team sees fresh rounds the moment they land. service: slack.
+  - id: notify_new_deals
+    type: notify
+    depends_on: [filter_material]
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :money_with_wings: DEAL RADAR - {steps.filter_material.output.material_count} new funding / M&A event(s)
+        Raw articles pulled : {steps.dedup_events.output.raw_article_count}
+        After dedup         : {steps.dedup_events.output.after_fingerprint_dedup}
+        Already-seen dropped: {steps.dedup_events.output.previously_seen_dropped}
+        Largest round       : ${steps.filter_material.output.max_amount_usd}
+        New events          : {steps.filter_material.output.material_events}
+        Upserted to HubSpot + appended to the deal sheet. Ledger refreshed - these will not re-fire next sweep.
+
+  # 14) NOTIFY (clean) - quiet "nothing new this sweep" digest. No CRM write, no ledger churn.
+  - id: notify_clean
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :white_check_mark: Deal radar sweep clean - {steps.dedup_events.output.raw_article_count} articles pulled, {steps.dedup_events.output.after_fingerprint_dedup} unique deals, {steps.dedup_events.output.previously_seen_dropped} already-seen dropped, 0 new material rounds. No CRM write.
+on_complete:
+  storage_path: "funding-and-ma-radar-dedup/{run_id}/result.json"

--- a/src/sandcastle/templates/inbox_to_tasks_triage_router.yaml
+++ b/src/sandcastle/templates/inbox_to_tasks_triage_router.yaml
@@ -1,0 +1,477 @@
+# name: Inbox-to-Tasks Triage Router
+# description: Pulls unread mail, DETERMINISTICALLY extracts dates / deadlines / dollar amounts / action verbs, classifies each message into task vs FYI vs spam, and GATES auto-created calendar/task entries so only confidently-actionable items become tasks - the rest just get notified. http GET pulls the unread messages and POSTs new tasks/events; code carries the load-bearing signal extraction, sender allowlist and dedup; a two-strategy gate (llm_eval actionability judge AND a non-LLM rule: has-a-date-OR-explicit-ask AND trusted-sender) must both pass before any task is created.
+# tags: [inbox, email, triage, tasks, calendar, productivity, GTD, deadlines, dedup, allowlist, gmail, todoist, notify]
+# category: personal
+# connectors: gmail, todoist, google-calendar, slack
+name: inbox-to-tasks-triage-router
+description: >-
+  A personal inbox triage engine that turns unread mail into a clean task list
+  without trusting a model to act on its own. A DETERMINISTIC http GET pulls the
+  unread messages from the mail provider (Gmail / IMAP-REST / Microsoft Graph
+  style), then a code step DETERMINISTICALLY extracts the load-bearing signals
+  from every message in pure Python: date / deadline regexes, dollar-amount
+  detection, action-verb / explicit-ask detection, a sender allowlist check
+  against the trusted_senders list, and a dedup of message ids already seen on a
+  prior run. A swappable CLASSIFY step LABELS each message task / fyi / spam, but
+  the create-or-not decision is NOT left to it. A two-strategy GATE must BOTH
+  pass before any calendar/task entry is auto-created: (1) a swappable llm_eval
+  actionability judge ("is this genuinely something the user must DO?", backable
+  by any provider) AND (2) a NON-LLM rule strategy fed only the pre-computed
+  booleans - it approves only when the message has a date OR an explicit ask AND
+  the sender is on the trusted allowlist. A CONDITION then routes confidently-
+  actionable messages to an http POST that creates the task/event in the task
+  connector, while everything else is only NOTIFIED to the user. A final code
+  step persists the seen message ids so the next run dedups. All extraction, the
+  allowlist, the dedup and the rule strategy are 100% deterministic and run even
+  with zero model providers available; the model is confined to the swappable
+  classifier label and the swappable gate judge.
+default_model: sonnet
+default_max_turns: 8
+default_timeout: 900
+input_schema:
+  required: ["mailbox_url", "tasks_api_url"]
+  properties:
+    mailbox_url:
+      type: string
+      description: "Mail provider unread-messages REST endpoint that returns the inbox of unread messages (Gmail API / IMAP-REST gateway / Microsoft Graph style)."
+      default: "https://gmail.googleapis.com/gmail/v1/users/me/messages?q=is:unread"
+      example: "https://gmail.googleapis.com/gmail/v1/users/me/messages?q=is:unread"
+    tasks_api_url:
+      type: string
+      description: "Task / calendar connector REST base that receives the auto-created task / event entries (Todoist / Google Calendar / Notion style)."
+      default: "https://api.todoist.com/rest/v2"
+      example: "https://api.todoist.com/rest/v2"
+    trusted_senders:
+      type: string
+      description: "DETERMINISTIC allowlist for the gate's rule strategy: comma-separated sender email addresses or domains that are trusted enough to auto-create a task. A message from outside this list can never be auto-actioned."
+      default: "boss@company.com,@company.com,billing@bank.com,calendar-invite@google.com"
+      example: "boss@company.com,@company.com,billing@bank.com"
+    seen_ids_url:
+      type: string
+      description: "Dedup store REST endpoint returning the message ids already triaged on prior runs (key-value / PostgREST / S3 JSON), so the same mail is never turned into a duplicate task."
+      default: "https://kv.internal/inbox-triage/seen-ids"
+      example: "https://kv.internal/inbox-triage/seen-ids"
+    gate_model:
+      type: string
+      description: "Swappable actionability-judge model for the gate. Any of the 7 providers can back it; pin an EU/local provider (mistral/large, ollama, omlx/qwen-3) for private mail. Triage still works with this unavailable - the non-LLM rule strategy stands alone."
+      default: "sonnet"
+      example: "mistral/large"
+    project_id:
+      type: string
+      description: "Target project / calendar id in the task connector that new entries are filed under."
+      default: "Inbox"
+      example: "2298765432"
+    slack_channel:
+      type: string
+      description: "Personal Slack channel / DM that receives the triage digest and the FYI / spam items that were NOT turned into tasks."
+      default: "#my-inbox-triage"
+      example: "#my-inbox-triage"
+steps:
+  # 1) DETERMINISTIC http GET of the unread messages from the mail provider. No model.
+  #    Returns the raw unread inbox the rest of the pipeline normalizes and triages.
+  - id: fetch_unread_mail
+    type: http
+    http_config:
+      url: "{input.mailbox_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.MAILBOX_API_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 2) DETERMINISTIC http GET of the already-seen message ids from the dedup store, so a
+  #    message that was triaged on a prior run is never turned into a duplicate task. No model.
+  - id: fetch_seen_ids
+    type: http
+    depends_on: [fetch_unread_mail]
+    http_config:
+      url: "{input.seen_ids_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.SEEN_STORE_TOKEN}"
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  # 3) DETERMINISTIC signal extraction - the load-bearing prep. NO model. For every unread
+  #    message: parse dates / deadlines (regex), detect dollar amounts, detect action verbs /
+  #    explicit asks, check the sender against the trusted_senders allowlist, and DROP any
+  #    message id already in the seen-ids dedup set. Emits one normalized, scored row per
+  #    fresh message that the classifier labels and the gate's rule strategy consumes.
+  - id: extract_signals
+    type: code
+    depends_on: [fetch_unread_mail, fetch_seen_ids]
+    code_config:
+      language: python
+      code: |
+        import re
+
+        raw = _steps.get('fetch_unread_mail') or {}
+        seen_raw = _steps.get('fetch_seen_ids') or {}
+
+        # --- coalesce the provider payload into a list of message dicts (vendor-agnostic).
+        if isinstance(raw, list):
+            rows = raw
+        elif isinstance(raw, dict):
+            rows = (raw.get('messages') or raw.get('value') or raw.get('data')
+                    or raw.get('items') or raw.get('results') or [])
+        else:
+            rows = []
+        if not isinstance(rows, list):
+            rows = [rows] if rows else []
+
+        # --- already-seen ids for dedup (accepts a bare list or a wrapped dict).
+        if isinstance(seen_raw, list):
+            seen_list = seen_raw
+        elif isinstance(seen_raw, dict):
+            seen_list = (seen_raw.get('seen_ids') or seen_raw.get('ids')
+                         or seen_raw.get('data') or seen_raw.get('value') or [])
+        else:
+            seen_list = []
+        seen_ids = {str(s).strip() for s in seen_list if str(s).strip()}
+
+        # --- trusted-sender allowlist (emails OR @domains), lowercased.
+        allow_raw = str(_input.get('trusted_senders') or '')
+        allowlist = {a.strip().lower() for a in allow_raw.replace(';', ',').split(',') if a.strip()}
+
+        # --- deterministic detectors --------------------------------------------------
+        # Dates: ISO 8601, slash dates, and month-name dates. Pattern strings only (no compile).
+        date_patterns = [
+            r'\b\d{4}-\d{2}-\d{2}\b',
+            r'\b\d{1,2}/\d{1,2}/\d{2,4}\b',
+            r'\b(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\.?\s+\d{1,2}(?:st|nd|rd|th)?\b',
+        ]
+        deadline_words = ('deadline', 'due', 'by eod', 'by end of', 'no later than',
+                          'expires', 'expiry', 'last day', 'before', 'asap', 'rsvp')
+        # Action verbs / explicit asks - the "you must DO something" signal.
+        ask_words = ('please', 'can you', 'could you', 'need you to', 'action required',
+                     'review', 'approve', 'sign', 'submit', 'send', 'confirm', 'schedule',
+                     'pay', 'complete', 'respond', 'reply', 'call', 'book', 'register')
+        # Dollar amounts: $1,234.56  /  1234 USD  /  EUR 99
+        amount_patterns = [
+            r'[$€£]\s?\d[\d,]*(?:\.\d{1,2})?',
+            r'\b\d[\d,]*(?:\.\d{1,2})?\s?(?:usd|eur|gbp|czk|dollars|euros)\b',
+        ]
+
+        def _sender_of(rec):
+            for k in ('from', 'sender', 'from_email', 'fromAddress', 'reply_to'):
+                v = rec.get(k)
+                if isinstance(v, dict):
+                    v = v.get('email') or v.get('address') or v.get('value') or ''
+                if v:
+                    return str(v).strip().lower()
+            return ''
+
+        def _trusted(sender):
+            if not sender or not allowlist:
+                return False
+            if sender in allowlist:
+                return True
+            dom = sender.split('@')[-1] if '@' in sender else ''
+            return ('@' + dom) in allowlist or dom in allowlist
+
+        messages = []
+        skipped_dupes = 0
+        for rec in rows:
+            if not isinstance(rec, dict):
+                continue
+            mid = str(rec.get('id') or rec.get('message_id') or rec.get('uid') or '').strip()
+            if mid and mid in seen_ids:
+                skipped_dupes += 1
+                continue
+
+            subject = str(rec.get('subject') or rec.get('title') or '').strip()
+            body = str(rec.get('snippet') or rec.get('body') or rec.get('text')
+                       or rec.get('preview') or '').strip()
+            sender = _sender_of(rec)
+            hay = (subject + ' ' + body).lower()
+
+            # date / deadline detection
+            found_dates = []
+            for pat in date_patterns:
+                found_dates.extend(re.findall(pat, hay, flags=re.IGNORECASE))
+            has_date = bool(found_dates)
+            has_deadline = any(w in hay for w in deadline_words)
+
+            # dollar-amount detection
+            found_amounts = []
+            for pat in amount_patterns:
+                found_amounts.extend(re.findall(pat, hay, flags=re.IGNORECASE))
+            has_amount = bool(found_amounts)
+
+            # action-verb / explicit-ask detection
+            matched_asks = [w for w in ask_words if w in hay]
+            has_ask = bool(matched_asks)
+
+            trusted = _trusted(sender)
+
+            # Deterministic rule-strategy verdict, pre-computed for the gate:
+            # actionable_by_rule = (has a date/deadline OR an explicit ask) AND trusted sender.
+            actionable_by_rule = bool((has_date or has_deadline or has_ask) and trusted)
+
+            # Lightweight signal score for ordering / the classifier prompt.
+            signal_score = (
+                (2 if has_date else 0) + (2 if has_deadline else 0)
+                + (2 if has_ask else 0) + (1 if has_amount else 0)
+                + (1 if trusted else 0)
+            )
+
+            messages.append({
+                'id': mid,
+                'subject': subject,
+                'snippet': body[:400],
+                'sender': sender,
+                'trusted_sender': trusted,
+                'has_date': has_date,
+                'dates': found_dates[:5],
+                'has_deadline': has_deadline,
+                'has_amount': has_amount,
+                'amounts': [str(a).strip() for a in found_amounts[:5]],
+                'has_ask': has_ask,
+                'matched_asks': matched_asks[:8],
+                'signal_score': signal_score,
+                'actionable_by_rule': actionable_by_rule,
+            })
+
+        messages.sort(key=lambda m: m['signal_score'], reverse=True)
+
+        result = {
+            'fetched_count': len(rows),
+            'skipped_duplicates': skipped_dupes,
+            'fresh_count': len(messages),
+            'messages': messages,
+            'has_messages': len(messages) > 0,
+        }
+
+  # 4) LOOP over each fresh message: a swappable CLASSIFY labels it, then a CONDITION on the
+  #    deterministic rule verdict routes it into the actionability gate or straight to the
+  #    FYI/notify bucket. Per-message child chain runs once per message.
+  - id: per_message_loop
+    type: loop
+    depends_on: [extract_signals]
+    loop_config:
+      over: "steps.extract_signals.output.messages"
+      step_ids:
+        - classify_message
+        - route_message
+      max_iterations: 500
+
+  # 4a) CLASSIFY (swappable) - LABEL the message task / fyi / spam. The model only LABELS;
+  #     the create-or-not decision is made by the deterministic rule + the gate, not here.
+  - id: classify_message
+    type: classify
+    classify_config:
+      model: haiku
+      input: >-
+        Classify this unread email into exactly one bucket using the pre-computed
+        deterministic signals. task = the recipient must DO something (it has a date /
+        deadline or an explicit ask). fyi = informational, no action required. spam =
+        promotional / unsolicited / junk. Subject: {input._item.subject} | From:
+        {input._item.sender} | has_date={input._item.has_date}
+        has_deadline={input._item.has_deadline} has_ask={input._item.has_ask}
+        has_amount={input._item.has_amount} trusted_sender={input._item.trusted_sender} |
+        Snippet: {input._item.snippet}
+      categories:
+        - task
+        - fyi
+        - spam
+      branches:
+        task: [route_message]
+        fyi: [route_message]
+        spam: [route_message]
+
+  # 4b) CONDITION - route on the DETERMINISTIC rule verdict (not the model label), so routing
+  #     survives a missing model provider. Only messages the rule strategy already deemed
+  #     actionable enter the gate; everything else goes straight to the FYI/notify bucket. No model.
+  - id: route_message
+    type: condition
+    condition_config:
+      expression: "{steps.extract_signals.output} and {input._item.actionable_by_rule}"
+      then: [actionability_gate, create_task]
+      else: [collect_message]
+
+  # 4c) ACTIONABILITY GATE (swappable + model-independent). TWO strategies, BOTH must pass
+  #     before a task is auto-created: (1) a swappable llm_eval actionability judge -
+  #     "is this genuinely something the user must DO?" (any of the 7 providers can back it);
+  #     (2) an llm_eval acting as a DETERMINISTIC rule check, fed ONLY the pre-computed booleans
+  #     (has_date / has_deadline / has_ask + trusted_sender) and told to answer purely from the
+  #     rule, so a message still passes/fails the gate on the non-LLM rule alone.
+  - id: actionability_gate
+    type: gate
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are a personal-assistant actionability judge. A message was flagged as
+              possibly requiring action. Decide whether it is GENUINELY something the user
+              must DO (a real task with an outcome), versus noise that merely mentions a date
+              or a polite word. Answer exactly 'approved' if it should become a real task,
+              otherwise 'rejected' and name the reason. Judge actionability only; the rule
+              eligibility is checked separately.
+            input: "Subject: {input._item.subject} | From: {input._item.sender} | dates={input._item.dates} amounts={input._item.amounts} asks={input._item.matched_asks} | Snippet: {input._item.snippet}"
+            model: "{input.gate_model}"
+        - type: llm_eval
+          config:
+            prompt: >-
+              Deterministic rule check. Answer exactly 'approved' if (has_date is True OR
+              has_deadline is True OR has_ask is True) AND trusted_sender is True; otherwise
+              answer 'rejected'. Use ONLY the supplied booleans - do not infer or reason
+              beyond the logical comparison.
+            input: "has_date={input._item.has_date} has_deadline={input._item.has_deadline} has_ask={input._item.has_ask} trusted_sender={input._item.trusted_sender}"
+            model: haiku
+
+  # 4d) http POST - CREATE the task / calendar entry in the task connector. Only reached when
+  #     the message was rule-eligible AND both gate strategies passed. Connector: todoist / gcal.
+  - id: create_task
+    type: http
+    http_config:
+      url: "{input.tasks_api_url}/tasks"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.TASKS_API_TOKEN}"
+      body: |
+        {
+          "project_id": "{input.project_id}",
+          "content": "{input._item.subject}",
+          "description": "Auto-triaged from inbox. From: {input._item.sender}. {input._item.snippet}",
+          "labels": ["inbox-triage"],
+          "source_message_id": "{input._item.id}"
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 4e) DETERMINISTIC per-message collector. Folds the classify label, the rule verdict and
+  #     whether a task was created into one canonical row the post-loop aggregator reads. No model.
+  - id: collect_message
+    type: code
+    code_config:
+      language: python
+      code: |
+        msg = _input.get('_item') or {}
+        label = str(_steps.get('classify_message') or '').strip().lower()
+        gate = _steps.get('actionability_gate')
+        created = _steps.get('create_task')
+
+        # Did the gate run, and did all strategies pass?
+        gate_ran = gate is not None
+        if isinstance(gate, dict):
+            gate_passed = bool(gate.get('passed', gate.get('approved', gate.get('result', False))))
+        else:
+            gate_passed = bool(gate) if gate is not None else False
+
+        task_created = created is not None
+
+        if task_created and gate_ran and gate_passed:
+            outcome = 'task_created'
+        elif gate_ran and not gate_passed:
+            outcome = 'gate_rejected'      # rule-eligible but the gate ruled it not actionable
+        else:
+            outcome = 'fyi'                # never entered the gate: informational / spam
+
+        result = {
+            'id': msg.get('id'),
+            'subject': msg.get('subject'),
+            'sender': msg.get('sender'),
+            'classify_label': label,
+            'actionable_by_rule': bool(msg.get('actionable_by_rule')),
+            'trusted_sender': bool(msg.get('trusted_sender')),
+            'has_date': bool(msg.get('has_date')),
+            'has_deadline': bool(msg.get('has_deadline')),
+            'has_ask': bool(msg.get('has_ask')),
+            'has_amount': bool(msg.get('has_amount')),
+            'gate_ran': gate_ran,
+            'gate_passed': gate_passed if gate_ran else None,
+            'outcome': outcome,
+        }
+
+  # 5) DETERMINISTIC aggregation of every per-message outcome from the loop. Splits
+  #     created-tasks / FYI / gate-rejected, and rebuilds the FULL fresh-id set so the dedup
+  #     store can be updated to never re-triage these messages. No model.
+  - id: aggregate_triage
+    type: code
+    depends_on: [per_message_loop, extract_signals]
+    code_config:
+      language: python
+      code: |
+        loop_out = _steps.get('per_message_loop') or {}
+        extracted = _steps.get('extract_signals') or {}
+
+        items = loop_out if isinstance(loop_out, list) else (
+            loop_out.get('results') or loop_out.get('items') or loop_out.get('iterations') or []
+        )
+
+        rows = []
+        for it in items:
+            row = it
+            if isinstance(it, dict) and 'outcome' not in it:
+                row = it.get('collect_message') or it.get('output') or it
+            if isinstance(row, dict) and row.get('id') is not None:
+                rows.append(row)
+
+        created = [r for r in rows if r.get('outcome') == 'task_created']
+        rejected = [r for r in rows if r.get('outcome') == 'gate_rejected']
+        fyi = [r for r in rows if r.get('outcome') == 'fyi']
+
+        # Every fresh message id triaged this run, to append to the dedup store.
+        fresh_messages = extracted.get('messages', [])
+        all_fresh_ids = [str(m.get('id')) for m in fresh_messages if m.get('id')]
+
+        result = {
+            'fresh_count': extracted.get('fresh_count', 0),
+            'skipped_duplicates': extracted.get('skipped_duplicates', 0),
+            'created_count': len(created),
+            'rejected_count': len(rejected),
+            'fyi_count': len(fyi),
+            'created_tasks': created,
+            'fyi_items': fyi + rejected,
+            'seen_ids': all_fresh_ids,
+            'has_created': len(created) > 0,
+        }
+
+  # 6) DETERMINISTIC persist of the seen message ids to the dedup store so the NEXT run skips
+  #     these messages. http PUT of the full fresh-id set. No model.
+  - id: persist_seen_ids
+    type: http
+    depends_on: [aggregate_triage]
+    http_config:
+      url: "{input.seen_ids_url}"
+      method: PUT
+      headers:
+        Content-Type: "application/json"
+      auth: "bearer:{env.SEEN_STORE_TOKEN}"
+      body: |
+        {
+          "seen_ids": {{ _steps['aggregate_triage']['seen_ids'] }}
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 7) NOTIFY the user with the triage digest: how many tasks were auto-created, and the
+  #     FYI / not-actioned items that were deliberately NOT turned into tasks. service: slack.
+  - id: notify_digest
+    type: notify
+    depends_on: [persist_seen_ids]
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :inbox_tray: Inbox triage complete - {steps.aggregate_triage.output.fresh_count} fresh, {steps.aggregate_triage.output.skipped_duplicates} dupes skipped
+        :white_check_mark: Auto-created tasks : {steps.aggregate_triage.output.created_count}
+        :no_entry_sign: Gate-rejected (not actionable): {steps.aggregate_triage.output.rejected_count}
+        :information_source: FYI / not actioned : {steps.aggregate_triage.output.fyi_count}
+        Tasks: {steps.aggregate_triage.output.created_tasks}
+        FYI items (review manually): {steps.aggregate_triage.output.fyi_items}
+on_complete:
+  storage_path: "inbox-to-tasks-triage-router/{run_id}/result.json"

--- a/src/sandcastle/templates/literature_source_triage_race.yaml
+++ b/src/sandcastle/templates/literature_source_triage_race.yaml
@@ -1,0 +1,490 @@
+# name: Multi-Source Literature & Source Triage
+# description: Research-triage engine that RACES the same topic query across several academic/source providers (firecrawl crawl, exa search, an arXiv/Semantic-Scholar-style http endpoint) and takes the first that returns a usable candidate list (provider failover, NOT a vote). A DETERMINISTIC code step normalizes each record, dedups by DOI then by lowercased-punctuation-stripped title, and computes a transparent 0-1 triage score from topic token-overlap + citation count + recency decay - never a model. A swappable CLASSIFY labels on/off/adjacent-topic and a two-strategy GATE pairs an llm_eval relevance reviewer with a mandatory HUMAN analyst sign-off so nothing enters the corpus unreviewed. Kept papers are embedded and upserted to Qdrant.
+# tags: [LiteratureReview, ResearchTriage, Dedup, DOI, Citations, RecencyDecay, arXiv, SemanticScholar, Exa, Firecrawl, Qdrant, VectorStore, race, classify, gate]
+# category: research_intel
+# connectors: firecrawl, exa, qdrant, slack
+name: literature-source-triage-race
+description: >-
+  A provider-neutral research-triage pipeline that turns a topic into a reviewed,
+  embedded shortlist. A cross-provider RACE fans the same topic query out to several
+  source providers in parallel - a firecrawl crawl of a literature index, an exa
+  neural search, and an arXiv / Semantic-Scholar-style http endpoint - and takes the
+  FIRST provider that returns a usable candidate list (provider failover, NOT a vote).
+  A DETERMINISTIC code step then normalizes each record into one shape, dedups first by
+  normalized DOI and then by a lowercased / punctuation-stripped title key, and computes
+  a transparent 0-1 triage score from three model-independent signals: token-overlap with
+  the research topic, a log-scaled citation count, and an exponential recency decay - the
+  load-bearing ranking is pure arithmetic, never a model. A swappable CLASSIFY labels each
+  shortlisted paper on_topic / adjacent_topic / off_topic (the only model in the path, and
+  it only labels). A two-strategy GATE then pairs an llm_eval relevance reviewer with a
+  MANDATORY human analyst sign-off, so no paper enters the corpus unreviewed. Kept papers
+  are embedded and upserted to a Qdrant collection, and a NOTIFY posts the triage digest to
+  the research channel. The dedup and scoring math are 100% deterministic and run even with
+  zero model providers available; the model is confined to the swappable classifier and the
+  gate's swappable relevance judge.
+default_model: sonnet
+default_max_turns: 8
+default_timeout: 1200
+input_schema:
+  required: ["research_topic", "source_provider_urls", "vector_collection"]
+  properties:
+    research_topic:
+      type: string
+      description: "The research topic / question to triage literature for. Drives the race query and the token-overlap relevance signal."
+      default: "retrieval-augmented generation for long-context legal question answering"
+      example: "retrieval-augmented generation for long-context legal question answering"
+    source_provider_urls:
+      type: string
+      description: "Comma-separated source-provider base URLs raced in parallel, in priority order: firecrawl crawl, exa search, an arXiv/Semantic-Scholar-style endpoint. First usable list wins."
+      default: "https://api.firecrawl.dev/v1/crawl,https://api.exa.ai/search,https://api.semanticscholar.org/graph/v1/paper/search"
+      example: "https://api.firecrawl.dev/v1/crawl,https://api.exa.ai/search,https://api.semanticscholar.org/graph/v1/paper/search"
+    min_triage_score:
+      type: number
+      description: "Deterministic triage score (0-1) at or above which a paper is shortlisted for human review. The gate's non-LLM strategy also enforces this floor."
+      default: 0.45
+      example: "0.45"
+    vector_collection:
+      type: string
+      description: "Qdrant collection name the kept, reviewed papers are embedded and upserted into."
+      default: "rag-legal-qa-corpus"
+      example: "rag-legal-qa-corpus"
+    max_shortlist:
+      type: integer
+      description: "Maximum number of top-ranked papers carried into classification + human review (keeps the analyst gate bounded)."
+      default: 25
+      example: "25"
+    recency_half_life_days:
+      type: number
+      description: "Half-life in days for the exponential recency-decay signal. A paper this old contributes half the recency weight of a brand-new one."
+      default: 540
+      example: "540"
+    qdrant_base_url:
+      type: string
+      description: "Qdrant REST base URL the kept papers are upserted to."
+      default: "https://your-cluster.qdrant.io"
+      example: "https://acme-xyz.eu-central-1-0.aws.cloud.qdrant.io:6333"
+    gate_model:
+      type: string
+      description: "Swappable relevance-judge model for the gate. Any provider can back it; for regulated data pin an EU/local provider (mistral/large, ollama, omlx/qwen-3). Triage works with this unavailable."
+      default: "sonnet"
+      example: "mistral/large"
+    slack_channel:
+      type: string
+      description: "Research channel that receives the triage digest."
+      default: "#research-literature-triage"
+      example: "#research-literature-triage"
+steps:
+  # 1) DETERMINISTIC query prep. Split the comma-separated provider URLs into ordered race
+  #    branches, build the topic token set the overlap signal uses, and emit the query string.
+  #    No model.
+  - id: prepare_query
+    type: code
+    code_config:
+      language: python
+      code: |
+        import re
+
+        topic = str(_input.get('research_topic') or '').strip()
+        urls_raw = str(_input.get('source_provider_urls') or '')
+        provider_urls = [u.strip() for u in urls_raw.replace(';', ',').split(',') if u.strip()]
+
+        # --- Topic token set (lowercased, alnum, stopwords dropped) for the overlap signal.
+        stop = {
+            'the', 'a', 'an', 'of', 'for', 'and', 'or', 'to', 'in', 'on', 'with',
+            'using', 'via', 'by', 'from', 'at', 'as', 'is', 'are', 'be',
+        }
+        words = re.sub(r'[^a-z0-9 ]+', ' ', topic.lower()).split()
+        topic_tokens = sorted({w for w in words if w and w not in stop and len(w) > 2})
+
+        result = {
+            'research_topic': topic,
+            'query_string': topic,
+            'topic_tokens': topic_tokens,
+            'provider_urls': provider_urls,
+            'provider_count': len(provider_urls),
+            # Resolve the three priority URLs by position with safe fallbacks.
+            'firecrawl_url': provider_urls[0] if len(provider_urls) > 0 else 'https://api.firecrawl.dev/v1/crawl',
+            'exa_url': provider_urls[1] if len(provider_urls) > 1 else 'https://api.exa.ai/search',
+            'scholar_url': provider_urls[2] if len(provider_urls) > 2 else 'https://api.semanticscholar.org/graph/v1/paper/search',
+        }
+
+  # 2) CROSS-PROVIDER RACE. Fan the SAME topic query across three source providers in parallel;
+  #    the FIRST provider that returns a usable candidate list wins (provider failover, NOT a
+  #    vote). Each branch is a different connector. Branch steps are DEFINED SEPARATELY with no
+  #    depends_on so the race owns their scheduling.
+  - id: crawl_firecrawl
+    type: http
+    http_config:
+      url: "{steps.prepare_query.output.firecrawl_url}"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.FIRECRAWL_API_KEY}"
+      body: |
+        {
+          "query": "{steps.prepare_query.output.query_string}",
+          "limit": 30,
+          "scrapeOptions": {"formats": ["markdown"]}
+        }
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  - id: search_exa
+    type: http
+    http_config:
+      url: "{steps.prepare_query.output.exa_url}"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.EXA_API_KEY}"
+      body: |
+        {
+          "query": "{steps.prepare_query.output.query_string}",
+          "numResults": 30,
+          "category": "research paper",
+          "type": "neural",
+          "contents": {"text": true}
+        }
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  - id: search_scholar
+    type: http
+    http_config:
+      url: "{steps.prepare_query.output.scholar_url}?query={steps.prepare_query.output.query_string}&limit=30&fields=title,abstract,year,citationCount,externalIds,url"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.SEMANTIC_SCHOLAR_API_KEY}"
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  - id: source_race
+    type: race
+    depends_on: [prepare_query]
+    race_config:
+      branches:
+        - [crawl_firecrawl]
+        - [search_exa]
+        - [search_scholar]
+      validator: "len(str(output).strip()) > 0"
+
+  # 3) DETERMINISTIC normalize + DEDUP + SCORE. The load-bearing decision. NO model.
+  #    Flatten whichever provider won the race into a uniform record shape, dedup first by
+  #    normalized DOI then by a lowercased / punctuation-stripped title key, then compute a
+  #    transparent 0-1 triage score = 0.5*token_overlap + 0.3*log_citation + 0.2*recency_decay.
+  - id: dedup_and_score
+    type: code
+    depends_on: [source_race, prepare_query]
+    code_config:
+      language: python
+      code: |
+        import re
+        import math
+        from datetime import datetime, timezone
+
+        prep = _steps.get('prepare_query') or {}
+        raw = _steps.get('source_race')
+        topic_tokens = set(prep.get('topic_tokens') or [])
+        half_life = float(_input.get('recency_half_life_days', 540) or 540)
+        max_shortlist = int(_input.get('max_shortlist', 25) or 25)
+        min_score = float(_input.get('min_triage_score', 0.45) or 0.45)
+
+        # The winning provider payload can be a dict or list in several shapes; coalesce.
+        if isinstance(raw, dict):
+            rows = (raw.get('data') or raw.get('results') or raw.get('hits')
+                    or raw.get('papers') or raw.get('content') or [])
+        elif isinstance(raw, list):
+            rows = raw
+        else:
+            rows = []
+        if not isinstance(rows, list):
+            rows = [rows] if rows else []
+
+        now = datetime.now(timezone.utc)
+
+        def norm_doi(value):
+            s = str(value or '').strip().lower()
+            s = re.sub(r'^https?://(dx\.)?doi\.org/', '', s)
+            s = re.sub(r'^doi:', '', s).strip()
+            return s
+
+        def title_key(value):
+            # Lowercase, strip punctuation, collapse whitespace - the secondary dedup key.
+            s = re.sub(r'[^a-z0-9 ]+', ' ', str(value or '').lower())
+            s = re.sub(r'\s+', ' ', s).strip()
+            return s
+
+        def extract_year(rec):
+            y = rec.get('year') or rec.get('publishedYear')
+            if y:
+                try:
+                    return int(str(y)[:4])
+                except (ValueError, TypeError):
+                    pass
+            for k in ('publishedDate', 'published', 'date'):
+                v = rec.get(k)
+                if v:
+                    m = re.search(r'(\d{4})', str(v))
+                    if m:
+                        return int(m.group(1))
+            return None
+
+        def get_doi(rec):
+            ext = rec.get('externalIds') if isinstance(rec.get('externalIds'), dict) else {}
+            return norm_doi(rec.get('doi') or ext.get('DOI') or ext.get('doi') or '')
+
+        normalized = []
+        for rec in rows:
+            if not isinstance(rec, dict):
+                # Bare string/URL result (some crawlers) - keep with empty metadata.
+                rec = {'title': str(rec)[:300], 'url': str(rec)}
+            title = str(rec.get('title') or rec.get('name') or rec.get('heading') or '').strip()
+            if not title:
+                continue
+            abstract = str(rec.get('abstract') or rec.get('summary') or rec.get('text') or rec.get('snippet') or '').strip()
+            url = str(rec.get('url') or rec.get('link') or rec.get('id') or '').strip()
+            try:
+                citations = int(rec.get('citationCount') or rec.get('citations') or rec.get('citation_count') or 0)
+            except (ValueError, TypeError):
+                citations = 0
+            year = extract_year(rec)
+            normalized.append({
+                'title': title,
+                'abstract': abstract[:1200],
+                'url': url,
+                'doi': get_doi(rec),
+                'citations': max(0, citations),
+                'year': year,
+                'title_key': title_key(title),
+            })
+
+        # --- DEDUP: first by normalized DOI, then by title key. Keep the higher-citation copy.
+        by_doi = {}
+        by_title = {}
+        deduped = []
+        for rec in normalized:
+            doi = rec['doi']
+            tkey = rec['title_key']
+            existing_idx = None
+            if doi and doi in by_doi:
+                existing_idx = by_doi[doi]
+            elif tkey and tkey in by_title:
+                existing_idx = by_title[tkey]
+            if existing_idx is not None:
+                # Duplicate: keep whichever has more citations / more metadata.
+                if rec['citations'] > deduped[existing_idx]['citations']:
+                    deduped[existing_idx] = rec
+                    if doi:
+                        by_doi[doi] = existing_idx
+                    if tkey:
+                        by_title[tkey] = existing_idx
+                continue
+            idx = len(deduped)
+            deduped.append(rec)
+            if doi:
+                by_doi[doi] = idx
+            if tkey:
+                by_title[tkey] = idx
+
+        duplicates_removed = len(normalized) - len(deduped)
+
+        # --- TRANSPARENT 0-1 TRIAGE SCORE. Three model-independent signals.
+        for rec in deduped:
+            # (a) token-overlap with the research topic (Jaccard of content tokens vs topic).
+            content = (rec['title'] + ' ' + rec['abstract']).lower()
+            cwords = set(re.sub(r'[^a-z0-9 ]+', ' ', content).split())
+            inter = topic_tokens & cwords
+            overlap = (len(inter) / len(topic_tokens)) if topic_tokens else 0.0
+
+            # (b) log-scaled citation count, capped at 1.0 around ~1000 citations.
+            citation_signal = min(1.0, math.log10(rec['citations'] + 1) / 3.0)
+
+            # (c) exponential recency decay vs now using the configured half-life.
+            if rec['year']:
+                age_days = max(0.0, (now.year - rec['year']) * 365.25)
+                recency = 0.5 ** (age_days / half_life) if half_life > 0 else 0.0
+            else:
+                recency = 0.0
+
+            score = round(0.5 * overlap + 0.3 * citation_signal + 0.2 * recency, 4)
+            rec['token_overlap'] = round(overlap, 4)
+            rec['citation_signal'] = round(citation_signal, 4)
+            rec['recency_signal'] = round(recency, 4)
+            rec['triage_score'] = score
+
+        # --- Rank by score desc, take the top max_shortlist as the human-review shortlist.
+        ranked = sorted(deduped, key=lambda r: r['triage_score'], reverse=True)
+        shortlist = [r for r in ranked if r['triage_score'] >= min_score][:max_shortlist]
+        max_score = ranked[0]['triage_score'] if ranked else 0.0
+
+        result = {
+            'research_topic': prep.get('research_topic'),
+            'raw_count': len(rows),
+            'normalized_count': len(normalized),
+            'deduped_count': len(deduped),
+            'duplicates_removed': duplicates_removed,
+            'shortlist_count': len(shortlist),
+            'max_triage_score': max_score,
+            'min_triage_score': min_score,
+            'shortlist': shortlist,
+            'all_ranked': ranked,
+        }
+
+  # 4) CLASSIFY topical fit. The ONLY model in the path and it ONLY labels: on_topic /
+  #    adjacent_topic / off_topic. Swappable to any provider; every label falls through to the
+  #    deterministic gate, which still enforces the numeric score floor on its own.
+  - id: classify_topicality
+    type: classify
+    depends_on: [dedup_and_score]
+    classify_config:
+      model: sonnet
+      input: >
+        You are a research librarian triaging papers for a literature review. Using ONLY the
+        titles and abstracts, decide the OVERALL topical fit of this shortlist to the research
+        topic. on_topic = most shortlisted papers directly address the topic; adjacent_topic =
+        they are in a neighbouring area (related methods or domain) but not squarely on it;
+        off_topic = most do not address the topic at all. Topic: {steps.prepare_query.output.research_topic}.
+        Shortlist (title + abstract + deterministic triage_score): {steps.dedup_and_score.output.shortlist}
+      categories:
+        - on_topic
+        - adjacent_topic
+        - off_topic
+      branches:
+        on_topic: [analyst_review_gate]
+        adjacent_topic: [analyst_review_gate]
+        off_topic: [analyst_review_gate]
+
+  # 5) TWO-STRATEGY GATE. BOTH must pass before anything enters the corpus:
+  #    (1) a SWAPPABLE llm_eval relevance reviewer ("are these papers genuinely relevant?");
+  #    (2) a mandatory HUMAN analyst sign-off. The non-LLM score floor was already applied by the
+  #        dedup_and_score shortlist, so a paper cannot reach the corpus on the model alone.
+  - id: analyst_review_gate
+    type: gate
+    depends_on: [dedup_and_score, classify_topicality]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are a research relevance reviewer. The shortlist was deterministically
+              deduped and ranked by a transparent triage score; a topicality label was assigned.
+              Answer exactly 'approved' if the shortlisted papers are genuinely relevant to the
+              research topic and worth embedding into the review corpus, otherwise answer
+              'rejected' and name the off-topic items. Judge relevance only; the numeric score
+              floor is enforced separately.
+            input: "Topic: {steps.prepare_query.output.research_topic} | Topicality: {steps.classify_topicality.output} | Shortlist: {steps.dedup_and_score.output.shortlist}"
+            model: "{input.gate_model}"
+        - type: human
+          config:
+            message: "Research analyst: review this deduped, score-ranked literature shortlist. Approve to embed the keepers into the corpus; reject to send back for re-query. Nothing enters the vector store without your sign-off."
+            timeout_hours: 72
+            on_timeout: abort
+
+  # 6) DETERMINISTIC embed-payload builder. NO model. Fold the approved shortlist into Qdrant
+  #    upsert points: a stable SHA-256 point id (from DOI or title key), the triage score + signal
+  #    breakdown as payload, and the title+abstract as the text to embed.
+  - id: build_upsert_payload
+    type: code
+    depends_on: [analyst_review_gate, dedup_and_score]
+    code_config:
+      language: python
+      code: |
+        import hashlib
+
+        scored = _steps.get('dedup_and_score') or {}
+        topic = scored.get('research_topic')
+        shortlist = scored.get('shortlist') or []
+        collection = str(_input.get('vector_collection') or '')
+
+        points = []
+        for rec in shortlist:
+            # Stable id: prefer DOI, else the title key. SHA-256 keeps it deterministic.
+            seed = rec.get('doi') or rec.get('title_key') or rec.get('title') or ''
+            point_id = hashlib.sha256(str(seed).encode('utf-8')).hexdigest()
+            embed_text = (str(rec.get('title') or '') + '. ' + str(rec.get('abstract') or '')).strip()
+            points.append({
+                'id': point_id,
+                'payload': {
+                    'title': rec.get('title'),
+                    'url': rec.get('url'),
+                    'doi': rec.get('doi'),
+                    'year': rec.get('year'),
+                    'citations': rec.get('citations'),
+                    'triage_score': rec.get('triage_score'),
+                    'token_overlap': rec.get('token_overlap'),
+                    'citation_signal': rec.get('citation_signal'),
+                    'recency_signal': rec.get('recency_signal'),
+                    'research_topic': topic,
+                },
+                'text': embed_text,
+            })
+
+        result = {
+            'collection': collection,
+            'point_count': len(points),
+            'has_points': len(points) > 0,
+            'points': points,
+            'research_topic': topic,
+        }
+
+  # 7) CONDITION - only upsert when the analyst approved at least one paper. An empty/ rejected
+  #    shortlist skips the vector write entirely. Deterministic branch off the payload count.
+  - id: route_upsert
+    type: condition
+    depends_on: [build_upsert_payload]
+    condition_config:
+      expression: "{steps.build_upsert_payload.output.has_points} == True"
+      then: [embed_and_upsert, notify_kept]
+      else: [notify_empty]
+
+  # 7a) EMBED + UPSERT the kept papers into Qdrant. The connector embeds the text and writes the
+  #     points with their triage payload into the configured collection. Connector: qdrant.
+  - id: embed_and_upsert
+    type: http
+    http_config:
+      url: "{input.qdrant_base_url}/collections/{input.vector_collection}/points?wait=true"
+      method: PUT
+      headers:
+        Content-Type: "application/json"
+        api-key: "{env.QDRANT_API_KEY}"
+      body: "{steps.build_upsert_payload.output}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 7b) NOTIFY (kept) - post the triage digest with dedup + score stats and the kept count.
+  - id: notify_kept
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :books: Literature triage for "{steps.dedup_and_score.output.research_topic}"
+        Raw candidates : {steps.dedup_and_score.output.raw_count}
+        Deduped        : {steps.dedup_and_score.output.deduped_count} ({steps.dedup_and_score.output.duplicates_removed} dup(s) removed)
+        Shortlisted    : {steps.dedup_and_score.output.shortlist_count} (score >= {steps.dedup_and_score.output.min_triage_score}, max {steps.dedup_and_score.output.max_triage_score})
+        Topicality     : {steps.classify_topicality.output}
+        Embedded to Qdrant collection {input.vector_collection}: {steps.build_upsert_payload.output.point_count} paper(s).
+
+  # 7c) NOTIFY (empty) - nothing cleared review; no vector write happened.
+  - id: notify_empty
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :mag: Literature triage for "{steps.dedup_and_score.output.research_topic}" produced no keepers.
+        {steps.dedup_and_score.output.deduped_count} deduped candidates, {steps.dedup_and_score.output.shortlist_count} shortlisted, but the analyst gate approved none. No embedding, no corpus write.
+
+on_complete:
+  storage_path: "literature-source-triage-race/{run_id}/result.json"

--- a/src/sandcastle/templates/mrr_waterfall_board_rollup.yaml
+++ b/src/sandcastle/templates/mrr_waterfall_board_rollup.yaml
@@ -1,0 +1,460 @@
+# name: MRR Waterfall Board Roll-Up
+# description: On a monthly schedule a durable SENSOR blocks until the month-end roll-up window opens, then http GETs subscription/billing events (Stripe) and closed-won + churn pipeline (Salesforce / HubSpot). A DETERMINISTIC code step computes the full MRR waterfall (new / expansion / contraction / churn / reactivation), net + gross revenue retention, logo and dollar churn and the SaaS quick ratio, then runs a reconciliation check that opening + new + expansion + reactivation - contraction - churn must equal the closing balance within tolerance. A CONDITION blocks the report if the bridge does not foot. A two-strategy GATE (a swappable llm_eval narrative-accuracy judge AND a non-LLM 'bridge_balances' boolean) must BOTH pass before publish. A REPORT assembles the board metrics pack PDF and NOTIFY posts it to the board channel + archives to object store. All metric math and the foot-check are 100% deterministic code; the only model is the swappable narrative judge.
+# tags: [MRR, ARR, SaaS, FP&A, Board, Waterfall, NRR, GRR, Churn, QuickRatio, Reconciliation, Stripe, Salesforce, HubSpot, Finance]
+# category: finance_ops
+# connectors: stripe, salesforce, hubspot, aws-s3, slack
+name: mrr-waterfall-board-rollup
+description: >-
+  The monthly board metrics engine for a subscription business. A durable SENSOR
+  blocks until the month-end roll-up window is open (close-the-books flag flips on
+  the FP&A calendar endpoint), so the workflow only runs once the period is actually
+  closed. A DETERMINISTIC http GET then pulls the period's subscription / billing
+  events from Stripe (subscription created / updated / deleted, invoice line MRR
+  deltas) and a parallel http GET pulls the CRM pipeline - closed-won new logos and
+  churned / downgraded accounts - from Salesforce or HubSpot. The LOAD-BEARING code
+  step computes the entire MRR waterfall in pure Python: it classifies every event
+  into new / expansion / contraction / churn / reactivation, sums each component,
+  derives the closing balance, then computes net revenue retention (NRR), gross
+  revenue retention (GRR), logo churn, dollar churn and the SaaS quick ratio. The
+  SAME code step performs a deterministic RECONCILIATION: opening + new + expansion
+  + reactivation - contraction - churn must equal the reported closing balance within
+  a currency tolerance; if it does not foot, bridge_balances is False. A CONDITION
+  blocks the entire publish path when the bridge does not reconcile. A two-strategy
+  GATE then guards publication: strategy (1) is a SWAPPABLE llm_eval narrative-accuracy
+  judge that checks the drafted board commentary does not misstate the numbers, and
+  strategy (2) is an llm_eval acting as a pure NON-LLM threshold that is fed only the
+  bridge_balances boolean and the residual, so the gate still passes/fails on the
+  arithmetic alone with zero model trust. Only when BOTH pass does a REPORT assemble
+  the board-ready metrics-pack PDF and a NOTIFY post it to the board channel while an
+  http PUT archives the sealed pack + raw waterfall JSON to an object-lock store. The
+  waterfall math, retention ratios and the foot-check are fully deterministic and run
+  even with zero model providers available; the model is confined to the gate's
+  swappable narrative judge.
+default_model: sonnet
+default_max_turns: 8
+default_timeout: 1800
+input_schema:
+  required: ["billing_events_base_url", "crm_pipeline_base_url"]
+  properties:
+    billing_events_base_url:
+      type: string
+      description: "Stripe (or Stripe-compatible) REST base exposing the period's subscription / invoice MRR-delta events for the closed month."
+      default: "https://api.stripe.com/v1"
+      example: "https://api.stripe.com/v1"
+    crm_pipeline_base_url:
+      type: string
+      description: "CRM pipeline REST base (Salesforce or HubSpot) exposing the period's closed-won new logos and churned / downgraded accounts."
+      default: "https://your-org.my.salesforce.com/services/data/v60.0"
+      example: "https://acme.my.salesforce.com/services/data/v60.0"
+    fpa_calendar_url:
+      type: string
+      description: "FP&A close-calendar REST base. The sensor polls this for the current period's books_closed / rollup_window_open flag so the roll-up only runs once the month is closed."
+      default: "https://fpa.internal/api/close-calendar"
+      example: "https://fpa.internal/api/close-calendar"
+    period:
+      type: string
+      description: "The accounting period being rolled up (YYYY-MM). Drives the event queries and the board pack title."
+      default: "2026-05"
+      example: "2026-05"
+    opening_mrr:
+      type: number
+      description: "Opening MRR for the period (the prior month's SEALED closing balance). The waterfall bridges FROM this number."
+      default: 0
+      example: "1250000"
+    closing_mrr_reported:
+      type: number
+      description: "The period's reported closing MRR from the system of record. The reconciliation check proves the computed bridge foots TO this number within tolerance."
+      default: 0
+      example: "1318500"
+    reconciliation_tolerance:
+      type: number
+      description: "Absolute currency tolerance (in the report currency's major units) within which the computed closing balance must match the reported closing balance for the bridge to foot."
+      default: 1.0
+      example: "1.0"
+    currency:
+      type: string
+      description: "ISO 4217 currency code the board pack is reported in. All MRR figures are assumed pre-normalized to this currency."
+      default: "USD"
+      example: "EUR"
+    gate_model:
+      type: string
+      description: "Swappable narrative-accuracy judge model for the publish gate. Any of the 7 providers can back it; for EU data residency pin a local/EU provider (mistral/large, ollama, omlx/qwen-3). The math and foot-check run with this unavailable."
+      default: "sonnet"
+      example: "mistral/large"
+    report_author:
+      type: string
+      description: "Author shown on the board metrics-pack PDF."
+      default: "FP&A / Office of the CFO"
+      example: "FP&A / Office of the CFO"
+    archive_base_url:
+      type: string
+      description: "Object-lock (WORM) S3-compatible REST base that receives the sealed board pack + raw waterfall JSON for audit retention."
+      default: "https://s3.eu-central-1.amazonaws.com"
+      example: "https://s3.eu-central-1.amazonaws.com"
+    archive_bucket:
+      type: string
+      description: "Bucket that stores the sealed board metrics packs tamper-evidently."
+      default: "board-metrics-packs"
+      example: "acme-board-metrics-packs"
+    board_channel:
+      type: string
+      description: "Slack channel where the published board metrics pack is posted."
+      default: "#board-metrics"
+      example: "#board-metrics"
+    sensor_timeout:
+      type: integer
+      description: "Sensor soft timeout in seconds - stop waiting for the roll-up window after this long (one run). Default 7 days to cover a late close."
+      default: 604800
+      example: "604800"
+steps:
+  # 1) DURABLE SENSOR - block until the FP&A close calendar reports the books are CLOSED for
+  #    the period and the roll-up window is open. The board pack must never be built on an open,
+  #    still-moving month. Polls the close-calendar endpoint until books_closed flips true. No model.
+  - id: await_rollup_window
+    type: sensor
+    sensor_config:
+      url: "{input.fpa_calendar_url}/periods/{input.period}?select=books_closed,rollup_window_open"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and (response.get('books_closed') == True or response.get('rollup_window_open') == True)"
+      check_interval: 3600
+      timeout: 604800
+
+  # 2) DETERMINISTIC http GET of the period's subscription / billing MRR-delta events from Stripe:
+  #    subscription created / updated / deleted and invoice line MRR deltas for the closed month.
+  #    Connector: stripe. No model.
+  - id: fetch_billing_events
+    type: http
+    depends_on: [await_rollup_window]
+    http_config:
+      url: "{input.billing_events_base_url}/subscription_events?period={input.period}&expand=mrr_delta,previous_mrr,status,customer"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.STRIPE_API_KEY}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 3) DETERMINISTIC http GET of the CRM pipeline for the period: closed-won new logos and
+  #    churned / downgraded accounts from Salesforce or HubSpot. Connector: salesforce / hubspot.
+  #    on_failure: skip so a missing CRM augmentation does not abort the billing-driven waterfall.
+  - id: fetch_crm_pipeline
+    type: http
+    depends_on: [await_rollup_window]
+    http_config:
+      url: "{input.crm_pipeline_base_url}/query?q=SELECT+AccountId,Type,MRR_Delta,CloseDate,StageName+FROM+Opportunity+WHERE+CloseDate+IN+{input.period}+AND+StageName+IN+('Closed Won','Churned','Downgraded')"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.CRM_API_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 4) LOAD-BEARING DETERMINISTIC MRR WATERFALL + RECONCILIATION. NO model. Classifies every
+  #    subscription event into new / expansion / contraction / churn / reactivation, sums each
+  #    component, derives the closing balance, and computes NRR, GRR, logo + dollar churn and the
+  #    SaaS quick ratio. THEN performs the foot-check: opening + new + expansion + reactivation
+  #    - contraction - churn must equal the reported closing balance within tolerance. If it does
+  #    not foot, bridge_balances is False and the publish path is blocked downstream.
+  - id: compute_waterfall
+    type: code
+    depends_on: [fetch_billing_events, fetch_crm_pipeline]
+    code_config:
+      language: python
+      code: |
+        billing = _steps.get('fetch_billing_events') or {}
+        crm = _steps.get('fetch_crm_pipeline') or {}
+
+        opening = float(_input.get('opening_mrr') or 0.0)
+        closing_reported = float(_input.get('closing_mrr_reported') or 0.0)
+        tolerance = abs(float(_input.get('reconciliation_tolerance') or 1.0))
+        currency = str(_input.get('currency') or 'USD').upper()
+        period = str(_input.get('period') or '')
+
+        # --- coalesce the provider payload into a flat list of event records --------------
+        def as_rows(blob, keys):
+            if isinstance(blob, list):
+                return [r for r in blob if isinstance(r, dict)]
+            if isinstance(blob, dict):
+                for k in keys:
+                    v = blob.get(k)
+                    if isinstance(v, list):
+                        return [r for r in v if isinstance(r, dict)]
+            return []
+
+        events = as_rows(billing, ('data', 'events', 'items', 'records', 'results'))
+        crm_rows = as_rows(crm, ('records', 'data', 'items', 'results', 'value'))
+
+        def num(v):
+            try:
+                return float(v)
+            except (TypeError, ValueError):
+                return 0.0
+
+        # --- waterfall component accumulators ---------------------------------------------
+        comp = {'new': 0.0, 'expansion': 0.0, 'contraction': 0.0, 'churn': 0.0, 'reactivation': 0.0}
+        new_logos = 0
+        churned_logos = 0
+        # active logos at period start, used for the logo-churn denominator.
+        opening_logos = int(num(billing.get('opening_active_logos')) if isinstance(billing, dict) else 0)
+
+        def classify(prev_mrr, cur_mrr, status, etype):
+            # Deterministic event classification from prev/current MRR + lifecycle status.
+            status = str(status or '').lower()
+            etype = str(etype or '').lower()
+            if status in ('canceled', 'cancelled', 'churned') or cur_mrr <= 0 and prev_mrr > 0:
+                return 'churn'
+            if status in ('reactivated', 'resurrected') or ('reactiv' in etype) or (prev_mrr <= 0 and cur_mrr > 0 and 'new' not in etype and status not in ('active_new', 'trialing')):
+                # came back from zero having previously existed
+                return 'reactivation' if etype == 'reactivation' or status in ('reactivated', 'resurrected') else 'new'
+            if prev_mrr <= 0 and cur_mrr > 0:
+                return 'new'
+            if cur_mrr > prev_mrr:
+                return 'expansion'
+            if cur_mrr < prev_mrr:
+                return 'contraction'
+            return 'flat'
+
+        for ev in events:
+            prev_mrr = num(ev.get('previous_mrr') if ev.get('previous_mrr') is not None else ev.get('prev_mrr'))
+            cur_mrr = num(ev.get('mrr') if ev.get('mrr') is not None else ev.get('current_mrr'))
+            delta = ev.get('mrr_delta')
+            delta = num(delta) if delta is not None else round(cur_mrr - prev_mrr, 6)
+            status = ev.get('status') or ev.get('subscription_status')
+            etype = ev.get('event_type') or ev.get('type')
+
+            kind = classify(prev_mrr, cur_mrr, status, etype)
+            if kind == 'new':
+                comp['new'] += max(0.0, delta if delta else cur_mrr)
+                new_logos += 1
+            elif kind == 'reactivation':
+                comp['reactivation'] += max(0.0, delta if delta else cur_mrr)
+                new_logos += 1
+            elif kind == 'expansion':
+                comp['expansion'] += max(0.0, delta)
+            elif kind == 'contraction':
+                comp['contraction'] += abs(min(0.0, delta))
+            elif kind == 'churn':
+                comp['churn'] += abs(prev_mrr if prev_mrr > 0 else delta)
+                churned_logos += 1
+            # 'flat' contributes nothing to the bridge
+
+        # --- CRM augmentation: fold in closed-won / churn rows the billing feed may miss ---
+        for row in crm_rows:
+            stage = str(row.get('StageName') or row.get('stage') or '').lower()
+            d = num(row.get('MRR_Delta') if row.get('MRR_Delta') is not None else row.get('mrr_delta'))
+            if 'won' in stage and d > 0:
+                comp['new'] += d
+                new_logos += 1
+            elif 'churn' in stage:
+                comp['churn'] += abs(d) if d else 0.0
+                churned_logos += 1
+            elif 'downgrade' in stage and d < 0:
+                comp['contraction'] += abs(d)
+
+        comp = {k: round(v, 2) for k, v in comp.items()}
+
+        # --- closing balance derived from the bridge ---------------------------------------
+        computed_closing = round(
+            opening + comp['new'] + comp['expansion'] + comp['reactivation']
+            - comp['contraction'] - comp['churn'], 2
+        )
+        # If no reported closing was supplied, the computed bridge IS the closing balance.
+        reported = closing_reported if closing_reported else computed_closing
+        residual = round(computed_closing - reported, 2)
+        bridge_balances = abs(residual) <= tolerance
+
+        # --- retention + churn ratios (all deterministic) ----------------------------------
+        gross_new = comp['new'] + comp['reactivation']
+        # NRR = retained + expansion - contraction - churn, over opening (expansion-inclusive).
+        if opening > 0:
+            nrr = round((opening + comp['expansion'] - comp['contraction'] - comp['churn']) / opening, 4)
+            grr = round((opening - comp['contraction'] - comp['churn']) / opening, 4)
+            dollar_churn_rate = round((comp['contraction'] + comp['churn']) / opening, 4)
+        else:
+            nrr = grr = dollar_churn_rate = 0.0
+
+        if opening_logos > 0:
+            logo_churn_rate = round(churned_logos / opening_logos, 4)
+        else:
+            logo_churn_rate = 0.0
+
+        # SaaS quick ratio = (new + expansion + reactivation) / (contraction + churn).
+        lost = comp['contraction'] + comp['churn']
+        quick_ratio = round((gross_new + comp['expansion']) / lost, 3) if lost > 0 else None
+
+        net_new_mrr = round(gross_new + comp['expansion'] - comp['contraction'] - comp['churn'], 2)
+
+        result = {
+            'period': period,
+            'currency': currency,
+            'opening_mrr': round(opening, 2),
+            'components': comp,
+            'computed_closing_mrr': computed_closing,
+            'reported_closing_mrr': round(reported, 2),
+            'net_new_mrr': net_new_mrr,
+            'reconciliation_residual': residual,
+            'reconciliation_tolerance': tolerance,
+            'bridge_balances': bool(bridge_balances),
+            'nrr': nrr,
+            'grr': grr,
+            'dollar_churn_rate': dollar_churn_rate,
+            'logo_churn_rate': logo_churn_rate,
+            'quick_ratio': quick_ratio,
+            'new_logos': new_logos,
+            'churned_logos': churned_logos,
+            'opening_logos': opening_logos,
+            'event_count': len(events),
+            'crm_row_count': len(crm_rows),
+        }
+
+  # 5) CONDITION - hard gate on the foot-check. If the bridge does NOT reconcile to the reported
+  #    closing balance within tolerance, the entire publish path is blocked and only a reconcile-
+  #    failure alert fires. Deterministic branch off the in-code bridge_balances flag. No model.
+  - id: reconciliation_branch
+    type: condition
+    depends_on: [compute_waterfall]
+    condition_config:
+      expression: "{steps.compute_waterfall.output.bridge_balances} == True"
+      then: [publish_gate, draft_board_pack, board_metrics_pack, archive_pack, notify_board]
+      else: [notify_reconcile_failure]
+
+  # 6) DRAFT the board commentary (swappable model, draft-only). The numbers it narrates were ALL
+  #    computed deterministically in compute_waterfall; this only writes prose AROUND them. The
+  #    gate below verifies the prose does not misstate any figure before anything is published.
+  - id: draft_board_pack
+    type: llm
+    depends_on: [compute_waterfall]
+    model: sonnet
+    prompt: >-
+      You are an FP&A analyst writing the board commentary for the monthly MRR roll-up. Write a
+      concise narrative (4-6 short paragraphs) that explains the MRR waterfall, net revenue
+      retention, churn and the SaaS quick ratio for the period. Use ONLY the figures provided -
+      do NOT invent, round differently, or restate any number. Cover: the bridge from opening to
+      closing MRR, the largest swing factor (new vs expansion vs churn), the NRR/GRR story, and
+      one forward-looking note on the quick ratio. Period {input.period}, currency {input.currency}.
+      Waterfall + metrics (authoritative, do not alter): {steps.compute_waterfall.output}
+
+  # 7) TWO-STRATEGY PUBLISH GATE (swappable + model-independent). BOTH strategies must pass:
+  #    (1) llm_eval narrative-accuracy judge on a SWAPPABLE provider - does the drafted commentary
+  #        faithfully match the deterministic numbers, with no misstated figure?
+  #    (2) llm_eval acting as a pure NON-LLM threshold - fed ONLY bridge_balances + the residual +
+  #        tolerance and told to answer purely from the arithmetic, so the gate still passes/fails
+  #        on the foot-check alone with zero model trust.
+  - id: publish_gate
+    type: gate
+    depends_on: [compute_waterfall, draft_board_pack]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are a board-pack reviewer. The MRR waterfall, retention ratios and quick ratio
+              were computed deterministically and are authoritative. Read the drafted board
+              commentary and answer exactly 'approved' ONLY if every number it states matches the
+              authoritative figures and no metric is mischaracterised (e.g. churn called expansion,
+              NRR overstated). Otherwise answer 'rejected' and name the misstatement. Judge
+              narrative accuracy only; the arithmetic foot-check is verified separately.
+            input: "Authoritative metrics: {steps.compute_waterfall.output}\n---\nDrafted commentary: {steps.draft_board_pack.output}"
+            model: "{input.gate_model}"
+        - type: llm_eval
+          config:
+            prompt: >-
+              Deterministic reconciliation check. Answer exactly 'approved' if bridge_balances is
+              True AND the absolute residual is at or below the tolerance; otherwise answer
+              'rejected'. Use ONLY the supplied numbers and boolean - do not infer or reason beyond
+              the arithmetic comparison.
+            input: "bridge_balances={steps.compute_waterfall.output.bridge_balances} residual={steps.compute_waterfall.output.reconciliation_residual} tolerance={steps.compute_waterfall.output.reconciliation_tolerance}"
+            model: haiku
+
+  # 8) REPORT - assemble the board-ready metrics-pack PDF: the full waterfall bridge, NRR/GRR,
+  #    logo + dollar churn, the quick ratio, the reconciliation proof, and the verified commentary.
+  - id: board_metrics_pack
+    type: report
+    depends_on: [publish_gate]
+    report_config:
+      template: research-report
+      format: pdf
+      theme: professional
+      title: "Board Metrics Pack - MRR Roll-Up {input.period} ({input.currency})"
+      author: "{input.report_author}"
+    prompt: |
+      Assemble the monthly board metrics pack for the subscription business. Every figure below is
+      authoritative and deterministically reconciled - present it faithfully for the board.
+
+      Section 1 - MRR Waterfall bridge (opening -> closing):
+      Opening MRR, then + New, + Expansion, + Reactivation, - Contraction, - Churn, to Closing MRR.
+      {steps.compute_waterfall.output.components}
+      Opening: {steps.compute_waterfall.output.opening_mrr}  Closing (computed): {steps.compute_waterfall.output.computed_closing_mrr}  Closing (reported): {steps.compute_waterfall.output.reported_closing_mrr}  Net new MRR: {steps.compute_waterfall.output.net_new_mrr}
+
+      Section 2 - Reconciliation proof (the bridge MUST foot):
+      Residual {steps.compute_waterfall.output.reconciliation_residual} within tolerance {steps.compute_waterfall.output.reconciliation_tolerance}; bridge_balances={steps.compute_waterfall.output.bridge_balances}.
+
+      Section 3 - Retention + churn:
+      NRR {steps.compute_waterfall.output.nrr}, GRR {steps.compute_waterfall.output.grr}, dollar churn rate {steps.compute_waterfall.output.dollar_churn_rate}, logo churn rate {steps.compute_waterfall.output.logo_churn_rate}, new logos {steps.compute_waterfall.output.new_logos}, churned logos {steps.compute_waterfall.output.churned_logos}.
+
+      Section 4 - Efficiency:
+      SaaS quick ratio {steps.compute_waterfall.output.quick_ratio}.
+
+      Section 5 - Board commentary (accuracy-verified narrative):
+      {steps.draft_board_pack.output}
+
+  # 9) ARCHIVE - http PUT the sealed board pack + raw waterfall JSON to the object-lock (WORM)
+  #    store for audit retention, with the period + reconciliation status as object metadata.
+  #    Connector: aws-s3.
+  - id: archive_pack
+    type: http
+    depends_on: [board_metrics_pack]
+    http_config:
+      url: "{input.archive_base_url}/{input.archive_bucket}/board-packs/{input.period}/mrr-board-pack.pdf"
+      method: PUT
+      headers:
+        Content-Type: "application/pdf"
+        x-amz-object-lock-mode: "COMPLIANCE"
+        x-amz-meta-period: "{input.period}"
+        x-amz-meta-currency: "{input.currency}"
+        x-amz-meta-bridge-balances: "{steps.compute_waterfall.output.bridge_balances}"
+        x-amz-meta-closing-mrr: "{steps.compute_waterfall.output.computed_closing_mrr}"
+      auth: "aws4:{env.AWS_ACCESS_KEY_ID}:{env.AWS_SECRET_ACCESS_KEY}"
+      body: "{steps.board_metrics_pack.output}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 10) NOTIFY (published) - post the verified, footed board metrics pack to the board channel
+  #     with the headline waterfall + retention numbers and the archive pointer. service: slack.
+  - id: notify_board
+    type: notify
+    depends_on: [archive_pack]
+    notify_config:
+      service: slack
+      channel: "{input.board_channel}"
+      message: |
+        :bar_chart: Board metrics pack published - MRR roll-up {steps.compute_waterfall.output.period} ({steps.compute_waterfall.output.currency})
+        Opening {steps.compute_waterfall.output.opening_mrr} -> Closing {steps.compute_waterfall.output.computed_closing_mrr} (net new {steps.compute_waterfall.output.net_new_mrr})
+        Bridge: +New {steps.compute_waterfall.output.components} (footed, residual {steps.compute_waterfall.output.reconciliation_residual})
+        NRR {steps.compute_waterfall.output.nrr} | GRR {steps.compute_waterfall.output.grr} | quick ratio {steps.compute_waterfall.output.quick_ratio}
+        Logos: +{steps.compute_waterfall.output.new_logos} / -{steps.compute_waterfall.output.churned_logos}
+        Archived (object-lock): board-packs/{steps.compute_waterfall.output.period}/mrr-board-pack.pdf
+
+  # 11) NOTIFY (reconcile failure) - the bridge did NOT foot. NO board pack is published; FP&A is
+  #     alerted to fix the source data and re-run, so the board never sees an unreconciled number.
+  - id: notify_reconcile_failure
+    type: notify
+    depends_on: [compute_waterfall]
+    notify_config:
+      service: slack
+      channel: "{input.board_channel}"
+      message: |
+        :no_entry: MRR roll-up {steps.compute_waterfall.output.period} did NOT foot - board pack BLOCKED.
+        Computed closing {steps.compute_waterfall.output.computed_closing_mrr} vs reported {steps.compute_waterfall.output.reported_closing_mrr}
+        Residual {steps.compute_waterfall.output.reconciliation_residual} exceeds tolerance {steps.compute_waterfall.output.reconciliation_tolerance}.
+        Fix the source billing / CRM data and re-run. No unreconciled pack will be published.
+on_complete:
+  storage_path: "mrr-waterfall-board-rollup/{run_id}/result.json"

--- a/src/sandcastle/templates/sec_filing_delta_extractor.yaml
+++ b/src/sandcastle/templates/sec_filing_delta_extractor.yaml
@@ -1,0 +1,608 @@
+# name: SEC Filing & Earnings Delta Extractor
+# description: Pulls a company's newest SEC/IR filing, deterministically section-diffs it against the prior filing to surface added/removed/changed risk factors, guidance numbers and language shifts, then gates the diff for materiality so analysts read ONLY what actually changed between quarters. A durable SENSOR polls the EDGAR-style filings index and blocks until a new accession appears; two http GETs fetch the newest and the prior filing; a PARSE extracts clean section text; a deterministic CODE step aligns sections by heading, computes a sentence-level added/removed/modified diff, pulls numeric guidance (revenue, EPS, margin) via regex and computes per-metric numeric deltas, and SHA-256-fingerprints each changed block - no model touches the diff. A CONDITION routes only non-trivial diffs into a swappable materiality GATE (llm_eval judge AND a non-LLM changed_blocks/guidance_delta threshold), a REPORT compiles the memo, and an http PUT archives the sealed diff to S3.
+# tags: [SEC, EDGAR, 10-K, 10-Q, 8-K, earnings, guidance, risk-factors, diff, sensor, S3, equity-research, materiality, financial-analysis]
+# category: research_intel
+# connectors: sec-edgar, aws-s3, slack
+name: sec-filing-delta-extractor
+description: >-
+  An equity-research delta engine that tells an analyst ONLY what changed between a
+  company's last two periodic filings. A durable SENSOR polls the EDGAR-style filings
+  index for the ticker and BLOCKS until a brand-new accession (a 10-K / 10-Q / 8-K not
+  yet seen) appears; until a new filing lands there is nothing to diff. A DETERMINISTIC
+  http GET then pulls the index, and a code step picks the two most-recent same-form
+  filings (newest vs prior) and resolves each primary document URL. Two http GETs fetch
+  the newest and the prior filing documents, and a PARSE step extracts clean per-section
+  text (Risk Factors, MD&A, Guidance / Outlook, Legal Proceedings). The load-bearing
+  decision is then 100% DETERMINISTIC code: align sections by normalized heading, compute
+  a sentence-level structured diff (added / removed / modified blocks) per section, pull
+  numeric guidance (revenue, EPS, gross margin) from both filings via regex and compute
+  per-metric numeric deltas (absolute + percent), and SHA-256-fingerprint each changed
+  block - no model ever touches the diff or the numbers. A CONDITION routes only
+  non-trivial diffs into a MATERIALITY GATE with TWO strategies that BOTH must pass: a
+  SWAPPABLE llm_eval judge ("is this change material to an investor?", backable by any of
+  the providers) AND a NON-LLM threshold strategy fed the pre-computed changed_blocks
+  count and the largest guidance_delta_pct, so the diff passes/fails with zero model
+  involvement. A REPORT compiles the materiality memo (what changed, by section, with the
+  numeric guidance table), and an http PUT archives the sealed, SHA-256-fingerprinted diff
+  to an S3 bucket for the research audit trail. A NOTIFY pushes the headline deltas to the
+  research channel. The section diff and the numeric deltas are pure deterministic code and
+  run even with zero model providers available; the model is confined to the gate's
+  swappable materiality judge.
+default_model: sonnet
+default_max_turns: 8
+default_timeout: 1800
+input_schema:
+  required: ["ticker", "filings_index_url"]
+  properties:
+    ticker:
+      type: string
+      description: "Issuer ticker whose newest periodic filing is diffed against its prior filing (e.g. 'AAPL')."
+      default: "AAPL"
+      example: "NVDA"
+    filings_index_url:
+      type: string
+      description: "EDGAR-style filings-index REST base that lists an issuer's accessions newest-first. The sensor polls this until a new accession appears (SEC EDGAR submissions API, or your IR mirror)."
+      default: "https://data.sec.gov/submissions"
+      example: "https://data.sec.gov/submissions"
+    form_type:
+      type: string
+      description: "Periodic form to track and diff like-for-like (10-K, 10-Q or 8-K). Newest is diffed against the prior filing of the SAME form."
+      default: "10-Q"
+      example: "10-K"
+    guidance_delta_threshold:
+      type: number
+      description: "Non-LLM materiality threshold (percent). The gate's deterministic strategy treats the diff as material if any guidance metric (revenue / EPS / margin) moved by at least this percent OR there are at least min_changed_blocks changed blocks."
+      default: 5.0
+      example: "5.0"
+    min_changed_blocks:
+      type: integer
+      description: "Non-LLM materiality threshold (count). The deterministic gate strategy also passes if the number of added/removed/modified text blocks is at or above this, even with no numeric guidance change."
+      default: 3
+      example: "3"
+    archive_bucket:
+      type: string
+      description: "S3 (or S3-compatible) bucket that receives the sealed, SHA-256-fingerprinted diff record for the research audit trail."
+      default: "equity-research-filing-deltas"
+      example: "acme-equity-research-filing-deltas"
+    archive_base_url:
+      type: string
+      description: "S3 REST base URL the sealed diff record is PUT to."
+      default: "https://s3.eu-central-1.amazonaws.com"
+      example: "https://s3.eu-central-1.amazonaws.com"
+    last_seen_accession:
+      type: string
+      description: "Accession number of the most recently diffed filing. The sensor only fires for an accession NEWER than this, so a re-run does not re-diff the same filing. Leave empty on first run."
+      default: ""
+      example: "0000320193-26-000045"
+    sensor_timeout:
+      type: integer
+      description: "Sensor soft timeout in seconds - stop waiting for a new filing after this long (one watch run). Default 24h."
+      default: 86400
+      example: "86400"
+    gate_model:
+      type: string
+      description: "Swappable materiality-judge model for the gate. Any provider can back it; for EU data residency pin a local/EU provider (mistral/large, ollama, omlx/qwen-3). The diff is computed with this unavailable."
+      default: "sonnet"
+      example: "mistral/large"
+    slack_channel:
+      type: string
+      description: "Research Slack channel that receives the headline delta digest."
+      default: "#equity-research-deltas"
+      example: "#equity-research-deltas"
+steps:
+  # 1) DURABLE SENSOR - block until a NEW accession for this ticker/form appears in the
+  #    EDGAR-style filings index. Polls the issuer's submissions endpoint; until a filing
+  #    newer than last_seen_accession lands there is nothing to diff. Event-driven within a
+  #    schedule: a fresh 10-Q/10-K/8-K makes the watch fire immediately.
+  - id: await_new_filing
+    type: sensor
+    sensor_config:
+      url: "{input.filings_index_url}/CIK-{input.ticker}.json"
+      method: GET
+      headers:
+        Accept: "application/json"
+        User-Agent: "sandcastle-equity-research filings@your-org.com"
+      condition: "status_code == 200 and str(response).find(input.get('form_type','10-Q')) != -1 and str(response).find(input.get('last_seen_accession','')) != (len(str(response)) if input.get('last_seen_accession') else -1)"
+      check_interval: 3600
+      timeout: 86400
+
+  # 2) DETERMINISTIC pull of the filings index newest-first. Returns the issuer's recent
+  #    accessions with form type, filing date and the document path. No model.
+  - id: pull_filings_index
+    type: http
+    depends_on: [await_new_filing]
+    http_config:
+      url: "{input.filings_index_url}/CIK-{input.ticker}.json"
+      method: GET
+      headers:
+        Accept: "application/json"
+        User-Agent: "sandcastle-equity-research filings@your-org.com"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 3) DETERMINISTIC selection of the two filings to diff: the newest filing of the tracked
+  #    form and the immediately-prior filing of the SAME form (like-for-like). Resolves each
+  #    primary-document URL and skips anything at or older than last_seen_accession. No model.
+  - id: select_filings
+    type: code
+    depends_on: [pull_filings_index]
+    code_config:
+      language: python
+      code: |
+        idx = _steps.get('pull_filings_index') or {}
+        ticker = str(_input.get('ticker') or '').strip()
+        want_form = str(_input.get('form_type') or '10-Q').strip().upper()
+        last_seen = str(_input.get('last_seen_accession') or '').strip()
+        base = str(_input.get('filings_index_url') or '').rstrip('/')
+
+        # EDGAR submissions shape: filings.recent is a dict of parallel arrays. Support that
+        # plus a flat list fallback so an IR mirror with a different shape still works.
+        recent = {}
+        if isinstance(idx, dict):
+            filings = idx.get('filings') or {}
+            if isinstance(filings, dict):
+                recent = filings.get('recent') or {}
+
+        rows = []
+        if isinstance(recent, dict) and isinstance(recent.get('accessionNumber'), list):
+            accs = recent.get('accessionNumber') or []
+            forms = recent.get('form') or []
+            dates = recent.get('filingDate') or []
+            docs = recent.get('primaryDocument') or []
+            for i in range(len(accs)):
+                rows.append({
+                    'accession': str(accs[i]),
+                    'form': str(forms[i]).upper() if i < len(forms) else '',
+                    'filing_date': str(dates[i]) if i < len(dates) else '',
+                    'primary_document': str(docs[i]) if i < len(docs) else '',
+                })
+        else:
+            flat = idx if isinstance(idx, list) else (
+                idx.get('filings') if isinstance(idx.get('filings'), list) else idx.get('data') or []
+            )
+            for r in (flat or []):
+                if isinstance(r, dict):
+                    rows.append({
+                        'accession': str(r.get('accessionNumber') or r.get('accession') or ''),
+                        'form': str(r.get('form') or r.get('type') or '').upper(),
+                        'filing_date': str(r.get('filingDate') or r.get('date') or ''),
+                        'primary_document': str(r.get('primaryDocument') or r.get('document') or ''),
+                    })
+
+        # Keep only the tracked form, newest first (already newest-first in EDGAR; sort defensively).
+        same_form = [r for r in rows if r['form'] == want_form and r['accession']]
+        same_form.sort(key=lambda r: r['filing_date'], reverse=True)
+
+        def doc_url(r):
+            # EDGAR archive path: accession with dashes stripped for the folder.
+            acc_nodash = r['accession'].replace('-', '')
+            doc = r['primary_document'] or 'index.json'
+            return f"{base}/Archives/{ticker}/{acc_nodash}/{doc}"
+
+        newest = same_form[0] if same_form else {}
+        prior = same_form[1] if len(same_form) > 1 else {}
+
+        # Is the newest filing genuinely newer than what we already diffed?
+        is_new = bool(newest.get('accession')) and newest.get('accession') != last_seen
+        has_pair = bool(newest.get('accession')) and bool(prior.get('accession'))
+
+        result = {
+            'ticker': ticker,
+            'form_type': want_form,
+            'is_new': is_new,
+            'has_pair': has_pair,
+            'newest_accession': newest.get('accession', ''),
+            'prior_accession': prior.get('accession', ''),
+            'newest_filing_date': newest.get('filing_date', ''),
+            'prior_filing_date': prior.get('filing_date', ''),
+            'newest_doc_url': doc_url(newest) if newest else '',
+            'prior_doc_url': doc_url(prior) if prior else '',
+            'candidate_count': len(same_form),
+        }
+
+  # 4a) http GET the NEWEST filing document (HTML/text). on_failure: abort - no document, no diff.
+  - id: fetch_newest_filing
+    type: http
+    depends_on: [select_filings]
+    http_config:
+      url: "{steps.select_filings.output.newest_doc_url}"
+      method: GET
+      headers:
+        Accept: "text/html,application/xhtml+xml,text/plain"
+        User-Agent: "sandcastle-equity-research filings@your-org.com"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 4b) http GET the PRIOR same-form filing document so the diff is like-for-like.
+  - id: fetch_prior_filing
+    type: http
+    depends_on: [select_filings]
+    http_config:
+      url: "{steps.select_filings.output.prior_doc_url}"
+      method: GET
+      headers:
+        Accept: "text/html,application/xhtml+xml,text/plain"
+        User-Agent: "sandcastle-equity-research filings@your-org.com"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 5) PARSE - extract clean, structured per-section text from both raw filing documents
+  #    (strip HTML/boilerplate, segment into the canonical filing sections: Risk Factors,
+  #    MD&A, Guidance/Outlook, Legal Proceedings). Document-extraction primitive, not a
+  #    free-form LLM; both filings go through the same extractor for an apples-to-apples diff.
+  - id: parse_sections
+    type: parse
+    depends_on: [fetch_newest_filing, fetch_prior_filing]
+    parse_config:
+      mode: sections
+      sources:
+        newest: "{steps.fetch_newest_filing.output}"
+        prior: "{steps.fetch_prior_filing.output}"
+      sections:
+        - "Risk Factors"
+        - "Management's Discussion and Analysis"
+        - "Guidance"
+        - "Outlook"
+        - "Legal Proceedings"
+        - "Quantitative and Qualitative Disclosures"
+
+  # 6) DETERMINISTIC SECTION DIFF + NUMERIC GUIDANCE DELTAS. THE load-bearing step. NO model.
+  #    Align sections by normalized heading, compute a sentence-level added/removed/modified
+  #    diff per section, pull numeric guidance (revenue, EPS, gross margin) from both filings
+  #    via regex, compute per-metric absolute + percent deltas, and SHA-256-fingerprint every
+  #    changed block. The gate's non-LLM threshold strategy consumes the counts and deltas.
+  - id: compute_diff
+    type: code
+    depends_on: [parse_sections, select_filings]
+    code_config:
+      language: python
+      code: |
+        import re
+        import hashlib
+        import difflib
+
+        meta = _steps.get('select_filings') or {}
+        parsed = _steps.get('parse_sections') or {}
+
+        # parse_sections is expected to yield {'newest': {section: text}, 'prior': {section: text}}.
+        # Be defensive about the shape so the diff still runs on a flat fallback.
+        def section_map(blob, side):
+            if isinstance(blob, dict):
+                side_blob = blob.get(side)
+                if isinstance(side_blob, dict):
+                    return {str(k): str(v) for k, v in side_blob.items()}
+                secs = blob.get('sections')
+                if isinstance(secs, dict) and side in secs and isinstance(secs[side], dict):
+                    return {str(k): str(v) for k, v in secs[side].items()}
+                if isinstance(side_blob, str):
+                    return {'document': side_blob}
+            if isinstance(blob, str):
+                return {'document': blob}
+            return {}
+
+        new_sections = section_map(parsed, 'newest')
+        old_sections = section_map(parsed, 'prior')
+
+        def norm_heading(h):
+            h = re.sub(r'[^a-z0-9 ]+', ' ', str(h).lower())
+            h = re.sub(r'\s+', ' ', h).strip()
+            return h
+
+        def sentences(text):
+            # Split into sentence-ish blocks for a sentence-level diff.
+            parts = re.split(r'(?<=[.!?])\s+|\n{2,}', str(text or ''))
+            return [p.strip() for p in parts if p and p.strip()]
+
+        # --- align sections by normalized heading -------------------------------------
+        new_by_norm = {norm_heading(k): (k, v) for k, v in new_sections.items()}
+        old_by_norm = {norm_heading(k): (k, v) for k, v in old_sections.items()}
+        all_norm = sorted(set(new_by_norm) | set(old_by_norm))
+
+        section_diffs = []
+        total_added = 0
+        total_removed = 0
+        total_modified = 0
+
+        for nk in all_norm:
+            new_label, new_text = new_by_norm.get(nk, ('', ''))
+            old_label, old_text = old_by_norm.get(nk, ('', ''))
+            new_sents = sentences(new_text)
+            old_sents = sentences(old_text)
+
+            sm = difflib.SequenceMatcher(a=old_sents, b=new_sents, autojunk=False)
+            added, removed, modified = [], [], []
+            for tag, i1, i2, j1, j2 in sm.get_opcodes():
+                if tag == 'insert':
+                    added.extend(new_sents[j1:j2])
+                elif tag == 'delete':
+                    removed.extend(old_sents[i1:i2])
+                elif tag == 'replace':
+                    modified.append({
+                        'before': ' '.join(old_sents[i1:i2])[:600],
+                        'after': ' '.join(new_sents[j1:j2])[:600],
+                    })
+
+            if not (added or removed or modified):
+                continue
+
+            total_added += len(added)
+            total_removed += len(removed)
+            total_modified += len(modified)
+
+            # SHA-256 fingerprint of this changed block so the diff is tamper-evident.
+            block_material = norm_heading(new_label or old_label) + '|' + \
+                '|'.join(added) + '|' + '|'.join(removed) + '|' + \
+                '|'.join(m['before'] + '>' + m['after'] for m in modified)
+            block_fp = hashlib.sha256(block_material.encode('utf-8')).hexdigest()
+
+            section_diffs.append({
+                'section': new_label or old_label,
+                'present_in_newest': bool(new_label),
+                'present_in_prior': bool(old_label),
+                'added': [s[:400] for s in added[:25]],
+                'removed': [s[:400] for s in removed[:25]],
+                'modified': modified[:25],
+                'added_count': len(added),
+                'removed_count': len(removed),
+                'modified_count': len(modified),
+                'fingerprint': block_fp,
+            })
+
+        changed_blocks = total_added + total_removed + total_modified
+
+        # --- numeric guidance extraction (revenue, EPS, gross margin) via regex ---------
+        def extract_metrics(text):
+            text = str(text or '')
+            metrics = {}
+            # Revenue / net sales in $ (millions/billions) - take the first stated figure.
+            m = re.search(r'(?:revenue|net sales|total revenue)[^$\d]{0,40}\$?\s*([\d,]+(?:\.\d+)?)\s*(billion|million|bn|mn|m|b)?', text, re.IGNORECASE)
+            if m:
+                val = float(m.group(1).replace(',', ''))
+                unit = (m.group(2) or '').lower()
+                if unit in ('billion', 'bn', 'b'):
+                    val *= 1000.0
+                metrics['revenue_musd'] = round(val, 2)
+            # EPS (diluted or basic) - a dollar-and-cents figure near 'per share'.
+            m = re.search(r'(?:earnings per share|diluted eps|eps|per (?:diluted )?share)[^$\d]{0,40}\$?\s*(\d+\.\d{2})', text, re.IGNORECASE)
+            if m:
+                metrics['eps_usd'] = float(m.group(1))
+            # Gross margin as a percent.
+            m = re.search(r'gross margin[^%\d]{0,40}(\d{1,3}(?:\.\d+)?)\s*%', text, re.IGNORECASE)
+            if m:
+                metrics['gross_margin_pct'] = float(m.group(1))
+            return metrics
+
+        new_full = '\n'.join(new_sections.values())
+        old_full = '\n'.join(old_sections.values())
+        new_metrics = extract_metrics(new_full)
+        old_metrics = extract_metrics(old_full)
+
+        guidance_deltas = []
+        max_abs_delta_pct = 0.0
+        for key in ('revenue_musd', 'eps_usd', 'gross_margin_pct'):
+            nv = new_metrics.get(key)
+            ov = old_metrics.get(key)
+            if nv is None or ov is None:
+                continue
+            abs_delta = round(nv - ov, 4)
+            pct = round((abs_delta / ov) * 100.0, 3) if ov else 0.0
+            if abs(pct) > max_abs_delta_pct:
+                max_abs_delta_pct = abs(pct)
+            guidance_deltas.append({
+                'metric': key,
+                'prior': ov,
+                'newest': nv,
+                'abs_delta': abs_delta,
+                'delta_pct': pct,
+            })
+
+        is_trivial = changed_blocks == 0 and not guidance_deltas
+
+        result = {
+            'ticker': meta.get('ticker'),
+            'form_type': meta.get('form_type'),
+            'newest_accession': meta.get('newest_accession'),
+            'prior_accession': meta.get('prior_accession'),
+            'newest_filing_date': meta.get('newest_filing_date'),
+            'prior_filing_date': meta.get('prior_filing_date'),
+            'section_diffs': section_diffs,
+            'changed_section_count': len(section_diffs),
+            'added_count': total_added,
+            'removed_count': total_removed,
+            'modified_count': total_modified,
+            'changed_blocks': changed_blocks,
+            'new_metrics': new_metrics,
+            'prior_metrics': old_metrics,
+            'guidance_deltas': guidance_deltas,
+            'max_abs_delta_pct': round(max_abs_delta_pct, 3),
+            'is_trivial': is_trivial,
+        }
+
+  # 7) CONDITION - route only NON-TRIVIAL diffs into the materiality gate. A filing whose
+  #    sections and guidance are unchanged skips the gate, the seal and the page entirely.
+  #    Deterministic branch off the in-code is_trivial flag. No model.
+  - id: route_diff
+    type: condition
+    depends_on: [compute_diff]
+    condition_config:
+      expression: "not {steps.compute_diff.output.is_trivial}"
+      then: [materiality_gate, seal_diff, memo, archive_diff, notify_deltas]
+      else: [notify_no_change]
+
+  # 8) MATERIALITY GATE (swappable + model-independent). TWO strategies, BOTH must pass:
+  #    (1) llm_eval materiality judge - "is this change material to an investor?", model
+  #        pinned to a SWAPPABLE provider (any can back it);
+  #    (2) llm_eval acting as a DETERMINISTIC threshold - fed ONLY the pre-computed
+  #        changed_blocks count and max_abs_delta_pct and told to answer purely from the
+  #        arithmetic, so the diff still passes/fails the gate on the non-LLM math alone.
+  - id: materiality_gate
+    type: gate
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are an equity-research analyst. Two consecutive periodic filings from the same
+              issuer were deterministically section-diffed in code. Decide whether the detected
+              changes are MATERIAL to an investor (a new or expanded risk factor, a guidance
+              revision, a litigation development, a meaningful language shift in MD&A) or
+              immaterial boilerplate (date roll-forward, formatting, restated prior-period labels).
+              Answer exactly 'approved' if the change is material and worth an analyst's time,
+              otherwise answer 'rejected' and name the reason. Judge materiality only; the numeric
+              magnitude is checked separately.
+            input: "Ticker {steps.compute_diff.output.ticker} {steps.compute_diff.output.form_type}: changed_sections={steps.compute_diff.output.changed_section_count} added={steps.compute_diff.output.added_count} removed={steps.compute_diff.output.removed_count} modified={steps.compute_diff.output.modified_count} guidance_deltas={steps.compute_diff.output.guidance_deltas} section_diffs={steps.compute_diff.output.section_diffs}"
+            model: "{input.gate_model}"
+        - type: llm_eval
+          config:
+            prompt: >-
+              Deterministic threshold check. Answer exactly 'approved' if changed_blocks is at or
+              above min_changed_blocks OR max_abs_delta_pct is at or above guidance_delta_threshold;
+              otherwise answer 'rejected'. Use ONLY the supplied numbers - do not infer or reason
+              beyond the arithmetic comparison.
+            input: "changed_blocks={steps.compute_diff.output.changed_blocks} min_changed_blocks={input.min_changed_blocks} max_abs_delta_pct={steps.compute_diff.output.max_abs_delta_pct} guidance_delta_threshold={input.guidance_delta_threshold}"
+            model: haiku
+
+  # 9) DETERMINISTIC SEAL. NO model. Canonical-fingerprint the whole diff record (per-block
+  #    fingerprints + the guidance deltas) into one diff_root SHA-256, and build the immutable
+  #    object key for the S3 archive PUT. This is the tamper-evident signature for the audit trail.
+  - id: seal_diff
+    type: code
+    depends_on: [compute_diff]
+    code_config:
+      language: python
+      code: |
+        import json
+        import hashlib
+        from datetime import datetime, timezone
+
+        diff = _steps.get('compute_diff') or {}
+        sealed_at = datetime.now(timezone.utc).isoformat()
+
+        block_fps = [b.get('fingerprint') for b in diff.get('section_diffs', []) if b.get('fingerprint')]
+        guidance = diff.get('guidance_deltas', [])
+
+        root_material = json.dumps(
+            {'blocks': block_fps, 'guidance': guidance, 'changed_blocks': diff.get('changed_blocks', 0)},
+            sort_keys=True, separators=(',', ':')
+        )
+        diff_root = hashlib.sha256(root_material.encode('utf-8')).hexdigest()
+
+        record = {
+            'ticker': diff.get('ticker'),
+            'form_type': diff.get('form_type'),
+            'newest_accession': diff.get('newest_accession'),
+            'prior_accession': diff.get('prior_accession'),
+            'newest_filing_date': diff.get('newest_filing_date'),
+            'prior_filing_date': diff.get('prior_filing_date'),
+            'sealed_at': sealed_at,
+            'diff_root_sha256': diff_root,
+            'changed_blocks': diff.get('changed_blocks', 0),
+            'max_abs_delta_pct': diff.get('max_abs_delta_pct', 0.0),
+            'section_diffs': diff.get('section_diffs', []),
+            'guidance_deltas': guidance,
+            'new_metrics': diff.get('new_metrics', {}),
+            'prior_metrics': diff.get('prior_metrics', {}),
+        }
+
+        canonical_record = json.dumps(record, sort_keys=True, separators=(',', ':'))
+        acc = str(diff.get('newest_accession') or 'unknown').replace('/', '-')
+        object_key = f"filing-deltas/{diff.get('ticker')}/{diff.get('form_type')}/{acc}.json"
+
+        result = {
+            'object_key': object_key,
+            'diff_root_sha256': diff_root,
+            'sealed_at': sealed_at,
+            'canonical_json': canonical_record,
+            'byte_length': len(canonical_record),
+            'record': record,
+        }
+
+  # 10) REPORT - compile the materiality memo: what changed by section, the added/removed risk
+  #     factors, and the numeric guidance table with per-metric deltas. The model only DRAFTS
+  #     prose around the deterministic diff; every number and block comes from compute_diff.
+  - id: memo
+    type: report
+    depends_on: [compute_diff, materiality_gate, seal_diff]
+    report_config:
+      template: research-report
+      format: pdf
+      theme: professional
+      title: "Filing Delta Memo - {input.ticker} {input.form_type} (newest vs prior)"
+      author: "Equity Research"
+    prompt: |
+      Write a tight equity-research "what changed this quarter" memo for the analyst. Use ONLY the
+      deterministic diff below - do not invent numbers or changes. Lead with the headline.
+
+      Section 1 - Filings compared (newest vs prior accession + dates):
+      ticker={steps.compute_diff.output.ticker} form={steps.compute_diff.output.form_type}
+      newest={steps.compute_diff.output.newest_accession} ({steps.compute_diff.output.newest_filing_date})
+      prior={steps.compute_diff.output.prior_accession} ({steps.compute_diff.output.prior_filing_date})
+
+      Section 2 - Numeric guidance deltas (revenue / EPS / gross margin, absolute + percent):
+      {steps.compute_diff.output.guidance_deltas}
+      Largest absolute move: {steps.compute_diff.output.max_abs_delta_pct}%
+
+      Section 3 - Section-by-section text changes (added / removed / modified risk factors,
+      MD&A language shifts, legal-proceedings developments):
+      {steps.compute_diff.output.section_diffs}
+
+      Section 4 - Materiality verdict (gate) and sealed-diff integrity reference:
+      gate={steps.materiality_gate.output}
+      diff_root_sha256={steps.seal_diff.output.diff_root_sha256}
+
+  # 11) ARCHIVE - PUT the sealed, SHA-256-fingerprinted diff record to the S3 audit bucket. The
+  #     diff_root hash travels as object metadata so the record is tamper-evident at rest.
+  #     Connector: aws-s3.
+  - id: archive_diff
+    type: http
+    depends_on: [seal_diff]
+    http_config:
+      url: "{input.archive_base_url}/{input.archive_bucket}/{steps.seal_diff.output.object_key}"
+      method: PUT
+      headers:
+        Content-Type: "application/json"
+        x-amz-meta-diff-root-sha256: "{steps.seal_diff.output.diff_root_sha256}"
+        x-amz-meta-ticker: "{input.ticker}"
+        x-amz-meta-newest-accession: "{steps.compute_diff.output.newest_accession}"
+      auth: "aws4:{env.AWS_ACCESS_KEY_ID}:{env.AWS_SECRET_ACCESS_KEY}"
+      body: "{steps.seal_diff.output.canonical_json}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 12) NOTIFY (deltas) - push the headline changes to the research channel so the analyst
+  #     reads only what actually moved between quarters. service: slack.
+  - id: notify_deltas
+    type: notify
+    depends_on: [compute_diff, seal_diff]
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :memo: Filing delta - {steps.compute_diff.output.ticker} {steps.compute_diff.output.form_type}
+        Newest {steps.compute_diff.output.newest_accession} ({steps.compute_diff.output.newest_filing_date}) vs prior {steps.compute_diff.output.prior_accession} ({steps.compute_diff.output.prior_filing_date})
+        Changed sections : {steps.compute_diff.output.changed_section_count}
+        Added/removed/modified blocks : {steps.compute_diff.output.added_count}/{steps.compute_diff.output.removed_count}/{steps.compute_diff.output.modified_count}
+        Largest guidance move : {steps.compute_diff.output.max_abs_delta_pct}%
+        Guidance deltas : {steps.compute_diff.output.guidance_deltas}
+        Sealed diff archived at {steps.seal_diff.output.object_key}
+        diff_root SHA-256: {steps.seal_diff.output.diff_root_sha256}
+
+  # 13) NOTIFY (no change) - quiet "nothing material changed" digest when the diff was trivial.
+  #     No seal, no memo, no archive.
+  - id: notify_no_change
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :white_check_mark: {steps.compute_diff.output.ticker} {steps.compute_diff.output.form_type} {steps.compute_diff.output.newest_accession}: no material section or guidance change vs prior filing. Nothing to read.
+on_complete:
+  storage_path: "sec-filing-delta-extractor/{run_id}/result.json"

--- a/src/sandcastle/templates/subscription_audit_cancel_warden.yaml
+++ b/src/sandcastle/templates/subscription_audit_cancel_warden.yaml
@@ -1,0 +1,441 @@
+# name: Subscription Audit & Cancel Warden
+# description: Pulls your card/bank transaction history, then a DETERMINISTIC code step normalizes merchants, infers monthly/annual cadence, dedups the noise into a real recurring-subscription ledger, and flags price-hikes and zombie (unused) subs with zero model involvement. A swappable CLASSIFY only labels keep/review/cancel from the precomputed flags. Any cancellation is held behind a GATE where a human approval strategy AND a non-LLM spend-threshold strategy must BOTH pass before a cancel request fires, then NOTIFY posts the audit.
+# tags: [Subscriptions, Personal Finance, Recurring Charges, Price Hike, Zombie Subs, Dedup, Cancel, Human Approval, Plaid, Stripe]
+# category: personal
+# connectors: plaid, stripe, slack
+name: subscription-audit-cancel-warden
+description: >-
+  A personal-finance warden that turns a noisy bank/card statement into a clean
+  recurring-subscription ledger and gates any cancellation behind human sign-off. A
+  DETERMINISTIC http GET pulls the transaction history from a bank/card aggregator
+  (Plaid / MX / Stripe style). A pure-Python code step then carries the load-bearing
+  work with ZERO model involvement: it normalizes merchant descriptors (strips the
+  trailing ref-codes, city/state tails, gateway prefixes), groups charges by normalized
+  merchant, infers the billing cadence (weekly / monthly / quarterly / annual) from the
+  median gap between charges, DEDUPS the repeats into a single subscription row, computes
+  the price-increase delta versus the prior charge, and scores each sub as a ZOMBIE when
+  it has not been touched within a deterministic inactivity window. A swappable CLASSIFY
+  step ONLY labels each precomputed sub keep / review / cancel - it never decides amounts
+  or cadence, and every label falls through to the deterministic router. A CONDITION
+  routes only the cancel-candidates into a CANCEL GATE that has TWO strategies which BOTH
+  must pass: a human approval ("confirm you want these cancelled") AND a non-LLM
+  spend-threshold strategy (auto-hold any cancel whose monthly cost is below the
+  rubber-stamp floor or above the dangerous-to-auto-cancel ceiling), so no cancellation
+  fires on a model's say-so. Approved cancels POST to the merchant/aggregator cancel
+  endpoint, and a NOTIFY pushes the full audit - new subs, price hikes, zombies, projected
+  annual savings - to the owner. All detection, dedup, cadence inference and price-delta
+  math are 100% deterministic and run even with zero model providers available.
+default_model: sonnet
+default_max_turns: 8
+default_timeout: 900
+input_schema:
+  required: ["transactions_url"]
+  properties:
+    transactions_url:
+      type: string
+      description: "Bank/card aggregator transaction-history REST endpoint (Plaid /transactions, MX, Stripe, or your bank's export gateway) returning dated charges."
+      default: "https://api.plaid.com/transactions/get"
+      example: "https://sandbox.plaid.com/transactions/get"
+    lookback_months:
+      type: integer
+      description: "How many months of statement history to scan for recurring charges. Longer windows make cadence inference and price-hike detection more reliable."
+      default: 12
+      example: "12"
+    zombie_inactivity_days:
+      type: integer
+      description: "Deterministic threshold (days since last charge relative to the expected next bill date) past which an active sub is flagged a ZOMBIE you likely forgot. Lower = more aggressive."
+      default: 75
+      example: "75"
+    price_hike_pct:
+      type: number
+      description: "Deterministic minimum percentage increase (vs the prior charge for the same sub) that counts as a flagged price hike. 0.10 = a 10% jump."
+      default: 0.10
+      example: "0.10"
+    min_cancel_cost:
+      type: number
+      description: "Non-LLM gate floor: a cancel whose MONTHLY cost is at/below this is too trivial to auto-fire (rubber-stamp risk) and is held for the human. In statement currency."
+      default: 3.0
+      example: "3.0"
+    max_cancel_cost:
+      type: number
+      description: "Non-LLM gate ceiling: a cancel whose MONTHLY cost is at/above this is too consequential to fire on automation and is held for explicit human review. In statement currency."
+      default: 200.0
+      example: "200.0"
+    cancel_api_url:
+      type: string
+      description: "Merchant / aggregator subscription-cancel REST endpoint that receives the approved cancellation requests."
+      default: "https://api.your-aggregator.example.com/subscriptions/cancel"
+      example: "https://api.acme-bank.example.com/subscriptions/cancel"
+    slack_channel:
+      type: string
+      description: "Channel that receives the subscription audit digest and the cancel confirmations."
+      default: "#money-subscriptions"
+      example: "#money-subscriptions"
+
+steps:
+  # 1) DETERMINISTIC pull of the raw transaction history from the bank/card aggregator.
+  #    Date-bounded by the lookback window. No model.
+  - id: pull_transactions
+    type: http
+    http_config:
+      url: "{input.transactions_url}?lookback_months={input.lookback_months}&pending=false&order=date.desc"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.AGGREGATOR_API_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 2) DETERMINISTIC RECURRING-CHARGE DETECTION. The load-bearing step, ZERO model:
+  #    normalize each merchant descriptor (drop trailing ref-codes, city/state tails, gateway
+  #    prefixes), group charges by normalized merchant, infer cadence from the median inter-charge
+  #    gap, DEDUP repeats into one subscription row, compute the price-increase delta vs the prior
+  #    charge, and score zombies by inactivity vs the expected next-bill date. All the money math
+  #    lives here, not in any model.
+  - id: detect_subscriptions
+    type: code
+    depends_on: [pull_transactions]
+    code_config:
+      language: python
+      code: |
+        import re
+        import statistics
+        from datetime import datetime, timezone, timedelta
+
+        raw = _steps.get('pull_transactions') or {}
+        # Coalesce the aggregator payload into a flat list of charge rows.
+        if isinstance(raw, list):
+            rows = raw
+        elif isinstance(raw, dict):
+            rows = (raw.get('transactions') or raw.get('data')
+                    or raw.get('results') or raw.get('items') or [])
+        else:
+            rows = []
+        if not isinstance(rows, list):
+            rows = [rows] if rows else []
+
+        zombie_days = int(_input.get('zombie_inactivity_days', 75) or 75)
+        hike_pct = float(_input.get('price_hike_pct', 0.10) or 0.10)
+
+        # --- Merchant descriptor normalizer (deterministic, no model). Strips the junk that
+        #     makes the same merchant look like ten different ones on a statement.
+        _gateway_pat = r'^(sq\s*\*|tst\*|paypal\s*\*|pp\*|google\s*\*|google\s|amzn\s+mktp|amazon\s+mktp|apl\*\s*|apple\.com/bill|stripe\s*\*|sp\s+|chk\*|dd\s*\*)'
+        def normalize_merchant(desc):
+            text = str(desc or '').strip().lower()
+            text = re.sub(_gateway_pat, '', text)
+            # drop trailing transaction/reference numbers and store ids
+            text = re.sub(r'[#*]?\s*\d{3,}\b', ' ', text)
+            # drop trailing US-style "city st" and 5-digit zips
+            text = re.sub(r'\b[a-z]{2}\s+\d{5}\b', ' ', text)
+            text = re.sub(r'\b\d{5}(-\d{4})?\b', ' ', text)
+            # drop punctuation and gateway noise tokens
+            text = re.sub(r'[^a-z0-9 ]+', ' ', text)
+            text = re.sub(r'\b(inc|llc|ltd|co|com|http|https|www|recurring|autopay|bill|payment|subscription|monthly|annual)\b', ' ', text)
+            text = re.sub(r'\s+', ' ', text).strip()
+            # keep the leading brand tokens (first 3) as the canonical key
+            tokens = [t for t in text.split(' ') if t]
+            return ' '.join(tokens[:3]) if tokens else 'unknown'
+
+        def parse_date(v):
+            try:
+                return datetime.fromisoformat(str(v).replace('Z', '+00:00').split('T')[0])
+            except (ValueError, TypeError):
+                return None
+
+        def parse_amount(v):
+            try:
+                return abs(round(float(v), 2))
+            except (ValueError, TypeError):
+                return None
+
+        # --- Group charges by normalized merchant key.
+        groups = {}
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            desc = (row.get('merchant_name') or row.get('name')
+                    or row.get('description') or row.get('merchant') or '')
+            amount = parse_amount(row.get('amount') or row.get('value') or row.get('price'))
+            dt = parse_date(row.get('date') or row.get('posted_at') or row.get('authorized_date') or row.get('timestamp'))
+            if amount is None or dt is None or amount == 0:
+                continue
+            key = normalize_merchant(desc)
+            groups.setdefault(key, {'raw_name': str(desc).strip(), 'charges': []})
+            groups[key]['charges'].append({'date': dt, 'amount': amount, 'raw': str(desc).strip()})
+
+        # --- Cadence inference + dedup + price-delta + zombie scoring, per group.
+        def cadence_from_gap(median_gap):
+            if median_gap is None:
+                return ('unknown', None, 0.0)
+            # (label, expected_period_days, per-month multiplier)
+            if median_gap <= 10:
+                return ('weekly', 7, 4.33)
+            if median_gap <= 45:
+                return ('monthly', 30, 1.0)
+            if median_gap <= 135:
+                return ('quarterly', 91, 1.0 / 3.0)
+            if median_gap <= 400:
+                return ('annual', 365, 1.0 / 12.0)
+            return ('irregular', int(median_gap), 30.0 / median_gap if median_gap else 0.0)
+
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        subscriptions = []
+        non_recurring = 0
+        for key, g in groups.items():
+            charges = sorted(g['charges'], key=lambda c: c['date'])
+            n = len(charges)
+            # A subscription needs at least 2 charges to have a cadence; otherwise it's a one-off.
+            if n < 2:
+                non_recurring += 1
+                continue
+            gaps = [(charges[i]['date'] - charges[i - 1]['date']).days for i in range(1, n)]
+            gaps = [g2 for g2 in gaps if g2 > 0]
+            if not gaps:
+                non_recurring += 1
+                continue
+            median_gap = statistics.median(gaps)
+            cadence, period_days, per_month = cadence_from_gap(median_gap)
+            # Irregular spacing with high variance is likely NOT a real subscription.
+            gap_spread = (max(gaps) - min(gaps)) if len(gaps) > 1 else 0
+            if cadence == 'irregular' and gap_spread > 60:
+                non_recurring += 1
+                continue
+
+            amounts = [c['amount'] for c in charges]
+            last = charges[-1]
+            prev = charges[-2]
+            current_amount = last['amount']
+            prior_amount = prev['amount']
+            # Price-increase delta vs the immediately prior charge for THIS sub.
+            price_delta = round(current_amount - prior_amount, 2)
+            price_delta_pct = round((price_delta / prior_amount), 4) if prior_amount else 0.0
+            price_hike = price_delta > 0 and price_delta_pct >= hike_pct
+
+            monthly_cost = round(current_amount * per_month, 2)
+            annual_cost = round(monthly_cost * 12, 2)
+
+            # Zombie scoring: days since the last charge vs when the next bill was DUE.
+            days_since_last = (now - last['date']).days
+            expected_next = last['date'] + timedelta(days=period_days or 30)
+            days_overdue = (now - expected_next).days
+            # A sub is a zombie when it is well past its expected next bill (it stopped billing /
+            # you cancelled the value but not the charge) OR untouched beyond the inactivity window.
+            is_zombie = days_overdue >= zombie_days or days_since_last >= (period_days or 30) + zombie_days
+
+            subscriptions.append({
+                'merchant_key': key,
+                'merchant_name': g['raw_name'],
+                'charge_count': n,
+                'cadence': cadence,
+                'median_gap_days': round(float(median_gap), 1),
+                'current_amount': current_amount,
+                'prior_amount': prior_amount,
+                'min_amount': min(amounts),
+                'max_amount': max(amounts),
+                'monthly_cost': monthly_cost,
+                'annual_cost': annual_cost,
+                'price_delta': price_delta,
+                'price_delta_pct': price_delta_pct,
+                'price_hike': price_hike,
+                'last_charge_date': last['date'].date().isoformat(),
+                'first_charge_date': charges[0]['date'].date().isoformat(),
+                'days_since_last': days_since_last,
+                'days_overdue': days_overdue,
+                'is_zombie': is_zombie,
+                # Deterministic pre-label the swappable classifier only confirms.
+                'flag': 'cancel' if (is_zombie or price_hike) else 'keep',
+            })
+
+        # Newly-appeared subs = only 2-3 charges and started within the last ~90 days.
+        new_subs = [s for s in subscriptions
+                    if s['charge_count'] <= 3
+                    and (now - parse_date(s['first_charge_date'])).days <= 90]
+        zombies = [s for s in subscriptions if s['is_zombie']]
+        hikes = [s for s in subscriptions if s['price_hike']]
+        cancel_candidates = [s for s in subscriptions if s['flag'] == 'cancel']
+
+        total_monthly = round(sum(s['monthly_cost'] for s in subscriptions), 2)
+        potential_savings_annual = round(sum(s['annual_cost'] for s in cancel_candidates), 2)
+
+        result = {
+            'transaction_count': len([r for r in rows if isinstance(r, dict)]),
+            'subscription_count': len(subscriptions),
+            'non_recurring_merchants': non_recurring,
+            'new_sub_count': len(new_subs),
+            'zombie_count': len(zombies),
+            'price_hike_count': len(hikes),
+            'cancel_candidate_count': len(cancel_candidates),
+            'total_monthly_cost': total_monthly,
+            'total_annual_cost': round(total_monthly * 12, 2),
+            'potential_savings_annual': potential_savings_annual,
+            'subscriptions': subscriptions,
+            'new_subs': new_subs,
+            'zombies': zombies,
+            'price_hikes': hikes,
+            'cancel_candidates': cancel_candidates,
+        }
+
+  # 3) CLASSIFY (swappable, LABEL-ONLY). The cheap model confirms keep / review / cancel from
+  #    the ALREADY-computed flags (zombie + price-hike). It NEVER computes amounts or cadence and
+  #    the deterministic router below trusts the in-code flag, not the label, so a missing model
+  #    provider cannot change which subs get cancelled.
+  - id: label_subscriptions
+    type: classify
+    depends_on: [detect_subscriptions]
+    classify_config:
+      model: haiku
+      input: >
+        You are a personal-finance assistant labeling subscriptions using ONLY the deterministic
+        flags already computed in code - do not recompute money or cadence. 'cancel' = the sub is
+        a zombie (unused / overdue past its next bill) OR took a flagged price hike and is no longer
+        worth it; 'review' = something looks off but it may still be wanted (a price hike on a
+        clearly-active service, an annual renewal coming up); 'keep' = a healthy active sub at a
+        stable price. Precomputed audit: total monthly cost {steps.detect_subscriptions.output.total_monthly_cost},
+        {steps.detect_subscriptions.output.zombie_count} zombies, {steps.detect_subscriptions.output.price_hike_count}
+        price hikes, {steps.detect_subscriptions.output.cancel_candidate_count} cancel candidates.
+        Candidates: {steps.detect_subscriptions.output.cancel_candidates}
+      categories:
+        - keep
+        - review
+        - cancel
+      branches:
+        keep: [route_cancel]
+        review: [route_cancel]
+        cancel: [route_cancel]
+
+  # 4) DETERMINISTIC build of the final cancel set + spend-threshold gate inputs. NO model.
+  #    Keeps only subs the IN-CODE flag marked cancel (not the model label), and pre-computes the
+  #    non-LLM gate facts: how many cancels fall inside the auto-fire band vs the floor/ceiling.
+  - id: build_cancel_set
+    type: code
+    depends_on: [detect_subscriptions, label_subscriptions]
+    code_config:
+      language: python
+      code: |
+        detect = _steps.get('detect_subscriptions') or {}
+        label = str(_steps.get('label_subscriptions') or '').strip().lower()
+        candidates = detect.get('cancel_candidates', []) or []
+
+        min_cost = float(_input.get('min_cancel_cost', 3.0) or 3.0)
+        max_cost = float(_input.get('max_cancel_cost', 200.0) or 200.0)
+
+        to_cancel = []
+        held_too_small = []
+        held_too_large = []
+        for s in candidates:
+            monthly = float(s.get('monthly_cost') or 0.0)
+            row = {
+                'merchant_name': s.get('merchant_name'),
+                'merchant_key': s.get('merchant_key'),
+                'monthly_cost': monthly,
+                'annual_cost': s.get('annual_cost'),
+                'cadence': s.get('cadence'),
+                'reason': 'zombie' if s.get('is_zombie') else ('price_hike' if s.get('price_hike') else 'flagged'),
+                'price_delta_pct': s.get('price_delta_pct'),
+                'last_charge_date': s.get('last_charge_date'),
+            }
+            if monthly <= min_cost:
+                held_too_small.append(row)
+            elif monthly >= max_cost:
+                held_too_large.append(row)
+            else:
+                to_cancel.append(row)
+
+        # The non-LLM gate fact: are there cancels inside the safe auto-fire band at all?
+        in_band_count = len(to_cancel)
+        savings_in_band = round(sum(r['annual_cost'] or 0.0 for r in to_cancel), 2)
+
+        result = {
+            'model_label': label,
+            'cancel_count': len(candidates),
+            'in_band_count': in_band_count,
+            'held_too_small_count': len(held_too_small),
+            'held_too_large_count': len(held_too_large),
+            'savings_in_band_annual': savings_in_band,
+            'to_cancel': to_cancel,
+            'held_too_small': held_too_small,
+            'held_too_large': held_too_large,
+            'has_cancellable': in_band_count > 0,
+        }
+
+  # 5) CONDITION - only enter the cancel gate when there is at least one cancel inside the
+  #    safe spend band. If nothing is cancellable, jump straight to the audit notify. No model.
+  - id: route_cancel
+    type: condition
+    depends_on: [build_cancel_set]
+    condition_config:
+      expression: "{steps.build_cancel_set.output.has_cancellable} == True"
+      then: [cancel_gate, fire_cancellations, notify_audit]
+      else: [notify_audit]
+
+  # 6) CANCEL GATE (model-independent, BOTH strategies must pass):
+  #    (1) HUMAN approval - the owner must explicitly confirm the cancellations before anything
+  #        is cancelled; this is irreversible spending behavior, so a human is mandatory.
+  #    (2) NON-LLM spend-threshold strategy - an llm_eval fed ONLY the pre-computed counts and the
+  #        floor/ceiling, told to answer purely from the arithmetic, so the gate still passes/fails
+  #        on the deterministic spend band alone with zero reasoning.
+  - id: cancel_gate
+    type: gate
+    depends_on: [build_cancel_set]
+    gate_config:
+      strategies:
+        - type: human
+          config:
+            message: "Subscription Warden wants to CANCEL these subscriptions (zombie or price-hiked, inside your safe spend band). Approve to fire the cancellations; reject to keep them. Cancels below your floor or above your ceiling were held automatically for manual handling."
+            timeout_hours: 72
+            on_timeout: abort
+        - type: llm_eval
+          config:
+            prompt: >-
+              Deterministic spend-band check. Answer exactly 'approved' if in_band_count >= 1 AND
+              every cancel's monthly cost is strictly above the floor and strictly below the
+              ceiling (the held_too_small / held_too_large lists are already excluded upstream).
+              Otherwise answer 'rejected'. Use ONLY the supplied numbers - do not reason beyond the
+              arithmetic comparison.
+            input: "in_band_count={steps.build_cancel_set.output.in_band_count} held_too_small={steps.build_cancel_set.output.held_too_small_count} held_too_large={steps.build_cancel_set.output.held_too_large_count} floor={input.min_cancel_cost} ceiling={input.max_cancel_cost}"
+            model: haiku
+
+  # 7) FIRE the approved cancellations. POST the safe-band cancel set to the merchant/aggregator
+  #    cancel endpoint. Only reached after BOTH gate strategies passed. Connector: plaid/stripe.
+  - id: fire_cancellations
+    type: http
+    depends_on: [cancel_gate]
+    http_config:
+      url: "{input.cancel_api_url}"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.AGGREGATOR_API_TOKEN}"
+      body: |
+        {
+          "action": "cancel_subscriptions",
+          "approved": true,
+          "subscriptions": {{ _steps['build_cancel_set']['to_cancel'] }},
+          "projected_annual_savings": {{ _steps['build_cancel_set']['savings_in_band_annual'] }}
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 8) NOTIFY the owner with the full subscription audit - new subs, price hikes, zombies,
+  #    what was cancelled vs held, and the projected annual savings. service: slack.
+  - id: notify_audit
+    type: notify
+    depends_on: [route_cancel]
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :receipt: Subscription audit complete - {steps.detect_subscriptions.output.subscription_count} recurring subs, {steps.detect_subscriptions.output.total_monthly_cost}/mo ({steps.detect_subscriptions.output.total_annual_cost}/yr)
+        New since last scan : {steps.detect_subscriptions.output.new_sub_count}
+        Price hikes flagged : {steps.detect_subscriptions.output.price_hike_count}
+        Zombie (unused) subs: {steps.detect_subscriptions.output.zombie_count}
+        Cancel candidates   : {steps.detect_subscriptions.output.cancel_candidate_count}
+        In-band cancelled   : {steps.build_cancel_set.output.in_band_count} (held small: {steps.build_cancel_set.output.held_too_small_count}, held large: {steps.build_cancel_set.output.held_too_large_count})
+        Projected annual savings: {steps.build_cancel_set.output.savings_in_band_annual}
+on_complete:
+  storage_path: "subscription-audit-cancel-warden/{run_id}/result.json"

--- a/src/sandcastle/templates/topic_share_of_voice_rank_monitor.yaml
+++ b/src/sandcastle/templates/topic_share_of_voice_rank_monitor.yaml
@@ -1,0 +1,707 @@
+# name: Topic Share-of-Voice Rank Monitor
+# description: Tracks where your brand and named rivals surface across multiple search / answer engines for a watched keyword set, then computes a DETERMINISTIC share-of-voice and rank-delta versus the last sealed snapshot - entirely in code. A SENSOR runs the sweep on schedule; a LOOP fans parallel http GETs to several providers (Tavily, Exa, a SERP-style endpoint) per keyword; a code step normalizes results, matches brand / competitor mentions, and computes per-keyword rank positions, an aggregate SoV percentage and the rank_delta of who gained or lost positions. A CLASSIFY labels each keyword steady / improving / overtaken, a CONDITION feeds adverse moves into a swappable GATE (llm_eval 'real ranking loss worth acting on?' AND a non-LLM 'rank_delta<=-N or sov_drop_pct>=threshold'). Confirmed losses NOTIFY Slack and append to an Airtable scoreboard, and the new snapshot is sealed back to the store. All SoV and rank-delta math is model-independent.
+# tags: [SEO, ShareOfVoice, RankTracking, AnswerEngine, GEO, CompetitiveIntel, Brand, Tavily, Exa, SERP, Airtable, Slack, monitoring]
+# category: research_intel
+# connectors: tavily, exa, airtable, slack
+name: topic-share-of-voice-rank-monitor
+description: >-
+  An always-on share-of-voice and competitive-rank watchdog for a watched keyword
+  set across multiple search / answer engines. A durable SENSOR blocks until the next
+  scheduled sweep window is due (or a webhook bumps it), then a LOOP iterates every
+  watched keyword and fans out PARALLEL http GETs (via a race) to several providers -
+  Tavily, Exa and a SERP-style endpoint - so a single dead provider never blinds the
+  sweep. A DETERMINISTIC code step normalizes each provider's results into a ranked
+  URL list, matches your brand and each named competitor by domain / alias, and computes
+  per-keyword rank positions plus a 0-100 aggregate share-of-voice percentage and the
+  rank_delta against the last SEALED snapshot (who gained or lost positions) - 100% in
+  code, no model. A CLASSIFY labels each keyword steady / improving / overtaken, and a
+  CONDITION routes only adverse moves into a MATERIALITY GATE with TWO strategies that
+  BOTH must pass: a swappable llm_eval judge ("is this a real ranking loss worth acting
+  on, or normal SERP churn?", backable by any provider) AND a NON-LLM threshold strategy
+  fed only the pre-computed rank_delta / sov_drop_pct, so a keyword passes or fails the
+  gate on the arithmetic alone. After the loop, a deterministic code step aggregates the
+  sweep, seals the new snapshot, and only confirmed overtakes NOTIFY the Slack channel
+  and append a row to the Airtable scoreboard. All SoV and rank-delta math runs even with
+  zero model providers available; the model is confined to the gate's swappable judge.
+default_model: sonnet
+default_max_turns: 8
+default_timeout: 1800
+input_schema:
+  required: ["watch_keywords", "brand_and_competitors"]
+  properties:
+    watch_keywords:
+      type: string
+      description: "Comma- or newline-separated topic keywords / queries to track share-of-voice on (e.g. 'workflow orchestrator, ai agent platform, eu ai act compliance')."
+      default: "ai workflow orchestrator, agent automation platform, eu ai act compliance tool"
+      example: "ai workflow orchestrator, agent automation platform, eu ai act compliance tool"
+    brand_and_competitors:
+      type: string
+      description: "Brand + rivals as 'Label=domain1|alias' entries, semicolon-separated. The FIRST entry is YOUR brand; the rest are tracked competitors. Domains / aliases drive deterministic mention matching."
+      default: "Sandcastle=sandcastle-ai.eu|sandcastle; Zapier=zapier.com; n8n=n8n.io|n8n; Make=make.com|integromat"
+      example: "Sandcastle=sandcastle-ai.eu|sandcastle; Zapier=zapier.com; n8n=n8n.io; Make=make.com|integromat"
+    search_provider_urls:
+      type: string
+      description: "Comma-separated search / answer-engine endpoints queried in parallel per keyword. Order is provider1=Tavily, provider2=Exa, provider3=SERP-style. Leave a slot empty to skip that provider."
+      default: "https://api.tavily.com/search, https://api.exa.ai/search, https://serpapi.com/search"
+      example: "https://api.tavily.com/search, https://api.exa.ai/search, https://serpapi.com/search"
+    rank_delta_threshold:
+      type: integer
+      description: "Deterministic rank-loss threshold (positive integer). The gate's non-LLM strategy treats a keyword as a material overtake when your brand's rank_delta <= -threshold (you fell at least this many positions) OR sov_drop_pct meets the SoV threshold."
+      default: 2
+      example: "3"
+    sov_drop_threshold_pct:
+      type: number
+      description: "Deterministic share-of-voice drop threshold in percentage points. The gate's non-LLM strategy fires when your brand's SoV fell by at least this many points versus the last sealed snapshot."
+      default: 5.0
+      example: "5.0"
+    snapshot_store_url:
+      type: string
+      description: "Snapshot store REST base (PostgREST / S3 REST gateway) holding the last SEALED per-keyword ranks + SoV that rank_delta is measured against."
+      default: "https://sov.internal/snapshots"
+      example: "https://sov.internal/snapshots"
+    sweep_interval:
+      type: integer
+      description: "Seconds between share-of-voice sweeps. The sensor blocks until the scheduler reports the next sweep window is due OR a webhook fires."
+      default: 86400
+      example: "86400"
+    sensor_timeout:
+      type: integer
+      description: "Sensor soft timeout in seconds - stop waiting for the next sweep window after this long (one watch run). Default 7 days."
+      default: 604800
+      example: "604800"
+    result_depth:
+      type: integer
+      description: "How many top ranked results per provider to consider when matching brand / competitor mentions and computing rank positions."
+      default: 10
+      example: "10"
+    gate_model:
+      type: string
+      description: "Swappable ranking-loss judge model for the gate. Any provider can back it; for EU data pin a local / EU provider (mistral/large, ollama, omlx/qwen-3). SoV + rank-delta detection works with this unavailable."
+      default: "sonnet"
+      example: "mistral/large"
+    airtable_base_id:
+      type: string
+      description: "Airtable base id that holds the competitive share-of-voice scoreboard table."
+      default: "appXXXXXXXXXXXXXX"
+      example: "app8sJ2kQfL0qWvZ1"
+    airtable_table:
+      type: string
+      description: "Airtable table name the confirmed overtakes are appended to as scoreboard rows."
+      default: "SoV Scoreboard"
+      example: "SoV Scoreboard"
+    slack_channel:
+      type: string
+      description: "Slack channel that receives the confirmed-overtake alert and the clean-sweep digest."
+      default: "#competitive-intel"
+      example: "#competitive-intel"
+steps:
+  # 1) DURABLE SENSOR - block until the next share-of-voice sweep window is DUE, or a webhook
+  #    has bumped the scheduler's pending flag (event-driven within a schedule). Polls the
+  #    sweep-window status endpoint; until a sweep is due there is nothing new to re-rank.
+  - id: await_sweep_window
+    type: sensor
+    sensor_config:
+      url: "{input.snapshot_store_url}/sweep-window?select=sweep_due,window_changed_since_last_seal"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and (response.get('sweep_due') == True or response.get('window_changed_since_last_seal') == True)"
+      check_interval: 3600
+      timeout: 604800
+
+  # 2) DETERMINISTIC parse of the watched-keyword set, the brand/competitor roster, and the
+  #    provider URL slots into a flat loopable plan. The FIRST roster entry is YOUR brand; the
+  #    rest are tracked competitors. Each keyword row carries its snapshot-store key for the
+  #    rank_delta measurement. No model.
+  - id: build_sweep_plan
+    type: code
+    depends_on: [await_sweep_window]
+    code_config:
+      language: python
+      code: |
+        import re
+
+        def split_multi(raw):
+            parts = re.split(r'[\n,;]+', str(raw or ''))
+            return [p.strip() for p in parts if p.strip()]
+
+        # --- keywords -------------------------------------------------------------------
+        keywords = [k for k in split_multi(_input.get('watch_keywords')) if k]
+        # de-dupe while preserving order (case-insensitive)
+        seen = set()
+        kw_clean = []
+        for k in keywords:
+            key = k.lower()
+            if key not in seen:
+                seen.add(key)
+                kw_clean.append(k)
+
+        # --- brand + competitor roster: 'Label=domain|alias; Label2=domain2' --------------
+        roster_raw = str(_input.get('brand_and_competitors') or '')
+        roster = []
+        for ent in roster_raw.split(';'):
+            ent = ent.strip()
+            if not ent:
+                continue
+            if '=' in ent:
+                label, rhs = ent.split('=', 1)
+            else:
+                label, rhs = ent, ent
+            label = label.strip()
+            aliases = [a.strip().lower() for a in rhs.split('|') if a.strip()]
+            if not aliases:
+                aliases = [label.lower()]
+            roster.append({'label': label, 'aliases': aliases})
+        brand = roster[0]['label'] if roster else ''
+
+        # --- provider URL slots (provider1=Tavily, provider2=Exa, provider3=SERP) ----------
+        prov_urls = split_multi(_input.get('search_provider_urls'))
+        providers = []
+        names = ['tavily', 'exa', 'serp']
+        for i, url in enumerate(prov_urls):
+            providers.append({'name': names[i] if i < len(names) else f'provider{i+1}', 'url': url})
+
+        depth = int(_input.get('result_depth', 10) or 10)
+        snap_base = str(_input.get('snapshot_store_url') or '').rstrip('/')
+
+        rows = []
+        for kw in kw_clean:
+            slug = re.sub(r'[^a-z0-9]+', '-', kw.lower()).strip('-')
+            rows.append({
+                'keyword': kw,
+                'keyword_slug': slug,
+                'roster': roster,
+                'brand': brand,
+                'providers': providers,
+                'depth': depth,
+                # snapshot store key holding this keyword's last sealed ranks + SoV.
+                'snapshot_url': f"{snap_base}?keyword=eq.{slug}&order=sealed_at.desc&limit=1",
+            })
+
+        result = {
+            'brand': brand,
+            'competitor_count': max(0, len(roster) - 1),
+            'keyword_count': len(rows),
+            'provider_count': len(providers),
+            'keywords': rows,
+        }
+
+  # 3) LOOP over every watched keyword. Per-keyword child chain: race parallel provider GETs ->
+  #    GET last sealed snapshot -> deterministic rank + SoV + rank_delta -> classify the move ->
+  #    condition routes adverse moves into the materiality gate.
+  - id: per_keyword_loop
+    type: loop
+    depends_on: [build_sweep_plan]
+    loop_config:
+      over: "steps.build_sweep_plan.output.keywords"
+      step_ids:
+        - query_tavily
+        - query_exa
+        - query_serp
+        - providers_race
+        - fetch_last_snapshot
+        - compute_rank_sov
+        - classify_move
+        - move_branch
+      max_iterations: 500
+
+  # 3a) http GET this keyword on TAVILY (provider1). on_failure: skip so one dead provider does
+  #     not abort the keyword - the race below takes whichever provider returns usable results.
+  - id: query_tavily
+    type: http
+    http_config:
+      url: "{input._item.providers[0].url}?query={input._item.keyword}&max_results={input._item.depth}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.TAVILY_API_KEY}"
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  # 3b) http GET this keyword on EXA (provider2) in parallel.
+  - id: query_exa
+    type: http
+    http_config:
+      url: "{input._item.providers[1].url}?q={input._item.keyword}&numResults={input._item.depth}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.EXA_API_KEY}"
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  # 3c) http GET this keyword on a SERP-style endpoint (provider3) in parallel.
+  - id: query_serp
+    type: http
+    http_config:
+      url: "{input._item.providers[2].url}?q={input._item.keyword}&num={input._item.depth}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.SERP_API_KEY}"
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  # 3d) RACE the three parallel provider GETs - FIRST provider that returns a usable ranked
+  #     list wins (provider failover, NOT a vote). The winning payload feeds the deterministic
+  #     rank / SoV math regardless of which vendor answered.
+  - id: providers_race
+    type: race
+    race_config:
+      branches:
+        - [query_tavily]
+        - [query_exa]
+        - [query_serp]
+      validator: "len(str(output).strip()) > 0"
+
+  # 3e) http GET this keyword's LAST SEALED snapshot (prior ranks + SoV) so rank_delta is
+  #     measured against the previously-sealed truth, not re-derived. on_failure: skip -> a
+  #     first-ever sweep simply has no prior and reports first_seal.
+  - id: fetch_last_snapshot
+    type: http
+    http_config:
+      url: "{input._item.snapshot_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.SNAPSHOT_STORE_TOKEN}"
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  # 3f) DETERMINISTIC RANK + SHARE-OF-VOICE + RANK_DELTA. NO model. Normalize the winning
+  #     provider payload into a ranked URL list, match brand + each competitor by domain / alias,
+  #     compute each player's best rank position, a 0-100 aggregate share-of-voice percentage
+  #     (presence + position-weighted), and the rank_delta vs the last sealed snapshot - who
+  #     gained or lost positions. This is the load-bearing math the gate's non-LLM strategy reads.
+  - id: compute_rank_sov
+    type: code
+    code_config:
+      language: python
+      code: |
+        import re
+
+        item = _input.get('_item') or {}
+        raw = _steps.get('providers_race')
+        snap_raw = _steps.get('fetch_last_snapshot') or {}
+        roster = item.get('roster') or []
+        brand = item.get('brand') or ''
+        depth = int(item.get('depth', 10) or 10)
+
+        # --- normalize the winning provider payload into a ranked list of result URLs/snippets.
+        def as_rows(blob):
+            if isinstance(blob, list):
+                return [r for r in blob if isinstance(r, dict)]
+            if isinstance(blob, dict):
+                for k in ('results', 'data', 'items', 'hits', 'organic_results', 'web', 'value'):
+                    v = blob.get(k)
+                    if isinstance(v, list):
+                        return [r for r in v if isinstance(r, dict)]
+            return []
+
+        rows = as_rows(raw)[:depth]
+
+        def hay(rec):
+            # searchable text per result: url + title + snippet, lowercased.
+            bits = [
+                rec.get('url'), rec.get('link'), rec.get('href'),
+                rec.get('title'), rec.get('name'),
+                rec.get('snippet'), rec.get('content'), rec.get('description'),
+            ]
+            return ' '.join(str(b) for b in bits if b).lower()
+
+        ranked = [{'position': i + 1, 'text': hay(rec)} for i, rec in enumerate(rows)]
+        total_slots = len(ranked)
+
+        # --- match each roster player by any alias; best (lowest) rank position wins.
+        players = {}
+        for entry in roster:
+            label = entry.get('label')
+            aliases = entry.get('aliases') or [str(label).lower()]
+            best_rank = None
+            appearances = 0
+            for r in ranked:
+                if any(a and a in r['text'] for a in aliases):
+                    appearances += 1
+                    if best_rank is None or r['position'] < best_rank:
+                        best_rank = r['position']
+            # position weight: rank 1 worth most, decaying linearly down the page.
+            weight = 0.0
+            if best_rank is not None and total_slots > 0:
+                weight = (total_slots - best_rank + 1) / total_slots
+            players[label] = {
+                'label': label,
+                'best_rank': best_rank,           # None = absent this sweep
+                'appearances': appearances,
+                'present': best_rank is not None,
+                'weight': round(weight, 4),
+            }
+
+        # --- aggregate share-of-voice: each player's position-weight as a share of the total.
+        total_weight = sum(p['weight'] for p in players.values())
+        for label, p in players.items():
+            p['sov_pct'] = round((p['weight'] / total_weight) * 100, 2) if total_weight > 0 else 0.0
+
+        brand_now = players.get(brand, {})
+        brand_rank_now = brand_now.get('best_rank')
+        brand_sov_now = brand_now.get('sov_pct', 0.0)
+
+        # --- rank_delta vs last SEALED snapshot. positive = improved (rose), negative = lost.
+        snap_rows = snap_raw if isinstance(snap_raw, list) else (
+            snap_raw.get('data') or snap_raw.get('items') or snap_raw.get('records') or [snap_raw]
+        )
+        prev = snap_rows[0] if snap_rows and isinstance(snap_rows[0], dict) else {}
+        prev_players = prev.get('players') if isinstance(prev.get('players'), dict) else {}
+        prev_brand = prev_players.get(brand) if isinstance(prev_players.get(brand), dict) else {}
+
+        def to_int(v):
+            try:
+                return int(v)
+            except (ValueError, TypeError):
+                return None
+
+        def to_float(v):
+            try:
+                return float(v)
+            except (ValueError, TypeError):
+                return None
+
+        prev_brand_rank = to_int(prev_brand.get('best_rank')) if prev_brand else None
+        prev_brand_sov = to_float(prev_brand.get('sov_pct')) if prev_brand else None
+        first_seal = not bool(prev)
+
+        # rank_delta: prev_rank - now_rank. positive = you moved UP; negative = you fell.
+        # absence is treated as worst rank (depth + 1) so dropping off the page counts as a loss.
+        def eff_rank(rk):
+            return rk if isinstance(rk, int) else (total_slots + 1)
+        if prev_brand_rank is not None or brand_rank_now is not None:
+            rank_delta = eff_rank(prev_brand_rank) - eff_rank(brand_rank_now)
+        else:
+            rank_delta = 0
+
+        # sov_drop_pct: how many SoV points the brand LOST since the last seal (0 if it gained/held).
+        if prev_brand_sov is not None:
+            sov_drop_pct = round(max(0.0, prev_brand_sov - brand_sov_now), 2)
+        else:
+            sov_drop_pct = 0.0
+
+        # who overtook us: competitors now ranked ahead of the brand that were behind / absent before.
+        overtakers = []
+        brand_eff = eff_rank(brand_rank_now)
+        for label, p in players.items():
+            if label == brand:
+                continue
+            comp_rank = p.get('best_rank')
+            if comp_rank is not None and comp_rank < brand_eff:
+                prev_comp = prev_players.get(label) if isinstance(prev_players.get(label), dict) else {}
+                prev_comp_rank = to_int(prev_comp.get('best_rank')) if prev_comp else None
+                was_behind = (prev_comp_rank is None) or (
+                    isinstance(prev_brand_rank, int) and prev_comp_rank > prev_brand_rank
+                )
+                if was_behind:
+                    overtakers.append({'label': label, 'rank': comp_rank, 'prev_rank': prev_comp_rank})
+
+        brand_lost = (rank_delta < 0) or (sov_drop_pct > 0) or bool(overtakers)
+
+        result = {
+            'keyword': item.get('keyword'),
+            'keyword_slug': item.get('keyword_slug'),
+            'brand': brand,
+            'total_results': total_slots,
+            'players': players,
+            'brand_rank_now': brand_rank_now,
+            'brand_rank_prev': prev_brand_rank,
+            'brand_sov_now': brand_sov_now,
+            'brand_sov_prev': prev_brand_sov,
+            'rank_delta': rank_delta,
+            'sov_drop_pct': sov_drop_pct,
+            'overtakers': overtakers,
+            'overtaker_count': len(overtakers),
+            'brand_lost': brand_lost,
+            'first_seal': first_seal,
+            # before/after captured for the sealed snapshot.
+            'before_state': {'players': prev_players, 'sealed': bool(prev)},
+            'after_state': {'players': players},
+        }
+
+  # 3g) CLASSIFY the keyword's competitive move. The cheap model only LABELS; the rank / SoV /
+  #     rank_delta decision was ALREADY made deterministically in code. steady (held) /
+  #     improving (gained rank or SoV) / overtaken (a competitor passed us or we lost position).
+  - id: classify_move
+    type: classify
+    classify_config:
+      model: haiku
+      input: "Classify this keyword's competitive move using ONLY the deterministic numbers. overtaken = rank_delta < 0 OR sov_drop_pct > 0 OR overtaker_count > 0; improving = rank_delta > 0 AND no overtakers; steady = none of those. rank_delta={steps.compute_rank_sov.output.rank_delta}, sov_drop_pct={steps.compute_rank_sov.output.sov_drop_pct}, overtaker_count={steps.compute_rank_sov.output.overtaker_count}, brand_lost={steps.compute_rank_sov.output.brand_lost}, first_seal={steps.compute_rank_sov.output.first_seal}."
+      categories:
+        - steady
+        - improving
+        - overtaken
+      branches:
+        steady: [record_keyword_status]
+        improving: [record_keyword_status]
+        overtaken: [move_branch]
+
+  # 3h) CONDITION - route adverse moves (brand lost rank / SoV, or got overtaken) into the
+  #     materiality gate; steady / improving keywords record directly. Deterministic branch off
+  #     the in-code flags (not the model label), so routing survives a missing provider. No model.
+  - id: move_branch
+    type: condition
+    condition_config:
+      expression: "{steps.compute_rank_sov.output.brand_lost} and not {steps.compute_rank_sov.output.first_seal}"
+      then: [materiality_gate, record_keyword_status]
+      else: [record_keyword_status]
+
+  # 3i) MATERIALITY GATE (swappable + model-independent). TWO strategies, BOTH must pass:
+  #     (1) llm_eval ranking-loss judge - "real loss worth acting on, or normal SERP churn?",
+  #         model pinned to a SWAPPABLE provider (any can back it);
+  #     (2) llm_eval acting as a DETERMINISTIC threshold - fed ONLY the pre-computed rank_delta /
+  #         sov_drop_pct / thresholds and told to answer purely from the arithmetic, so a keyword
+  #         still passes / fails the gate on the non-LLM math alone.
+  - id: materiality_gate
+    type: gate
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are a competitive-intelligence reviewer. For a watched keyword, your brand
+              deterministically lost rank or share-of-voice versus the last sealed snapshot, and
+              a code step already computed the magnitude. Decide whether this is a REAL,
+              actionable positioning loss (a competitor genuinely overtook you and is holding) or
+              normal day-to-day SERP / answer-engine churn not worth alerting on. Answer exactly
+              'approved' if it is a material ranking loss worth acting on, otherwise answer
+              'rejected' and name the reason. Judge materiality only; the numeric magnitude is
+              checked separately.
+            input: "Keyword '{steps.compute_rank_sov.output.keyword}': brand_rank_now={steps.compute_rank_sov.output.brand_rank_now} brand_rank_prev={steps.compute_rank_sov.output.brand_rank_prev} rank_delta={steps.compute_rank_sov.output.rank_delta} sov_drop_pct={steps.compute_rank_sov.output.sov_drop_pct} overtakers={steps.compute_rank_sov.output.overtakers}"
+            model: "{input.gate_model}"
+        - type: llm_eval
+          config:
+            prompt: >-
+              Deterministic threshold check. Answer exactly 'approved' if rank_delta <=
+              -{input.rank_delta_threshold} OR sov_drop_pct >= {input.sov_drop_threshold_pct};
+              otherwise answer 'rejected'. Use ONLY the supplied numbers - do not infer or reason
+              beyond the arithmetic comparison.
+            input: "rank_delta={steps.compute_rank_sov.output.rank_delta} rank_delta_threshold={input.rank_delta_threshold} sov_drop_pct={steps.compute_rank_sov.output.sov_drop_pct} sov_drop_threshold_pct={input.sov_drop_threshold_pct}"
+            model: haiku
+
+  # 3j) DETERMINISTIC per-keyword status record. Folds the rank/SoV result, the classify label
+  #     and (when the gate ran) the materiality outcome into one canonical row. A keyword is a
+  #     CONFIRMED overtake only when the brand lost AND the materiality gate passed. No model.
+  - id: record_keyword_status
+    type: code
+    code_config:
+      language: python
+      code: |
+        ev = _steps.get('compute_rank_sov') or {}
+        label = str(_steps.get('classify_move') or '').strip().lower()
+        gate = _steps.get('materiality_gate')
+
+        gate_ran = gate is not None
+        if isinstance(gate, dict):
+            gate_passed = bool(gate.get('passed', gate.get('approved', gate.get('result', False))))
+        else:
+            gate_passed = bool(gate) if gate is not None else False
+
+        brand_lost = bool(ev.get('brand_lost'))
+        rank_delta = ev.get('rank_delta')
+        sov_drop_pct = ev.get('sov_drop_pct')
+
+        if brand_lost and gate_ran and gate_passed:
+            status = 'overtaken'
+        elif brand_lost and gate_ran and not gate_passed:
+            status = 'churn'            # move detected but gate ruled it immaterial
+        elif (rank_delta or 0) > 0:
+            status = 'improving'
+        else:
+            status = 'steady'
+
+        confirmed_overtake = status == 'overtaken'
+
+        result = {
+            'keyword': ev.get('keyword'),
+            'keyword_slug': ev.get('keyword_slug'),
+            'brand': ev.get('brand'),
+            'status': status,
+            'classify_label': label,
+            'brand_rank_now': ev.get('brand_rank_now'),
+            'brand_rank_prev': ev.get('brand_rank_prev'),
+            'brand_sov_now': ev.get('brand_sov_now'),
+            'brand_sov_prev': ev.get('brand_sov_prev'),
+            'rank_delta': rank_delta,
+            'sov_drop_pct': sov_drop_pct,
+            'overtakers': ev.get('overtakers'),
+            'overtaker_count': ev.get('overtaker_count'),
+            'gate_ran': gate_ran,
+            'gate_passed': gate_passed if gate_ran else None,
+            'confirmed_overtake': confirmed_overtake,
+            'players': ev.get('players'),
+            'first_seal': ev.get('first_seal'),
+        }
+
+  # 4) DETERMINISTIC aggregation of every per-keyword status from the loop. Splits steady /
+  #    improving / confirmed-overtake / churn, builds the confirmed-overtake list with overtakers,
+  #    and seals the new per-keyword snapshot payload. fail_count drives the alert path. No model.
+  - id: aggregate_sweep
+    type: code
+    depends_on: [per_keyword_loop]
+    code_config:
+      language: python
+      code: |
+        from datetime import datetime, timezone
+
+        loop_out = _steps.get('per_keyword_loop') or {}
+        plan = _steps.get('build_sweep_plan') or {}
+
+        items = loop_out if isinstance(loop_out, list) else (
+            loop_out.get('results') or loop_out.get('items') or loop_out.get('iterations') or []
+        )
+
+        keywords = []
+        for it in items:
+            row = it
+            if isinstance(it, dict) and 'keyword' not in it:
+                row = it.get('record_keyword_status') or it.get('output') or it
+            if isinstance(row, dict) and row.get('keyword'):
+                keywords.append(row)
+
+        total = len(keywords)
+        confirmed = [k for k in keywords if k.get('confirmed_overtake')]
+        churn = [k for k in keywords if k.get('status') == 'churn']
+        improving = [k for k in keywords if k.get('status') == 'improving']
+        steady = [k for k in keywords if k.get('status') == 'steady']
+
+        # aggregate brand SoV across the watched set (mean of per-keyword SoV).
+        sov_vals = [float(k.get('brand_sov_now') or 0.0) for k in keywords]
+        avg_brand_sov = round(sum(sov_vals) / len(sov_vals), 2) if sov_vals else 0.0
+
+        overtake_events = [
+            {
+                'keyword': k.get('keyword'),
+                'brand_rank_now': k.get('brand_rank_now'),
+                'brand_rank_prev': k.get('brand_rank_prev'),
+                'rank_delta': k.get('rank_delta'),
+                'sov_drop_pct': k.get('sov_drop_pct'),
+                'overtakers': k.get('overtakers'),
+            }
+            for k in confirmed
+        ]
+
+        sealed_at = datetime.now(timezone.utc).isoformat()
+        # new snapshot payload to seal back to the store, one row per keyword.
+        snapshot_rows = [
+            {
+                'keyword': k.get('keyword_slug'),
+                'sealed_at': sealed_at,
+                'players': k.get('players'),
+                'brand_sov': k.get('brand_sov_now'),
+                'brand_rank': k.get('brand_rank_now'),
+            }
+            for k in keywords
+        ]
+
+        result = {
+            'brand': plan.get('brand'),
+            'sealed_at': sealed_at,
+            'total_keywords': total,
+            'steady_count': len(steady),
+            'improving_count': len(improving),
+            'churn_count': len(churn),
+            'confirmed_overtake_count': len(confirmed),
+            'avg_brand_sov': avg_brand_sov,
+            'overtake_events': overtake_events,
+            'snapshot_rows': snapshot_rows,
+            # fail_count > 0 -> confirmed material overtakes to alert + scoreboard.
+            'fail_count': len(confirmed),
+        }
+
+  # 5) CONDITION - only alert Slack + append the Airtable scoreboard when there is at least one
+  #    CONFIRMED material overtake. A clean / improving sweep just re-seals the snapshot quietly.
+  #    Deterministic branch off the aggregate fail_count. No model.
+  - id: route_sweep
+    type: condition
+    depends_on: [aggregate_sweep]
+    condition_config:
+      expression: "{steps.aggregate_sweep.output.fail_count} > 0"
+      then: [seal_snapshot, append_scoreboard, notify_overtaken]
+      else: [seal_snapshot, notify_clean]
+
+  # 5a) SEAL the new per-keyword snapshot back to the store so the NEXT sweep measures its
+  #     rank_delta against this sealed truth. Connector-agnostic REST PUT. Runs every sweep.
+  - id: seal_snapshot
+    type: http
+    http_config:
+      url: "{input.snapshot_store_url}/snapshots"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Prefer: "resolution=merge-duplicates"
+      auth: "bearer:{env.SNAPSHOT_STORE_TOKEN}"
+      body: "{steps.aggregate_sweep.output.snapshot_rows}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 5b) APPEND the confirmed overtakes to the Airtable competitive share-of-voice scoreboard so
+  #     positioning shifts accrue in a durable record the team can review. Connector: airtable.
+  - id: append_scoreboard
+    type: http
+    http_config:
+      url: "https://api.airtable.com/v0/{input.airtable_base_id}/{input.airtable_table}"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.AIRTABLE_API_KEY}"
+      body: |
+        {
+          "typecast": true,
+          "records": [
+            {
+              "fields": {
+                "Brand": "{steps.aggregate_sweep.output.brand}",
+                "Sealed At": "{steps.aggregate_sweep.output.sealed_at}",
+                "Confirmed Overtakes": "{steps.aggregate_sweep.output.confirmed_overtake_count}",
+                "Avg Brand SoV": "{steps.aggregate_sweep.output.avg_brand_sov}",
+                "Events": "{steps.aggregate_sweep.output.overtake_events}"
+              }
+            }
+          ]
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 5c) NOTIFY (overtaken) - alert the competitive-intel channel with the confirmed overtakes,
+  #     who passed you, and the SoV / rank moves so positioning shifts surface in real time.
+  - id: notify_overtaken
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :chart_with_downwards_trend: SHARE-OF-VOICE ALERT - {steps.aggregate_sweep.output.confirmed_overtake_count} keyword(s) where {steps.aggregate_sweep.output.brand} was materially overtaken.
+        Avg brand SoV this sweep: {steps.aggregate_sweep.output.avg_brand_sov}%
+        Improving: {steps.aggregate_sweep.output.improving_count} | Steady: {steps.aggregate_sweep.output.steady_count} | Churn filtered: {steps.aggregate_sweep.output.churn_count}
+        Overtake events: {steps.aggregate_sweep.output.overtake_events}
+        Snapshot sealed at {steps.aggregate_sweep.output.sealed_at}
+
+  # 5d) NOTIFY (clean) - quiet "no material overtakes" digest on a clean / improving sweep.
+  - id: notify_clean
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :white_check_mark: SoV sweep clean for {steps.aggregate_sweep.output.brand}: 0 confirmed overtakes across {steps.aggregate_sweep.output.total_keywords} keyword(s).
+        {steps.aggregate_sweep.output.improving_count} improving, {steps.aggregate_sweep.output.steady_count} steady, {steps.aggregate_sweep.output.churn_count} immaterial blips filtered. Avg brand SoV {steps.aggregate_sweep.output.avg_brand_sov}%. Snapshot re-sealed.
+on_complete:
+  storage_path: "topic-share-of-voice-rank-monitor/{run_id}/result.json"

--- a/src/sandcastle/templates/trip_itinerary_race_planner.yaml
+++ b/src/sandcastle/templates/trip_itinerary_race_planner.yaml
@@ -1,0 +1,594 @@
+# name: Trip Itinerary Race Planner
+# description: Races two travel itinerary providers (failover across model providers - first that returns a usable day-by-day plan wins), then HTTP-verifies the draft against the live flight-status feed and the destination weather forecast for the exact trip dates. A DETERMINISTIC code step runs the feasibility math - minimum-connection-time gaps between legs, outdoor-activity vs precipitation conflicts, and a budget sum vs your cap - and the plan only lands in your inbox after a GATE where a swappable llm_eval quality judge AND a non-LLM feasibility-threshold strategy BOTH pass. All the go/no-go math is model-independent.
+# tags: [Travel, Itinerary, Trip, Flights, Weather, Race, Failover, Feasibility, Personal, Planner, Layover, Budget]
+# category: personal
+# connectors: flightaware, openweather, sendgrid, slack
+name: trip-itinerary-race-planner
+description: >-
+  A personal trip planner that proves Sandcastle as an ENGINE rather than a single
+  model call. A deterministic code step first normalizes your destination + date range
+  into a clean trip spec (trip length, ISO dates, IATA/city, budget cap). A cross-provider
+  RACE then fans the same brief out to TWO itinerary drafters backed by DIFFERENT model
+  providers and takes the FIRST that returns a usable day-by-day plan (provider failover,
+  not a vote), so the plan still drafts when one provider is down. The draft is then
+  VERIFIED against reality: an http GET pulls live flight status for the booked legs and a
+  second http GET pulls the destination weather forecast for the exact trip dates. A
+  load-bearing DETERMINISTIC code step does the feasibility math with NO model - minimum
+  connection time between consecutive legs, outdoor-activity days that collide with a
+  rained-out forecast, and the summed activity budget against your cap - and emits hard
+  pass/fail booleans plus a 0-1 feasibility score. A GATE then requires TWO strategies to
+  BOTH pass: a swappable llm_eval plan-quality judge (any provider can back it) AND a
+  second llm_eval fed ONLY the pre-computed feasibility booleans so the plan can pass or
+  fail purely on the arithmetic. A CONDITION routes a feasible plan to a polished itinerary
+  REPORT that is emailed to you, while an infeasible plan is bounced back with the exact
+  blocking reasons. Every go/no-go decision is deterministic and runs with zero model
+  providers available; the model only drafts and acts as the swappable quality judge.
+default_model: sonnet
+default_max_turns: 8
+default_timeout: 900
+input_schema:
+  required: ["destination", "date_range", "flight_status_url", "weather_api_url"]
+  properties:
+    destination:
+      type: string
+      description: "Destination city name or IATA airport code the trip is built around."
+      default: "Lisbon (LIS)"
+      example: "Lisbon (LIS)"
+    date_range:
+      type: string
+      description: "Trip start and end dates as 'YYYY-MM-DD..YYYY-MM-DD' (or 'start to end'). Drives the per-day plan, the weather window and the flight-status dates."
+      default: "2026-07-10..2026-07-14"
+      example: "2026-07-10..2026-07-14"
+    flight_status_url:
+      type: string
+      description: "Live flight-status REST endpoint (FlightAware AeroAPI / Aviationstack style) returning the booked legs with scheduled/estimated times and status for the trip dates."
+      default: "https://aeroapi.flightaware.com/aeroapi/flights"
+      example: "https://aeroapi.flightaware.com/aeroapi/flights/search?query=dest LIS"
+    weather_api_url:
+      type: string
+      description: "Destination weather-forecast REST endpoint (OpenWeather / Open-Meteo style) returning a daily forecast (precipitation probability, condition) covering the trip dates."
+      default: "https://api.openweathermap.org/data/2.5/forecast/daily"
+      example: "https://api.open-meteo.com/v1/forecast?daily=precipitation_probability_max"
+    budget_cap:
+      type: number
+      description: "Total activity/excursion budget cap in your currency. The deterministic feasibility step sums the drafted activity costs and fails the plan if it exceeds this."
+      default: 800
+      example: "800"
+    min_connection_minutes:
+      type: integer
+      description: "Minimum legal/comfortable connection time in minutes between two consecutive flight legs. A drafted layover shorter than this is a hard feasibility failure."
+      default: 45
+      example: "45"
+    rain_threshold:
+      type: number
+      description: "Precipitation-probability threshold (0-100). A forecast day at or above this is treated as a wash-out; an outdoor activity scheduled that day is a feasibility conflict."
+      default: 70
+      example: "70"
+    min_feasibility_score:
+      type: number
+      description: "Deterministic feasibility score (0-1) the plan must reach for the gate's non-LLM strategy to approve it. Computed purely from the layover/weather/budget checks."
+      default: 1.0
+      example: "1.0"
+    judge_model:
+      type: string
+      description: "Swappable plan-quality judge model for the gate. Any of the providers can back it; the feasibility math passes/fails without it. The two race drafters run on DIFFERENT providers (sonnet and google/gemini-2.5-pro) for genuine cross-provider failover."
+      default: "sonnet"
+      example: "ollama/qwen-3"
+    recipient_email:
+      type: string
+      description: "Inbox that receives the final itinerary (or the bounce-back with blocking reasons)."
+      default: "me@example.com"
+      example: "traveler@example.com"
+    slack_channel:
+      type: string
+      description: "Optional Slack channel for a short trip-planned ping alongside the email."
+      default: "#my-trips"
+      example: "#my-trips"
+steps:
+  # 1) DETERMINISTIC trip-spec normalization. NO model. Parse the date_range into ISO start/end,
+  #    compute trip length + the explicit list of trip dates, pull the IATA code out of the
+  #    destination string, and surface the budget cap / thresholds as a clean brief the drafters
+  #    and every downstream verifier read from one shape.
+  - id: normalize_trip
+    type: code
+    code_config:
+      language: python
+      code: |
+        import re
+        from datetime import date, timedelta
+
+        dest_raw = str(_input.get('destination') or '').strip()
+        dr_raw = str(_input.get('date_range') or '').strip()
+
+        # --- Pull an IATA-ish 3-letter code from "Lisbon (LIS)" / "LIS" if present.
+        iata = ''
+        m = re.search(r'\(([A-Za-z]{3})\)', dest_raw)
+        if m:
+            iata = m.group(1).upper()
+        elif re.fullmatch(r'[A-Za-z]{3}', dest_raw):
+            iata = dest_raw.upper()
+        city = re.sub(r'\s*\([A-Za-z]{3}\)\s*', '', dest_raw).strip() or dest_raw
+
+        # --- Parse "start..end" or "start to end" into two ISO dates.
+        parts = re.split(r'\.\.|\bto\b|–|/', dr_raw)
+        iso = [p for p in (x.strip() for x in parts) if re.fullmatch(r'\d{4}-\d{2}-\d{2}', p)]
+
+        def _d(s):
+            y, mo, dd = (int(x) for x in s.split('-'))
+            return date(y, mo, dd)
+
+        start_d = _d(iso[0]) if len(iso) >= 1 else date.today()
+        end_d = _d(iso[1]) if len(iso) >= 2 else start_d
+        if end_d < start_d:
+            start_d, end_d = end_d, start_d
+
+        nights = (end_d - start_d).days
+        days = nights + 1
+        trip_dates = [(start_d + timedelta(days=i)).isoformat() for i in range(days)]
+
+        try:
+            budget_cap = float(_input.get('budget_cap', 800) or 800)
+        except (ValueError, TypeError):
+            budget_cap = 800.0
+
+        result = {
+            'destination_raw': dest_raw,
+            'city': city,
+            'iata': iata,
+            'start_date': start_d.isoformat(),
+            'end_date': end_d.isoformat(),
+            'nights': nights,
+            'days': days,
+            'trip_dates': trip_dates,
+            'budget_cap': budget_cap,
+            'min_connection_minutes': int(_input.get('min_connection_minutes', 45) or 45),
+            'rain_threshold': float(_input.get('rain_threshold', 70) or 70),
+            'valid': len(iso) >= 2 and days >= 1,
+        }
+
+  # 2) CROSS-PROVIDER RACE. Fan the SAME brief out to TWO itinerary drafters backed by DIFFERENT
+  #    model providers; the FIRST that returns a usable day-by-day plan wins (provider failover,
+  #    not a vote). Each drafter must emit machine-parseable JSON so the deterministic verifier can
+  #    read legs + activities. Branch steps are DEFINED SEPARATELY below with NO depends_on.
+  - id: draft_itinerary_a
+    type: llm
+    model: sonnet
+    prompt: >-
+      You are a meticulous trip planner. Build a day-by-day itinerary for {steps.normalize_trip.output.days}
+      day(s) in {steps.normalize_trip.output.city} ({steps.normalize_trip.output.iata}) covering exactly the
+      dates {steps.normalize_trip.output.trip_dates}, keeping total activity cost under
+      {steps.normalize_trip.output.budget_cap}. Return ONLY a JSON object with this shape and no prose:
+      {"summary": "...", "flights": [{"flight": "TP123", "from": "LHR", "to": "LIS", "depart": "2026-07-10T08:00",
+      "arrive": "2026-07-10T11:10"}], "days": [{"date": "2026-07-10", "title": "...",
+      "activities": [{"name": "...", "outdoor": true, "cost": 35}]}]}. Use realistic flight times so that any
+      connection between consecutive legs is at least {input.min_connection_minutes} minutes.
+      Mark each activity outdoor true/false honestly. Keep the summed activity cost under the cap.
+    retry:
+      max_attempts: 1
+      on_failure: skip
+
+  - id: draft_itinerary_b
+    type: llm
+    model: google/gemini-2.5-pro
+    prompt: >-
+      Act as a travel concierge. Produce a JSON-only day-by-day itinerary for
+      {steps.normalize_trip.output.days} day(s) in {steps.normalize_trip.output.city}
+      ({steps.normalize_trip.output.iata}) for the dates {steps.normalize_trip.output.trip_dates},
+      with total activity spend below {steps.normalize_trip.output.budget_cap}. Output ONLY this JSON
+      object: {"summary": "...", "flights": [{"flight": "...", "from": "...", "to": "...",
+      "depart": "ISO8601", "arrive": "ISO8601"}], "days": [{"date": "YYYY-MM-DD", "title": "...",
+      "activities": [{"name": "...", "outdoor": true, "cost": 0}]}]}. Ensure consecutive legs leave at
+      least {input.min_connection_minutes} minutes to connect and flag outdoor activities truthfully.
+    retry:
+      max_attempts: 1
+      on_failure: skip
+
+  - id: itinerary_race
+    type: race
+    depends_on: [normalize_trip]
+    race_config:
+      branches:
+        - [draft_itinerary_a]
+        - [draft_itinerary_b]
+      validator: "'days' in str(output) and len(str(output).strip()) > 40"
+
+  # 3) DETERMINISTIC parse of whichever drafter won the race into a uniform plan (flights[],
+  #    day-by-day activities[]) regardless of which provider produced it. NO model - just JSON
+  #    extraction + coercion so the verifier and feasibility math read one shape.
+  - id: parse_draft
+    type: code
+    depends_on: [itinerary_race, normalize_trip]
+    code_config:
+      language: python
+      code: |
+        import json
+        import re
+
+        raw = _steps.get('itinerary_race')
+        trip = _steps.get('normalize_trip') or {}
+
+        # The winning branch output may be a dict already or a string with JSON embedded.
+        plan = {}
+        if isinstance(raw, dict) and ('days' in raw or 'flights' in raw):
+            plan = raw
+        else:
+            text = raw if isinstance(raw, str) else json.dumps(raw) if raw is not None else ''
+            # Grab the first {...} block and parse it.
+            mt = re.search(r'\{.*\}', text, re.DOTALL)
+            if mt:
+                try:
+                    plan = json.loads(mt.group(0))
+                except (ValueError, TypeError):
+                    plan = {}
+        if not isinstance(plan, dict):
+            plan = {}
+
+        # --- Normalize flights into ordered legs with depart/arrive strings.
+        flights_in = plan.get('flights') or plan.get('legs') or []
+        flights = []
+        if isinstance(flights_in, list):
+            for f in flights_in:
+                if not isinstance(f, dict):
+                    continue
+                flights.append({
+                    'flight': str(f.get('flight') or f.get('number') or f.get('code') or '').strip(),
+                    'from': str(f.get('from') or f.get('origin') or '').strip().upper(),
+                    'to': str(f.get('to') or f.get('destination') or '').strip().upper(),
+                    'depart': str(f.get('depart') or f.get('departure') or f.get('std') or '').strip(),
+                    'arrive': str(f.get('arrive') or f.get('arrival') or f.get('sta') or '').strip(),
+                })
+
+        # --- Normalize the day plan + flatten activities with outdoor flag + numeric cost.
+        days_in = plan.get('days') or plan.get('itinerary') or []
+        days = []
+        activities = []
+        if isinstance(days_in, list):
+            for d in days_in:
+                if not isinstance(d, dict):
+                    continue
+                dd = str(d.get('date') or '').strip()
+                acts_in = d.get('activities') or d.get('items') or []
+                day_acts = []
+                if isinstance(acts_in, list):
+                    for a in acts_in:
+                        if not isinstance(a, dict):
+                            a = {'name': str(a)}
+                        try:
+                            cost = float(a.get('cost') or a.get('price') or 0)
+                        except (ValueError, TypeError):
+                            cost = 0.0
+                        outdoor = str(a.get('outdoor', a.get('is_outdoor', False))).strip().lower() in (
+                            'true', '1', 'yes', 'outdoor'
+                        )
+                        rec = {
+                            'name': str(a.get('name') or a.get('title') or '').strip(),
+                            'outdoor': outdoor,
+                            'cost': round(cost, 2),
+                            'date': dd,
+                        }
+                        day_acts.append(rec)
+                        activities.append(rec)
+                days.append({'date': dd, 'title': str(d.get('title') or '').strip(), 'activities': day_acts})
+
+        result = {
+            'summary': str(plan.get('summary') or '').strip(),
+            'flights': flights,
+            'days': days,
+            'activities': activities,
+            'flight_count': len(flights),
+            'day_count': len(days),
+            'activity_count': len(activities),
+            'total_activity_cost': round(sum(a['cost'] for a in activities), 2),
+            'has_plan': len(days) > 0 or len(flights) > 0,
+            'trip_dates': trip.get('trip_dates', []),
+        }
+
+  # 4) VERIFY vs reality (1/2): http GET LIVE flight status for the booked legs on the trip dates
+  #    from the real flight-status feed (FlightAware AeroAPI / Aviationstack style). Connector:
+  #    flightaware. on_failure: skip so a feed outage degrades to plan-only, it does not abort.
+  - id: fetch_flight_status
+    type: http
+    depends_on: [parse_draft]
+    http_config:
+      url: "{input.flight_status_url}?dest={steps.normalize_trip.output.iata}&start={steps.normalize_trip.output.start_date}&end={steps.normalize_trip.output.end_date}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.FLIGHT_STATUS_API_KEY}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 5) VERIFY vs reality (2/2): http GET the destination weather FORECAST for the exact trip
+  #    window (OpenWeather / Open-Meteo style) - daily precipitation probability + condition.
+  #    Connector: openweather. on_failure: skip so a missing forecast degrades gracefully.
+  - id: fetch_weather_forecast
+    type: http
+    depends_on: [parse_draft]
+    http_config:
+      url: "{input.weather_api_url}?q={steps.normalize_trip.output.city}&start={steps.normalize_trip.output.start_date}&end={steps.normalize_trip.output.end_date}&units=metric"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.WEATHER_API_KEY}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 6) LOAD-BEARING DETERMINISTIC FEASIBILITY MATH. NO model. Three hard checks against the parsed
+  #    plan + the live feeds: (a) minimum connection time between consecutive legs (using live
+  #    flight status when available, else the drafted times), (b) outdoor activities scheduled on a
+  #    forecast wash-out day (precip prob >= rain_threshold), (c) summed activity budget vs the cap.
+  #    Emits hard pass/fail booleans + a 0-1 feasibility score the gate's non-LLM strategy consumes.
+  - id: check_feasibility
+    type: code
+    depends_on: [parse_draft, fetch_flight_status, fetch_weather_forecast]
+    code_config:
+      language: python
+      code: |
+        from datetime import datetime
+
+        plan = _steps.get('parse_draft') or {}
+        trip = _steps.get('normalize_trip') or {}
+        flight_live = _steps.get('fetch_flight_status') or {}
+        weather = _steps.get('fetch_weather_forecast') or {}
+
+        min_conn = int(trip.get('min_connection_minutes', 45) or 45)
+        rain_threshold = float(trip.get('rain_threshold', 70) or 70)
+        try:
+            budget_cap = float(_input.get('budget_cap', 800) or 800)
+        except (ValueError, TypeError):
+            budget_cap = 800.0
+        try:
+            min_score = float(_input.get('min_feasibility_score', 1.0) or 1.0)
+        except (ValueError, TypeError):
+            min_score = 1.0
+
+        def _parse_dt(s):
+            s = str(s or '').strip().replace('Z', '+00:00')
+            for fmt in ('%Y-%m-%dT%H:%M:%S', '%Y-%m-%dT%H:%M', '%Y-%m-%d %H:%M'):
+                try:
+                    return datetime.strptime(s[:len(fmt) + 2] if '+' not in s else s.split('+')[0], fmt)
+                except (ValueError, TypeError):
+                    continue
+            try:
+                return datetime.fromisoformat(s)
+            except (ValueError, TypeError):
+                return None
+
+        # --- Build a map of live actual times keyed by flight number, when the feed gave us rows.
+        def _rows(blob):
+            if isinstance(blob, list):
+                return [r for r in blob if isinstance(r, dict)]
+            if isinstance(blob, dict):
+                for k in ('flights', 'data', 'results', 'items', 'records'):
+                    v = blob.get(k)
+                    if isinstance(v, list):
+                        return [r for r in v if isinstance(r, dict)]
+            return []
+
+        live_rows = _rows(flight_live)
+        live_by_flight = {}
+        for r in live_rows:
+            key = str(r.get('flight') or r.get('ident') or r.get('flight_number') or '').strip().upper()
+            if key:
+                live_by_flight[key] = r
+
+        # --- (a) Minimum-connection-time check between consecutive legs.
+        flights = plan.get('flights', [])
+        layover_conflicts = []
+        min_observed_gap = None
+        for i in range(len(flights) - 1):
+            cur = flights[i]
+            nxt = flights[i + 1]
+            # Prefer the live-actual arrival/departure when the feed has the flight.
+            cur_live = live_by_flight.get(str(cur.get('flight', '')).upper(), {})
+            nxt_live = live_by_flight.get(str(nxt.get('flight', '')).upper(), {})
+            arr = _parse_dt(cur_live.get('arrival_estimated') or cur_live.get('arrival') or cur.get('arrive'))
+            dep = _parse_dt(nxt_live.get('departure_estimated') or nxt_live.get('departure') or nxt.get('depart'))
+            if arr and dep:
+                gap_min = (dep - arr).total_seconds() / 60.0
+                if min_observed_gap is None or gap_min < min_observed_gap:
+                    min_observed_gap = round(gap_min, 1)
+                if gap_min < min_conn:
+                    layover_conflicts.append({
+                        'after_flight': cur.get('flight'),
+                        'before_flight': nxt.get('flight'),
+                        'connection_minutes': round(gap_min, 1),
+                        'required_minutes': min_conn,
+                    })
+        layover_ok = len(layover_conflicts) == 0
+
+        # --- Build a forecast wash-out set: dates with precip prob >= threshold.
+        wx_rows = _rows(weather)
+        if not wx_rows and isinstance(weather, dict):
+            # Open-Meteo style: parallel arrays under 'daily'.
+            daily = weather.get('daily')
+            if isinstance(daily, dict):
+                dates = daily.get('time') or daily.get('date') or []
+                pops = (daily.get('precipitation_probability_max')
+                        or daily.get('precipitation_probability') or daily.get('pop') or [])
+                if isinstance(dates, list) and isinstance(pops, list):
+                    wx_rows = [
+                        {'date': dates[i], 'pop': pops[i]}
+                        for i in range(min(len(dates), len(pops)))
+                    ]
+        washout_dates = set()
+        for r in wx_rows:
+            dt = str(r.get('date') or r.get('dt') or r.get('day') or '').strip()[:10]
+            pop = r.get('pop')
+            if pop is None:
+                pop = r.get('precipitation_probability_max', r.get('precipitation_probability', 0))
+            try:
+                popf = float(pop)
+            except (ValueError, TypeError):
+                popf = 0.0
+            # Some feeds give 0-1 probability; lift to 0-100.
+            if popf <= 1.0:
+                popf = popf * 100.0
+            if dt and popf >= rain_threshold:
+                washout_dates.add(dt)
+
+        # --- (b) Outdoor activity vs precipitation conflict.
+        weather_conflicts = []
+        for a in plan.get('activities', []):
+            if a.get('outdoor') and str(a.get('date', ''))[:10] in washout_dates:
+                weather_conflicts.append({
+                    'activity': a.get('name'),
+                    'date': a.get('date'),
+                    'reason': 'outdoor_on_washout_day',
+                })
+        weather_ok = len(weather_conflicts) == 0
+
+        # --- (c) Budget sum vs cap.
+        total_cost = round(sum(float(a.get('cost', 0) or 0) for a in plan.get('activities', [])), 2)
+        budget_ok = total_cost <= budget_cap
+
+        # --- Deterministic 0-1 feasibility score: fraction of the three hard checks that passed.
+        checks = [layover_ok, weather_ok, budget_ok]
+        feasibility_score = round(sum(1 for c in checks if c) / len(checks), 4)
+        feasible = all(checks) and feasibility_score >= min_score
+
+        blocking_reasons = []
+        if not layover_ok:
+            blocking_reasons.append(f"{len(layover_conflicts)} tight layover(s) below {min_conn} min")
+        if not weather_ok:
+            blocking_reasons.append(f"{len(weather_conflicts)} outdoor activity(ies) on a forecast wash-out day")
+        if not budget_ok:
+            blocking_reasons.append(f"activity budget {total_cost} exceeds cap {budget_cap}")
+
+        result = {
+            'feasible': feasible,
+            'feasibility_score': feasibility_score,
+            'min_feasibility_score': min_score,
+            'layover_ok': layover_ok,
+            'weather_ok': weather_ok,
+            'budget_ok': budget_ok,
+            'min_connection_minutes': min_conn,
+            'min_observed_gap_minutes': min_observed_gap,
+            'layover_conflicts': layover_conflicts,
+            'weather_conflicts': weather_conflicts,
+            'washout_dates': sorted(washout_dates),
+            'total_activity_cost': total_cost,
+            'budget_cap': budget_cap,
+            'flight_status_checked': bool(live_rows),
+            'weather_checked': bool(wx_rows),
+            'blocking_reasons': blocking_reasons,
+        }
+
+  # 7) GATE (swappable + model-independent). TWO strategies, BOTH must pass:
+  #    (1) llm_eval plan-quality judge - "is this a coherent, enjoyable, well-paced itinerary?",
+  #        model pinned to a SWAPPABLE provider (any provider can back it);
+  #    (2) llm_eval acting as a DETERMINISTIC threshold - fed ONLY the pre-computed feasibility
+  #        booleans + score, told to answer purely from the arithmetic, so the plan still passes
+  #        or fails the gate on the non-LLM feasibility math alone.
+  - id: plan_gate
+    type: gate
+    depends_on: [check_feasibility]
+    gate_config:
+      strategies:
+        - type: llm_eval
+          config:
+            prompt: >-
+              You are a travel-quality reviewer. The numeric feasibility (layovers, weather,
+              budget) was already checked deterministically in code; judge ONLY plan QUALITY:
+              is this a coherent, sensibly paced, enjoyable day-by-day itinerary for the
+              destination and trip length, with a reasonable mix of activities? Answer exactly
+              'approved' if the plan reads as a good trip worth sending, otherwise 'rejected'
+              and name the weakness. Do not re-judge the numbers.
+            input: "Summary: {steps.parse_draft.output.summary} | Days: {steps.parse_draft.output.days} | Flights: {steps.parse_draft.output.flights}"
+            model: "{input.judge_model}"
+        - type: llm_eval
+          config:
+            prompt: >-
+              Deterministic feasibility threshold check. Answer exactly 'approved' if feasible is
+              True AND feasibility_score >= min_feasibility_score AND layover_ok AND weather_ok
+              AND budget_ok are all True; otherwise answer 'rejected'. Use ONLY the supplied
+              booleans and numbers - do not infer or reason beyond the comparison.
+            input: "feasible={steps.check_feasibility.output.feasible} feasibility_score={steps.check_feasibility.output.feasibility_score} min={steps.check_feasibility.output.min_feasibility_score} layover_ok={steps.check_feasibility.output.layover_ok} weather_ok={steps.check_feasibility.output.weather_ok} budget_ok={steps.check_feasibility.output.budget_ok}"
+            model: haiku
+
+  # 8) CONDITION - route on the DETERMINISTIC feasibility verdict (not the model label), so a plan
+  #    only proceeds to the final report when the feasibility math passed. A failed plan is bounced
+  #    back with the exact blocking reasons. No model.
+  - id: route_plan
+    type: condition
+    depends_on: [plan_gate, check_feasibility]
+    condition_config:
+      expression: "{steps.check_feasibility.output.feasible} == True"
+      then: [build_itinerary_report, email_itinerary, ping_slack]
+      else: [bounce_back]
+
+  # 8a) REPORT - the final, polished day-by-day itinerary assembled from the winning draft plus the
+  #     live-verification evidence (flight status checked, weather window, feasibility breakdown).
+  - id: build_itinerary_report
+    type: report
+    report_config:
+      template: research-report
+      format: pdf
+      theme: professional
+      title: "Trip Itinerary - {input.destination} ({input.date_range})"
+      author: "Trip Itinerary Race Planner"
+    prompt: |
+      Assemble a clean, traveler-friendly day-by-day itinerary that has already passed
+      deterministic feasibility verification (layovers, weather, budget) and a quality gate.
+
+      Trip overview:
+      {steps.normalize_trip.output}
+
+      Day-by-day plan (winning drafter, parsed):
+      {steps.parse_draft.output}
+
+      Live verification + feasibility breakdown (layover gaps, weather wash-outs, budget vs cap):
+      {steps.check_feasibility.output}
+
+      Present the days clearly with flights, activities and costs, note the verified weather
+      window and connection times, and finish with the total activity spend vs the budget cap.
+
+  # 8b) EMAIL the finished itinerary to the traveler's inbox. Connector: sendgrid.
+  - id: email_itinerary
+    type: http
+    http_config:
+      url: "https://api.sendgrid.com/v3/mail/send"
+      method: POST
+      headers:
+        Content-Type: "application/json"
+        Accept: "application/json"
+      auth: "bearer:{env.SENDGRID_API_KEY}"
+      body: |
+        {
+          "personalizations": [{"to": [{"email": "{input.recipient_email}"}]}],
+          "from": {"email": "trips@example.com", "name": "Trip Itinerary Race Planner"},
+          "subject": "Your verified itinerary: {input.destination} ({input.date_range})",
+          "content": [{"type": "text/plain", "value": "Your itinerary for {input.destination} passed all feasibility checks (layovers, weather, budget). Total activity spend {steps.check_feasibility.output.total_activity_cost} vs cap {steps.check_feasibility.output.budget_cap}. Full day-by-day plan attached."}]
+        }
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 8c) NOTIFY - a short trip-planned ping in Slack alongside the email. service: slack.
+  - id: ping_slack
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :airplane: Itinerary ready for {input.destination} ({input.date_range}) - feasibility {steps.check_feasibility.output.feasibility_score}, layovers OK, weather window clear, spend {steps.check_feasibility.output.total_activity_cost}/{steps.check_feasibility.output.budget_cap}. Emailed to {input.recipient_email}.
+
+  # 8d) BOUNCE-BACK - an infeasible plan is NOT sent as a trip; the traveler gets the exact
+  #     blocking reasons (tight layovers, rained-out outdoor days, over-budget) instead. service: slack.
+  - id: bounce_back
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :warning: Itinerary for {input.destination} ({input.date_range}) did NOT pass feasibility and was held back.
+        Feasibility score: {steps.check_feasibility.output.feasibility_score} (need {steps.check_feasibility.output.min_feasibility_score})
+        Layover OK: {steps.check_feasibility.output.layover_ok} | Weather OK: {steps.check_feasibility.output.weather_ok} | Budget OK: {steps.check_feasibility.output.budget_ok}
+        Blocking reasons: {steps.check_feasibility.output.blocking_reasons}
+on_complete:
+  storage_path: "trip-itinerary-race-planner/{run_id}/result.json"

--- a/src/sandcastle/templates/vendor_spend_anomaly_zscore_detector.yaml
+++ b/src/sandcastle/templates/vendor_spend_anomaly_zscore_detector.yaml
@@ -1,0 +1,635 @@
+# name: Vendor Spend Anomaly Detector
+# description: Streams the AP transaction ledger, builds a per-vendor spend baseline and computes a robust z-score (median / MAD) plus split-invoice, duplicate-payment and new-vendor-spike detectors in pure code, classifies each outlier by likely cause, then SHA-256 seals a tamper-evident anomaly record before opening a triage ticket. The load-bearing detection is deterministic code (sensor + http + code + loop carry it); the only model is a swappable classify label on precomputed signals. No model ever does the spend math.
+# tags: [FinanceOps, AccountsPayable, AP, anomaly-detection, z-score, MAD, duplicate-payment, split-invoice, maverick-spend, SAP, NetSuite, QuickBooks, Jira, Slack, audit]
+# category: finance_ops
+# connectors: sap, netsuite, quickbooks, jira, linear, slack
+name: vendor-spend-anomaly-zscore-detector
+description: >-
+  An always-on Accounts Payable anomaly detector for FP&A and controllership. A
+  durable SENSOR blocks until the next AP batch posts (or a scheduled nightly
+  sweep is due). A DETERMINISTIC http GET then streams the AP transaction ledger
+  from the ERP / AP system (SAP, NetSuite or QuickBooks AP), and a code step
+  normalizes every payment into a canonical row and groups them per vendor. The
+  workflow LOOPS over each vendor cohort: a single DETERMINISTIC code step builds
+  the per-vendor spend baseline and runs FOUR pure-Python detectors - a robust
+  z-score using the median and the Median Absolute Deviation (MAD, resistant to
+  the very outliers it hunts), a duplicate-payment detector via canonical hashing
+  of (vendor, amount, invoice, near-date), a split-invoice detector that flags
+  clusters of same-day same-vendor invoices each landing just under the approval
+  threshold, and a new-vendor first-spend spike detector. A CLASSIFY step applies
+  a SWAPPABLE label (duplicate / split / spike / seasonal / benign) reading ONLY
+  the precomputed signals - it never touches the arithmetic. A deterministic code
+  step then aggregates every flagged outlier, computes an anomaly score, and
+  SHA-256 SEALS the confirmed anomaly batch into a tamper-evident immutable
+  record with a ledger root hash. A CONDITION opens a ticket ONLY when the batch
+  anomaly score clears the floor, an http PUT archives the sealed record to the
+  audit object store, a NOTIFY files a Jira / Linear triage ticket, and a final
+  NOTIFY pings the AP controller channel. Every detector, baseline and score is
+  100% deterministic and runs with zero model providers available; the model is
+  confined to the swappable classify label on signals it cannot alter.
+default_model: sonnet
+default_max_turns: 8
+default_timeout: 1800
+input_schema:
+  required: ["ap_ledger_base_url"]
+  properties:
+    ap_ledger_base_url:
+      type: string
+      description: "AP / ERP REST base URL exposing posted vendor payments (SAP, NetSuite, QuickBooks AP). The detector GETs the lookback window of transactions from here."
+      default: "https://your-erp.example.com/api/ap"
+      example: "https://acme.netsuite.com/services/rest/record/v1/vendorPayment"
+    batch_id:
+      type: string
+      description: "Identifier for this AP batch / sweep, used in the sealed record and the triage ticket."
+      default: "AP-SWEEP-2026-06"
+      example: "AP-BATCH-2026-06-02"
+    lookback_window:
+      type: integer
+      description: "Days of AP history to pull and build each vendor's baseline against. A larger window stabilizes the median / MAD baseline."
+      default: 180
+      example: "180"
+    zscore_threshold:
+      type: number
+      description: "Robust z-score (modified, median / MAD based) at or above which a single payment is flagged as an amount outlier. 3.5 is the conventional modified-z cutoff."
+      default: 3.5
+      example: "3.5"
+    approval_threshold:
+      type: number
+      description: "The dollar approval threshold. Invoices that land just under this value, clustered same-day same-vendor, are flagged as a likely split-invoice to dodge approval."
+      default: 10000
+      example: "10000"
+    split_band_fraction:
+      type: number
+      description: "How close under the approval threshold counts as 'just under' for split-invoice detection (0-1). 0.1 means invoices within the top 10% band below the threshold."
+      default: 0.1
+      example: "0.1"
+    min_baseline_n:
+      type: integer
+      description: "Minimum number of prior payments a vendor needs before the z-score baseline is trusted. Below this the vendor is treated as new (spike detector applies instead)."
+      default: 5
+      example: "5"
+    spike_multiple:
+      type: number
+      description: "A new vendor's first payment is flagged as a spike when it is at least this multiple of the median first-payment across all new vendors in the batch."
+      default: 3.0
+      example: "3.0"
+    anomaly_score_floor:
+      type: number
+      description: "Batch anomaly score (0-100) at or above which a triage ticket is opened. Below the floor the sweep is logged clean and no ticket is filed."
+      default: 25
+      example: "25"
+    classify_model:
+      type: string
+      description: "Swappable model that LABELS each outlier's likely cause from precomputed signals only - set the classify step's model field to any of the 7 providers (for regulated data pin an EU / local provider like mistral/large or omlx/qwen-3). Detection works with this unavailable."
+      default: "sonnet"
+      example: "mistral/large"
+    ap_triage_project:
+      type: string
+      description: "Jira / Linear project key that receives the AP anomaly triage ticket."
+      default: "APRISK"
+      example: "APRISK"
+    issue_tracker_url:
+      type: string
+      description: "Issue-tracker REST endpoint that creates the triage ticket (Jira /rest/api/3/issue or Linear GraphQL gateway)."
+      default: "https://your-org.atlassian.net/rest/api/3/issue"
+      example: "https://acme.atlassian.net/rest/api/3/issue"
+    record_store_base_url:
+      type: string
+      description: "Object-store (S3-compatible) REST base URL that receives the SHA-256-sealed immutable anomaly record for audit retention."
+      default: "https://s3.eu-central-1.amazonaws.com"
+      example: "https://s3.eu-central-1.amazonaws.com"
+    record_store_bucket:
+      type: string
+      description: "Bucket holding the sealed AP anomaly records tamper-evidently."
+      default: "ap-anomaly-ledger"
+      example: "acme-ap-anomaly-ledger"
+    controller_channel:
+      type: string
+      description: "AP controller Slack channel that receives the anomaly digest / ticket link."
+      default: "#ap-controllership"
+      example: "#ap-controllership"
+    sweep_timeout:
+      type: integer
+      description: "Sensor soft timeout in seconds - stop waiting for the next AP batch after this long (one sweep run). Default 24h."
+      default: 86400
+      example: "86400"
+steps:
+  # 1) DURABLE SENSOR - block until the next AP batch posts or the scheduled nightly sweep is
+  #    due. Polls the AP system's batch-status endpoint; until a batch is ready to scan there is
+  #    nothing to detect. Event-driven within a schedule: a posted batch flips batch_ready true.
+  - id: await_ap_batch
+    type: sensor
+    sensor_config:
+      url: "{input.ap_ledger_base_url}/batch-status?select=batch_ready,sweep_due,batch_id"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and (response.get('batch_ready') == True or response.get('sweep_due') == True)"
+      check_interval: 3600
+      timeout: 86400
+
+  # 2) DETERMINISTIC http GET of the AP transaction ledger for the lookback window. Streams
+  #    posted vendor payments straight from the ERP / AP system (SAP / NetSuite / QuickBooks AP).
+  #    Connector: sap / netsuite / quickbooks. No model.
+  - id: pull_ap_ledger
+    type: http
+    depends_on: [await_ap_batch]
+    http_config:
+      url: "{input.ap_ledger_base_url}/payments?window_days={input.lookback_window}&status=posted&expand=vendor,invoice"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.AP_API_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 3) DETERMINISTIC normalization. Flatten whatever shape the ERP returned into canonical
+  #    payment rows (vendor_id, vendor_name, amount, invoice_number, payment_date) and GROUP
+  #    them per vendor into a loopable cohort list. No model - this is the prep the detectors
+  #    consume. Each cohort carries every threshold the per-vendor code step needs.
+  - id: normalize_payments
+    type: code
+    depends_on: [pull_ap_ledger]
+    code_config:
+      language: python
+      code: |
+        import re
+
+        ledger = _steps.get('pull_ap_ledger') or {}
+        rows = ledger if isinstance(ledger, list) else (
+            ledger.get('payments') or ledger.get('items') or ledger.get('data')
+            or ledger.get('records') or ledger.get('results') or []
+        )
+        if not isinstance(rows, list):
+            rows = [rows] if rows else []
+
+        def _num(v):
+            try:
+                return float(str(v).replace(',', '').replace('$', '').strip())
+            except (TypeError, ValueError):
+                return None
+
+        def _date_key(v):
+            # Keep just the yyyy-mm-dd prefix as a sortable, comparable string.
+            s = str(v or '').strip()
+            m = re.match(r'(\d{4})-(\d{2})-(\d{2})', s)
+            return f"{m.group(1)}-{m.group(2)}-{m.group(3)}" if m else s[:10]
+
+        payments = []
+        for rec in rows:
+            if not isinstance(rec, dict):
+                continue
+            amount = _num(rec.get('amount') or rec.get('paid_amount')
+                          or rec.get('total') or rec.get('value'))
+            if amount is None:
+                continue
+            vendor_id = str(rec.get('vendor_id') or rec.get('vendorId')
+                            or rec.get('supplier_id') or rec.get('vendor') or '').strip()
+            vendor_name = str(rec.get('vendor_name') or rec.get('vendorName')
+                              or rec.get('supplier') or vendor_id or 'unknown').strip()
+            if not vendor_id:
+                vendor_id = vendor_name.upper().replace(' ', '_') or 'UNKNOWN'
+            inv = str(rec.get('invoice_number') or rec.get('invoiceNumber')
+                      or rec.get('invoice') or rec.get('reference') or '').strip()
+            pdate = _date_key(rec.get('payment_date') or rec.get('paymentDate')
+                              or rec.get('date') or rec.get('posted_at'))
+            payments.append({
+                'payment_id': str(rec.get('payment_id') or rec.get('id')
+                                  or rec.get('transaction_id') or f"{vendor_id}-{inv}-{pdate}"),
+                'vendor_id': vendor_id,
+                'vendor_name': vendor_name,
+                'amount': round(amount, 2),
+                'invoice_number': inv,
+                'payment_date': pdate,
+            })
+
+        # Group into per-vendor cohorts; attach every threshold the detector step needs so the
+        # loop body is self-contained per item.
+        thresholds = {
+            'zscore_threshold': float(_input.get('zscore_threshold', 3.5) or 3.5),
+            'approval_threshold': float(_input.get('approval_threshold', 10000) or 10000),
+            'split_band_fraction': float(_input.get('split_band_fraction', 0.1) or 0.1),
+            'min_baseline_n': int(_input.get('min_baseline_n', 5) or 5),
+            'spike_multiple': float(_input.get('spike_multiple', 3.0) or 3.0),
+        }
+
+        by_vendor = {}
+        for p in payments:
+            by_vendor.setdefault(p['vendor_id'], []).append(p)
+
+        cohorts = []
+        for vid, plist in by_vendor.items():
+            plist_sorted = sorted(plist, key=lambda r: r['payment_date'])
+            cohorts.append({
+                'vendor_id': vid,
+                'vendor_name': plist_sorted[0]['vendor_name'],
+                'payment_count': len(plist_sorted),
+                'payments': plist_sorted,
+                'thresholds': thresholds,
+            })
+
+        result = {
+            'batch_id': _input.get('batch_id'),
+            'total_payments': len(payments),
+            'vendor_count': len(cohorts),
+            'cohorts': cohorts,
+        }
+
+  # 4) LOOP over every vendor cohort. Per-cohort child chain: one DETERMINISTIC detector code
+  #    step (baseline + robust z-score + duplicate + split + new-vendor spike) -> a SWAPPABLE
+  #    classify that only LABELS the precomputed outliers.
+  - id: per_vendor_loop
+    type: loop
+    depends_on: [normalize_payments]
+    loop_config:
+      over: "steps.normalize_payments.output.cohorts"
+      step_ids:
+        - detect_vendor_anomalies
+        - classify_outlier_cause
+      max_iterations: 5000
+
+  # 4a) THE LOAD-BEARING DETECTION. NO model. For THIS vendor cohort compute, in pure Python:
+  #     (1) a robust baseline = median + MAD of historical amounts (MAD resists the outliers it
+  #         hunts, unlike mean / stdev); (2) a modified z-score per payment = 0.6745 * (x - median)
+  #         / MAD, flagged at zscore_threshold; (3) duplicate payments via a canonical hash of
+  #         (vendor, rounded amount, invoice, payment date) - exact repeats across the batch;
+  #         (4) split invoices = same-vendor same-day clusters of 2+ invoices EACH just under the
+  #         approval threshold whose sum crosses it; (5) new-vendor first-spend spike when a vendor
+  #         has < min_baseline_n history. Emits one outlier list with the signals the classifier reads.
+  - id: detect_vendor_anomalies
+    type: code
+    code_config:
+      language: python
+      code: |
+        import hashlib
+
+        cohort = _input.get('_item') or {}
+        payments = cohort.get('payments') or []
+        th = cohort.get('thresholds') or {}
+        z_thresh = float(th.get('zscore_threshold', 3.5) or 3.5)
+        approval = float(th.get('approval_threshold', 10000) or 10000)
+        band_frac = float(th.get('split_band_fraction', 0.1) or 0.1)
+        min_n = int(th.get('min_baseline_n', 5) or 5)
+        spike_mult = float(th.get('spike_multiple', 3.0) or 3.0)
+
+        amounts = [float(p.get('amount') or 0.0) for p in payments]
+        n = len(amounts)
+
+        def _median(xs):
+            s = sorted(xs)
+            m = len(s)
+            if m == 0:
+                return 0.0
+            mid = m // 2
+            return s[mid] if m % 2 else (s[mid - 1] + s[mid]) / 2.0
+
+        med = _median(amounts)
+        # MAD = median of absolute deviations from the median. Scaled by 1.4826 it estimates
+        # the standard deviation for normal data but is robust to extreme outliers.
+        abs_dev = [abs(x - med) for x in amounts]
+        mad = _median(abs_dev)
+        mad_scaled = mad * 1.4826
+
+        baseline_trusted = n >= min_n and mad_scaled > 0
+
+        outliers = []
+
+        # --- (1) + (2) robust modified z-score per payment (amount outlier) ---------------
+        if baseline_trusted:
+            for p in payments:
+                x = float(p.get('amount') or 0.0)
+                mod_z = round(0.6745 * (x - med) / mad if mad > 0 else 0.0, 3)
+                if abs(mod_z) >= z_thresh:
+                    outliers.append({
+                        'kind': 'amount_outlier',
+                        'payment_id': p.get('payment_id'),
+                        'invoice_number': p.get('invoice_number'),
+                        'payment_date': p.get('payment_date'),
+                        'amount': x,
+                        'modified_z': mod_z,
+                        'baseline_median': round(med, 2),
+                        'baseline_mad_scaled': round(mad_scaled, 2),
+                    })
+
+        # --- (3) duplicate payments via canonical hashing --------------------------------
+        seen = {}
+        for p in payments:
+            key_material = '|'.join([
+                str(cohort.get('vendor_id') or ''),
+                f"{float(p.get('amount') or 0.0):.2f}",
+                str(p.get('invoice_number') or ''),
+                str(p.get('payment_date') or ''),
+            ])
+            dup_hash = hashlib.sha256(key_material.encode('utf-8')).hexdigest()[:16]
+            if dup_hash in seen:
+                outliers.append({
+                    'kind': 'duplicate_payment',
+                    'payment_id': p.get('payment_id'),
+                    'duplicate_of': seen[dup_hash],
+                    'invoice_number': p.get('invoice_number'),
+                    'payment_date': p.get('payment_date'),
+                    'amount': float(p.get('amount') or 0.0),
+                    'dup_hash': dup_hash,
+                })
+            else:
+                seen[dup_hash] = p.get('payment_id')
+
+        # --- (4) split invoice: same-day clusters of 2+ invoices each JUST under approval --
+        band_low = approval * (1.0 - band_frac)
+        by_day = {}
+        for p in payments:
+            amt = float(p.get('amount') or 0.0)
+            if band_low <= amt < approval:
+                by_day.setdefault(p.get('payment_date'), []).append(p)
+        for day, plist in by_day.items():
+            if len(plist) >= 2 and sum(float(q.get('amount') or 0.0) for q in plist) >= approval:
+                outliers.append({
+                    'kind': 'split_invoice',
+                    'payment_date': day,
+                    'invoice_count': len(plist),
+                    'combined_amount': round(sum(float(q.get('amount') or 0.0) for q in plist), 2),
+                    'approval_threshold': approval,
+                    'payment_ids': [q.get('payment_id') for q in plist],
+                    'invoice_numbers': [q.get('invoice_number') for q in plist],
+                })
+
+        # --- (5) new-vendor first-spend spike --------------------------------------------
+        new_vendor = n < min_n
+        first_payment = amounts[0] if amounts else 0.0
+        if new_vendor and amounts:
+            outliers.append({
+                'kind': 'new_vendor_spike',
+                'payment_count': n,
+                'first_payment_amount': round(first_payment, 2),
+                'total_spend': round(sum(amounts), 2),
+                'note': 'vendor below baseline history - judged against batch new-vendor median downstream',
+            })
+
+        result = {
+            'vendor_id': cohort.get('vendor_id'),
+            'vendor_name': cohort.get('vendor_name'),
+            'payment_count': n,
+            'baseline_median': round(med, 2),
+            'baseline_mad_scaled': round(mad_scaled, 2),
+            'baseline_trusted': baseline_trusted,
+            'new_vendor': new_vendor,
+            'outlier_count': len(outliers),
+            'has_outlier': len(outliers) > 0,
+            'outliers': outliers,
+        }
+
+  # 4b) CLASSIFY the outlier's likely cause. The model ONLY LABELS using the precomputed signals;
+  #     the detection / z-score / dedup math was ALREADY done deterministically in code. Swappable
+  #     to any provider. Every category routes to the same downstream record step.
+  - id: classify_outlier_cause
+    type: classify
+    classify_config:
+      model: sonnet
+      input: >-
+        You label the most likely CAUSE of this vendor's AP anomalies using ONLY the precomputed
+        deterministic signals - never recompute any number. duplicate = the outliers include a
+        duplicate_payment kind; split = the outliers include a split_invoice kind (invoices split
+        just under the approval threshold); spike = a new_vendor_spike or a large positive
+        modified_z amount_outlier with no other explanation; seasonal = amount_outlier(s) that
+        plausibly reflect periodic / seasonal buying rather than error or fraud; benign = no
+        outliers at all. Vendor {steps.detect_vendor_anomalies.output.vendor_name}: new_vendor={steps.detect_vendor_anomalies.output.new_vendor},
+        baseline_trusted={steps.detect_vendor_anomalies.output.baseline_trusted},
+        outlier_count={steps.detect_vendor_anomalies.output.outlier_count},
+        outliers={steps.detect_vendor_anomalies.output.outliers}
+      categories:
+        - duplicate
+        - split
+        - spike
+        - seasonal
+        - benign
+
+  # 5) DETERMINISTIC aggregation + anomaly SCORE. NO model. Collect every per-vendor detector
+  #    result from the loop, fold in the classify label, weight each outlier kind, and compute a
+  #    0-100 batch anomaly score. Also resolves new-vendor spikes against the batch-wide
+  #    new-vendor median (the cross-cohort comparison that needs the whole batch). No model does math.
+  - id: aggregate_anomalies
+    type: code
+    depends_on: [per_vendor_loop, normalize_payments]
+    code_config:
+      language: python
+      code: |
+        loop_out = _steps.get('per_vendor_loop') or {}
+        norm = _steps.get('normalize_payments') or {}
+        spike_mult = float(_input.get('spike_multiple', 3.0) or 3.0)
+
+        items = loop_out if isinstance(loop_out, list) else (
+            loop_out.get('results') or loop_out.get('items') or loop_out.get('iterations') or []
+        )
+
+        vendors = []
+        for it in items:
+            det = it
+            label = None
+            if isinstance(it, dict) and 'vendor_id' not in it:
+                det = it.get('detect_vendor_anomalies') or it.get('output') or it
+                label = it.get('classify_outlier_cause')
+            if isinstance(det, dict) and det.get('vendor_id'):
+                row = dict(det)
+                row['cause_label'] = str(label or '').strip().lower() if label else ''
+                vendors.append(row)
+
+        # --- resolve new-vendor spikes against the batch-wide new-vendor first-payment median --
+        first_amts = []
+        for v in vendors:
+            for o in v.get('outliers', []):
+                if o.get('kind') == 'new_vendor_spike':
+                    first_amts.append(float(o.get('first_payment_amount') or 0.0))
+        s = sorted(first_amts)
+        m = len(s)
+        nv_median = (s[m // 2] if m % 2 else (s[m // 2 - 1] + s[m // 2]) / 2.0) if m else 0.0
+
+        # weight per outlier kind; duplicate / split are the costliest (real cash leakage / control evasion)
+        weights = {
+            'duplicate_payment': 30.0,
+            'split_invoice': 25.0,
+            'amount_outlier': 12.0,
+            'new_vendor_spike': 8.0,
+        }
+
+        flagged_vendors = []
+        raw_score = 0.0
+        kind_counts = {'duplicate_payment': 0, 'split_invoice': 0, 'amount_outlier': 0, 'new_vendor_spike': 0}
+
+        for v in vendors:
+            confirmed = []
+            for o in v.get('outliers', []):
+                kind = o.get('kind')
+                if kind == 'new_vendor_spike':
+                    # only a true spike if first payment >= spike_mult * batch new-vendor median
+                    fa = float(o.get('first_payment_amount') or 0.0)
+                    if not (nv_median > 0 and fa >= spike_mult * nv_median):
+                        continue
+                confirmed.append(o)
+                if kind in kind_counts:
+                    kind_counts[kind] += 1
+                    raw_score += weights.get(kind, 5.0)
+            if confirmed:
+                flagged_vendors.append({
+                    'vendor_id': v.get('vendor_id'),
+                    'vendor_name': v.get('vendor_name'),
+                    'cause_label': v.get('cause_label'),
+                    'baseline_median': v.get('baseline_median'),
+                    'baseline_mad_scaled': v.get('baseline_mad_scaled'),
+                    'outliers': confirmed,
+                    'outlier_count': len(confirmed),
+                })
+
+        anomaly_score = round(min(100.0, raw_score), 2)
+        total_outliers = sum(kind_counts.values())
+
+        result = {
+            'batch_id': norm.get('batch_id'),
+            'vendor_count': norm.get('vendor_count'),
+            'total_payments': norm.get('total_payments'),
+            'flagged_vendor_count': len(flagged_vendors),
+            'total_outliers': total_outliers,
+            'kind_counts': kind_counts,
+            'new_vendor_median': round(nv_median, 2),
+            'anomaly_score': anomaly_score,
+            'flagged_vendors': flagged_vendors,
+            'has_anomaly': total_outliers > 0,
+        }
+
+  # 6) DETERMINISTIC SHA-256 SEAL. NO model. Canonical-JSON each flagged vendor's confirmed
+  #    outliers, hash it, then hash the ordered list of per-vendor digests into one ledger root
+  #    hash. This is the tamper-evident signature an auditor verifies. Builds the immutable
+  #    object key for the audit-store PUT.
+  - id: seal_anomaly_record
+    type: code
+    depends_on: [aggregate_anomalies]
+    code_config:
+      language: python
+      code: |
+        import json
+        import hashlib
+        from datetime import datetime, timezone
+
+        agg = _steps.get('aggregate_anomalies') or {}
+        flagged = agg.get('flagged_vendors', [])
+        sealed_at = datetime.now(timezone.utc).isoformat()
+
+        sealed_vendors = []
+        for v in flagged:
+            canonical = json.dumps(v, sort_keys=True, separators=(',', ':'))
+            digest = hashlib.sha256(canonical.encode('utf-8')).hexdigest()
+            sealed_vendors.append({
+                'vendor_id': v.get('vendor_id'),
+                'vendor_name': v.get('vendor_name'),
+                'cause_label': v.get('cause_label'),
+                'outlier_count': v.get('outlier_count'),
+                'sha256': digest,
+            })
+
+        # Ledger root binds every per-vendor digest in deterministic order.
+        root_material = json.dumps([e['sha256'] for e in sealed_vendors], separators=(',', ':'))
+        ledger_root = hashlib.sha256(root_material.encode('utf-8')).hexdigest()
+
+        record = {
+            'batch_id': agg.get('batch_id'),
+            'sealed_at': sealed_at,
+            'anomaly_score': agg.get('anomaly_score'),
+            'flagged_vendor_count': agg.get('flagged_vendor_count'),
+            'total_outliers': agg.get('total_outliers'),
+            'kind_counts': agg.get('kind_counts'),
+            'ledger_root_sha256': ledger_root,
+            'vendors': sealed_vendors,
+        }
+
+        canonical_record = json.dumps(record, sort_keys=True, separators=(',', ':'))
+        safe_ts = sealed_at.replace(':', '-')
+        object_key = f"ap-anomaly-ledger/{agg.get('batch_id')}/{safe_ts}.json"
+
+        result = {
+            'object_key': object_key,
+            'ledger_root_sha256': ledger_root,
+            'sealed_at': sealed_at,
+            'record': record,
+            'canonical_json': canonical_record,
+            'byte_length': len(canonical_record),
+            'has_anomaly': bool(sealed_vendors),
+        }
+
+  # 7) CONDITION - open a ticket + seal-to-store + page ONLY when the batch anomaly score clears
+  #    the floor. A quiet sweep (score below floor) skips the ticket and only logs clean. No model.
+  - id: route_anomaly
+    type: condition
+    depends_on: [aggregate_anomalies, seal_anomaly_record]
+    condition_config:
+      expression: "{steps.aggregate_anomalies.output.anomaly_score} >= {input.anomaly_score_floor}"
+      then: [archive_record, open_triage_ticket, notify_controller]
+      else: [notify_clean]
+
+  # 7a) ARCHIVE the sealed record to the audit object store (S3-compatible, immutable retention).
+  #     The ledger root hash travels as object metadata so the record is tamper-evident at rest.
+  #     Connector: aws-s3. Real persistence path.
+  - id: archive_record
+    type: http
+    http_config:
+      url: "{input.record_store_base_url}/{input.record_store_bucket}/{steps.seal_anomaly_record.output.object_key}"
+      method: PUT
+      headers:
+        Content-Type: "application/json"
+        x-amz-object-lock-mode: "COMPLIANCE"
+        x-amz-object-lock-retain-until-date: "2034-01-01T00:00:00Z"
+        x-amz-meta-ledger-root-sha256: "{steps.seal_anomaly_record.output.ledger_root_sha256}"
+        x-amz-meta-batch-id: "{input.batch_id}"
+        x-amz-meta-anomaly-score: "{steps.aggregate_anomalies.output.anomaly_score}"
+      auth: "aws4:{env.AWS_ACCESS_KEY_ID}:{env.AWS_SECRET_ACCESS_KEY}"
+      body: "{steps.seal_anomaly_record.output.canonical_json}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: skip
+
+  # 7b) OPEN the triage ticket - file a Jira / Linear issue so AP controllership investigates the
+  #     flagged vendors. The sealed ledger root hash is embedded for chain-of-custody. Connector:
+  #     jira / linear.
+  - id: open_triage_ticket
+    type: notify
+    notify_config:
+      service: jira
+      project: "{input.ap_triage_project}"
+      title: "AP spend anomalies on {input.batch_id} - {steps.aggregate_anomalies.output.flagged_vendor_count} vendor(s), score {steps.aggregate_anomalies.output.anomaly_score}/100"
+      message: |
+        Deterministic AP anomaly sweep flagged {steps.aggregate_anomalies.output.flagged_vendor_count} vendor(s) on batch {input.batch_id}.
+        Anomaly score: {steps.aggregate_anomalies.output.anomaly_score}/100 (floor {input.anomaly_score_floor}).
+        Detector counts (model touched none of these): {steps.aggregate_anomalies.output.kind_counts}
+        Flagged vendors + outliers: {steps.aggregate_anomalies.output.flagged_vendors}
+        Sealed record (object-lock): {steps.seal_anomaly_record.output.object_key}
+        Ledger root SHA-256: {steps.seal_anomaly_record.output.ledger_root_sha256}
+
+  # 7c) NOTIFY the AP controller channel with the anomaly digest + the sealed ledger reference.
+  #     service: slack.
+  - id: notify_controller
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.controller_channel}"
+      message: |
+        :mag: AP SPEND ANOMALIES - {steps.aggregate_anomalies.output.flagged_vendor_count} vendor(s) on {steps.aggregate_anomalies.output.batch_id}
+        Anomaly score : {steps.aggregate_anomalies.output.anomaly_score}/100 (floor {input.anomaly_score_floor})
+        Duplicates    : {steps.aggregate_anomalies.output.kind_counts}
+        Total outliers: {steps.aggregate_anomalies.output.total_outliers}
+        Triage ticket filed in {input.ap_triage_project}.
+        Sealed (object-lock) at {steps.seal_anomaly_record.output.object_key}
+        Ledger root SHA-256: {steps.seal_anomaly_record.output.ledger_root_sha256}
+
+  # 7d) NOTIFY (clean) - quiet "no material AP anomalies" digest when the score is below the floor.
+  #     No ticket, no seal-to-store. service: slack.
+  - id: notify_clean
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.controller_channel}"
+      message: |
+        :white_check_mark: AP anomaly sweep clean on {steps.aggregate_anomalies.output.batch_id}.
+        {steps.aggregate_anomalies.output.total_outliers} outlier(s) below the score floor ({input.anomaly_score_floor}). No ticket filed, no seal.
+on_complete:
+  storage_path: "vendor-spend-anomaly-zscore-detector/{run_id}/result.json"

--- a/src/sandcastle/templates/warranty_return_window_tracker.yaml
+++ b/src/sandcastle/templates/warranty_return_window_tracker.yaml
@@ -1,0 +1,543 @@
+# name: Warranty & Return-Window Tracker
+# description: Watches your purchases and counts down each item's return window and warranty expiry with DETERMINISTIC date math. A cross-source RACE takes the first valid purchase date from two order/receipt providers (retailer order-history API vs an email-receipt parser - provider failover, NOT a vote), a PARSE pulls purchase_date / price / warranty_term out of the winning payload, deterministic CODE computes return_window_days_left and warranty_days_left, buckets urgency, and dedups idempotently, then a CONDITION + NOTIFY ping you ONLY for items whose window is about to close so you never miss a return or a warranty claim.
+# tags: [warranty, returns, personal, life-admin, countdown, receipts, orders, race, parse, deadline, reminder, Slack]
+# category: personal
+# connectors: http, slack
+name: warranty-return-window-tracker
+description: >-
+  A personal "don't-miss-the-window" watchdog for everything you buy. A durable
+  SENSOR blocks until the next daily sweep is due, then a DETERMINISTIC http GET
+  pulls your recent purchases from the order-history endpoint and a code step
+  normalizes them into a loopable list. The workflow LOOPS over each purchase and,
+  per item, runs a cross-source RACE: the retailer/order-history API and a
+  secondary email-receipt parser are queried in parallel and the FIRST one that
+  returns a usable purchase-date payload wins (provider failover, NOT a vote, so a
+  single dead source never blocks the countdown). A PARSE step extracts
+  purchase_date / price / warranty_term from whichever payload won, and a
+  DETERMINISTIC code step does the load-bearing math entirely in Python: it computes
+  return_window_days_left and warranty_days_left from the purchase date plus the
+  return/warranty terms (falling back to your default policy when the source omits
+  them), buckets each item into an urgency tier, and builds a stable idempotency key
+  so the same item is never alerted twice in a sweep. A CONDITION then routes ONLY
+  the items whose return window or warranty is inside the closing-soon threshold,
+  and a NOTIFY pings you with exactly what is about to expire, how many days are
+  left, and the claim/return link. All the date arithmetic, bucketing and dedup are
+  100% deterministic code and run with ZERO model providers available; the only
+  optional model is a swappable one-line summary draft on the digest.
+default_model: sonnet
+default_max_turns: 6
+default_timeout: 1200
+input_schema:
+  required: ["orders_api_url", "receipt_parse_url"]
+  properties:
+    orders_api_url:
+      type: string
+      description: "Retailer / order-history REST base that lists your recent purchases and (per order) the authoritative purchase date. The primary race branch for the purchase date."
+      default: "https://your-retailer.example.com/api/orders"
+      example: "https://www.amazon.com/api/order-history/v1"
+    receipt_parse_url:
+      type: string
+      description: "Secondary receipt / email-receipt parser endpoint raced against the order API. Given an order reference it returns the parsed receipt (purchase_date, price, warranty_term). Provider failover, not a vote."
+      default: "https://receipt-parser.internal/api/parse"
+      example: "https://api.veryfi.com/api/v8/partner/documents"
+    return_window_default_days:
+      type: integer
+      description: "Fallback return-window length in days, applied ONLY when neither source reports an explicit return policy for the item (e.g. retailer default 30)."
+      default: 30
+      example: "30"
+    warranty_default_days:
+      type: integer
+      description: "Fallback warranty length in days, applied ONLY when neither source reports an explicit warranty term (e.g. manufacturer default 365)."
+      default: 365
+      example: "365"
+    closing_soon_days:
+      type: integer
+      description: "Alert threshold in days. An item is 'closing soon' when its return window OR its warranty has this many days (or fewer) left but is not yet expired. Drives the condition + notify."
+      default: 7
+      example: "7"
+    lookback_days:
+      type: integer
+      description: "Only sweep purchases made within this many days back, so very old already-closed orders are not re-evaluated every run."
+      default: 400
+      example: "400"
+    sweep_interval:
+      type: integer
+      description: "Seconds between sweeps. The sensor blocks until the order endpoint reports the next daily sweep window is due. Default 24h."
+      default: 86400
+      example: "86400"
+    sensor_timeout:
+      type: integer
+      description: "Sensor soft timeout in seconds - stop waiting for the next sweep window after this long (one watch run). Default 48h."
+      default: 172800
+      example: "172800"
+    summary_model:
+      type: string
+      description: "Swappable model for the optional one-line digest header (draft_header step). Repoint it to any of the 7 providers - pin an EU/local provider (mistral/large, ollama, omlx/qwen-3) for privacy. The countdown decision is pure code and works with this unavailable."
+      default: "haiku"
+      example: "mistral/large"
+    slack_channel:
+      type: string
+      description: "Channel / DM that receives the closing-soon reminder digest."
+      default: "#purchases-warranty"
+      example: "#purchases-warranty"
+steps:
+  # 1) DURABLE SENSOR - block until the next daily sweep window is due for your account.
+  #    Polls the order endpoint's sweep-status flag; until a sweep is due there is nothing
+  #    new to re-count. Event-driven within a schedule, no busy-looping. No model.
+  - id: await_sweep_window
+    type: sensor
+    sensor_config:
+      url: "{input.orders_api_url}/sweep-window?select=status,sweep_due"
+      method: GET
+      headers:
+        Accept: "application/json"
+      condition: "status_code == 200 and response.get('sweep_due') == True"
+      check_interval: 3600
+      timeout: 172800
+
+  # 2) DETERMINISTIC pull of your recent purchases from the order-history endpoint, limited
+  #    to the lookback window so long-closed orders are not re-swept. No model.
+  - id: pull_orders
+    type: http
+    depends_on: [await_sweep_window]
+    http_config:
+      url: "{input.orders_api_url}?status=delivered&since_days={input.lookback_days}&expand=items"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.ORDERS_API_TOKEN}"
+    retry:
+      max_attempts: 3
+      backoff: exponential
+      on_failure: abort
+
+  # 3) DETERMINISTIC normalization of the order payload into a flat, loopable list. Each row
+  #    carries the order reference, the item label, the return/warranty links, and the two
+  #    race URLs (order-detail + receipt-parse) that the per-item race will query. No model.
+  - id: normalize_purchases
+    type: code
+    depends_on: [pull_orders]
+    code_config:
+      language: python
+      code: |
+        raw = _steps.get('pull_orders') or {}
+        rows = raw if isinstance(raw, list) else (
+            raw.get('orders') or raw.get('data') or raw.get('items') or raw.get('results') or []
+        )
+
+        orders_base = str(_input.get('orders_api_url') or '').rstrip('/')
+        receipt_base = str(_input.get('receipt_parse_url') or '').rstrip('/')
+
+        purchases = []
+        for rec in rows:
+            if not isinstance(rec, dict):
+                continue
+            oid = str(rec.get('order_id') or rec.get('id') or rec.get('reference') or '').strip()
+            if not oid:
+                continue
+            # An order may bundle several line items; emit one countdown row per item.
+            line_items = rec.get('items') or rec.get('line_items') or [rec]
+            if not isinstance(line_items, list) or not line_items:
+                line_items = [rec]
+            for li in line_items:
+                if not isinstance(li, dict):
+                    li = {}
+                item_id = str(li.get('item_id') or li.get('sku') or li.get('id') or oid).strip()
+                label = str(li.get('name') or li.get('title') or li.get('product') or oid).strip()
+                purchases.append({
+                    'order_id': oid,
+                    'item_id': item_id,
+                    'label': label,
+                    'retailer': rec.get('retailer') or rec.get('merchant') or 'unknown',
+                    'return_url': li.get('return_url') or rec.get('return_url') or '',
+                    'warranty_url': li.get('warranty_url') or rec.get('warranty_url') or '',
+                    # Race branch A: the order-detail endpoint (authoritative purchase date).
+                    'order_detail_url': f"{orders_base}/{oid}?expand=purchase_date,return_policy,warranty",
+                    # Race branch B: the receipt parser for the same order reference.
+                    'receipt_url': f"{receipt_base}?order_ref={oid}",
+                })
+
+        result = {
+            'purchase_count': len(purchases),
+            'lookback_days': int(_input.get('lookback_days') or 400),
+            'purchases': purchases,
+        }
+
+  # 4) LOOP over every purchase. Per-item child chain: RACE the order API vs the receipt
+  #    parser for the purchase-date payload -> PARSE purchase_date/price/warranty_term ->
+  #    DETERMINISTIC countdown math -> CONDITION routes closing-soon items into a reminder.
+  - id: per_item_loop
+    type: loop
+    depends_on: [normalize_purchases]
+    loop_config:
+      over: "steps.normalize_purchases.output.purchases"
+      step_ids:
+        - fetch_order_detail
+        - fetch_receipt
+        - purchase_date_race
+        - parse_receipt
+        - compute_countdown
+        - closing_branch
+      max_iterations: 1000
+
+  # 4a) RACE BRANCH A - http GET the order-detail from the retailer/order-history API. Carries
+  #     the authoritative purchase date + return policy + warranty term. on_failure: skip so a
+  #     dead order endpoint just lets the receipt parser win the race instead of aborting.
+  - id: fetch_order_detail
+    type: http
+    http_config:
+      url: "{input._item.order_detail_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.ORDERS_API_TOKEN}"
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  # 4b) RACE BRANCH B - http GET the parsed receipt for the same order reference from the
+  #     secondary email-receipt parser. Independent vendor; wins the race when the order API
+  #     is slow or omits the purchase date. on_failure: skip.
+  - id: fetch_receipt
+    type: http
+    http_config:
+      url: "{input._item.receipt_url}"
+      method: GET
+      headers:
+        Accept: "application/json"
+      auth: "bearer:{env.RECEIPT_PARSER_TOKEN}"
+    retry:
+      max_attempts: 2
+      backoff: exponential
+      on_failure: skip
+
+  # 4c) CROSS-SOURCE RACE for the authoritative purchase date. The order-detail API and the
+  #     receipt parser were fired in parallel; the FIRST that returns a usable payload (one that
+  #     actually carries a purchase/order date field) wins. Provider FAILOVER, not a vote - the
+  #     countdown is anchored on whichever source answers first, the other is a hot standby.
+  - id: purchase_date_race
+    type: race
+    race_config:
+      branches:
+        - [fetch_order_detail]
+        - [fetch_receipt]
+      validator: "isinstance(output, dict) and any(k in str(output).lower() for k in ('purchase_date','order_date','purchased_at','date'))"
+
+  # 4d) PARSE the winning race payload into the three fields the math needs: purchase_date,
+  #     price and warranty_term. A schema-guided extraction over whichever vendor shape won;
+  #     the deterministic countdown reads ONE normalized record regardless of source.
+  - id: parse_receipt
+    type: parse
+    prompt: |
+      Extract these fields as JSON from the receipt/order payload below, normalizing across
+      whichever vendor shape won the race:
+        purchase_date     - ISO 8601 yyyy-mm-dd the item was purchased (from purchase_date /
+                            order_date / purchased_at / date), empty if none.
+        price             - item price as a number, 0 if absent.
+        currency          - ISO currency code if present, else empty.
+        warranty_term_days - explicit warranty length in days if the source reports one, else 0.
+        return_window_days - explicit return-window length in days if the source reports one, else 0.
+      Do not invent values - leave a field empty/0 when the payload does not state it.
+      Payload: {steps.purchase_date_race.output}
+    parse_config:
+      output: json
+
+  # 4e) DETERMINISTIC COUNTDOWN. NO model. The load-bearing math: from the parsed purchase_date
+  #     and the explicit-or-default return/warranty terms, compute return_window_days_left and
+  #     warranty_days_left as of today, bucket urgency (expired / closing_soon / open), and build
+  #     a stable idempotency key so the same item is never alerted twice in one sweep. Reads the
+  #     loop item, the parsed receipt and the input thresholds; trusts no model output.
+  - id: compute_countdown
+    type: code
+    code_config:
+      language: python
+      code: |
+        import re
+        import hashlib
+        from datetime import datetime, timezone, timedelta
+
+        item = _input.get('_item') or {}
+        parsed = _steps.get('parse_receipt') or {}
+        if not isinstance(parsed, dict):
+            parsed = {}
+
+        return_default = int(_input.get('return_window_default_days') or 30)
+        warranty_default = int(_input.get('warranty_default_days') or 365)
+        closing_soon = int(_input.get('closing_soon_days') or 7)
+
+        # --- parse the purchase date robustly; accept ISO date or datetime, else None.
+        def _parse_date(v):
+            s = str(v or '').strip()
+            if not s:
+                return None
+            s = s.replace('Z', '+00:00')
+            try:
+                dt = datetime.fromisoformat(s)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                return dt
+            except (ValueError, TypeError):
+                pass
+            # last resort: pull a yyyy-mm-dd substring out of free text
+            m = re.search(r'(\d{4})-(\d{2})-(\d{2})', s)
+            if m:
+                try:
+                    return datetime(int(m.group(1)), int(m.group(2)), int(m.group(3)), tzinfo=timezone.utc)
+                except ValueError:
+                    return None
+            return None
+
+        def _to_int(v, fallback=0):
+            try:
+                n = int(float(v))
+                return n if n > 0 else fallback
+            except (ValueError, TypeError):
+                return fallback
+
+        purchase_dt = _parse_date(parsed.get('purchase_date'))
+        now = datetime.now(timezone.utc)
+
+        # --- effective terms: explicit from the source, else fall back to the input policy.
+        return_term = _to_int(parsed.get('return_window_days'), return_default)
+        warranty_term = _to_int(parsed.get('warranty_term_days'), warranty_default)
+
+        have_date = purchase_dt is not None
+        if have_date:
+            age_days = (now - purchase_dt).days
+            return_deadline = purchase_dt + timedelta(days=return_term)
+            warranty_deadline = purchase_dt + timedelta(days=warranty_term)
+            return_days_left = (return_deadline - now).days
+            warranty_days_left = (warranty_deadline - now).days
+        else:
+            # No reliable purchase date from EITHER source - cannot count down. Flag for review.
+            age_days = None
+            return_days_left = None
+            warranty_days_left = None
+
+        def _bucket(days_left):
+            if days_left is None:
+                return 'unknown'
+            if days_left < 0:
+                return 'expired'
+            if days_left <= closing_soon:
+                return 'closing_soon'
+            return 'open'
+
+        return_bucket = _bucket(return_days_left)
+        warranty_bucket = _bucket(warranty_days_left)
+
+        # Closing-soon = at least one of the two windows is inside the threshold but not yet gone.
+        return_closing = return_bucket == 'closing_soon'
+        warranty_closing = warranty_bucket == 'closing_soon'
+        is_closing_soon = return_closing or warranty_closing
+
+        # The single soonest deadline drives sort + the headline number in the alert.
+        candidates = [d for d in (return_days_left, warranty_days_left) if d is not None and d >= 0]
+        soonest_days_left = min(candidates) if candidates else None
+
+        # Stable idempotency key: same order+item+sweep-day -> same key, so one alert per item.
+        sweep_day = now.strftime('%Y-%m-%d')
+        key_material = f"{item.get('order_id')}|{item.get('item_id')}|{sweep_day}"
+        idempotency_key = hashlib.sha256(key_material.encode('utf-8')).hexdigest()[:16]
+
+        result = {
+            'order_id': item.get('order_id'),
+            'item_id': item.get('item_id'),
+            'label': item.get('label'),
+            'retailer': item.get('retailer'),
+            'return_url': item.get('return_url'),
+            'warranty_url': item.get('warranty_url'),
+            'have_purchase_date': have_date,
+            'purchase_date': purchase_dt.date().isoformat() if have_date else None,
+            'age_days': age_days,
+            'price': parsed.get('price'),
+            'currency': parsed.get('currency') or '',
+            'return_term_days': return_term,
+            'warranty_term_days': warranty_term,
+            'return_days_left': return_days_left,
+            'warranty_days_left': warranty_days_left,
+            'return_bucket': return_bucket,
+            'warranty_bucket': warranty_bucket,
+            'return_closing': return_closing,
+            'warranty_closing': warranty_closing,
+            'is_closing_soon': is_closing_soon,
+            'soonest_days_left': soonest_days_left,
+            'idempotency_key': idempotency_key,
+        }
+
+  # 4f) CONDITION - route ONLY items whose return window OR warranty is inside the closing
+  #     threshold into the per-item collection list. Deterministic branch off the in-code
+  #     is_closing_soon flag (not any model output). Open / expired items just fall through.
+  - id: closing_branch
+    type: condition
+    condition_config:
+      expression: "{steps.compute_countdown.output.is_closing_soon} == True"
+      then: [record_closing_item]
+      else: [record_open_item]
+
+  # 4g) DETERMINISTIC record of a CLOSING-SOON item, deduped by the idempotency key so the same
+  #     item appears once in the digest. No model.
+  - id: record_closing_item
+    type: code
+    code_config:
+      language: python
+      code: |
+        cd = _steps.get('compute_countdown') or {}
+        result = {
+            'idempotency_key': cd.get('idempotency_key'),
+            'order_id': cd.get('order_id'),
+            'item_id': cd.get('item_id'),
+            'label': cd.get('label'),
+            'retailer': cd.get('retailer'),
+            'return_days_left': cd.get('return_days_left'),
+            'warranty_days_left': cd.get('warranty_days_left'),
+            'soonest_days_left': cd.get('soonest_days_left'),
+            'return_closing': cd.get('return_closing'),
+            'warranty_closing': cd.get('warranty_closing'),
+            'return_url': cd.get('return_url'),
+            'warranty_url': cd.get('warranty_url'),
+            'price': cd.get('price'),
+            'currency': cd.get('currency'),
+            'status': 'closing_soon',
+        }
+
+  # 4h) DETERMINISTIC record of a non-alerting item (open or expired or undated) so the sweep
+  #     totals reconcile. No model.
+  - id: record_open_item
+    type: code
+    code_config:
+      language: python
+      code: |
+        cd = _steps.get('compute_countdown') or {}
+        if not cd.get('have_purchase_date'):
+            status = 'undated'
+        elif cd.get('return_bucket') == 'expired' and cd.get('warranty_bucket') == 'expired':
+            status = 'expired'
+        else:
+            status = 'open'
+        result = {
+            'idempotency_key': cd.get('idempotency_key'),
+            'order_id': cd.get('order_id'),
+            'item_id': cd.get('item_id'),
+            'label': cd.get('label'),
+            'status': status,
+            'return_days_left': cd.get('return_days_left'),
+            'warranty_days_left': cd.get('warranty_days_left'),
+        }
+
+  # 5) DETERMINISTIC aggregation of every per-item record from the loop. Dedups closing-soon
+  #    items by idempotency key, sorts by soonest deadline, and counts each bucket. The
+  #    alert_count drives whether a reminder is sent. No model.
+  - id: aggregate_sweep
+    type: code
+    depends_on: [per_item_loop]
+    code_config:
+      language: python
+      code: |
+        loop_out = _steps.get('per_item_loop') or {}
+        items = loop_out if isinstance(loop_out, list) else (
+            loop_out.get('results') or loop_out.get('items') or loop_out.get('iterations') or []
+        )
+
+        closing = {}
+        open_count = 0
+        expired_count = 0
+        undated_count = 0
+
+        for it in items:
+            row = it
+            if isinstance(it, dict) and 'status' not in it:
+                row = (it.get('record_closing_item') or it.get('record_open_item')
+                       or it.get('output') or it)
+            if not isinstance(row, dict):
+                continue
+            status = str(row.get('status') or '')
+            if status == 'closing_soon':
+                key = row.get('idempotency_key') or f"{row.get('order_id')}|{row.get('item_id')}"
+                # idempotent dedup: keep the soonest view of a given item only once.
+                if key not in closing:
+                    closing[key] = row
+            elif status == 'open':
+                open_count += 1
+            elif status == 'expired':
+                expired_count += 1
+            elif status == 'undated':
+                undated_count += 1
+
+        def _sort_key(r):
+            v = r.get('soonest_days_left')
+            return v if isinstance(v, int) else 10 ** 9
+
+        closing_items = sorted(closing.values(), key=_sort_key)
+
+        # Human-readable lines for the digest, soonest first.
+        lines = []
+        for r in closing_items:
+            parts = []
+            if r.get('return_closing') and isinstance(r.get('return_days_left'), int):
+                parts.append(f"return in {r['return_days_left']}d")
+            if r.get('warranty_closing') and isinstance(r.get('warranty_days_left'), int):
+                parts.append(f"warranty in {r['warranty_days_left']}d")
+            window = ', '.join(parts) if parts else 'closing soon'
+            lines.append(f"- {r.get('label')} ({r.get('retailer')}): {window}")
+
+        result = {
+            'total_items': len(items),
+            'alert_count': len(closing_items),
+            'open_count': open_count,
+            'expired_count': expired_count,
+            'undated_count': undated_count,
+            'closing_items': closing_items,
+            'digest_lines': lines,
+            'has_alerts': len(closing_items) > 0,
+        }
+
+  # 6) Swappable one-line digest header DRAFT. The ONLY model in the path and it is optional +
+  #    provider-agnostic: it just phrases a friendly header from the already-computed counts.
+  #    Every number it shows was decided deterministically in code. Pinnable to any provider.
+  - id: draft_header
+    type: llm
+    depends_on: [aggregate_sweep]
+    model: haiku
+    prompt: >-
+      Write ONE short friendly line (max 18 words) for a purchases reminder. There are
+      {steps.aggregate_sweep.output.alert_count} item(s) whose return window or warranty is
+      about to close. Do not invent numbers - use only the count given. No emoji.
+
+  # 7) CONDITION - only send the reminder when at least one item is actually closing soon.
+  #    A clean sweep (alert_count == 0) stays silent. Deterministic branch off the in-code
+  #    has_alerts flag. No model.
+  - id: route_alert
+    type: condition
+    depends_on: [aggregate_sweep]
+    condition_config:
+      expression: "{steps.aggregate_sweep.output.alert_count} > 0"
+      then: [notify_closing]
+      else: [notify_quiet]
+
+  # 7a) NOTIFY (reminder) - ping you with exactly what is about to expire, how many days are
+  #     left on each, and the return/warranty links so you can act before the window shuts.
+  - id: notify_closing
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :alarm_clock: {steps.draft_header.output}
+        {steps.aggregate_sweep.output.alert_count} item(s) closing within {input.closing_soon_days} days:
+        {steps.aggregate_sweep.output.digest_lines}
+        ({steps.aggregate_sweep.output.expired_count} already expired, {steps.aggregate_sweep.output.open_count} still open, {steps.aggregate_sweep.output.undated_count} undated)
+
+  # 7b) NOTIFY (quiet) - a silent-ish "nothing closing" confirmation on a clean sweep so you
+  #     know the watch ran. No model required.
+  - id: notify_quiet
+    type: notify
+    notify_config:
+      service: slack
+      channel: "{input.slack_channel}"
+      message: |
+        :white_check_mark: Warranty/return sweep clean - nothing closing within {input.closing_soon_days} days.
+        {steps.aggregate_sweep.output.open_count} window(s) still open, {steps.aggregate_sweep.output.expired_count} already closed.
+on_complete:
+  storage_path: "warranty-return-window-tracker/{run_id}/result.json"

--- a/tests/test_template_hub_nextwave.py
+++ b/tests/test_template_hub_nextwave.py
@@ -1,0 +1,158 @@
+"""Validation for the next-wave Template Hub category expansion.
+
+Adds three new categories to the built-in catalog - personal (Personal & Life
+Admin), research_intel (Research & Intelligence) and finance_ops (Finance & FP&A
+Operations) - and surfaces them in the public web hub registry. The checks mirror
+the v034 hub suite (parse, validate, build-plan coverage, control-flow references,
+code-sandbox blocklist, category header, catalog discovery) and add an engine-first
+guard: each template must carry the load on a non-LLM step type (deterministic code,
+http, sensor, race, gate, classify, condition, loop), not a bare LLM prompt - that is
+the whole point of a provider-neutral template.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+from sandcastle.engine.dag import (
+    VALID_STEP_TYPES,
+    build_plan,
+    parse_yaml_string,
+    validate,
+)
+from sandcastle.engine.executor import _CODE_STEP_BLOCKED_PATTERNS
+from sandcastle.engine.tools.registry import KNOWN_TOOLS
+from sandcastle.templates import list_templates
+
+HUB_TEMPLATES = {
+    "personal": [
+        "bill_renewal_late_fee_sentinel", "subscription_audit_cancel_warden",
+        "warranty_return_window_tracker", "trip_itinerary_race_planner",
+        "inbox_to_tasks_triage_router",
+    ],
+    "research_intel": [
+        "competitor_pricing_page_change_sentinel", "funding_and_ma_radar_dedup",
+        "literature_source_triage_race", "sec_filing_delta_extractor",
+        "topic_share_of_voice_rank_monitor",
+    ],
+    "finance_ops": [
+        "budget_variance_materiality_sentinel", "expense_policy_line_item_auditor",
+        "ar_collections_dunning_prioritizer", "mrr_waterfall_board_rollup",
+        "vendor_spend_anomaly_zscore_detector",
+    ],
+}
+ALL = [(cat, name) for cat, names in HUB_TEMPLATES.items() for name in names]
+
+# Non-LLM step types that can carry the load-bearing decision in a provider-neutral
+# workflow. A template that uses none of these is "just prompt a model" and fails.
+ENGINE_STEP_TYPES = {"http", "code", "sensor", "race", "gate", "classify", "condition", "loop"}
+
+ROOT = Path(__file__).resolve().parent.parent
+TEMPLATES_DIR = ROOT / "src" / "sandcastle" / "templates"
+REGISTRY = ROOT / "site" / "hub" / "registry.json"
+
+
+def _load(name: str) -> str:
+    path = TEMPLATES_DIR / f"{name}.yaml"
+    assert path.exists(), f"Template file not found: {path}"
+    return path.read_text()
+
+
+def _header_category(text: str) -> str | None:
+    for line in text.splitlines():
+        s = line.strip()
+        if not s.startswith("#"):
+            break
+        s = s.lstrip("#").strip()
+        if s.startswith("category:"):
+            return s.split(":", 1)[1].strip()
+    return None
+
+
+@pytest.mark.parametrize("cat,name", ALL)
+def test_parses_validates_and_plans(cat: str, name: str) -> None:
+    wf = parse_yaml_string(_load(name))
+    assert wf.name and len(wf.steps) > 0
+    assert validate(wf) == [], f"{name} did not validate"
+    planned = [sid for stage in build_plan(wf).stages for sid in stage]
+    assert len(planned) == len(set(planned)) and set(planned) == {s.id for s in wf.steps}
+
+
+@pytest.mark.parametrize("cat,name", ALL)
+def test_step_types_and_refs(cat: str, name: str) -> None:
+    wf = parse_yaml_string(_load(name))
+    ids = {s.id for s in wf.steps}
+    for step in wf.steps:
+        assert step.type in VALID_STEP_TYPES, f"{name}/{step.id} bad type {step.type!r}"
+        for dep in step.depends_on:
+            assert dep in ids, f"{name}/{step.id} depends on unknown {dep!r}"
+        if step.tool_config and step.tool_config.tool:
+            assert step.tool_config.tool.split(":")[0] in KNOWN_TOOLS
+        if step.condition_config:
+            for sid in step.condition_config.then_steps + step.condition_config.else_steps:
+                assert sid in ids
+        if step.loop_config:
+            for sid in step.loop_config.step_ids:
+                assert sid in ids
+        if step.race_config:
+            for branch in step.race_config.branches:
+                for sid in branch:
+                    assert sid in ids
+
+
+@pytest.mark.parametrize("cat,name", ALL)
+def test_carries_new_category(cat: str, name: str) -> None:
+    assert _header_category(_load(name)) == cat, f"{name} should be category {cat}"
+
+
+@pytest.mark.parametrize("cat,name", ALL)
+def test_is_engine_first_not_a_bare_prompt(cat: str, name: str) -> None:
+    wf = parse_yaml_string(_load(name))
+    used = {s.type for s in wf.steps}
+    assert used & ENGINE_STEP_TYPES, (
+        f"{name} uses no engine step type {ENGINE_STEP_TYPES} - it is just an LLM prompt"
+    )
+
+
+@pytest.mark.parametrize("cat,name", ALL)
+def test_code_steps_pass_sandbox_blocklist(cat: str, name: str) -> None:
+    wf = parse_yaml_string(_load(name))
+    for step in wf.steps:
+        if step.type == "code" and step.code_config and step.code_config.code:
+            code = step.code_config.code
+            match = _CODE_STEP_BLOCKED_PATTERNS.search(code)
+            assert match is None, f"{name}/{step.id} sandbox-blocked {match.group(0)!r}"
+            ast.parse(code)
+
+
+@pytest.mark.parametrize("cat,name", ALL)
+def test_discovered_in_catalog(cat: str, name: str) -> None:
+    by_file = {t.file_name: t for t in list_templates()}
+    info = by_file.get(f"{name}.yaml")
+    assert info is not None and info.category == cat and info.step_count > 0
+
+
+def test_new_categories_span_three() -> None:
+    cats = {_header_category(_load(n)) for _, n in ALL}
+    assert cats == {"personal", "research_intel", "finance_ops"}
+
+
+def test_web_hub_registry_surfaces_new_categories() -> None:
+    """The generator's invariant: registry categories[] counts equal the actual
+    per-category counts in templates[], and each new category surfaces real
+    templates in the public hub bar."""
+    reg = json.loads(REGISTRY.read_text())
+    template_counts = Counter(t.get("category", "general_ai") for t in reg["templates"])
+    bar = {c["id"]: c["count"] for c in reg["categories"]}
+    assert bar == dict(template_counts), (
+        "registry categories[] is out of sync with templates[] - run "
+        "scripts/update_hub_registry.py"
+    )
+    for cat in HUB_TEMPLATES:
+        assert bar.get(cat, 0) >= len(HUB_TEMPLATES[cat]), f"{cat} missing from web hub bar"
+    assert reg["stats"]["total_templates"] == len(reg["templates"])


### PR DESCRIPTION
## What

Extends the two-axis taxonomy with the **next-wave categories** from the hub ideation: a prosumer on-ramp (**Personal & Life Admin**) plus two ops disciplines (**Research & Intelligence**, **Finance & FP&A Operations**). **15 provider-neutral templates**, evenly 5/5/5. Built-in catalog 226 -> 241; public hub 235 -> **250 templates / 13 categories**.

| Category | Templates |
|---|---|
| **personal** | bill_renewal_late_fee_sentinel, subscription_audit_cancel_warden, warranty_return_window_tracker, trip_itinerary_race_planner, inbox_to_tasks_triage_router |
| **research_intel** | competitor_pricing_page_change_sentinel, funding_and_ma_radar_dedup, literature_source_triage_race, sec_filing_delta_extractor, topic_share_of_voice_rank_monitor |
| **finance_ops** | budget_variance_materiality_sentinel, expense_policy_line_item_auditor, ar_collections_dunning_prioritizer, mrr_waterfall_board_rollup, vendor_spend_anomaly_zscore_detector |

## Engine-first, not bare prompts

Across the 15 the step mix is **54 http, 47 code**, 27 notify, 19 condition, **12 gate, 9 sensor, 8 classify, 8 loop, 5 race** - and only **7 llm steps total**. The load-bearing decision (date math, dedup, diff, variance, z-score, aging buckets) is deterministic code or a cross-provider race/gate; any model use is a swappable judge/draft, so each template runs with **zero model providers available**. Even the prosumer `personal` set keeps the engine - a bill **sensor** + http due-date check, a subscription audit that http-pulls statements and code-dedups recurring charges.

## Web hub

`scripts/update_hub_registry.py` `NEW_CATEGORIES` + `CATEGORY_LABELS` gain `research_intel` + `finance_ops` (`personal` was already registered); `--ingest` surfaces the 15 as `gizmax/` entries. Registry is now **250 templates / 13 categories**, drift invariant intact. `index.html` gains 3 chips + color vars (personal amber, research_intel violet, finance_ops lime).

## Tests

`tests/test_template_hub_nextwave.py` (**90**): each template parses / validates / build-plans, carries its category, is sandbox-clean, is discovered in the catalog, and passes an **engine-first guard** (must use a non-LLM load-bearing step type) - plus the registry drift invariant. Authoritative sweep: **15/15 clean**. **Live-verified**: hub shows 250 / 13 and each new chip filters to its 5 cards.