### PR TITLE
feat(dashboard): Lite mode wizard, keyless web search, run-activity heatmap

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,9 +1,10 @@
-import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
-import { Suspense } from "react";
+import { BrowserRouter, Routes, Route, Link, Navigate, useLocation, useNavigate } from "react-router-dom";
+import { Suspense, useEffect } from "react";
 import { Layout } from "@/components/layout/Layout";
 import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
 import { ErrorBoundary } from "@/components/shared/ErrorBoundary";
 import { EventStreamProvider } from "@/components/providers/EventStreamProvider";
+import { UiModeProvider, useUiMode } from "@/contexts/UiModeContext";
 import { useAuth } from "@/hooks/useAuth";
 import { AuthGate } from "@/components/auth/AuthGate";
 import { usePageTracking } from "@/hooks/usePageTracking";
@@ -49,6 +50,31 @@ function PageTracker() {
   return null;
 }
 
+/** Redirect brand-new installs (onboarding not completed) to the guided wizard. */
+function FirstRunGuard() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  useEffect(() => {
+    let done = true;
+    try {
+      done = localStorage.getItem("sandcastle-onboarding-done") === "true";
+    } catch {
+      done = true; // storage unavailable - don't trap the user in a redirect loop
+    }
+    if (!done && location.pathname !== "/onboarding") {
+      navigate("/onboarding", { replace: true });
+    }
+  }, [location.pathname, navigate]);
+  return null;
+}
+
+/** In Lite mode, advanced pages are hidden - redirect their routes to Overview. */
+function LiteGuard({ children }: { children: React.ReactNode }) {
+  const { isLite } = useUiMode();
+  if (isLite) return <Navigate to="/" replace />;
+  return <>{children}</>;
+}
+
 function NotFound() {
   return (
     <div className="flex flex-col items-center justify-center py-24 gap-4">
@@ -80,8 +106,10 @@ export default function App() {
   }
 
   return (
+    <UiModeProvider>
     <BrowserRouter basename={import.meta.env.BASE_URL}>
       <PageTracker />
+      <FirstRunGuard />
       {state === "offline" && (
         <div className="bg-yellow-500/90 text-yellow-950 text-center text-sm py-1.5 px-4 font-medium">
           Backend unreachable - running in offline/demo mode. Data shown may be stale.
@@ -111,19 +139,19 @@ export default function App() {
               <Route path="/templates" element={<PageBoundary name="templates"><TemplatesPage /></PageBoundary>} />
               <Route path="/integrations" element={<PageBoundary name="integrations"><IntegrationsPage /></PageBoundary>} />
               <Route path="/approvals" element={<PageBoundary name="approvals"><ApprovalsPage /></PageBoundary>} />
-              <Route path="/evaluations" element={<PageBoundary name="evaluations"><EvaluationsPage /></PageBoundary>} />
-              <Route path="/autopilot" element={<PageBoundary name="autopilot"><AutoPilotPage /></PageBoundary>} />
-              <Route path="/evolution" element={<PageBoundary name="evolution"><EvolutionPage /></PageBoundary>} />
-              <Route path="/violations" element={<PageBoundary name="violations"><ViolationsPage /></PageBoundary>} />
-              <Route path="/optimizer" element={<PageBoundary name="optimizer"><OptimizerPage /></PageBoundary>} />
+              <Route path="/evaluations" element={<LiteGuard><PageBoundary name="evaluations"><EvaluationsPage /></PageBoundary></LiteGuard>} />
+              <Route path="/autopilot" element={<LiteGuard><PageBoundary name="autopilot"><AutoPilotPage /></PageBoundary></LiteGuard>} />
+              <Route path="/evolution" element={<LiteGuard><PageBoundary name="evolution"><EvolutionPage /></PageBoundary></LiteGuard>} />
+              <Route path="/violations" element={<LiteGuard><PageBoundary name="violations"><ViolationsPage /></PageBoundary></LiteGuard>} />
+              <Route path="/optimizer" element={<LiteGuard><PageBoundary name="optimizer"><OptimizerPage /></PageBoundary></LiteGuard>} />
               <Route path="/schedules" element={<PageBoundary name="schedules"><Schedules /></PageBoundary>} />
-              <Route path="/schedule-monitor" element={<PageBoundary name="schedule-monitor"><ScheduleMonitorPage /></PageBoundary>} />
-              <Route path="/dead-letter" element={<PageBoundary name="dead-letter"><DeadLetterPage /></PageBoundary>} />
-              <Route path="/api-keys" element={<PageBoundary name="api-keys"><ApiKeysPage /></PageBoundary>} />
+              <Route path="/schedule-monitor" element={<LiteGuard><PageBoundary name="schedule-monitor"><ScheduleMonitorPage /></PageBoundary></LiteGuard>} />
+              <Route path="/dead-letter" element={<LiteGuard><PageBoundary name="dead-letter"><DeadLetterPage /></PageBoundary></LiteGuard>} />
+              <Route path="/api-keys" element={<LiteGuard><PageBoundary name="api-keys"><ApiKeysPage /></PageBoundary></LiteGuard>} />
               <Route path="/settings" element={<PageBoundary name="settings"><SettingsPage /></PageBoundary>} />
               <Route path="/system-health" element={<PageBoundary name="system-health"><SystemHealthPage /></PageBoundary>} />
-              <Route path="/compliance" element={<PageBoundary name="compliance"><CompliancePage /></PageBoundary>} />
-              <Route path="/memory" element={<PageBoundary name="memory"><MemoryPage /></PageBoundary>} />
+              <Route path="/compliance" element={<LiteGuard><PageBoundary name="compliance"><CompliancePage /></PageBoundary></LiteGuard>} />
+              <Route path="/memory" element={<LiteGuard><PageBoundary name="memory"><MemoryPage /></PageBoundary></LiteGuard>} />
               <Route path="*" element={<NotFound />} />
             </Route>
           </Routes>
@@ -131,5 +159,6 @@ export default function App() {
       </EventStreamProvider>
       </ErrorBoundary>
     </BrowserRouter>
+    </UiModeProvider>
   );
 }

--- a/dashboard/src/__tests__/v27-onboarding.test.tsx
+++ b/dashboard/src/__tests__/v27-onboarding.test.tsx
@@ -678,14 +678,18 @@ describe("OnboardingWizard (guided beginner flow)", () => {
       if (url === "/templates") {
         return Promise.resolve(okResponse([
           {
-            name: "text-summarizer",
-            description: "Summarize text.",
+            name: "What Does AI Say About Your Brand?",
+            description: "Audit AI brand perception.",
             input_schema: {
-              required: ["text"],
-              properties: { text: { type: "string", description: "Text to summarize" } },
+              required: ["brand"],
+              properties: { brand: { type: "string", description: "Brand to audit" } },
             },
           },
         ]));
+      }
+      // StepRun fetches the template YAML to run it inline.
+      if (url.startsWith("/templates/")) {
+        return Promise.resolve(okResponse({ content: "name: x\nsteps: []\n" }));
       }
       return Promise.resolve({ data: null, error: null });
     });
@@ -711,9 +715,9 @@ describe("OnboardingWizard (guided beginner flow)", () => {
     });
     await waitFor(() => expect(screen.getByText("Pick your first flow")).toBeInTheDocument());
 
-    // Pick the Text Summarizer card -> Configure
+    // Pick the AI Brand Audit card -> Configure
     await act(async () => {
-      fireEvent.click(screen.getByText("Text Summarizer"));
+      fireEvent.click(screen.getByText("AI Brand Audit"));
     });
     await act(async () => {
       fireEvent.click(screen.getByText("Continue"));

--- a/dashboard/src/__tests__/v27-onboarding.test.tsx
+++ b/dashboard/src/__tests__/v27-onboarding.test.tsx
@@ -548,8 +548,18 @@ describe("One-click demo workflow card", () => {
 // ============================================================================
 
 import { OnboardingWizard } from "@/components/onboarding/OnboardingWizard";
+import { UiModeProvider } from "@/contexts/UiModeContext";
 
-describe("OnboardingWizard (simplified 2-step)", () => {
+/** The guided wizard reads/writes UI mode, so renders are wrapped in its provider. */
+function renderWizard(onFinish: () => void) {
+  return render(
+    <UiModeProvider>
+      <OnboardingWizard onFinish={onFinish} />
+    </UiModeProvider>
+  );
+}
+
+describe("OnboardingWizard (guided beginner flow)", () => {
   const mockOnFinish = vi.fn();
 
   beforeEach(() => {
@@ -563,116 +573,86 @@ describe("OnboardingWizard (simplified 2-step)", () => {
     vi.useRealTimers();
   });
 
-  it("has only 2 steps (not 5)", async () => {
-    // Mock the /health/providers call made by StepConnect
+  it("has 5 guided steps", async () => {
     mockApi.get.mockResolvedValue(okResponse({}));
 
     await act(async () => {
-      render(<OnboardingWizard onFinish={mockOnFinish} />);
+      renderWizard(mockOnFinish);
     });
 
-    // Progress bar should show exactly "Connect" and "Try it" labels
-    expect(screen.getByText("Connect")).toBeInTheDocument();
-    expect(screen.getByText("Try it")).toBeInTheDocument();
-
-    // There should be exactly 2 step indicators in the progress bar
     const progressNav = screen.getByRole("navigation", { name: /progress/i });
     const stepItems = progressNav.querySelectorAll("li");
-    expect(stepItems.length).toBe(2);
+    expect(stepItems.length).toBe(5);
   });
 
-  it("Step 1 shows provider detection heading", async () => {
-    mockApi.get.mockResolvedValue(okResponse({
-      ollama: { status: "ok", latency_ms: 10, region: "local" },
-    }));
-
-    await act(async () => {
-      render(<OnboardingWizard onFinish={mockOnFinish} />);
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText("Connect a provider")).toBeInTheDocument();
-    });
-
-    expect(screen.getByText(/at least one AI provider/)).toBeInTheDocument();
-  });
-
-  it("Step 1 shows API key input when no providers detected", async () => {
-    // Return empty providers (none running or ok)
+  it("starts on the Welcome step", async () => {
     mockApi.get.mockResolvedValue(okResponse({}));
 
     await act(async () => {
-      render(<OnboardingWizard onFinish={mockOnFinish} />);
+      renderWizard(mockOnFinish);
+    });
+
+    expect(screen.getByText("Welcome to Sandcastle")).toBeInTheDocument();
+    expect(screen.getByText("Get Started")).toBeInTheDocument();
+  });
+
+  it("Welcome -> Connect asks local or cloud", async () => {
+    mockApi.get.mockResolvedValue(okResponse({}));
+
+    await act(async () => {
+      renderWizard(mockOnFinish);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Get Started"));
     });
 
     await waitFor(() => {
-      expect(screen.getByText(/No providers detected/)).toBeInTheDocument();
+      expect(screen.getByText("Local or cloud?")).toBeInTheDocument();
+    });
+  });
+
+  it("Connect shows the local hint when no providers are detected", async () => {
+    mockApi.get.mockResolvedValue(okResponse({}));
+
+    await act(async () => {
+      renderWizard(mockOnFinish);
     });
 
-    // Should have a password input for API key
+    await act(async () => {
+      fireEvent.click(screen.getByText("Get Started"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("ollama run llama3")).toBeInTheDocument();
+    });
     expect(screen.getByPlaceholderText("sk-...")).toBeInTheDocument();
-
-    // Save button should be present
-    expect(screen.getByText("Save")).toBeInTheDocument();
   });
 
-  it("Step 1 shows auto-detected providers when available", async () => {
-    mockApi.get.mockResolvedValue(okResponse({
-      ollama: { status: "running", latency_ms: 8, region: "local" },
-      anthropic: { status: "ok", latency_ms: 120, region: "us" },
-    }));
-
-    await act(async () => {
-      render(<OnboardingWizard onFinish={mockOnFinish} />);
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText("Auto-detected providers:")).toBeInTheDocument();
-    });
-
-    expect(screen.getByText("ollama")).toBeInTheDocument();
-    expect(screen.getByText("anthropic")).toBeInTheDocument();
-  });
-
-  it("Step 2 shows 'Run Demo Workflow' button", async () => {
-    // Set up providers so Next button is enabled
+  it("Connect shows auto-detected local provider", async () => {
     mockApi.get.mockResolvedValue(okResponse({
       ollama: { status: "running", latency_ms: 8, region: "local" },
     }));
 
     await act(async () => {
-      render(<OnboardingWizard onFinish={mockOnFinish} />);
+      renderWizard(mockOnFinish);
     });
 
-    // Wait for providers to load
-    await waitFor(() => {
-      expect(screen.getByText("Auto-detected providers:")).toBeInTheDocument();
-    });
-
-    // Click Next to go to step 2
     await act(async () => {
-      fireEvent.click(screen.getByText("Next"));
+      fireEvent.click(screen.getByText("Get Started"));
     });
-
-    // Mock the advisor/status call made by StepTryIt
-    mockApi.get.mockResolvedValue(okResponse({
-      current_provider: "ollama",
-      available_providers: [{ id: "ollama", configured: true, status: "running", region: "local" }],
-    }));
 
     await waitFor(() => {
-      expect(screen.getByText("Run Demo Workflow")).toBeInTheDocument();
+      expect(screen.getByText("ollama")).toBeInTheDocument();
     });
-
-    // "Try it out" heading should be visible
-    expect(screen.getByText("Try it out")).toBeInTheDocument();
+    expect(screen.getByText("Ready!")).toBeInTheDocument();
   });
 
-  it("Skip button navigates to dashboard", async () => {
+  it("Skip keeps Full mode and marks onboarding done", async () => {
     mockApi.get.mockResolvedValue(okResponse({}));
 
     await act(async () => {
-      render(<OnboardingWizard onFinish={mockOnFinish} />);
+      renderWizard(mockOnFinish);
     });
 
     await waitFor(() => {
@@ -683,104 +663,82 @@ describe("OnboardingWizard (simplified 2-step)", () => {
       fireEvent.click(screen.getByText("Skip to dashboard"));
     });
 
-    // Should navigate to root
     expect(mockNavigate).toHaveBeenCalledWith("/");
-
-    // Should mark onboarding as done in localStorage
     expect(localStorage.getItem("sandcastle-onboarding-done")).toBe("true");
+    expect(localStorage.getItem("sandcastle-ui-mode")).toBe("full");
   });
 
-  it("completion stored in localStorage on finish", async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
-
-    // Step 1: providers detected
-    mockApi.get.mockResolvedValue(okResponse({
-      ollama: { status: "running", latency_ms: 5, region: "local" },
-    }));
-
-    await act(async () => {
-      render(<OnboardingWizard onFinish={mockOnFinish} />);
+  it("completing the guided flow opts into Lite mode", async () => {
+    mockApi.get.mockImplementation((url: string) => {
+      if (url === "/health/providers") {
+        return Promise.resolve(okResponse({
+          ollama: { status: "running", latency_ms: 5, region: "local" },
+        }));
+      }
+      if (url === "/templates") {
+        return Promise.resolve(okResponse([
+          {
+            name: "text-summarizer",
+            description: "Summarize text.",
+            input_schema: {
+              required: ["text"],
+              properties: { text: { type: "string", description: "Text to summarize" } },
+            },
+          },
+        ]));
+      }
+      return Promise.resolve({ data: null, error: null });
     });
-
-    await waitFor(() => {
-      expect(screen.getByText("Auto-detected providers:")).toBeInTheDocument();
-    });
-
-    // Go to step 2
-    await act(async () => {
-      fireEvent.click(screen.getByText("Next"));
-    });
-
-    // Mock advisor/status for StepTryIt cost hint
-    mockApi.get.mockResolvedValue(okResponse({
-      current_provider: "ollama",
-      available_providers: [{ id: "ollama", configured: true, status: "running", region: "local" }],
-    }));
-
-    await waitFor(() => {
-      expect(screen.getByText("Run Demo Workflow")).toBeInTheDocument();
-    });
-
-    // Run the demo
     mockApi.post.mockResolvedValue(okResponse({
-      run_id: "demo-456",
+      run_id: "run-1",
       status: "completed",
-      outputs: { generate: "Facts.", summarize: "Summary." },
-      total_cost_usd: 0,
+      outputs: { summary: "A concise summary." },
     }));
 
     await act(async () => {
-      fireEvent.click(screen.getByText("Run Demo Workflow"));
+      renderWizard(mockOnFinish);
     });
 
-    // Advance past internal setTimeout(1000)
+    // Welcome -> Connect
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1100);
+      fireEvent.click(screen.getByText("Get Started"));
     });
+    await waitFor(() => expect(screen.getByText("Ready!")).toBeInTheDocument());
 
-    await waitFor(() => {
-      expect(screen.getByText("Done!")).toBeInTheDocument();
-    });
-
-    // Click "Go to Dashboard"
-    await act(async () => {
-      fireEvent.click(screen.getByText("Go to Dashboard"));
-    });
-
-    // onFinish callback should be called
-    expect(mockOnFinish).toHaveBeenCalledTimes(1);
-
-    // localStorage should mark onboarding as done
-    expect(localStorage.getItem("sandcastle-onboarding-done")).toBe("true");
-
-    // Step progress key should be removed
-    expect(localStorage.getItem("sandcastle-onboarding-step")).toBeNull();
-  });
-
-  it("saves step progress to localStorage on step change", async () => {
-    mockApi.get.mockResolvedValue(okResponse({
-      ollama: { status: "running", latency_ms: 5, region: "local" },
-    }));
-
-    await act(async () => {
-      render(<OnboardingWizard onFinish={mockOnFinish} />);
-    });
-
-    // Initially at step 0
-    await waitFor(() => {
-      expect(localStorage.getItem("sandcastle-onboarding-step")).toBe("0");
-    });
-
-    // Navigate to step 2
-    await waitFor(() => {
-      expect(screen.getByText("Auto-detected providers:")).toBeInTheDocument();
-    });
-
+    // Connect -> Pick
     await act(async () => {
       fireEvent.click(screen.getByText("Next"));
     });
+    await waitFor(() => expect(screen.getByText("Pick your first flow")).toBeInTheDocument());
 
-    // Step progress should be saved as "1"
-    expect(localStorage.getItem("sandcastle-onboarding-step")).toBe("1");
+    // Pick the Text Summarizer card -> Configure
+    await act(async () => {
+      fireEvent.click(screen.getByText("Text Summarizer"));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("Continue"));
+    });
+    await waitFor(() => expect(screen.getByText("Configure Inputs")).toBeInTheDocument());
+
+    // Configure -> Run
+    await act(async () => {
+      fireEvent.click(screen.getByText("Continue"));
+    });
+    await waitFor(() => expect(screen.getByText("Run your first flow")).toBeInTheDocument());
+
+    // Run it
+    await act(async () => {
+      fireEvent.click(screen.getByText("Run workflow"));
+    });
+    await waitFor(() => expect(screen.getByText("Done!")).toBeInTheDocument());
+
+    // Finish into the dashboard
+    await act(async () => {
+      fireEvent.click(screen.getByText("Go to my dashboard"));
+    });
+
+    expect(mockOnFinish).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem("sandcastle-onboarding-done")).toBe("true");
+    expect(localStorage.getItem("sandcastle-ui-mode")).toBe("lite");
   });
 });

--- a/dashboard/src/__tests__/v27-onboarding.test.tsx
+++ b/dashboard/src/__tests__/v27-onboarding.test.tsx
@@ -724,6 +724,13 @@ describe("OnboardingWizard (guided beginner flow)", () => {
     });
     await waitFor(() => expect(screen.getByText("Configure Inputs")).toBeInTheDocument());
 
+    // Required field gates Continue - fill the brand, then proceed
+    await act(async () => {
+      fireEvent.change(screen.getByPlaceholderText("brand"), {
+        target: { value: "Sandcastle" },
+      });
+    });
+
     // Configure -> Run
     await act(async () => {
       fireEvent.click(screen.getByText("Continue"));

--- a/dashboard/src/api/mock.ts
+++ b/dashboard/src/api/mock.ts
@@ -6589,9 +6589,9 @@ const routes: MockRoute[] = [
         t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
         return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
       };
-      return Array.from({ length: 182 }, (_, idx) => {
+      return Array.from({ length: 364 }, (_, idx) => {
         const d = new Date(today);
-        d.setDate(d.getDate() - (181 - idx));
+        d.setDate(d.getDate() - (363 - idx));
         const dayOfWeek = (d.getDay() + 6) % 7; // 0=Mon ... 6=Sun
         const isWeekend = dayOfWeek >= 5;
         const maxRuns = isWeekend ? 8 : 30;

--- a/dashboard/src/components/integrations/ToolConfigPanel.tsx
+++ b/dashboard/src/components/integrations/ToolConfigPanel.tsx
@@ -23,6 +23,9 @@ interface Tool {
   credential_env_vars: string[];
   functions: { name: string; description: string }[];
   connections?: ToolConnection[];
+  keyless?: boolean;
+  optional_credential_env_vars?: string[];
+  optional_present?: string[];
 }
 
 interface ToolConfigPanelProps {
@@ -48,9 +51,8 @@ export function ToolConfigPanel({ tool, onClose, onSaved }: ToolConfigPanelProps
   useEffect(() => {
     if (tool) {
       const init: Record<string, string> = {};
-      for (const v of tool.credential_env_vars) {
-        init[v] = "";
-      }
+      for (const v of tool.credential_env_vars) init[v] = "";
+      for (const v of tool.optional_credential_env_vars ?? []) init[v] = "";
       setValues(init);
       setVisible({});
     }
@@ -97,6 +99,9 @@ export function ToolConfigPanel({ tool, onClose, onSaved }: ToolConfigPanelProps
   const colors = CATEGORY_COLORS[tool.category] ?? CATEGORY_COLORS.general;
   const catLabel = CATEGORY_LABELS[tool.category] ?? tool.category;
   const hasVars = tool.credential_env_vars.length > 0;
+  const optionalVars = tool.optional_credential_env_vars ?? [];
+  const hasOptional = optionalVars.length > 0;
+  const optionalSet = (tool.optional_present ?? []).length > 0;
 
   return (
     <>
@@ -156,7 +161,14 @@ export function ToolConfigPanel({ tool, onClose, onSaved }: ToolConfigPanelProps
 
           {/* Status */}
           <div className="flex items-center gap-2">
-            {tool.configured ? (
+            {tool.keyless ? (
+              <>
+                <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+                <span className="text-sm text-emerald-500 font-medium">
+                  Free - works with no key{optionalSet ? " - key added" : ""}
+                </span>
+              </>
+            ) : tool.configured ? (
               <>
                 <CheckCircle2 className="h-4 w-4 text-emerald-500" />
                 <span className="text-sm text-emerald-500 font-medium">All credentials configured</span>
@@ -227,6 +239,60 @@ export function ToolConfigPanel({ tool, onClose, onSaved }: ToolConfigPanelProps
             </div>
           )}
 
+          {/* Optional upgrade key (keyless tools) */}
+          {hasOptional && (
+            <div className="space-y-3 rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-4">
+              <h3 className="text-sm font-medium text-foreground">Optional - raise the rate limit</h3>
+              <p className="text-xs text-muted">
+                This tool is free and works with no key. Add an optional key to lift the rate limit.
+                {tool.name === "websearch" && (
+                  <>
+                    {" "}
+                    <a href="https://jina.ai" target="_blank" rel="noopener noreferrer" className="text-accent hover:underline">
+                      Get a free Jina key (no card)
+                    </a>.
+                  </>
+                )}
+              </p>
+              {optionalVars.map((envVar) => {
+                const isVisible = visible[envVar] ?? false;
+                const credInfo = CREDENTIAL_LABELS[envVar];
+                const displayLabel = credInfo?.label ?? autoLabel(envVar, tool.name);
+                const isSet = (tool.optional_present ?? []).includes(envVar);
+                return (
+                  <div key={envVar}>
+                    <label className="mb-0.5 flex items-center gap-2 text-sm font-medium text-foreground">
+                      {displayLabel}
+                      <span className={cn(
+                        "rounded px-1.5 py-0.5 text-[10px] font-semibold",
+                        isSet ? "bg-emerald-500/15 text-emerald-500" : "bg-border/60 text-muted"
+                      )}>
+                        {isSet ? "SET" : "OPTIONAL"}
+                      </span>
+                    </label>
+                    <p className="text-[11px] text-muted-foreground mt-0.5 mb-1.5 font-mono">{envVar}</p>
+                    <div className="relative">
+                      <input
+                        type={isVisible ? "text" : "password"}
+                        value={values[envVar] ?? ""}
+                        onChange={(e) => setValues((prev) => ({ ...prev, [envVar]: e.target.value }))}
+                        placeholder={credInfo?.hint ?? "Optional - enter a key to raise limits..."}
+                        className="w-full rounded-lg border border-border bg-background px-3 py-2 pr-10 text-sm text-foreground placeholder:text-muted-foreground/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:border-accent transition-colors"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setVisible((prev) => ({ ...prev, [envVar]: !isVisible }))}
+                        className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted hover:text-foreground transition-colors"
+                      >
+                        {isVisible ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
           {/* Named Connections */}
           {hasVars && (
             <ConnectionsSection tool={tool} onSaved={onSaved} />
@@ -254,7 +320,7 @@ export function ToolConfigPanel({ tool, onClose, onSaved }: ToolConfigPanelProps
         </div>
 
         {/* Footer */}
-        {hasVars && (
+        {(hasVars || hasOptional) && (
           <div className="flex items-center justify-end gap-3 border-t border-border px-6 py-4">
             <button
               onClick={onClose}

--- a/dashboard/src/components/layout/Sidebar.tsx
+++ b/dashboard/src/components/layout/Sidebar.tsx
@@ -29,6 +29,7 @@ import { cn } from "@/lib/utils";
 import { useRuntimeInfo } from "@/hooks/useRuntimeInfo";
 import { useUpdateCheck } from "@/hooks/useUpdateCheck";
 import { usePinnedWorkflows } from "@/hooks/usePinnedWorkflows";
+import { useUiMode } from "@/contexts/UiModeContext";
 
 interface SidebarProps {
   open: boolean;
@@ -101,7 +102,20 @@ export function Sidebar({ open, onClose, dlqCount = 0, approvalsCount = 0 }: Sid
   const { info } = useRuntimeInfo();
   const { updateAvailable } = useUpdateCheck();
   const { pinnedWorkflows } = usePinnedWorkflows();
+  const { isLite, setMode } = useUiMode();
   const version = info?.version ?? "-";
+
+  // In Lite mode, show only the beginner-relevant navigation: drop the whole
+  // OPERATIONS section and API Keys; advanced pages are route-guarded too.
+  const sections = isLite
+    ? navSections
+        .filter((s) => s.label !== "OPERATIONS")
+        .map((s) =>
+          s.label === "SYSTEM"
+            ? { ...s, items: s.items.filter((i) => i.to !== "/api-keys") }
+            : s
+        )
+    : navSections;
 
   const [opsExpanded, setOpsExpanded] = useState(() => {
     try {
@@ -183,7 +197,7 @@ export function Sidebar({ open, onClose, dlqCount = 0, approvalsCount = 0 }: Sid
         </div>
 
         <nav className="flex-1 overflow-y-auto px-3 py-3" aria-label="Sidebar">
-          {navSections.map((section, sectionIdx) => {
+          {sections.map((section, sectionIdx) => {
             const renderItems = (items: NavItem[]) => (
               <div className="space-y-0.5">
                 {items.map((item) => (
@@ -274,8 +288,8 @@ export function Sidebar({ open, onClose, dlqCount = 0, approvalsCount = 0 }: Sid
                   )}
                 </div>
 
-                {/* Pinned workflows section - rendered after MAIN */}
-                {section.label === "MAIN" && pinnedWorkflows.length > 0 && (
+                {/* Pinned workflows section - rendered after MAIN (full mode only) */}
+                {section.label === "MAIN" && !isLite && pinnedWorkflows.length > 0 && (
                   <div className="mt-5">
                     <p className="mb-1.5 px-3 text-[10px] font-medium uppercase tracking-widest text-muted-foreground">
                       Pinned
@@ -308,7 +322,16 @@ export function Sidebar({ open, onClose, dlqCount = 0, approvalsCount = 0 }: Sid
           })}
         </nav>
 
-        <div className="border-t border-border px-5 py-4">
+        <div className="border-t border-border px-5 py-4 space-y-3">
+          <button
+            type="button"
+            onClick={() => setMode(isLite ? "full" : "lite")}
+            title={isLite ? "Show all advanced features" : "Switch to the simplified beginner view"}
+            className="flex w-full items-center justify-between rounded-lg border border-border px-3 py-2 text-xs font-medium text-muted hover:text-foreground hover:border-accent/40 transition-colors"
+          >
+            <span>{isLite ? "Lite mode" : "Full mode"}</span>
+            <span className="text-accent">{isLite ? "Switch to Full" : "Switch to Lite"}</span>
+          </button>
           <NavLink
             to="/settings"
             onClick={onClose}

--- a/dashboard/src/components/onboarding/OnboardingWizard.tsx
+++ b/dashboard/src/components/onboarding/OnboardingWizard.tsx
@@ -216,6 +216,9 @@ function StepRun({
 }) {
   const [status, setStatus] = useState<"idle" | "running" | "done" | "error">("idle");
   const [output, setOutput] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState("");
+  const isWeb = template?.category === "Live web";
+  const rateLimited = /rate.?limit|RATE_LIMIT|429/i.test(errorMsg);
 
   const run = async () => {
     if (!template) return;
@@ -240,7 +243,8 @@ function StepRun({
       const res = await api.post<RunResult>("/workflows/run", body);
       setOutput(firstOutput(res.data?.outputs) || "Workflow completed successfully.");
       setStatus("done");
-    } catch {
+    } catch (e) {
+      setErrorMsg(e instanceof Error ? e.message : "");
       setStatus("error");
     }
   };
@@ -253,6 +257,12 @@ function StepRun({
           Let's run <span className="font-medium text-foreground">{template?.name ?? "your workflow"}</span> once to see it work.
         </p>
       </div>
+
+      {isWeb && (
+        <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 px-3 py-2 text-xs text-muted-foreground">
+          🌐 Uses <strong className="text-foreground">live web search</strong> - free, no key needed. Hitting limits? Add a free Jina key (no card) in Settings &rarr; Integrations.
+        </div>
+      )}
 
       <div className="rounded-xl border border-border p-5 space-y-4">
         {status === "idle" && (
@@ -292,9 +302,16 @@ function StepRun({
 
         {status === "error" && (
           <div className="space-y-2">
-            <p className="text-sm text-muted-foreground">
-              Couldn't complete the run here - but your setup is ready. You can run flows from the dashboard.
-            </p>
+            {rateLimited ? (
+              <p className="text-sm text-amber-500">
+                Free web-search rate limit reached. Add a free Jina key (no card) in
+                Settings &rarr; Integrations &rarr; Web Search to raise the limit, then retry.
+              </p>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Couldn't complete the run here - but your setup is ready. You can run flows from the dashboard.
+              </p>
+            )}
             <button
               onClick={() => void run()}
               className="inline-flex items-center gap-1.5 text-xs font-medium text-accent hover:text-accent-hover transition-colors"

--- a/dashboard/src/components/onboarding/OnboardingWizard.tsx
+++ b/dashboard/src/components/onboarding/OnboardingWizard.tsx
@@ -226,10 +226,18 @@ function StepRun({
       for (const [k, v] of Object.entries(inputs)) {
         if (v !== undefined && v !== null && String(v).trim() !== "") cleanInputs[k] = v;
       }
-      const res = await api.post<RunResult>("/workflows/run", {
-        workflow_name: template.name,
-        inputs: cleanInputs,
-      });
+      // Built-in templates only resolve by name for user workflows, so fetch the
+      // template's YAML and run it inline; fall back to running by name.
+      let body: Record<string, unknown> = { workflow_name: template.name, inputs: cleanInputs };
+      try {
+        const tpl = await api.get<{ content?: string }>(
+          `/templates/${encodeURIComponent(template.name)}`
+        );
+        if (tpl.data?.content) body = { workflow: tpl.data.content, inputs: cleanInputs };
+      } catch {
+        // Keep the workflow_name fallback.
+      }
+      const res = await api.post<RunResult>("/workflows/run", body);
       setOutput(firstOutput(res.data?.outputs) || "Workflow completed successfully.");
       setStatus("done");
     } catch {

--- a/dashboard/src/components/onboarding/OnboardingWizard.tsx
+++ b/dashboard/src/components/onboarding/OnboardingWizard.tsx
@@ -1,11 +1,16 @@
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { CheckCircle2, Loader2, LayoutDashboard, RotateCw } from "lucide-react";
 import { api } from "@/api/client";
 import { ProgressBar } from "./ProgressBar";
+import { StepWelcome } from "./StepWelcome";
+import { StepChooseTemplate } from "./StepChooseTemplate";
+import { StepConfigureInputs } from "./StepConfigureInputs";
 import { cn } from "@/lib/utils";
+import { useUiMode } from "@/contexts/UiModeContext";
 import type { InputSchema } from "@/types/inputSchema";
 
-/** Template selection state shared between wizard steps (kept for backward compat). */
+/** Template selection state shared between wizard steps. */
 export interface SelectedTemplate {
   name: string;
   description?: string;
@@ -13,49 +18,23 @@ export interface SelectedTemplate {
   inputSchema?: InputSchema | null;
 }
 
-interface ProviderEntry {
-  id: string;
-  name?: string;
-  configured: boolean;
-  status: string;
-  region: string;
-}
-
-interface AdvisorStatus {
-  current_provider: string;
-  available_providers: ProviderEntry[];
-}
-
 interface HealthProviders {
   [key: string]: { status: string; latency_ms: number | null; region: string };
-}
-
-interface DemoRunResult {
-  run_id: string;
-  status: string;
-  outputs: { generate: string; summarize: string };
-  total_cost_usd: number;
 }
 
 interface OnboardingWizardProps {
   onFinish: () => void;
 }
 
-const STEP_LABELS = ["Connect", "Try it"];
+const STEP_LABELS = ["Welcome", "Connect", "Pick", "Configure", "Run"];
 const STORAGE_KEY = "sandcastle-onboarding-step";
-const MAX_STEP = 1;
+const MAX_STEP = 4;
 
 // -----------------------------------------------------------------------
-// Step 1: Connect - auto-detect providers or prompt for an API key
+// Step 1: Connect - choose local (auto-detected) or cloud (paste a key)
 // -----------------------------------------------------------------------
 
-function StepConnect({
-  onNext,
-  onSkip,
-}: {
-  onNext: () => void;
-  onSkip: () => void;
-}) {
+function StepConnect({ onNext, onSkip }: { onNext: () => void; onSkip: () => void }) {
   const [providers, setProviders] = useState<HealthProviders | null>(null);
   const [loading, setLoading] = useState(true);
   const [apiKey, setApiKey] = useState("");
@@ -63,14 +42,13 @@ function StepConnect({
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
 
-  // Fetch provider health on mount
   useEffect(() => {
     void (async () => {
       try {
         const res = await api.get<HealthProviders>("/health/providers");
         setProviders(res.data);
       } catch {
-        // Ignore - will show fallback API key input
+        // Ignore - will show the cloud API key input as a fallback.
       } finally {
         setLoading(false);
       }
@@ -83,6 +61,7 @@ function StepConnect({
       )
     : [];
   const hasReady = readyProviders.length > 0;
+  const hasLocal = readyProviders.some(([, v]) => v.region === "local");
 
   const handleSaveKey = async () => {
     if (!apiKey.trim()) return;
@@ -102,10 +81,10 @@ function StepConnect({
     <div className="space-y-6">
       <div className="text-center">
         <h2 className="text-xl font-bold text-foreground tracking-tight">
-          Connect a provider
+          Local or cloud?
         </h2>
         <p className="mt-1 text-sm text-muted">
-          Sandcastle needs at least one AI provider to run workflows.
+          Run models privately on your own machine, or connect a cloud provider.
         </p>
       </div>
 
@@ -116,7 +95,7 @@ function StepConnect({
       ) : hasReady ? (
         <div className="space-y-3">
           <p className="text-sm font-medium text-foreground">
-            Auto-detected providers:
+            {hasLocal ? "Running locally - $0/run, data stays on your box:" : "Detected providers:"}
           </p>
           {readyProviders.map(([id, info]) => (
             <div
@@ -124,16 +103,14 @@ function StepConnect({
               className="flex items-center gap-3 rounded-xl border border-success/30 bg-success/5 p-3"
             >
               <div className="flex items-center justify-center w-6 h-6 rounded-full bg-success text-white shrink-0">
-                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                </svg>
+                <CheckCircle2 className="h-4 w-4" />
               </div>
               <div className="flex-1 min-w-0">
-                <span className="text-sm font-medium text-foreground capitalize">
-                  {id}
-                </span>
+                <span className="text-sm font-medium text-foreground capitalize">{id}</span>
                 <span className="ml-2 text-xs text-muted-foreground">
-                  {info.region} - {info.latency_ms ? `${Math.round(info.latency_ms)}ms` : "ready"}
+                  {info.region}
+                  {info.region === "local" ? " - $0/run" : ""}
+                  {info.latency_ms ? ` - ${Math.round(info.latency_ms)}ms` : ""}
                 </span>
               </div>
               <span className="text-xs font-semibold text-success">Ready!</span>
@@ -142,11 +119,18 @@ function StepConnect({
         </div>
       ) : (
         <div className="space-y-3">
-          <p className="text-sm text-muted-foreground">
-            No providers detected. Paste your API key below to get started.
-          </p>
+          <div className="rounded-xl border border-border bg-background p-3">
+            <p className="text-sm font-medium text-foreground">Run locally (private, free)</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              No provider detected. Start a local model, then come back:
+            </p>
+            <code className="mt-2 block rounded-md bg-surface px-2 py-1.5 text-xs text-accent">
+              ollama run llama3
+            </code>
+          </div>
+          <p className="text-center text-xs text-muted-foreground">or use the cloud</p>
           <label className="block text-sm font-medium text-foreground">
-            Paste your Anthropic, Mistral, or OpenAI API key
+            Paste an Anthropic, Mistral, or OpenAI API key
           </label>
           <div className="flex gap-2">
             <input
@@ -168,18 +152,13 @@ function StepConnect({
               {saving ? "Saving..." : "Save"}
             </button>
           </div>
-          {saveError && (
-            <p className="text-xs text-error">{saveError}</p>
-          )}
+          {saveError && <p className="text-xs text-error">{saveError}</p>}
           {saveSuccess && (
-            <p className="text-xs text-success font-medium">
-              Key saved! You can continue.
-            </p>
+            <p className="text-xs text-success font-medium">Key saved! You can continue.</p>
           )}
         </div>
       )}
 
-      {/* Actions */}
       <div className="flex items-center justify-between pt-2">
         <button
           onClick={onSkip}
@@ -197,9 +176,6 @@ function StepConnect({
           )}
         >
           Next
-          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-          </svg>
         </button>
       </div>
     </div>
@@ -207,172 +183,120 @@ function StepConnect({
 }
 
 // -----------------------------------------------------------------------
-// Step 2: Try it - run the demo workflow
+// Step 4: Run the chosen template (best-effort) and finish into Lite mode
 // -----------------------------------------------------------------------
 
-function StepTryIt({
+interface RunResult {
+  run_id?: string;
+  status?: string;
+  outputs?: Record<string, unknown>;
+}
+
+function firstOutput(outputs?: Record<string, unknown>): string | null {
+  if (!outputs) return null;
+  const vals = Object.values(outputs);
+  for (let i = vals.length - 1; i >= 0; i--) {
+    if (typeof vals[i] === "string" && (vals[i] as string).trim()) {
+      return vals[i] as string;
+    }
+  }
+  return null;
+}
+
+function StepRun({
+  template,
+  inputs,
   onFinish,
-  onSkip,
   onBack,
 }: {
+  template: SelectedTemplate | null;
+  inputs: Record<string, string>;
   onFinish: () => void;
-  onSkip: () => void;
   onBack: () => void;
 }) {
-  const [demoState, setDemoState] = useState<
-    "idle" | "step1" | "step2" | "done" | "error"
-  >("idle");
+  const [status, setStatus] = useState<"idle" | "running" | "done" | "error">("idle");
   const [output, setOutput] = useState<string | null>(null);
-  const [costHint, setCostHint] = useState("Free with Ollama / ~$0.01 with Claude");
 
-  // Detect cost hint from providers
-  useEffect(() => {
-    void (async () => {
-      try {
-        const res = await api.get<AdvisorStatus>("/advisor/status");
-        if (!res.data) return;
-        const ollama = res.data.available_providers.find((p) => p.id === "ollama");
-        if (ollama?.status === "running") {
-          setCostHint("Free with Ollama");
-        }
-      } catch {
-        // Keep default hint
-      }
-    })();
-  }, []);
-
-  const runDemo = async () => {
-    setDemoState("step1");
+  const run = async () => {
+    if (!template) return;
+    setStatus("running");
     setOutput(null);
-
     try {
-      // Simulate step-by-step progress with a small delay before step2
-      await new Promise((r) => setTimeout(r, 1000));
-      setDemoState("step2");
-
-      const res = await api.post<DemoRunResult>("/workflows/run", {
-        workflow_name: "demo-hello-world",
-        workflow: {
-          name: "demo-hello-world",
-          description: "Your first Sandcastle workflow",
-          default_model: "sonnet",
-          steps: [
-            {
-              id: "generate",
-              prompt: "Write 3 interesting facts about sandcastles.",
-            },
-            {
-              id: "summarize",
-              prompt:
-                "Summarize these facts in one sentence: {steps.generate.output}",
-              depends_on: ["generate"],
-            },
-          ],
-        },
-      });
-
-      if (res.data) {
-        setOutput(res.data.outputs?.summarize || "Workflow completed successfully.");
-        setDemoState("done");
-
-        // Auto-check "first-run" in the Getting Started checklist
-        try {
-          const raw = localStorage.getItem("sandcastle_getting_started");
-          const cls = raw
-            ? JSON.parse(raw)
-            : { dismissed: false, completed: {} };
-          cls.completed["first-run"] = true;
-          localStorage.setItem(
-            "sandcastle_getting_started",
-            JSON.stringify(cls)
-          );
-        } catch {
-          // Not critical
-        }
-      } else {
-        setDemoState("error");
+      const cleanInputs: Record<string, string> = {};
+      for (const [k, v] of Object.entries(inputs)) {
+        if (v !== undefined && v !== null && String(v).trim() !== "") cleanInputs[k] = v;
       }
+      const res = await api.post<RunResult>("/workflows/run", {
+        workflow_name: template.name,
+        inputs: cleanInputs,
+      });
+      setOutput(firstOutput(res.data?.outputs) || "Workflow completed successfully.");
+      setStatus("done");
     } catch {
-      setDemoState("error");
+      setStatus("error");
     }
   };
 
   return (
     <div className="space-y-6">
       <div className="text-center">
-        <h2 className="text-xl font-bold text-foreground tracking-tight">
-          Try it out
-        </h2>
+        <h2 className="text-xl font-bold text-foreground tracking-tight">Run your first flow</h2>
         <p className="mt-1 text-sm text-muted">
-          Watch a 2-step workflow run in real-time. Takes ~10 seconds.
+          Let's run <span className="font-medium text-foreground">{template?.name ?? "your workflow"}</span> once to see it work.
         </p>
       </div>
 
-      {/* Demo card */}
       <div className="rounded-xl border border-border p-5 space-y-4">
-        {demoState === "idle" && (
-          <>
-            <button
-              onClick={() => void runDemo()}
-              className={cn(
-                "w-full rounded-lg bg-accent px-5 py-3 text-sm font-semibold text-accent-foreground",
-                "hover:bg-accent-hover transition-all shadow-sm hover:shadow-md btn-shimmer"
-              )}
-            >
-              Run Demo Workflow
-            </button>
-            <p className="text-xs text-center text-muted-foreground">
-              {costHint}
-            </p>
-          </>
+        {status === "idle" && (
+          <button
+            onClick={() => void run()}
+            disabled={!template}
+            className={cn(
+              "w-full rounded-lg bg-accent px-5 py-3 text-sm font-semibold text-accent-foreground",
+              "hover:bg-accent-hover transition-all shadow-sm hover:shadow-md btn-shimmer",
+              "disabled:opacity-50 disabled:cursor-not-allowed"
+            )}
+          >
+            Run workflow
+          </button>
         )}
 
-        {demoState === "step1" && (
+        {status === "running" && (
           <div className="flex items-center gap-3 py-2">
-            <div className="h-5 w-5 rounded-full border-2 border-accent border-t-transparent animate-spin shrink-0" />
-            <span className="text-sm text-foreground">Running step 1 of 2 - Generating facts...</span>
+            <Loader2 className="h-5 w-5 animate-spin text-accent shrink-0" />
+            <span className="text-sm text-foreground">Running...</span>
           </div>
         )}
 
-        {demoState === "step2" && (
-          <div className="flex items-center gap-3 py-2">
-            <div className="h-5 w-5 rounded-full border-2 border-accent border-t-transparent animate-spin shrink-0" />
-            <span className="text-sm text-foreground">Running step 2 of 2 - Summarizing...</span>
-          </div>
-        )}
-
-        {demoState === "done" && output && (
+        {status === "done" && (
           <div className="space-y-3">
             <div className="flex items-center gap-2">
-              <div className="flex items-center justify-center w-6 h-6 rounded-full bg-success text-white shrink-0">
-                <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                </svg>
-              </div>
+              <CheckCircle2 className="h-5 w-5 text-success" />
               <span className="text-sm font-semibold text-success">Done!</span>
             </div>
-            <div className="rounded-lg bg-accent/5 border border-accent/20 p-3">
-              <p className="text-sm text-foreground leading-relaxed">{output}</p>
-            </div>
+            {output && (
+              <div className="rounded-lg bg-accent/5 border border-accent/20 p-3 max-h-40 overflow-y-auto">
+                <p className="text-sm text-foreground leading-relaxed whitespace-pre-wrap">{output}</p>
+              </div>
+            )}
           </div>
         )}
 
-        {demoState === "error" && (
+        {status === "error" && (
           <div className="space-y-2">
-            <p className="text-sm text-error">
-              Something went wrong. You can try again or skip to the dashboard.
+            <p className="text-sm text-muted-foreground">
+              Couldn't complete the run here - but your setup is ready. You can run flows from the dashboard.
             </p>
             <button
-              onClick={() => void runDemo()}
-              className="text-xs font-medium text-accent hover:text-accent-hover transition-colors"
+              onClick={() => void run()}
+              className="inline-flex items-center gap-1.5 text-xs font-medium text-accent hover:text-accent-hover transition-colors"
             >
-              Retry
+              <RotateCw className="h-3 w-3" /> Retry
             </button>
           </div>
         )}
       </div>
 
-      {/* Actions */}
       <div className="flex items-center justify-between pt-2">
         <button
           onClick={onBack}
@@ -380,28 +304,18 @@ function StepTryIt({
         >
           Back
         </button>
-        <div className="flex items-center gap-3">
-          <button
-            onClick={onSkip}
-            className="text-xs text-muted hover:text-foreground transition-colors"
-          >
-            Skip
-          </button>
-          {demoState === "done" && (
-            <button
-              onClick={onFinish}
-              className={cn(
-                "inline-flex items-center gap-2 rounded-lg bg-accent px-5 py-2 text-sm font-medium text-accent-foreground",
-                "hover:bg-accent-hover transition-all"
-              )}
-            >
-              Go to Dashboard
-              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-              </svg>
-            </button>
+        <button
+          onClick={onFinish}
+          className={cn(
+            "inline-flex items-center gap-2 rounded-lg px-5 py-2 text-sm font-medium transition-all",
+            status === "done"
+              ? "bg-accent text-accent-foreground hover:bg-accent-hover"
+              : "border border-border text-muted hover:text-foreground"
           )}
-        </div>
+        >
+          <LayoutDashboard className="h-4 w-4" />
+          {status === "done" ? "Go to my dashboard" : "Skip to dashboard"}
+        </button>
       </div>
     </div>
   );
@@ -412,29 +326,31 @@ function StepTryIt({
 // -----------------------------------------------------------------------
 
 /**
- * Simplified 2-step onboarding wizard:
- *   Step 1: Connect - detect providers or paste an API key
- *   Step 2: Try it  - run a demo workflow in one click
+ * Guided beginner onboarding wizard:
+ *   0 Welcome   - value props
+ *   1 Connect   - local (auto-detected) or cloud (paste a key)
+ *   2 Pick      - choose one of 3 beginner-friendly templates
+ *   3 Configure - fill the template's inputs
+ *   4 Run       - run it once, then land in the simplified "Lite" dashboard
  */
 export function OnboardingWizard({ onFinish }: OnboardingWizardProps) {
   const navigate = useNavigate();
+  const { setMode } = useUiMode();
 
-  // Restore saved step from localStorage (clamped to new range)
   const [currentStep, setCurrentStep] = useState(() => {
     const saved = localStorage.getItem(STORAGE_KEY);
     const parsed = saved ? parseInt(saved, 10) : 0;
     return isNaN(parsed) || parsed < 0 || parsed > MAX_STEP ? 0 : parsed;
   });
-
   const [stepKey, setStepKey] = useState(0);
+  const [template, setTemplate] = useState<SelectedTemplate | null>(null);
+  const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
 
-  // Save progress to localStorage on step change. Wrapped so private
-  // browsing / quota exceeded never breaks the wizard mid-flight.
   useEffect(() => {
     try {
       localStorage.setItem(STORAGE_KEY, String(currentStep));
     } catch {
-      // Best-effort: progress isn't persisted across reloads in this mode.
+      // Best-effort persistence only.
     }
   }, [currentStep]);
 
@@ -443,47 +359,64 @@ export function OnboardingWizard({ onFinish }: OnboardingWizardProps) {
     setStepKey((k) => k + 1);
   }, []);
 
-  const handleSkipToDashboard = useCallback(() => {
+  const markDone = useCallback(() => {
     try {
       localStorage.setItem("sandcastle-onboarding-done", "true");
       localStorage.removeItem(STORAGE_KEY);
     } catch {
-      // Storage unavailable - the user can still proceed; onboarding will
-      // re-appear next visit.
+      // Storage unavailable - onboarding may re-appear next visit.
     }
-    navigate("/");
-  }, [navigate]);
+  }, []);
 
+  // Skip = keep the full dashboard (don't force a beginner into Lite).
+  const handleSkipToDashboard = useCallback(() => {
+    markDone();
+    setMode("full");
+    navigate("/");
+  }, [markDone, navigate, setMode]);
+
+  // Finish the guided flow = opt into the simplified Lite experience.
   const handleFinish = useCallback(() => {
-    try {
-      localStorage.setItem("sandcastle-onboarding-done", "true");
-      localStorage.removeItem(STORAGE_KEY);
-    } catch {
-      // Storage unavailable - proceed anyway.
-    }
+    markDone();
+    setMode("lite");
     onFinish();
-  }, [onFinish]);
+  }, [markDone, onFinish, setMode]);
 
   return (
     <div className="flex w-full flex-col gap-8">
-      {/* Progress bar */}
       <ProgressBar steps={STEP_LABELS} currentStep={currentStep} />
 
-      {/* Step content */}
       <div className="mx-auto w-full max-w-xl rounded-xl border border-border bg-surface p-6 sm:p-8 shadow-sm">
         <div key={stepKey} className="wizard-step-enter">
           {currentStep === 0 && (
-            <StepConnect
-              onNext={() => goTo(1)}
-              onSkip={handleSkipToDashboard}
+            <StepWelcome onNext={() => goTo(1)} onSkip={handleSkipToDashboard} />
+          )}
+          {currentStep === 1 && (
+            <StepConnect onNext={() => goTo(2)} onSkip={handleSkipToDashboard} />
+          )}
+          {currentStep === 2 && (
+            <StepChooseTemplate
+              selected={template}
+              onSelect={setTemplate}
+              onNext={() => goTo(3)}
+              onBack={() => goTo(1)}
             />
           )}
-
-          {currentStep === 1 && (
-            <StepTryIt
+          {currentStep === 3 && (
+            <StepConfigureInputs
+              template={template}
+              fieldValues={fieldValues}
+              onFieldValuesChange={setFieldValues}
+              onNext={() => goTo(4)}
+              onBack={() => goTo(2)}
+            />
+          )}
+          {currentStep === 4 && (
+            <StepRun
+              template={template}
+              inputs={fieldValues}
               onFinish={handleFinish}
-              onSkip={handleSkipToDashboard}
-              onBack={() => goTo(0)}
+              onBack={() => goTo(3)}
             />
           )}
         </div>

--- a/dashboard/src/components/onboarding/StepChooseTemplate.tsx
+++ b/dashboard/src/components/onboarding/StepChooseTemplate.tsx
@@ -2,11 +2,9 @@ import { useEffect, useState } from "react";
 import {
   ArrowLeft,
   ArrowRight,
-  Camera,
   FileText,
-  Search,
-  Database,
-  Network,
+  MessageSquareText,
+  Globe,
   Loader2,
 } from "lucide-react";
 import { api } from "@/api/client";
@@ -31,47 +29,32 @@ interface FeaturedTemplate {
   color: string;
 }
 
-// The 4 popular built-in templates to feature
+// 3 beginner-friendly templates: pure LLM, no external API keys or sandbox,
+// so they run on a local model (Ollama) OR any cloud key.
 const FEATURED_TEMPLATES: FeaturedTemplate[] = [
   {
-    name: "ugc-studio",
-    displayName: "UGC Studio",
-    description: "Drop a product photo, pick a mode - get faithful, social-ready UGC shots, scored and auto-fixed by a vision judge.",
-    category: "Creative",
-    icon: Camera,
-    color: "text-[#F472B6] bg-[#F472B6]/10",
-  },
-  {
-    name: "ai-content-pipeline",
-    displayName: "AI Content Pipeline",
-    description: "Research, draft, and publish content with automated SEO optimization.",
-    category: "Marketing",
+    name: "text-summarizer",
+    displayName: "Text Summarizer",
+    description: "Paste any text and get a clean, concise summary. The simplest possible first flow.",
+    category: "Easy",
     icon: FileText,
     color: "text-[#60A5FA] bg-[#60A5FA]/10",
   },
   {
-    name: "market-opportunity-scout",
-    displayName: "Market Opportunity Scout",
-    description: "Analyze markets, competitors, and trends to identify growth opportunities.",
-    category: "Research",
-    icon: Search,
+    name: "review-sentiment",
+    displayName: "Review Sentiment",
+    description: "Drop a batch of customer reviews and get sentiment trends plus actionable insights.",
+    category: "Easy",
+    icon: MessageSquareText,
     color: "text-[#34D399] bg-[#34D399]/10",
   },
   {
-    name: "ai-rag-pipeline",
-    displayName: "AI RAG Pipeline",
-    description: "Build retrieval-augmented generation pipelines over your own documents.",
-    category: "Data",
-    icon: Database,
+    name: "eu-presidents",
+    displayName: "EU Heads of State",
+    description: "A zero-input demo - research, enrich and summarize EU heads of state. Great no-config first run.",
+    category: "Demo",
+    icon: Globe,
     color: "text-[#A78BFA] bg-[#A78BFA]/10",
-  },
-  {
-    name: "provider-consensus-decision-engine",
-    displayName: "Provider Consensus",
-    description: "Ask three AI providers the same question and act on their agreement. Provider-neutral by design: swap or lose a provider and the decision holds.",
-    category: "Engine",
-    icon: Network,
-    color: "text-[#2DD4BF] bg-[#2DD4BF]/10",
   },
 ];
 
@@ -131,9 +114,9 @@ export function StepChooseTemplate({
   return (
     <div className="space-y-6">
       <div className="text-center">
-        <h2 className="text-lg font-semibold text-foreground">Choose a Template</h2>
+        <h2 className="text-lg font-semibold text-foreground">Pick your first flow</h2>
         <p className="mt-1 text-sm text-muted">
-          Pick a popular workflow template to get started quickly.
+          Start with a simple, ready-to-run workflow. Each one works on local or cloud models.
         </p>
       </div>
 

--- a/dashboard/src/components/onboarding/StepChooseTemplate.tsx
+++ b/dashboard/src/components/onboarding/StepChooseTemplate.tsx
@@ -2,9 +2,10 @@ import { useEffect, useState } from "react";
 import {
   ArrowLeft,
   ArrowRight,
-  FileText,
-  MessageSquareText,
-  Globe,
+  ScanSearch,
+  Megaphone,
+  Palette,
+  Swords,
   Loader2,
 } from "lucide-react";
 import { api } from "@/api/client";
@@ -29,32 +30,41 @@ interface FeaturedTemplate {
   color: string;
 }
 
-// 3 beginner-friendly templates: pure LLM, no external API keys or sandbox,
-// so they run on a local model (Ollama) OR any cloud key.
+// 4 bold, pure-text starter templates (run local on Ollama OR any cloud key) for
+// power users / marketing / creative. The `name` matches the /templates display
+// title so its input schema resolves and it can be fetched + run inline.
 const FEATURED_TEMPLATES: FeaturedTemplate[] = [
   {
-    name: "text-summarizer",
-    displayName: "Text Summarizer",
-    description: "Paste any text and get a clean, concise summary. The simplest possible first flow.",
-    category: "Easy",
-    icon: FileText,
+    name: "What Does AI Say About Your Brand?",
+    displayName: "AI Brand Audit",
+    description: "Probe the model's own memory of your brand - sentiment + positioning scorecard, the riskiest misperceptions, and 5 fixes.",
+    category: "Marketing",
+    icon: ScanSearch,
     color: "text-[#60A5FA] bg-[#60A5FA]/10",
   },
   {
-    name: "review-sentiment",
-    displayName: "Review Sentiment",
-    description: "Drop a batch of customer reviews and get sentiment trends plus actionable insights.",
-    category: "Easy",
-    icon: MessageSquareText,
-    color: "text-[#34D399] bg-[#34D399]/10",
+    name: "Campaign-in-a-Box",
+    displayName: "Campaign-in-a-Box",
+    description: "One product line in - big idea, 3 competing angles judged, channel copy, and a 4-week launch calendar out.",
+    category: "Marketing",
+    icon: Megaphone,
+    color: "text-[#F472B6] bg-[#F472B6]/10",
   },
   {
-    name: "eu-presidents",
-    displayName: "EU Heads of State",
-    description: "A zero-input demo - research, enrich and summarize EU heads of state. Great no-config first run.",
-    category: "Demo",
-    icon: Globe,
+    name: "Brand Voice Kit Forge",
+    displayName: "Brand Voice Kit",
+    description: "One idea in - 4 voice directions judged into names, taglines, voice pillars, and copy-paste in-voice samples.",
+    category: "Creative",
+    icon: Palette,
     color: "text-[#A78BFA] bg-[#A78BFA]/10",
+  },
+  {
+    name: "Competitor Analysis",
+    displayName: "Competitor Teardown",
+    description: "Name a rival - get a full SWOT, a positioning map, and a ready-to-use sales battlecard.",
+    category: "Power",
+    icon: Swords,
+    color: "text-[#34D399] bg-[#34D399]/10",
   },
 ];
 

--- a/dashboard/src/components/onboarding/StepChooseTemplate.tsx
+++ b/dashboard/src/components/onboarding/StepChooseTemplate.tsx
@@ -40,8 +40,8 @@ const FEATURED_TEMPLATES: FeaturedTemplate[] = [
   {
     name: "What Does AI Say About Your Brand?",
     displayName: "AI Brand Audit",
-    description: "Probe the model's own memory of your brand - sentiment + positioning scorecard, the riskiest misperceptions, and 5 fixes.",
-    category: "Marketing",
+    description: "Searches the live web and compares it to what AI believes - sentiment + positioning scorecard, the riskiest gaps, and GEO fixes.",
+    category: "Live web",
     icon: ScanSearch,
     color: "text-[#60A5FA] bg-[#60A5FA]/10",
     inputSchema: {
@@ -55,8 +55,8 @@ const FEATURED_TEMPLATES: FeaturedTemplate[] = [
   {
     name: "Campaign-in-a-Box",
     displayName: "Campaign-in-a-Box",
-    description: "One product line in - big idea, 3 competing angles judged, channel copy, and a 4-week launch calendar out.",
-    category: "Marketing",
+    description: "Live market research, then a big idea, 3 judged angles, channel copy, and a 4-week launch calendar.",
+    category: "Live web",
     icon: Megaphone,
     color: "text-[#F472B6] bg-[#F472B6]/10",
     inputSchema: {
@@ -83,18 +83,17 @@ const FEATURED_TEMPLATES: FeaturedTemplate[] = [
     },
   },
   {
-    name: "Competitor Analysis",
+    name: "Competitor Teardown (Live)",
     displayName: "Competitor Teardown",
-    description: "Name a rival - get a full SWOT, a positioning map, and a ready-to-use sales battlecard.",
-    category: "Power",
+    description: "Name a rival - we web-research it live into a SWOT, a positioning + pricing read, and a sales battlecard.",
+    category: "Live web",
     icon: Swords,
     color: "text-[#34D399] bg-[#34D399]/10",
     inputSchema: {
       required: ["competitor"],
       properties: {
-        competitor: { type: "string", description: "Name of the competitor to analyze" },
-        our_company: { type: "string", description: "Your company name + a brief description for comparison" },
-        industry: { type: "string", description: "Industry / vertical for context, e.g. 'B2B SaaS'" },
+        competitor: { type: "string", description: "Competitor to tear down" },
+        our_company: { type: "string", description: "Optional - your company + one line, for head-to-head positioning" },
       },
     },
   },

--- a/dashboard/src/components/onboarding/StepChooseTemplate.tsx
+++ b/dashboard/src/components/onboarding/StepChooseTemplate.tsx
@@ -28,6 +28,9 @@ interface FeaturedTemplate {
   category: string;
   icon: LucideIcon;
   color: string;
+  /** Fallback input schema so the Configure step shows fields even when the
+   *  backend /templates list doesn't carry one (e.g. offline / mock mode). */
+  inputSchema: InputSchema;
 }
 
 // 4 bold, pure-text starter templates (run local on Ollama OR any cloud key) for
@@ -41,6 +44,13 @@ const FEATURED_TEMPLATES: FeaturedTemplate[] = [
     category: "Marketing",
     icon: ScanSearch,
     color: "text-[#60A5FA] bg-[#60A5FA]/10",
+    inputSchema: {
+      required: ["brand"],
+      properties: {
+        brand: { type: "string", description: "Brand, product, or person to audit (e.g. 'Sandcastle')" },
+        category: { type: "string", description: "Optional one-line category, e.g. 'AI workflow orchestrator'" },
+      },
+    },
   },
   {
     name: "Campaign-in-a-Box",
@@ -49,6 +59,13 @@ const FEATURED_TEMPLATES: FeaturedTemplate[] = [
     category: "Marketing",
     icon: Megaphone,
     color: "text-[#F472B6] bg-[#F472B6]/10",
+    inputSchema: {
+      required: ["product_or_offer"],
+      properties: {
+        product_or_offer: { type: "string", description: "The product, feature, or offer to build a campaign around" },
+        campaign_goal: { type: "string", description: "Optional goal, e.g. 'drive signups', 'launch announcement'" },
+      },
+    },
   },
   {
     name: "Brand Voice Kit Forge",
@@ -57,6 +74,13 @@ const FEATURED_TEMPLATES: FeaturedTemplate[] = [
     category: "Creative",
     icon: Palette,
     color: "text-[#A78BFA] bg-[#A78BFA]/10",
+    inputSchema: {
+      required: ["what_youre_building"],
+      properties: {
+        what_youre_building: { type: "string", description: "One line about what you're building" },
+        vibe: { type: "string", description: "Optional vibe words, e.g. 'bold, warm, irreverent'" },
+      },
+    },
   },
   {
     name: "Competitor Analysis",
@@ -65,6 +89,14 @@ const FEATURED_TEMPLATES: FeaturedTemplate[] = [
     category: "Power",
     icon: Swords,
     color: "text-[#34D399] bg-[#34D399]/10",
+    inputSchema: {
+      required: ["competitor"],
+      properties: {
+        competitor: { type: "string", description: "Name of the competitor to analyze" },
+        our_company: { type: "string", description: "Your company name + a brief description for comparison" },
+        industry: { type: "string", description: "Industry / vertical for context, e.g. 'B2B SaaS'" },
+      },
+    },
   },
 ];
 
@@ -117,7 +149,8 @@ export function StepChooseTemplate({
       name: featured.name,
       description: featured.description,
       category: featured.category,
-      inputSchema: schemaMap[featured.name] ?? null,
+      // Prefer the live schema from the backend, fall back to the bundled one.
+      inputSchema: schemaMap[featured.name] ?? featured.inputSchema,
     });
   }
 

--- a/dashboard/src/components/onboarding/StepConfigureInputs.tsx
+++ b/dashboard/src/components/onboarding/StepConfigureInputs.tsx
@@ -40,6 +40,11 @@ export function StepConfigureInputs({
 
   const hasSchema = fields.length > 0;
 
+  const missingRequired = useMemo(
+    () => [...requiredFields].some((k) => !(fieldValues[k] && fieldValues[k].trim())),
+    [requiredFields, fieldValues]
+  );
+
   function handleChange(key: string, value: string) {
     onFieldValuesChange({ ...fieldValues, [key]: value });
   }
@@ -204,9 +209,12 @@ export function StepConfigureInputs({
         </button>
         <button
           onClick={onNext}
+          disabled={missingRequired}
+          title={missingRequired ? "Fill the required fields first" : undefined}
           className={cn(
             "inline-flex items-center gap-2 rounded-lg bg-accent px-5 py-2 text-sm font-medium text-accent-foreground",
-            "hover:bg-accent-hover transition-all duration-200 shadow-sm"
+            "hover:bg-accent-hover transition-all duration-200 shadow-sm",
+            "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-accent"
           )}
         >
           Continue

--- a/dashboard/src/components/overview/BentoHeatmap.tsx
+++ b/dashboard/src/components/overview/BentoHeatmap.tsx
@@ -1,16 +1,14 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { cn } from "@/lib/utils";
 import type { HeatmapCell } from "./bentoTypes";
 
-// dayOfWeek: 0=Monday ... 6=Sunday — label Mon/Wed/Fri on their rows.
+// dayOfWeek: 0=Monday ... 6=Sunday - label Mon/Wed/Fri on their rows.
 const DAY_LABELS = ["Mon", "", "Wed", "", "Fri", "", ""];
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
-// Fixed-size cells keep the grid crisp (no flex-stretching = no "mush").
-const CELL = 14;
 const GAP = 3;
-const STEP = CELL + GAP;
+const DAY_GUTTER = 34; // room for the Mon/Wed/Fri column
 
 /** 0..4 intensity bucket for a count. */
 function level(count: number, max: number): number {
@@ -33,6 +31,22 @@ const LEVEL_CLASS = [
 export function BentoHeatmap({ cells }: { cells: HeatmapCell[] }) {
   const navigate = useNavigate();
   const [tooltip, setTooltip] = useState<{ x: number; y: number; text: string } | null>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
+
+  // Measure the container so cells fill the full card width (crisp squares,
+  // sized to the data) instead of leaving the right side empty.
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    setWidth(el.clientWidth);
+    if (typeof ResizeObserver === "undefined") return; // jsdom / SSR safety
+    const ro = new ResizeObserver((entries) => {
+      for (const e of entries) setWidth(e.contentRect.width);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
 
   const { weeks, maxCount, monthLabels, total, busiest } = useMemo(() => {
     const weeks: (HeatmapCell | null)[][] = [];
@@ -69,6 +83,13 @@ export function BentoHeatmap({ cells }: { cells: HeatmapCell[] }) {
     return { weeks, maxCount, monthLabels, total, busiest };
   }, [cells]);
 
+  // Size each cell so the grid fills the available width.
+  const cell =
+    width <= 0 || weeks.length === 0
+      ? 15
+      : Math.max(9, Math.min(22, Math.floor((width - DAY_GUTTER - (weeks.length - 1) * GAP) / weeks.length)));
+  const step = cell + GAP;
+
   return (
     <div
       className={cn(
@@ -81,7 +102,7 @@ export function BentoHeatmap({ cells }: { cells: HeatmapCell[] }) {
         <div>
           <h3 className="text-sm font-semibold text-foreground">Run activity</h3>
           <p className="mt-0.5 text-[11px] text-muted-foreground">
-            {total.toLocaleString()} runs
+            {total.toLocaleString()} runs · last 52 weeks
             {busiest && busiest.count > 0 && (
               <> · busiest {busiest.date.slice(5)} ({busiest.count})</>
             )}
@@ -96,69 +117,67 @@ export function BentoHeatmap({ cells }: { cells: HeatmapCell[] }) {
         </div>
       </div>
 
-      <div className="overflow-x-auto pb-1">
-        <div className="flex gap-2" style={{ width: "max-content" }}>
-          {/* Day-of-week labels */}
-          <div className="flex flex-col" style={{ gap: GAP, paddingTop: 18 }}>
-            {DAY_LABELS.map((label, i) => (
-              <div
-                key={i}
-                className="flex items-center text-[10px] leading-none text-muted-foreground"
-                style={{ height: CELL }}
+      <div ref={wrapRef} className="flex gap-2">
+        {/* Day-of-week labels */}
+        <div className="flex flex-col" style={{ gap: GAP, paddingTop: 18, width: DAY_GUTTER - 8 }}>
+          {DAY_LABELS.map((label, i) => (
+            <div
+              key={i}
+              className="flex items-center text-[10px] leading-none text-muted-foreground"
+              style={{ height: cell }}
+            >
+              {label}
+            </div>
+          ))}
+        </div>
+
+        {/* Month labels + grid */}
+        <div className="relative flex-1 min-w-0">
+          <div className="relative" style={{ height: 18 }}>
+            {monthLabels.map((m) => (
+              <span
+                key={`${m.col}-${m.label}`}
+                className="absolute top-0 text-[10px] font-medium text-muted-foreground"
+                style={{ left: m.col * step }}
               >
-                {label}
-              </div>
+                {m.label}
+              </span>
             ))}
           </div>
 
-          {/* Month labels + grid */}
-          <div className="relative">
-            <div className="relative" style={{ height: 18 }}>
-              {monthLabels.map((m) => (
-                <span
-                  key={`${m.col}-${m.label}`}
-                  className="absolute top-0 text-[10px] font-medium text-muted-foreground"
-                  style={{ left: m.col * STEP }}
-                >
-                  {m.label}
-                </span>
-              ))}
-            </div>
-
-            <div className="flex" style={{ gap: GAP }}>
-              {weeks.map((week, col) => (
-                <div key={col} className="flex flex-col" style={{ gap: GAP }}>
-                  {week.map((cell, row) => {
-                    if (!cell) {
-                      return <div key={row} style={{ width: CELL, height: CELL }} />;
-                    }
-                    const lvl = level(cell.count, maxCount);
-                    return (
-                      <div
-                        key={row}
-                        className={cn(
-                          "rounded-[3px] cursor-pointer outline-none",
-                          "transition-[transform,box-shadow] duration-150 ease-out",
-                          "hover:scale-[1.35] hover:ring-2 hover:ring-accent/60 hover:z-10",
-                          LEVEL_CLASS[lvl],
-                        )}
-                        style={{ width: CELL, height: CELL }}
-                        onClick={() => navigate(`/runs?date=${cell.date}`)}
-                        onMouseEnter={(e) => {
-                          const rect = e.currentTarget.getBoundingClientRect();
-                          setTooltip({
-                            x: rect.left + rect.width / 2,
-                            y: rect.top - 8,
-                            text: `${cell.date}: ${cell.count} run${cell.count !== 1 ? "s" : ""}`,
-                          });
-                        }}
-                        onMouseLeave={() => setTooltip(null)}
-                      />
-                    );
-                  })}
-                </div>
-              ))}
-            </div>
+          <div className="flex" style={{ gap: GAP }}>
+            {weeks.map((week, col) => (
+              <div key={col} className="flex flex-col" style={{ gap: GAP }}>
+                {week.map((c, row) => {
+                  if (!c) {
+                    return <div key={row} style={{ width: cell, height: cell }} />;
+                  }
+                  const lvl = level(c.count, maxCount);
+                  return (
+                    <div
+                      key={row}
+                      className={cn(
+                        "rounded-[3px] cursor-pointer outline-none",
+                        "transition-[transform,box-shadow] duration-150 ease-out",
+                        "hover:scale-[1.35] hover:ring-2 hover:ring-accent/60 hover:z-10",
+                        LEVEL_CLASS[lvl],
+                      )}
+                      style={{ width: cell, height: cell }}
+                      onClick={() => navigate(`/runs?date=${c.date}`)}
+                      onMouseEnter={(e) => {
+                        const rect = e.currentTarget.getBoundingClientRect();
+                        setTooltip({
+                          x: rect.left + rect.width / 2,
+                          y: rect.top - 8,
+                          text: `${c.date}: ${c.count} run${c.count !== 1 ? "s" : ""}`,
+                        });
+                      }}
+                      onMouseLeave={() => setTooltip(null)}
+                    />
+                  );
+                })}
+              </div>
+            ))}
           </div>
         </div>
       </div>

--- a/dashboard/src/components/overview/BentoHeatmap.tsx
+++ b/dashboard/src/components/overview/BentoHeatmap.tsx
@@ -1,120 +1,164 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { cn } from "@/lib/utils";
 import type { HeatmapCell } from "./bentoTypes";
 
-const DAY_LABELS = ["M", "", "W", "", "F", "", ""];
+// dayOfWeek: 0=Monday ... 6=Sunday — label Mon/Wed/Fri on their rows.
+const DAY_LABELS = ["Mon", "", "Wed", "", "Fri", "", ""];
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
-function getHeatmapIntensityClass(count: number, maxCount: number): string {
-  if (count === 0) return "bg-border";
-  const ratio = count / maxCount;
-  if (ratio < 0.25) return "bg-accent/20";
-  if (ratio < 0.5) return "bg-accent/40";
-  if (ratio < 0.75) return "bg-accent/70";
-  return "bg-accent";
+// Fixed-size cells keep the grid crisp (no flex-stretching = no "mush").
+const CELL = 14;
+const GAP = 3;
+const STEP = CELL + GAP;
+
+/** 0..4 intensity bucket for a count. */
+function level(count: number, max: number): number {
+  if (count <= 0) return 0;
+  const r = count / max;
+  if (r < 0.25) return 1;
+  if (r < 0.5) return 2;
+  if (r < 0.75) return 3;
+  return 4;
 }
+
+const LEVEL_CLASS = [
+  "bg-foreground/[0.06]", // 0 - empty, subtle
+  "bg-accent/30",
+  "bg-accent/55",
+  "bg-accent/80",
+  "bg-accent shadow-[0_0_8px_-1px] shadow-accent/70", // 4 - hottest, glows
+];
 
 export function BentoHeatmap({ cells }: { cells: HeatmapCell[] }) {
   const navigate = useNavigate();
   const [tooltip, setTooltip] = useState<{ x: number; y: number; text: string } | null>(null);
 
-  const weeks: (HeatmapCell | null)[][] = [];
-  let currentWeek: (HeatmapCell | null)[] = Array(7).fill(null);
-
-  for (const cell of cells) {
-    const row = cell.dayOfWeek;
-    if (row === 0 && currentWeek.some((c) => c !== null)) {
-      weeks.push(currentWeek);
-      currentWeek = Array(7).fill(null);
+  const { weeks, maxCount, monthLabels, total, busiest } = useMemo(() => {
+    const weeks: (HeatmapCell | null)[][] = [];
+    let currentWeek: (HeatmapCell | null)[] = Array(7).fill(null);
+    for (const cell of cells) {
+      const row = cell.dayOfWeek;
+      if (row === 0 && currentWeek.some((c) => c !== null)) {
+        weeks.push(currentWeek);
+        currentWeek = Array(7).fill(null);
+      }
+      currentWeek[row] = cell;
     }
-    currentWeek[row] = cell;
-  }
-  if (currentWeek.some((c) => c !== null)) weeks.push(currentWeek);
+    if (currentWeek.some((c) => c !== null)) weeks.push(currentWeek);
 
-  const maxCount = Math.max(1, ...cells.map((c) => c.count));
+    const maxCount = Math.max(1, ...cells.map((c) => c.count));
+    const total = cells.reduce((s, c) => s + c.count, 0);
+    const busiest = cells.reduce<HeatmapCell | null>(
+      (best, c) => (c.count > (best?.count ?? 0) ? c : best),
+      null,
+    );
 
-  const monthLabels: { col: number; label: string }[] = [];
-  const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-  let prevMonth = -1;
-  for (let col = 0; col < weeks.length; col++) {
-    const firstCell = weeks[col].find((c) => c !== null);
-    if (firstCell) {
-      const month = parseInt(firstCell.date.slice(5, 7), 10) - 1;
-      if (month !== prevMonth) {
-        monthLabels.push({ col, label: monthNames[month] });
-        prevMonth = month;
+    const monthLabels: { col: number; label: string }[] = [];
+    let prevMonth = -1;
+    for (let col = 0; col < weeks.length; col++) {
+      const firstCell = weeks[col].find((c) => c !== null);
+      if (firstCell) {
+        const month = parseInt(firstCell.date.slice(5, 7), 10) - 1;
+        if (month !== prevMonth) {
+          monthLabels.push({ col, label: MONTHS[month] });
+          prevMonth = month;
+        }
       }
     }
-  }
+    return { weeks, maxCount, monthLabels, total, busiest };
+  }, [cells]);
 
   return (
-    <div className={cn(
-      "bg-surface rounded-2xl shadow-sm border border-border",
-      "hover:border-accent/30 transition-all duration-300",
-      "p-6",
-    )}>
-      <div className="mb-4 flex items-center justify-between">
-        <h3 className="text-sm font-semibold text-foreground">Activity</h3>
+    <div
+      className={cn(
+        "bg-surface rounded-2xl shadow-sm border border-border",
+        "hover:border-accent/30 transition-all duration-300",
+        "p-6",
+      )}
+    >
+      <div className="mb-4 flex items-end justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-foreground">Run activity</h3>
+          <p className="mt-0.5 text-[11px] text-muted-foreground">
+            {total.toLocaleString()} runs
+            {busiest && busiest.count > 0 && (
+              <> · busiest {busiest.date.slice(5)} ({busiest.count})</>
+            )}
+          </p>
+        </div>
         <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
           <span>Less</span>
-          <div className="h-[9px] w-[9px] rounded-[2px] bg-border" />
-          <div className="h-[9px] w-[9px] rounded-[2px] bg-accent/20" />
-          <div className="h-[9px] w-[9px] rounded-[2px] bg-accent/40" />
-          <div className="h-[9px] w-[9px] rounded-[2px] bg-accent/70" />
-          <div className="h-[9px] w-[9px] rounded-[2px] bg-accent" />
+          {LEVEL_CLASS.map((c, i) => (
+            <div key={i} className={cn("h-[10px] w-[10px] rounded-[3px]", c)} />
+          ))}
           <span>More</span>
         </div>
       </div>
 
-      <div className="relative overflow-x-auto">
-        <div className="flex gap-[3px]" style={{ paddingLeft: "28px" }}>
-          {weeks.map((_, col) => {
-            const ml = monthLabels.find((m) => m.col === col);
-            return (
-              <div key={col} className="flex-1 text-[10px] text-muted-foreground min-w-0">
-                {ml ? ml.label : ""}
-              </div>
-            );
-          })}
-        </div>
-
-        <div className="flex gap-0">
-          <div className="flex flex-col gap-[3px] pr-1.5 pt-[3px]" style={{ width: "28px", minWidth: "28px" }}>
+      <div className="overflow-x-auto pb-1">
+        <div className="flex gap-2" style={{ width: "max-content" }}>
+          {/* Day-of-week labels */}
+          <div className="flex flex-col" style={{ gap: GAP, paddingTop: 18 }}>
             {DAY_LABELS.map((label, i) => (
-              <div key={i} className="flex h-[14px] items-center text-[10px] leading-none text-muted-foreground">
+              <div
+                key={i}
+                className="flex items-center text-[10px] leading-none text-muted-foreground"
+                style={{ height: CELL }}
+              >
                 {label}
               </div>
             ))}
           </div>
 
-          <div className="flex gap-[3px] flex-1">
-            {weeks.map((week, col) => (
-              <div key={col} className="flex flex-col gap-[3px] flex-1">
-                {week.map((cell, row) => (
-                  <div
-                    key={row}
-                    className={cn(
-                      "h-[14px] rounded-[3px] transition-colors duration-100",
-                      cell ? "cursor-pointer" : "cursor-default",
-                      cell ? getHeatmapIntensityClass(cell.count, maxCount) : "bg-transparent",
-                    )}
-                    onClick={() => {
-                      if (cell) navigate(`/runs?date=${cell.date}`);
-                    }}
-                    onMouseEnter={(e) => {
-                      if (!cell) return;
-                      const rect = e.currentTarget.getBoundingClientRect();
-                      setTooltip({
-                        x: rect.left + rect.width / 2,
-                        y: rect.top - 8,
-                        text: `${cell.date}: ${cell.count} run${cell.count !== 1 ? "s" : ""}`,
-                      });
-                    }}
-                    onMouseLeave={() => setTooltip(null)}
-                  />
-                ))}
-              </div>
-            ))}
+          {/* Month labels + grid */}
+          <div className="relative">
+            <div className="relative" style={{ height: 18 }}>
+              {monthLabels.map((m) => (
+                <span
+                  key={`${m.col}-${m.label}`}
+                  className="absolute top-0 text-[10px] font-medium text-muted-foreground"
+                  style={{ left: m.col * STEP }}
+                >
+                  {m.label}
+                </span>
+              ))}
+            </div>
+
+            <div className="flex" style={{ gap: GAP }}>
+              {weeks.map((week, col) => (
+                <div key={col} className="flex flex-col" style={{ gap: GAP }}>
+                  {week.map((cell, row) => {
+                    if (!cell) {
+                      return <div key={row} style={{ width: CELL, height: CELL }} />;
+                    }
+                    const lvl = level(cell.count, maxCount);
+                    return (
+                      <div
+                        key={row}
+                        className={cn(
+                          "rounded-[3px] cursor-pointer outline-none",
+                          "transition-[transform,box-shadow] duration-150 ease-out",
+                          "hover:scale-[1.35] hover:ring-2 hover:ring-accent/60 hover:z-10",
+                          LEVEL_CLASS[lvl],
+                        )}
+                        style={{ width: CELL, height: CELL }}
+                        onClick={() => navigate(`/runs?date=${cell.date}`)}
+                        onMouseEnter={(e) => {
+                          const rect = e.currentTarget.getBoundingClientRect();
+                          setTooltip({
+                            x: rect.left + rect.width / 2,
+                            y: rect.top - 8,
+                            text: `${cell.date}: ${cell.count} run${cell.count !== 1 ? "s" : ""}`,
+                          });
+                        }}
+                        onMouseLeave={() => setTooltip(null)}
+                      />
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       </div>
@@ -122,10 +166,7 @@ export function BentoHeatmap({ cells }: { cells: HeatmapCell[] }) {
       {tooltip && (
         <div
           className="pointer-events-none fixed z-50 rounded-lg bg-foreground px-2.5 py-1.5 text-[11px] font-medium text-background shadow-xl"
-          style={{
-            left: tooltip.x, top: tooltip.y,
-            transform: "translate(-50%, -100%)",
-          }}
+          style={{ left: tooltip.x, top: tooltip.y, transform: "translate(-50%, -100%)" }}
         >
           {tooltip.text}
         </div>

--- a/dashboard/src/contexts/UiModeContext.tsx
+++ b/dashboard/src/contexts/UiModeContext.tsx
@@ -1,0 +1,65 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  type ReactNode,
+} from "react";
+
+/**
+ * UI complexity mode.
+ *   "lite" - beginner experience: trimmed sidebar, advanced pages hidden,
+ *            simpler overview. Set after the guided onboarding wizard.
+ *   "full" - the complete dashboard (default for existing users).
+ *   null   - never chosen yet (a brand-new install before onboarding).
+ */
+export type UiMode = "lite" | "full";
+
+const STORAGE_KEY = "sandcastle-ui-mode";
+
+interface UiModeContextValue {
+  /** null until the user has been through onboarding / explicitly chosen. */
+  mode: UiMode | null;
+  setMode: (mode: UiMode) => void;
+  /** Convenience: true only when the active mode is "lite". null counts as full. */
+  isLite: boolean;
+}
+
+const UiModeContext = createContext<UiModeContextValue | undefined>(undefined);
+
+function readStored(): UiMode | null {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY);
+    return v === "lite" || v === "full" ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export function UiModeProvider({ children }: { children: ReactNode }) {
+  const [mode, setModeState] = useState<UiMode | null>(() => readStored());
+
+  const setMode = useCallback((next: UiMode) => {
+    setModeState(next);
+    try {
+      localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // Best-effort: private browsing / quota exceeded must not break mode switching.
+    }
+  }, []);
+
+  return (
+    <UiModeContext.Provider value={{ mode, setMode, isLite: mode === "lite" }}>
+      {children}
+    </UiModeContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useUiMode(): UiModeContextValue {
+  const ctx = useContext(UiModeContext);
+  if (!ctx) {
+    throw new Error("useUiMode must be used within a UiModeProvider");
+  }
+  return ctx;
+}

--- a/dashboard/src/pages/IntegrationsPage.tsx
+++ b/dashboard/src/pages/IntegrationsPage.tsx
@@ -39,6 +39,9 @@ interface Tool {
   credential_env_vars: string[];
   functions: { name: string; description: string }[];
   connections: ToolConnection[];
+  keyless?: boolean;
+  optional_credential_env_vars?: string[];
+  optional_present?: string[];
 }
 
 const CATEGORIES = [
@@ -102,7 +105,8 @@ export default function IntegrationsPage() {
   const configuredTools = useMemo(
     () =>
       tools
-        .filter((t) => t.configured)
+        // Keyless tools (e.g. free web search) are ready to use with no setup.
+        .filter((t) => t.configured || t.keyless)
         .sort((a, b) => {
           const aNeedsAttention = a.missing_credentials.length > 0 ? 0 : 1;
           const bNeedsAttention = b.missing_credentials.length > 0 ? 0 : 1;
@@ -114,7 +118,7 @@ export default function IntegrationsPage() {
   );
 
   const unconfiguredTools = useMemo(
-    () => tools.filter((t) => !t.configured),
+    () => tools.filter((t) => !t.configured && !t.keyless),
     [tools],
   );
 

--- a/src/sandcastle/api/routes.py
+++ b/src/sandcastle/api/routes.py
@@ -2647,11 +2647,11 @@ async def get_sparklines(request: Request, response: Response) -> ApiResponse:
 
 @router.get("/stats/heatmap")
 async def get_heatmap(request: Request, response: Response) -> ApiResponse:
-    """Return daily run counts for the last 26 weeks (182 days)."""
+    """Return daily run counts for the last 52 weeks (364 days)."""
     response.headers["Cache-Control"] = "public, max-age=60"
     tenant_id = get_tenant_id(request)
     now = datetime.now(timezone.utc)
-    start_date = now - timedelta(days=181)
+    start_date = now - timedelta(days=363)
 
     async with async_session() as session:
         daily_q = (
@@ -2672,9 +2672,9 @@ async def get_heatmap(request: Request, response: Response) -> ApiResponse:
         day_str = row.day.strftime("%Y-%m-%d") if hasattr(row.day, "strftime") else str(row.day)
         db_counts[day_str] = int(row.count)
 
-    # Zero-fill all 182 days
+    # Zero-fill all 364 days (52 weeks)
     cells = []
-    for i in range(181, -1, -1):
+    for i in range(363, -1, -1):
         d = now - timedelta(days=i)
         day_str = d.strftime("%Y-%m-%d")
         cells.append({

--- a/src/sandcastle/api/routes.py
+++ b/src/sandcastle/api/routes.py
@@ -9117,6 +9117,7 @@ _SENSITIVE_KEYS = frozenset({
     "tool_cloudflare_api_token",
     "tool_firecrawl_api_key",
     "tool_tavily_api_key",
+    "tool_jina_api_key",
     "tool_elevenlabs_api_key",
     "tool_nano_banana_api_key",
     "tool_zapier_webhook_url",
@@ -10815,6 +10816,9 @@ async def _build_tool_response(
         configured=status.get("configured", False),
         missing_credentials=status.get("missing", []),
         connections=connections or [],
+        keyless=status.get("keyless", False),
+        optional_credential_env_vars=getattr(tool, "optional_credential_env_vars", []),
+        optional_present=status.get("optional_present", []),
     )
 
 
@@ -10908,8 +10912,11 @@ async def update_tool_credentials(
             ).model_dump(),
         )
 
-    # Only allow setting env vars that belong to this tool
-    allowed = set(tool.credential_env_vars)
+    # Only allow setting env vars that belong to this tool (required + optional
+    # upgrade keys, e.g. a free key that lifts a keyless tool's rate limit).
+    allowed = set(tool.credential_env_vars) | set(
+        getattr(tool, "optional_credential_env_vars", [])
+    )
     rejected = set(body.credentials.keys()) - allowed
     if rejected:
         raise HTTPException(

--- a/src/sandcastle/api/schemas.py
+++ b/src/sandcastle/api/schemas.py
@@ -915,6 +915,10 @@ class ToolResponse(BaseModel):
     configured: bool = False
     missing_credentials: list[str] = []
     connections: list[ToolConnectionResponse] = []
+    # Keyless tools work with no required creds; an optional key may upgrade them.
+    keyless: bool = False
+    optional_credential_env_vars: list[str] = []
+    optional_present: list[str] = []
 
 
 class ToolListResponse(BaseModel):

--- a/src/sandcastle/engine/tools/connectors/websearch.mjs
+++ b/src/sandcastle/engine/tools/connectors/websearch.mjs
@@ -1,23 +1,22 @@
 /**
- * Keyless web search + clean content extraction. FREE, no API key required.
+ * Keyless web search + clean content extraction. FREE, NO API KEY REQUIRED.
  *
- *   search:  DuckDuckGo Lite (keyless) for result links, then Jina Reader
- *            (https://r.jina.ai, keyless) to pull clean Markdown for the top hits.
- *            If TOOL_JINA_API_KEY is set, upgrade to s.jina.ai (one-shot, higher
- *            quality). Output shape mirrors tavily.mjs exactly (drop-in tool swap).
+ *   search:  Jina Reader (https://r.jina.ai, keyless) renders a DuckDuckGo SERP
+ *            server-side - this bypasses the bot-blocks that hit a direct scrape -
+ *            we parse the organic results, then Jina Reader pulls clean Markdown
+ *            for the top hits. If TOOL_JINA_API_KEY is set, upgrade to s.jina.ai
+ *            (one-shot). Output shape mirrors tavily.mjs exactly (drop-in swap).
  *   extract: Jina Reader (keyless).
  *
- * Credentials: NONE required. TOOL_JINA_API_KEY is OPTIONAL (lifts quality + limits).
- * Note: the keyless DuckDuckGo path is best-effort (HTML scrape, rate-limited); add a
- * free Jina key or fall back to the paid `tavily` tool for production reliability.
+ * Credentials: NONE required. TOOL_JINA_API_KEY is OPTIONAL (higher quality + limits).
  */
 
 const JINA_KEY = process.env.TOOL_JINA_API_KEY || "";
-const DDG_LITE = "https://lite.duckduckgo.com/lite/";
-const JINA_SEARCH = "https://s.jina.ai";
 const JINA_READER = "https://r.jina.ai";
+const JINA_SEARCH = "https://s.jina.ai";
+const SERP_URL = "https://html.duckduckgo.com/html/?q="; // read THROUGH the keyless reader
 const UA = "Mozilla/5.0 (compatible; SandcastleBot/1.0)";
-const TIMEOUT = 40_000;
+const TIMEOUT = 45_000;
 const EXTRACT_TOP_N = 5;
 
 function makeSignal() {
@@ -26,57 +25,55 @@ function makeSignal() {
   return { signal: controller.signal, clear: () => clearTimeout(timer) };
 }
 
-async function fetchText(url, init = {}) {
+function jinaAuth() {
+  return JINA_KEY ? { Authorization: `Bearer ${JINA_KEY}` } : {};
+}
+
+/** GET a URL through the keyless Jina Reader and return its { title, url, content }. */
+async function readerGet(target) {
   const { signal, clear } = makeSignal();
   try {
-    const resp = await fetch(url, { signal, headers: { "User-Agent": UA, ...(init.headers || {}) }, ...init });
-    if (!resp.ok) throw new Error(`${url} -> HTTP ${resp.status}`);
-    return resp.text();
+    const resp = await fetch(`${JINA_READER}/${target}`, {
+      method: "GET",
+      signal,
+      headers: { Accept: "application/json", "User-Agent": UA, ...jinaAuth() },
+    });
+    if (!resp.ok) throw new Error(`Jina Reader ${resp.status}`);
+    const data = await resp.json();
+    return data?.data ?? data;
   } finally {
     clear();
   }
 }
 
-async function fetchJson(url, init = {}) {
-  const text = await fetchText(url, { headers: { Accept: "application/json", ...(init.headers || {}) }, ...init });
-  return JSON.parse(text);
-}
-
-function jinaAuth() {
-  return JINA_KEY ? { Authorization: `Bearer ${JINA_KEY}` } : {};
-}
-
-function decodeEntities(s) {
-  return (s || "")
-    .replace(/<[^>]+>/g, "")
-    .replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"').replace(/&#x27;|&#39;/g, "'").replace(/&nbsp;/g, " ")
-    .trim();
-}
-
-/** DuckDuckGo Lite keyless search -> [{title, url, snippet}]. Best-effort HTML parse. */
-async function ddgSearch(query, maxResults) {
-  const html = await fetchText(DDG_LITE, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: `q=${encodeURIComponent(query)}`,
-  });
-  const links = [...html.matchAll(/<a[^>]*class=["']result-link["'][^>]*href=["']([^"']+)["'][^>]*>(.*?)<\/a>/gis)];
-  const snippets = [...html.matchAll(/<td[^>]*class=["']result-snippet["'][^>]*>(.*?)<\/td>/gis)].map((m) => decodeEntities(m[1]));
+/** Parse the Reader's Markdown of a DuckDuckGo SERP into organic results. */
+function parseSerp(markdown, max) {
+  const blocks = (markdown || "").split(/\n##\s+/).slice(1); // each: "[title](url)\n snippet..."
   const out = [];
-  for (let i = 0; i < links.length && out.length < (maxResults || 8); i++) {
-    let href = links[i][1];
-    const uddg = href.match(/[?&]uddg=([^&]+)/);
-    if (uddg) href = decodeURIComponent(uddg[1]);
-    if (!/^https?:\/\//.test(href)) continue;
-    out.push({ title: decodeEntities(links[i][2]) || href, url: href, snippet: snippets[i] || "" });
+  for (const b of blocks) {
+    const m = b.match(/^\[([^\]]*)\]\((https?:\/\/[^)]+)\)/);
+    if (!m) continue;
+    let url = m[2];
+    const uddg = url.match(/[?&]uddg=([^&]+)/);
+    if (uddg) {
+      try { url = decodeURIComponent(uddg[1]); } catch { /* keep raw */ }
+    }
+    // Drop ads + DuckDuckGo-internal links; keep organic external results only.
+    if (!/^https?:\/\//.test(url) || url.includes("duckduckgo.com") || url.includes("/y.js")) continue;
+    const snippet = b
+      .slice(m[0].length)
+      .replace(/\[[^\]]*\]\([^)]*\)/g, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 300);
+    out.push({ title: m[1] || url, url, snippet });
+    if (out.length >= max) break;
   }
   return out;
 }
 
 async function jinaRead(url) {
-  const data = await fetchJson(`${JINA_READER}/${url}`, { headers: jinaAuth() });
-  const doc = data?.data ?? data;
+  const doc = await readerGet(url);
   return doc?.content ?? "";
 }
 
@@ -85,29 +82,44 @@ export async function search(query, options = "{}") {
   const opts = typeof options === "string" ? JSON.parse(options) : options;
   const max = opts.max_results || 5;
 
-  // Best path: keyed Jina returns search + content in one shot.
+  // Optional upgrade: keyed Jina returns search + content in one shot.
   if (JINA_KEY) {
     try {
-      const data = await fetchJson(`${JINA_SEARCH}/?q=${encodeURIComponent(query)}`, { headers: jinaAuth() });
-      const items = (Array.isArray(data?.data) ? data.data : []).slice(0, max);
-      return {
-        answer: null,
-        results: items.map((r) => ({
-          title: r.title ?? r.url ?? "",
-          url: r.url,
-          content: r.content ?? r.description ?? "",
-          score: null,
-          published_date: r.date ?? null,
-        })),
-        query,
-      };
+      const { signal, clear } = makeSignal();
+      try {
+        const resp = await fetch(`${JINA_SEARCH}/?q=${encodeURIComponent(query)}`, {
+          method: "GET",
+          signal,
+          headers: { Accept: "application/json", ...jinaAuth() },
+        });
+        if (resp.ok) {
+          const data = await resp.json();
+          const items = (Array.isArray(data?.data) ? data.data : []).slice(0, max);
+          if (items.length) {
+            return {
+              answer: null,
+              results: items.map((r) => ({
+                title: r.title ?? r.url ?? "",
+                url: r.url,
+                content: r.content ?? r.description ?? "",
+                score: null,
+                published_date: r.date ?? null,
+              })),
+              query,
+            };
+          }
+        }
+      } finally {
+        clear();
+      }
     } catch {
-      // fall through to the keyless path
+      /* fall through to keyless */
     }
   }
 
-  // Keyless path: DDG Lite for links, Jina Reader for clean content on the top hits.
-  const hits = await ddgSearch(query, max);
+  // Keyless: read a DuckDuckGo SERP through Jina Reader, then read the top hits.
+  const serp = await readerGet(`${SERP_URL}${encodeURIComponent(query)}`);
+  const hits = parseSerp(serp?.content, max);
   const results = [];
   for (let i = 0; i < hits.length; i++) {
     let content = hits[i].snippet;
@@ -115,19 +127,12 @@ export async function search(query, options = "{}") {
       try {
         const full = await jinaRead(hits[i].url);
         if (full) content = full;
-      } catch {
-        // keep the snippet as content
-      }
+      } catch { /* keep snippet */ }
     }
     results.push({ title: hits[i].title, url: hits[i].url, content, score: null, published_date: null });
   }
-  // Keyless search backends are frequently bot-blocked. If we got nothing, throw so
-  // the agent falls through to the next tool in the list (e.g. paid tavily) instead
-  // of silently returning an empty result set.
   if (results.length === 0) {
-    throw new Error(
-      "websearch: no keyless results (DuckDuckGo blocked). Set TOOL_JINA_API_KEY (free, no card) or configure the tavily fallback."
-    );
+    throw new Error("websearch: no results (search backend unavailable). Try the tavily fallback.");
   }
   return { answer: null, results, query };
 }

--- a/src/sandcastle/engine/tools/connectors/websearch.mjs
+++ b/src/sandcastle/engine/tools/connectors/websearch.mjs
@@ -38,7 +38,16 @@ async function readerGet(target) {
       signal,
       headers: { Accept: "application/json", "User-Agent": UA, ...jinaAuth() },
     });
-    if (!resp.ok) throw new Error(`Jina Reader ${resp.status}`);
+    if (!resp.ok) {
+      if (resp.status === 429 || resp.status === 402) {
+        throw new Error(
+          "RATE_LIMIT: the free keyless web search hit its rate limit. " +
+            "Add a free TOOL_JINA_API_KEY (no card required, get one at jina.ai) to raise the limit, " +
+            "or configure the paid tavily fallback (TOOL_TAVILY_API_KEY)."
+        );
+      }
+      throw new Error(`Jina Reader ${resp.status}`);
+    }
     const data = await resp.json();
     return data?.data ?? data;
   } finally {

--- a/src/sandcastle/engine/tools/connectors/websearch.mjs
+++ b/src/sandcastle/engine/tools/connectors/websearch.mjs
@@ -1,0 +1,165 @@
+/**
+ * Keyless web search + clean content extraction. FREE, no API key required.
+ *
+ *   search:  DuckDuckGo Lite (keyless) for result links, then Jina Reader
+ *            (https://r.jina.ai, keyless) to pull clean Markdown for the top hits.
+ *            If TOOL_JINA_API_KEY is set, upgrade to s.jina.ai (one-shot, higher
+ *            quality). Output shape mirrors tavily.mjs exactly (drop-in tool swap).
+ *   extract: Jina Reader (keyless).
+ *
+ * Credentials: NONE required. TOOL_JINA_API_KEY is OPTIONAL (lifts quality + limits).
+ * Note: the keyless DuckDuckGo path is best-effort (HTML scrape, rate-limited); add a
+ * free Jina key or fall back to the paid `tavily` tool for production reliability.
+ */
+
+const JINA_KEY = process.env.TOOL_JINA_API_KEY || "";
+const DDG_LITE = "https://lite.duckduckgo.com/lite/";
+const JINA_SEARCH = "https://s.jina.ai";
+const JINA_READER = "https://r.jina.ai";
+const UA = "Mozilla/5.0 (compatible; SandcastleBot/1.0)";
+const TIMEOUT = 40_000;
+const EXTRACT_TOP_N = 5;
+
+function makeSignal() {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT);
+  return { signal: controller.signal, clear: () => clearTimeout(timer) };
+}
+
+async function fetchText(url, init = {}) {
+  const { signal, clear } = makeSignal();
+  try {
+    const resp = await fetch(url, { signal, headers: { "User-Agent": UA, ...(init.headers || {}) }, ...init });
+    if (!resp.ok) throw new Error(`${url} -> HTTP ${resp.status}`);
+    return resp.text();
+  } finally {
+    clear();
+  }
+}
+
+async function fetchJson(url, init = {}) {
+  const text = await fetchText(url, { headers: { Accept: "application/json", ...(init.headers || {}) }, ...init });
+  return JSON.parse(text);
+}
+
+function jinaAuth() {
+  return JINA_KEY ? { Authorization: `Bearer ${JINA_KEY}` } : {};
+}
+
+function decodeEntities(s) {
+  return (s || "")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"').replace(/&#x27;|&#39;/g, "'").replace(/&nbsp;/g, " ")
+    .trim();
+}
+
+/** DuckDuckGo Lite keyless search -> [{title, url, snippet}]. Best-effort HTML parse. */
+async function ddgSearch(query, maxResults) {
+  const html = await fetchText(DDG_LITE, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: `q=${encodeURIComponent(query)}`,
+  });
+  const links = [...html.matchAll(/<a[^>]*class=["']result-link["'][^>]*href=["']([^"']+)["'][^>]*>(.*?)<\/a>/gis)];
+  const snippets = [...html.matchAll(/<td[^>]*class=["']result-snippet["'][^>]*>(.*?)<\/td>/gis)].map((m) => decodeEntities(m[1]));
+  const out = [];
+  for (let i = 0; i < links.length && out.length < (maxResults || 8); i++) {
+    let href = links[i][1];
+    const uddg = href.match(/[?&]uddg=([^&]+)/);
+    if (uddg) href = decodeURIComponent(uddg[1]);
+    if (!/^https?:\/\//.test(href)) continue;
+    out.push({ title: decodeEntities(links[i][2]) || href, url: href, snippet: snippets[i] || "" });
+  }
+  return out;
+}
+
+async function jinaRead(url) {
+  const data = await fetchJson(`${JINA_READER}/${url}`, { headers: jinaAuth() });
+  const doc = data?.data ?? data;
+  return doc?.content ?? "";
+}
+
+/** Web search returning clean, LLM-ready content. Same shape as tavily.search. */
+export async function search(query, options = "{}") {
+  const opts = typeof options === "string" ? JSON.parse(options) : options;
+  const max = opts.max_results || 5;
+
+  // Best path: keyed Jina returns search + content in one shot.
+  if (JINA_KEY) {
+    try {
+      const data = await fetchJson(`${JINA_SEARCH}/?q=${encodeURIComponent(query)}`, { headers: jinaAuth() });
+      const items = (Array.isArray(data?.data) ? data.data : []).slice(0, max);
+      return {
+        answer: null,
+        results: items.map((r) => ({
+          title: r.title ?? r.url ?? "",
+          url: r.url,
+          content: r.content ?? r.description ?? "",
+          score: null,
+          published_date: r.date ?? null,
+        })),
+        query,
+      };
+    } catch {
+      // fall through to the keyless path
+    }
+  }
+
+  // Keyless path: DDG Lite for links, Jina Reader for clean content on the top hits.
+  const hits = await ddgSearch(query, max);
+  const results = [];
+  for (let i = 0; i < hits.length; i++) {
+    let content = hits[i].snippet;
+    if (i < EXTRACT_TOP_N) {
+      try {
+        const full = await jinaRead(hits[i].url);
+        if (full) content = full;
+      } catch {
+        // keep the snippet as content
+      }
+    }
+    results.push({ title: hits[i].title, url: hits[i].url, content, score: null, published_date: null });
+  }
+  // Keyless search backends are frequently bot-blocked. If we got nothing, throw so
+  // the agent falls through to the next tool in the list (e.g. paid tavily) instead
+  // of silently returning an empty result set.
+  if (results.length === 0) {
+    throw new Error(
+      "websearch: no keyless results (DuckDuckGo blocked). Set TOOL_JINA_API_KEY (free, no card) or configure the tavily fallback."
+    );
+  }
+  return { answer: null, results, query };
+}
+
+/** Extract clean content for one or more URLs (keyless). Same shape as tavily.extract. */
+export async function extract(urls) {
+  const urlList = typeof urls === "string" ? JSON.parse(urls) : urls;
+  const list = Array.isArray(urlList) ? urlList : [urlList];
+  const results = [];
+  const failed = [];
+  for (const url of list) {
+    try {
+      results.push({ url, raw_content: await jinaRead(url) });
+    } catch (err) {
+      failed.push({ url, error: err.message });
+    }
+  }
+  return { results, failed };
+}
+
+// CLI dispatch
+if (process.argv[1]?.endsWith("websearch.mjs")) {
+  const [fn, ...args] = process.argv.slice(2);
+  const dispatch = { search, extract };
+  if (!dispatch[fn]) {
+    console.error(`Usage: node websearch.mjs <${Object.keys(dispatch).join("|")}> [args...]`);
+    process.exit(1);
+  }
+  try {
+    console.log(JSON.stringify(await dispatch[fn](...args), null, 2));
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/src/sandcastle/engine/tools/credentials.py
+++ b/src/sandcastle/engine/tools/credentials.py
@@ -165,10 +165,18 @@ def validate_tool_credentials(tool_names: list[str]) -> dict[str, dict]:
             else:
                 missing.append(env_var)
 
+        optional = list(getattr(tool, "optional_credential_env_vars", []) or [])
+        optional_present = [v for v in optional if os.environ.get(v)]
+
         result[name] = {
             "configured": len(missing) == 0 and len(tool.credential_env_vars) > 0,
             "missing": missing,
             "present": present,
+            # Keyless tools (no required creds) report whether an optional upgrade
+            # key is set - drives the "free / keyed" status in the dashboard.
+            "keyless": len(tool.credential_env_vars) == 0,
+            "optional": optional,
+            "optional_present": optional_present,
         }
     return result
 

--- a/src/sandcastle/engine/tools/registry.py
+++ b/src/sandcastle/engine/tools/registry.py
@@ -8,7 +8,7 @@ loader, and dashboard UI.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
@@ -31,6 +31,9 @@ class ToolDefinition:
     credential_env_vars: list[str]  # Required env vars (e.g. ["TOOL_SLACK_BOT_TOKEN"])
     connector_file: str  # Filename in connectors/ (e.g. "slack.mjs")
     icon: str = ""  # Optional icon identifier for dashboard
+    # Env vars that are NOT required (the tool works without them) but, if set,
+    # upgrade it - e.g. a free key that lifts a keyless tool's rate limit.
+    optional_credential_env_vars: list[str] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -2195,6 +2198,7 @@ TOOL_REGISTRY: dict[str, ToolDefinition] = {
             ),
         ],
         credential_env_vars=[],
+        optional_credential_env_vars=["TOOL_JINA_API_KEY"],
         connector_file="websearch.mjs",
         icon="search",
     ),

--- a/src/sandcastle/engine/tools/registry.py
+++ b/src/sandcastle/engine/tools/registry.py
@@ -2167,6 +2167,37 @@ TOOL_REGISTRY: dict[str, ToolDefinition] = {
         connector_file="firecrawl.mjs",
         icon="firecrawl",
     ),
+    "websearch": ToolDefinition(
+        name="websearch",
+        description="Keyless free web search + clean content extraction (DuckDuckGo + Jina Reader; optional TOOL_JINA_API_KEY upgrades quality)",
+        category="ai",
+        functions=[
+            ToolFunction(
+                name="search",
+                description="Keyless web search returning clean, LLM-ready content",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "options": {"type": "object"},
+                    },
+                    "required": ["query"],
+                },
+            ),
+            ToolFunction(
+                name="extract",
+                description="Extract clean content from URLs",
+                parameters={
+                    "type": "object",
+                    "properties": {"urls": {"type": "array"}},
+                    "required": ["urls"],
+                },
+            ),
+        ],
+        credential_env_vars=[],
+        connector_file="websearch.mjs",
+        icon="search",
+    ),
     "tavily": ToolDefinition(
         name="tavily",
         description="Tavily - AI-optimized web search",

--- a/src/sandcastle/templates/ai_brand_perception_audit.yaml
+++ b/src/sandcastle/templates/ai_brand_perception_audit.yaml
@@ -1,14 +1,18 @@
 # name: What Does AI Say About Your Brand?
-# description: Probe the model's own memory of your brand, then get a sentiment + positioning scorecard with the riskiest misperceptions and concrete fixes
-# tags: [marketing, brand, ai-perception, sentiment, geo]
+# description: Search the live web for what's said about your brand, compare it to what AI models believe, and get a sentiment + positioning scorecard with the riskiest gaps and concrete GEO fixes
+# tags: [marketing, brand, ai-perception, sentiment, geo, web]
 # category: marketing
 
 name: ai-brand-perception-audit
-description: Probe the model's own memory of your brand, then get a sentiment + positioning scorecard with the riskiest misperceptions and concrete fixes
+description: Search the live web for what's said about your brand, compare it to what AI models believe, and get a sentiment + positioning scorecard with the riskiest gaps and concrete GEO fixes
 
 default_model: sonnet
-default_max_turns: 6
-default_timeout: 180
+default_max_turns: 8
+default_timeout: 300
+# Live web search. `websearch` is keyless/free (DuckDuckGo + Jina Reader; optional
+# TOOL_JINA_API_KEY upgrades quality); Tavily is an optional paid fallback. Needs a
+# tool-capable (cloud) model - local models without tool use skip search and degrade.
+default_tools: [websearch, tavily]
 
 input_schema:
   required: ["brand"]
@@ -23,65 +27,57 @@ input_schema:
       example: "AI workflow orchestrator"
 
 steps:
-  - id: cold-probe
+  - id: web-listen
     prompt: >
-      You are answering a curious user with NO outside research - rely only on what you
-      already know. The brand is "{input.brand}" (category hint, may be empty: {input.category}).
-      Without hedging, tell them everything you associate with this brand:
-      a one-paragraph description, who it is for, what it is known/respected for,
-      its reputation, the 5 strongest word-associations that come to mind, and
-      who you would name as its main alternatives. If you are genuinely unsure whether
-      you know this brand, say so plainly. Do not invent specifics you are not confident about.
+      Use web search to find what is CURRENTLY being said about "{input.brand}"
+      (category hint, may be empty: {input.category}). Run several distinct searches, e.g.
+      the brand name, "{input.brand} reviews", "{input.brand} vs", "{input.brand} alternatives",
+      and recent news/launches. From the results collect: how the brand is described, who it's for,
+      its reputation, recurring praise and complaints, the competitors/alternatives people name,
+      pricing perception, and any notable recent coverage. Quote specifics and CITE the source URLs
+      you relied on. If results are thin, say so plainly rather than guessing.
+    model: sonnet
+    max_turns: 10
+
+  - id: ai-memory
+    prompt: >
+      Now answer from your OWN training memory only, with NO web search: what do you, as an AI model,
+      already believe about "{input.brand}"? Give a one-paragraph description, who it's for, its
+      reputation, the 5 strongest associations, and the alternatives you'd name. If you're not
+      confident you know this brand, say so plainly - do not invent specifics.
     model: sonnet
     max_turns: 4
 
-  - id: sentiment-positioning
-    depends_on: [cold-probe]
+  - id: gap-analysis
+    depends_on: [web-listen, ai-memory]
     prompt: >
-      Analyze the AI's raw impression below and turn it into a crisp positioning read.
-      Impression: {steps.cold-probe.output}
-
-      Produce: (1) an overall sentiment label (Positive / Neutral / Mixed / Negative) with a
-      one-line justification; (2) the perceived price/quality tier; (3) the single positioning
-      sentence an AI would give a customer who asked "what is {input.brand}?"; (4) the top 3
-      perceived strengths and top 3 perceived weaknesses; (5) the 5 strongest associations,
-      each flagged as on-brand or off-brand.
+      Compare the live web reality against the AI's memory.
+      WEB (current): {steps.web-listen.output}
+      AI MEMORY: {steps.ai-memory.output}
+      Identify: (1) where the AI is STALE or WRONG vs the web; (2) what the web shows that the AI
+      OMITS entirely; (3) any likely hallucinations (claims in AI memory not supported by the web).
+      Be specific - this gap is where the brand is most misrepresented by AI.
     model: sonnet
-    max_turns: 5
-
-  - id: blind-spots
-    depends_on: [cold-probe]
-    prompt: >
-      Act as a skeptical brand auditor. Looking at the AI's impression of "{input.brand}":
-      {steps.cold-probe.output}
-
-      List what the model is clearly UNSURE about, what it OMITS that a real buyer would want,
-      and any claims that look like guesses or possible hallucinations (stale facts, confused
-      with another company, made-up specifics). Be specific and honest - this is where the risk hides.
-    model: sonnet
-    max_turns: 4
+    max_turns: 6
 
   - id: scorecard
-    depends_on: [sentiment-positioning, blind-spots]
+    depends_on: [gap-analysis]
     prompt: >
-      Write a one-page "AI Perception Scorecard" for {input.brand}.
-      Positioning read: {steps.sentiment-positioning.output}
-      Blind spots & risks: {steps.blind-spots.output}
-
-      Format with these sections: a top-line Sentiment Score (one of Positive/Neutral/Mixed/Negative
-      plus a 0-100 confidence the model even knows the brand), "How AI describes you" (the positioning
-      line), "What's working", and "The 3 riskiest misperceptions" (the ones most likely to cost a sale).
-      Keep it skimmable.
+      Write a one-page "Brand Perception Scorecard" for {input.brand}, grounded in both web and AI.
+      Web + AI gap: {steps.gap-analysis.output}
+      Sections: a top-line Sentiment label (Positive/Neutral/Mixed/Negative) + a 0-100 confidence
+      the brand is even well-known; "How AI describes you" vs "How the web describes you" (one line
+      each); "What's working"; and "The 3 riskiest misperceptions" most likely to cost a sale.
     model: sonnet
-    max_turns: 5
+    max_turns: 6
 
   - id: action-plan
     depends_on: [scorecard]
     prompt: >
       Based on this scorecard for {input.brand}, give 5 concrete, prioritized moves to shift how
-      AI models describe the brand (Generative Engine Optimization): each move = what to publish or
-      change, why it works on LLMs, and the misperception it fixes. End with one re-test prompt the
-      user can run later to measure movement.
+      AI models and search describe the brand (Generative Engine Optimization): each move = what to
+      publish or change, why it works on LLMs/AI search, and the misperception it fixes. End with one
+      re-run note so the user can measure movement later.
       Scorecard: {steps.scorecard.output}
     model: haiku
     max_turns: 4

--- a/src/sandcastle/templates/ai_brand_perception_audit.yaml
+++ b/src/sandcastle/templates/ai_brand_perception_audit.yaml
@@ -1,0 +1,87 @@
+# name: What Does AI Say About Your Brand?
+# description: Probe the model's own memory of your brand, then get a sentiment + positioning scorecard with the riskiest misperceptions and concrete fixes
+# tags: [marketing, brand, ai-perception, sentiment, geo]
+# category: marketing
+
+name: ai-brand-perception-audit
+description: Probe the model's own memory of your brand, then get a sentiment + positioning scorecard with the riskiest misperceptions and concrete fixes
+
+default_model: sonnet
+default_max_turns: 6
+default_timeout: 180
+
+input_schema:
+  required: ["brand"]
+  properties:
+    brand:
+      type: string
+      description: "Brand, product, or person to audit"
+      example: "Sandcastle"
+    category:
+      type: string
+      description: "Optional one-line category to disambiguate, e.g. 'AI workflow orchestrator'"
+      example: "AI workflow orchestrator"
+
+steps:
+  - id: cold-probe
+    prompt: >
+      You are answering a curious user with NO outside research - rely only on what you
+      already know. The brand is "{input.brand}" (category hint, may be empty: {input.category}).
+      Without hedging, tell them everything you associate with this brand:
+      a one-paragraph description, who it is for, what it is known/respected for,
+      its reputation, the 5 strongest word-associations that come to mind, and
+      who you would name as its main alternatives. If you are genuinely unsure whether
+      you know this brand, say so plainly. Do not invent specifics you are not confident about.
+    model: sonnet
+    max_turns: 4
+
+  - id: sentiment-positioning
+    depends_on: [cold-probe]
+    prompt: >
+      Analyze the AI's raw impression below and turn it into a crisp positioning read.
+      Impression: {steps.cold-probe.output}
+
+      Produce: (1) an overall sentiment label (Positive / Neutral / Mixed / Negative) with a
+      one-line justification; (2) the perceived price/quality tier; (3) the single positioning
+      sentence an AI would give a customer who asked "what is {input.brand}?"; (4) the top 3
+      perceived strengths and top 3 perceived weaknesses; (5) the 5 strongest associations,
+      each flagged as on-brand or off-brand.
+    model: sonnet
+    max_turns: 5
+
+  - id: blind-spots
+    depends_on: [cold-probe]
+    prompt: >
+      Act as a skeptical brand auditor. Looking at the AI's impression of "{input.brand}":
+      {steps.cold-probe.output}
+
+      List what the model is clearly UNSURE about, what it OMITS that a real buyer would want,
+      and any claims that look like guesses or possible hallucinations (stale facts, confused
+      with another company, made-up specifics). Be specific and honest - this is where the risk hides.
+    model: sonnet
+    max_turns: 4
+
+  - id: scorecard
+    depends_on: [sentiment-positioning, blind-spots]
+    prompt: >
+      Write a one-page "AI Perception Scorecard" for {input.brand}.
+      Positioning read: {steps.sentiment-positioning.output}
+      Blind spots & risks: {steps.blind-spots.output}
+
+      Format with these sections: a top-line Sentiment Score (one of Positive/Neutral/Mixed/Negative
+      plus a 0-100 confidence the model even knows the brand), "How AI describes you" (the positioning
+      line), "What's working", and "The 3 riskiest misperceptions" (the ones most likely to cost a sale).
+      Keep it skimmable.
+    model: sonnet
+    max_turns: 5
+
+  - id: action-plan
+    depends_on: [scorecard]
+    prompt: >
+      Based on this scorecard for {input.brand}, give 5 concrete, prioritized moves to shift how
+      AI models describe the brand (Generative Engine Optimization): each move = what to publish or
+      change, why it works on LLMs, and the misperception it fixes. End with one re-test prompt the
+      user can run later to measure movement.
+      Scorecard: {steps.scorecard.output}
+    model: haiku
+    max_turns: 4

--- a/src/sandcastle/templates/brand_voice_kit.yaml
+++ b/src/sandcastle/templates/brand_voice_kit.yaml
@@ -1,0 +1,86 @@
+# name: Brand Voice Kit Forge
+# description: One idea in, a complete brand voice out - 4 voice directions judged into names, taglines, voice pillars, a do/don't word list, and in-voice samples
+# tags: [creative, branding, voice, naming, copywriting]
+# category: creative
+
+name: brand-voice-kit
+description: One idea in, a complete brand voice out - 4 voice directions judged into names, taglines, voice pillars, a do/don't word list, and in-voice samples
+
+default_model: sonnet
+default_max_turns: 6
+default_timeout: 200
+
+input_schema:
+  required: ["what_youre_building"]
+  properties:
+    what_youre_building:
+      type: string
+      description: "One line about what you're building"
+      example: "a tool that lets agents run locally on your own hardware"
+    vibe:
+      type: string
+      description: "Optional vibe words, e.g. 'bold, warm, irreverent'"
+      example: "bold, confident, a little rebellious"
+
+steps:
+  - id: essence
+    prompt: >
+      From this one-liner, extract the product essence and audience in a few crisp bullets:
+      what it is, who it's for, the feeling it should leave behind, and (if given) the requested vibe.
+      One-liner: {input.what_youre_building}. Vibe (may be empty): {input.vibe}.
+    model: sonnet
+    max_turns: 4
+
+  - id: voice-insider
+    depends_on: [essence]
+    prompt: >
+      Propose a brand voice called "The Insider" (knowing, peer-to-peer, no fluff) for this essence:
+      {steps.essence.output}. Give 3 voice traits and one sample sentence in that voice.
+    model: sonnet
+    max_turns: 3
+
+  - id: voice-rebel
+    depends_on: [essence]
+    prompt: >
+      Propose a brand voice called "The Rebel" (bold, challenges the status quo) for this essence:
+      {steps.essence.output}. Give 3 voice traits and one sample sentence in that voice.
+    model: sonnet
+    max_turns: 3
+
+  - id: voice-mentor
+    depends_on: [essence]
+    prompt: >
+      Propose a brand voice called "The Mentor" (warm, guiding, reassuring) for this essence:
+      {steps.essence.output}. Give 3 voice traits and one sample sentence in that voice.
+    model: sonnet
+    max_turns: 3
+
+  - id: voice-minimalist
+    depends_on: [essence]
+    prompt: >
+      Propose a brand voice called "The Minimalist" (spare, calm, every word earns its place) for
+      this essence: {steps.essence.output}. Give 3 voice traits and one sample sentence in that voice.
+    model: sonnet
+    max_turns: 3
+
+  - id: judge
+    depends_on: [voice-insider, voice-rebel, voice-mentor, voice-minimalist]
+    prompt: >
+      You are a brand director. Four voice directions are below. Score each on memorability and
+      fit-to-audience, then crown ONE winner with a two-line justification.
+      INSIDER: {steps.voice-insider.output}
+      REBEL: {steps.voice-rebel.output}
+      MENTOR: {steps.voice-mentor.output}
+      MINIMALIST: {steps.voice-minimalist.output}
+    model: sonnet
+    max_turns: 5
+
+  - id: kit
+    depends_on: [judge]
+    prompt: >
+      Build the final Brand Voice Kit around the winning voice. Winner: {steps.judge.output}.
+      Include: 3 candidate brand names each with a tagline, 3 voice pillars, a do/don't word list
+      (8 do, 8 don't), and three in-voice samples (a tweet, a one-line email opener, and a button CTA).
+      Make it copy-paste ready for any writer.
+    model: sonnet
+    max_turns: 6

--- a/src/sandcastle/templates/campaign_in_a_box.yaml
+++ b/src/sandcastle/templates/campaign_in_a_box.yaml
@@ -8,7 +8,10 @@ description: One product line in, a launch-ready campaign out - big idea, 3 comp
 
 default_model: sonnet
 default_max_turns: 6
-default_timeout: 240
+default_timeout: 300
+# Live market research. `websearch` is keyless/free (DuckDuckGo + Jina Reader); Tavily
+# is an optional paid fallback (TOOL_TAVILY_API_KEY). Needs a tool-capable cloud model.
+default_tools: [websearch, tavily]
 
 input_schema:
   required: ["product_or_offer"]
@@ -23,10 +26,20 @@ input_schema:
       example: "launch announcement"
 
 steps:
-  - id: brief
+  - id: research
     prompt: >
-      Read this offer and write a tight creative brief. Offer: {input.product_or_offer}.
-      Goal (may be empty): {input.campaign_goal}.
+      Use web search to ground the campaign in reality for: {input.product_or_offer}
+      (goal, may be empty: {input.campaign_goal}). Search the category, the target audience's
+      language and real pains, how competitors currently position and message, and any recent
+      trends or angles worth riding. Summarize the live findings with a few cited source URLs.
+    model: sonnet
+    max_turns: 10
+
+  - id: brief
+    depends_on: [research]
+    prompt: >
+      Using the live research, write a tight creative brief. Offer: {input.product_or_offer}.
+      Goal (may be empty): {input.campaign_goal}. Research: {steps.research.output}
       Extract: the core promise, the target audience, the pain it removes, and the single most
       ownable "big idea" (one memorable sentence). Keep it to half a page.
     model: sonnet

--- a/src/sandcastle/templates/campaign_in_a_box.yaml
+++ b/src/sandcastle/templates/campaign_in_a_box.yaml
@@ -1,0 +1,89 @@
+# name: Campaign-in-a-Box
+# description: One product line in, a launch-ready campaign out - big idea, 3 competing angles judged, channel copy, and a 4-week calendar
+# tags: [marketing, campaign, copywriting, launch]
+# category: marketing
+
+name: campaign-in-a-box
+description: One product line in, a launch-ready campaign out - big idea, 3 competing angles judged, channel copy, and a 4-week calendar
+
+default_model: sonnet
+default_max_turns: 6
+default_timeout: 240
+
+input_schema:
+  required: ["product_or_offer"]
+  properties:
+    product_or_offer:
+      type: string
+      description: "The product, feature, or offer to build a campaign around"
+      example: "a local-first AI agent that runs on your own hardware"
+    campaign_goal:
+      type: string
+      description: "Optional goal, e.g. 'drive signups', 'launch announcement', 'reposition'"
+      example: "launch announcement"
+
+steps:
+  - id: brief
+    prompt: >
+      Read this offer and write a tight creative brief. Offer: {input.product_or_offer}.
+      Goal (may be empty): {input.campaign_goal}.
+      Extract: the core promise, the target audience, the pain it removes, and the single most
+      ownable "big idea" (one memorable sentence). Keep it to half a page.
+    model: sonnet
+    max_turns: 4
+
+  - id: angle-rational
+    depends_on: [brief]
+    prompt: >
+      You are a Creative Director who sells with logic and proof. From this brief, pitch ONE
+      campaign angle: the headline idea, the argument, and a sample hero line. Brief: {steps.brief.output}
+    model: sonnet
+    max_turns: 4
+
+  - id: angle-emotional
+    depends_on: [brief]
+    prompt: >
+      You are a Creative Director who sells with emotion and story. From this brief, pitch ONE
+      campaign angle: the headline idea, the feeling it evokes, and a sample hero line.
+      Brief: {steps.brief.output}
+    model: sonnet
+    max_turns: 4
+
+  - id: angle-contrarian
+    depends_on: [brief]
+    prompt: >
+      You are a contrarian Creative Director who wins attention by challenging the category's
+      orthodoxy. From this brief, pitch ONE bold, against-the-grain angle: the provocation, why
+      it's true, and a sample hero line. Brief: {steps.brief.output}
+    model: sonnet
+    max_turns: 4
+
+  - id: pick-winner
+    depends_on: [angle-rational, angle-emotional, angle-contrarian]
+    prompt: >
+      You are the Executive Creative Director. Three angles are on the table:
+      RATIONAL: {steps.angle-rational.output}
+      EMOTIONAL: {steps.angle-emotional.output}
+      CONTRARIAN: {steps.angle-contrarian.output}
+      Pick the single strongest angle for the goal, explain in 2 lines why it wins, and briefly
+      say why each of the other two was rejected. Restate the winning big idea and hero line.
+    model: sonnet
+    max_turns: 5
+
+  - id: channel-copy
+    depends_on: [pick-winner]
+    prompt: >
+      Expand the winning angle into ready-to-ship copy. Winner: {steps.pick-winner.output}.
+      Produce: a 3-email launch sequence (subject + body), 3 LinkedIn posts, a landing-page hero
+      (headline, subhead, CTA), and 5 ad headlines. Keep the voice consistent with the big idea.
+    model: sonnet
+    max_turns: 6
+
+  - id: calendar
+    depends_on: [channel-copy]
+    prompt: >
+      Turn this campaign into a 4-week phased rollout calendar (tease -> launch -> proof -> push),
+      mapping the assets to weeks, with one KPI per phase and a launch-day checklist.
+      Assets: {steps.channel-copy.output}
+    model: haiku
+    max_turns: 4

--- a/src/sandcastle/templates/competitor_teardown_live.yaml
+++ b/src/sandcastle/templates/competitor_teardown_live.yaml
@@ -1,0 +1,66 @@
+# name: Competitor Teardown (Live)
+# description: Name a rival and get a web-researched teardown - live SWOT, positioning map, pricing read, and a ready-to-use sales battlecard
+# tags: [marketing, power, competitive, swot, battlecard, web]
+# category: marketing
+
+name: competitor-teardown-live
+description: Name a rival and get a web-researched teardown - live SWOT, positioning map, pricing read, and a ready-to-use sales battlecard
+
+default_model: sonnet
+default_max_turns: 8
+default_timeout: 300
+# Live web research. `websearch` is keyless/free (DuckDuckGo + Jina Reader); Tavily
+# is an optional paid fallback (TOOL_TAVILY_API_KEY). Needs a tool-capable cloud model.
+default_tools: [websearch, tavily]
+
+input_schema:
+  required: ["competitor"]
+  properties:
+    competitor:
+      type: string
+      description: "Competitor to tear down"
+      example: "Acme CRM"
+    our_company:
+      type: string
+      description: "Optional - your company + one line, for head-to-head positioning"
+      example: "Sandcastle - local-first AI workflow orchestrator"
+
+steps:
+  - id: research
+    prompt: >
+      Use web search to build a current dossier on "{input.competitor}". Run several searches:
+      the product/site, "{input.competitor} pricing", "{input.competitor} reviews",
+      "{input.competitor} vs", and recent news/launches. Collect: what they sell, target customer,
+      pricing/packaging, positioning and messaging, notable customers, recent moves, and the praise
+      and complaints users actually voice. Quote specifics and CITE source URLs. Flag anything you
+      could not verify rather than guessing.
+    model: sonnet
+    max_turns: 12
+
+  - id: strengths
+    depends_on: [research]
+    prompt: >
+      From the live dossier, assess {input.competitor}'s real strengths and moats (product, brand,
+      distribution, pricing power, ecosystem). Dossier: {steps.research.output}
+    model: sonnet
+    max_turns: 5
+
+  - id: weaknesses
+    depends_on: [research]
+    prompt: >
+      From the live dossier, find {input.competitor}'s exploitable weaknesses and gaps (product holes,
+      common complaints, pricing friction, segments they underserve). Dossier: {steps.research.output}
+    model: sonnet
+    max_turns: 5
+
+  - id: battlecard
+    depends_on: [strengths, weaknesses]
+    prompt: >
+      Build the final teardown for {input.competitor}. Our side (may be empty): {input.our_company}.
+      Strengths: {steps.strengths.output}
+      Weaknesses: {steps.weaknesses.output}
+      Produce: a SWOT, a one-paragraph positioning read, a pricing read, and a sales BATTLECARD with
+      5 "when they say X, we say Y" objection handlers and the 3 sharpest ways to win against them.
+      Keep it skimmable and ready to hand a rep.
+    model: sonnet
+    max_turns: 6

--- a/tests/test_api_integration_v27.py
+++ b/tests/test_api_integration_v27.py
@@ -443,12 +443,12 @@ class TestStatsHeatmap:
         resp = client.get("/api/stats/heatmap")
         assert resp.status_code == 200
 
-    def test_returns_182_days(self):
-        """Heatmap covers 26 weeks = 182 days."""
+    def test_returns_364_days(self):
+        """Heatmap covers 52 weeks = 364 days."""
         resp = client.get("/api/stats/heatmap")
         data = resp.json()["data"]
         assert isinstance(data, list)
-        assert len(data) == 182
+        assert len(data) == 364
 
     def test_each_cell_has_date_count_day_of_week(self):
         resp = client.get("/api/stats/heatmap")

--- a/tests/test_connectors_deep.py
+++ b/tests/test_connectors_deep.py
@@ -475,11 +475,11 @@ class TestDuplicateDetection:
 # ---------------------------------------------------------------------------
 
 class TestTotalConnectorCount:
-    EXPECTED_REGISTRY_COUNT = 63  # 62 + gemini vision connector (tool-step UGC)
-    EXPECTED_MJS_ON_DISK = 64    # 63 + gemini.mjs
+    EXPECTED_REGISTRY_COUNT = 64  # 63 + websearch (keyless free web search)
+    EXPECTED_MJS_ON_DISK = 65    # 64 + websearch.mjs
 
     def test_registry_has_expected_count(self):
-        """TOOL_REGISTRY must have exactly 63 entries."""
+        """TOOL_REGISTRY must have exactly 64 entries."""
         count = len(TOOL_REGISTRY)
         assert count == self.EXPECTED_REGISTRY_COUNT, (
             f"Expected {self.EXPECTED_REGISTRY_COUNT} registry entries, got {count}. "
@@ -487,7 +487,7 @@ class TestTotalConnectorCount:
         )
 
     def test_mjs_files_on_disk_count(self):
-        """There must be exactly 64 .mjs files in connectors/ (63 tools + 1 utility)."""
+        """There must be exactly 65 .mjs files in connectors/ (64 tools + 1 utility)."""
         mjs_files = list(CONNECTORS_DIR.glob("*.mjs"))
         count = len(mjs_files)
         assert count == self.EXPECTED_MJS_ON_DISK, (

--- a/tests/test_living_dashboard.py
+++ b/tests/test_living_dashboard.py
@@ -121,11 +121,11 @@ class TestHeatmap:
         body = resp.json()
         assert "data" in body
 
-    def test_returns_182_days(self):
+    def test_returns_364_days(self):
         resp = client.get("/api/stats/heatmap")
         data = resp.json()["data"]
         assert isinstance(data, list)
-        assert len(data) == 182
+        assert len(data) == 364
 
     def test_cell_schema(self):
         resp = client.get("/api/stats/heatmap")
@@ -157,8 +157,8 @@ class TestHeatmap:
         """Days with no runs should appear with count=0, not be omitted."""
         resp = client.get("/api/stats/heatmap")
         data = resp.json()["data"]
-        # All 182 days must be present regardless of whether there are runs
-        assert len(data) == 182
+        # All 364 days must be present regardless of whether there are runs
+        assert len(data) == 364
 
     @pytest.mark.anyio
     async def test_counts_reflect_real_runs(self):

--- a/tests/test_routes_coverage.py
+++ b/tests/test_routes_coverage.py
@@ -231,12 +231,12 @@ class TestStatsSparklines:
 class TestStatsHeatmap:
     """GET /stats/heatmap"""
 
-    def test_heatmap_returns_182_days(self):
-        """Heatmap always returns 182 cells (26 weeks)."""
+    def test_heatmap_returns_364_days(self):
+        """Heatmap always returns 364 cells (52 weeks)."""
         resp = client.get("/api/stats/heatmap")
         assert resp.status_code == 200
         cells = resp.json()["data"]
-        assert len(cells) == 182
+        assert len(cells) == 364
 
     def test_heatmap_cell_structure(self):
         """Each cell has date, count, day_of_week."""


### PR DESCRIPTION
Base of the visual-revamp stack. Bundles the dashboard groundwork the revamp builds on:

- **Lite mode**: guided beginner wizard + simplified UI, 4 pro starter templates, required template inputs before Run
- **Keyless web search**: free reader-on-SERP search with optional-key UX, actionable rate-limit messaging, web-powered marketing templates
- **Run-activity heatmap**: crisper full-width 52-week heatmap with responsive cells

Stack: this PR ← `feat/visual-sand-ink` ← (`feat/visual-panels`, `feat/visual-status-lights`, `feat/visual-brand-moments`, `feat/visual-motion`). Merge this first.