### PR TITLE
feat(dashboard): Sand & Ink — warm brand palette + display typography (visual 1/5)

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="light">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' ws: wss:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' ws: wss:;">
     <link rel="icon" type="image/svg+xml" href="/sandcastle-logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sandcastle Dashboard</title>

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "dashboard",
-  "version": "0.0.0",
+  "version": "0.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard",
-      "version": "0.0.0",
+      "version": "0.33.0",
       "dependencies": {
+        "@fontsource/bricolage-grotesque": "^5.2.10",
         "@xyflow/react": "^12.10.2",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -1168,6 +1169,15 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource/bricolage-grotesque": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource/bricolage-grotesque/-/bricolage-grotesque-5.2.10.tgz",
+      "integrity": "sha512-V2xS+1P7C8IrSypXLUx/bLtX/LsTlYtV2k2CsU+S/0t8qepZ2hvKSlyJIx7Ub/iY8Bbnj+IjAuUF9nvFz+BbIg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@fontsource/bricolage-grotesque": "^5.2.10",
     "@xyflow/react": "^12.10.2",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/dashboard/src/components/overview/BentoHealthHero.tsx
+++ b/dashboard/src/components/overview/BentoHealthHero.tsx
@@ -54,7 +54,7 @@ export function BentoHealthHero({
         <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1">
           Workflow Command Center
         </p>
-        <p className="text-5xl font-bold text-foreground tracking-tight leading-none">
+        <p className="font-display text-5xl font-bold text-foreground tracking-tight leading-none">
           {totalRuns}
         </p>
         <p className="mt-1 text-sm text-muted-foreground">workflows ran today</p>

--- a/dashboard/src/components/overview/BentoStats.tsx
+++ b/dashboard/src/components/overview/BentoStats.tsx
@@ -73,7 +73,7 @@ export function BentoStatCard({
       <div className="flex items-end justify-between gap-2">
         <div>
           <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-0.5">{label}</p>
-          <p className="text-3xl font-bold text-foreground tracking-tight leading-none">{value}</p>
+          <p className="font-display text-3xl font-bold text-foreground tracking-tight leading-none">{value}</p>
         </div>
         {spark && spark.values.length >= 2 && <Sparkline values={spark.values} />}
       </div>

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -1,24 +1,29 @@
 @import "tailwindcss";
 
+/* ──── Sand & Ink brand tokens ────
+   Light = "paper & sand": warm paper ground, ink-black text, amber accent.
+   Dark = "midnight control room": warm near-black, phosphor-amber accent. */
+
 @theme {
   --font-sans: "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif;
   --font-mono: "IBM Plex Mono", ui-monospace, monospace;
+  --font-display: "Bricolage Grotesque", "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif;
 
-  --color-background: #FAFAFA;
-  --color-surface: #FFFFFF;
-  --color-border: #E5E5E5;
-  --color-foreground: #171717;
-  --color-muted: #737373;
-  --color-muted-foreground: #A3A3A3;
+  --color-background: #F7F3EC;
+  --color-surface: #FDFBF7;
+  --color-border: #E8E0D2;
+  --color-foreground: #1C1814;
+  --color-muted: #6E6356;
+  --color-muted-foreground: #857A6A;
   --color-accent: #F59E0B;
   --color-accent-hover: #D97706;
-  --color-accent-foreground: #FFFFFF;
-  --color-success: #22C55E;
-  --color-error: #EF4444;
+  --color-accent-foreground: #1C1814;
+  --color-success: #3FB950;
+  --color-error: #E8543F;
   --color-warning: #F59E0B;
   --color-running: #3B82F6;
   --color-queued: #A78BFA;
-  --color-input: #E5E5E5;
+  --color-input: #E8E0D2;
   --color-ring: #F59E0B;
 
   --radius-sm: 0.25rem;
@@ -28,16 +33,16 @@
 }
 
 .dark {
-  --color-background: #0A0A0A;
-  --color-surface: #171717;
-  --color-border: #262626;
-  --color-foreground: #FAFAFA;
-  --color-muted: #A3A3A3;
-  --color-muted-foreground: #737373;
+  --color-background: #0E0C09;
+  --color-surface: #181410;
+  --color-border: #2A241C;
+  --color-foreground: #F4EFE6;
+  --color-muted: #B0A595;
+  --color-muted-foreground: #867B6B;
   --color-accent: #FBBF24;
   --color-accent-hover: #F59E0B;
-  --color-accent-foreground: #171717;
-  --color-input: #262626;
+  --color-accent-foreground: #1C1814;
+  --color-input: #2A241C;
   --color-ring: #FBBF24;
 }
 
@@ -46,10 +51,20 @@
     outline: none;
   }
   :focus-visible {
-    outline: 2px solid var(--accent);
+    outline: 2px solid var(--color-ring);
     outline-offset: 2px;
     border-radius: inherit;
   }
+}
+
+/* Text selection: amber on ink */
+::selection {
+  background: #F59E0B;
+  color: #1C1814;
+}
+.dark ::selection {
+  background: #FBBF24;
+  color: #0E0C09;
 }
 
 body {
@@ -64,17 +79,26 @@ body {
   font-variant-numeric: tabular-nums;
 }
 
-/* Utility: amber glow for featured elements */
-.glow-accent {
-  box-shadow: 0 0 20px rgba(245, 158, 11, 0.15), 0 0 40px rgba(245, 158, 11, 0.05);
-}
-.dark .glow-accent {
-  box-shadow: 0 0 20px rgba(251, 191, 36, 0.2), 0 0 40px rgba(251, 191, 36, 0.08);
+/* Utility: display face for hero numbers and page-title headlines only */
+.font-display {
+  font-family: var(--font-display);
 }
 
-/* Utility: grid dot pattern background */
+/* Utility: amber glow for featured elements */
+.glow-accent {
+  box-shadow: 0 0 20px rgba(217, 119, 6, 0.16), 0 0 40px rgba(217, 119, 6, 0.06);
+}
+.dark .glow-accent {
+  box-shadow: 0 0 20px rgba(251, 191, 36, 0.22), 0 0 40px rgba(251, 191, 36, 0.09);
+}
+
+/* Utility: grid dot pattern background (sand-tinted dots) */
 .bg-grid {
-  background-image: radial-gradient(circle, var(--color-border) 1px, transparent 1px);
+  background-image: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--color-border) 80%, var(--color-accent) 20%) 1px,
+    transparent 1px
+  );
   background-size: 24px 24px;
 }
 
@@ -88,7 +112,7 @@ body {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--color-border);
+  background: color-mix(in srgb, var(--color-border) 85%, var(--color-accent) 15%);
   border-radius: 3px;
 }
 
@@ -260,13 +284,13 @@ button:active:not(:disabled), [role="button"]:active:not(:disabled), .btn:active
 }
 
 @keyframes terminal-success-flash {
-  0%   { box-shadow: inset 0 0 30px rgba(34, 197, 94, 0.08); }
-  100% { box-shadow: inset 0 0 0px rgba(34, 197, 94, 0); }
+  0%   { box-shadow: inset 0 0 30px rgba(63, 185, 80, 0.08); }
+  100% { box-shadow: inset 0 0 0px rgba(63, 185, 80, 0); }
 }
 
 @keyframes terminal-error-flash {
-  0%   { box-shadow: inset 0 0 30px rgba(239, 68, 68, 0.08); }
-  100% { box-shadow: inset 0 0 0px rgba(239, 68, 68, 0); }
+  0%   { box-shadow: inset 0 0 30px rgba(232, 84, 63, 0.08); }
+  100% { box-shadow: inset 0 0 0px rgba(232, 84, 63, 0); }
 }
 
 @keyframes log-line-enter {
@@ -338,11 +362,11 @@ button:active:not(:disabled), [role="button"]:active:not(:disabled), .btn:active
 }
 .terminal-success {
   animation: terminal-success-flash 0.8s ease-out both;
-  border-color: rgba(34, 197, 94, 0.3);
+  border-color: rgba(63, 185, 80, 0.3);
 }
 .terminal-error {
   animation: terminal-error-flash 0.8s ease-out both;
-  border-color: rgba(239, 68, 68, 0.3);
+  border-color: rgba(232, 84, 63, 0.3);
 }
 
 /* SVG checkmark stroke draw */
@@ -403,8 +427,8 @@ button:active:not(:disabled), [role="button"]:active:not(:disabled), .btn:active
 /* ──── Bell pulse animation (critical insights) ──── */
 
 @keyframes bell-pulse-critical {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0); }
-  50%      { box-shadow: 0 0 6px 2px rgba(239, 68, 68, 0.25); }
+  0%, 100% { box-shadow: 0 0 0 0 rgba(232, 84, 63, 0); }
+  50%      { box-shadow: 0 0 6px 2px rgba(232, 84, 63, 0.25); }
 }
 
 .bell-pulse-critical {

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -1,6 +1,9 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { Toaster } from "sonner";
+// Self-hosted display face (local-first; no CDN). Used only via .font-display.
+import "@fontsource/bricolage-grotesque/600.css";
+import "@fontsource/bricolage-grotesque/700.css";
 import "./index.css";
 import App from "./App.tsx";
 

--- a/dashboard/src/pages/ApiKeysPage.tsx
+++ b/dashboard/src/pages/ApiKeysPage.tsx
@@ -193,7 +193,7 @@ export default function ApiKeysPage() {
   if (error) {
     return (
       <div>
-        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold tracking-tight text-foreground">API Keys</h1>
+        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">API Keys</h1>
         <div className="rounded-xl border border-error/30 bg-error/5 p-4">
           <p className="text-sm text-error">{error}</p>
           <button
@@ -210,7 +210,7 @@ export default function ApiKeysPage() {
   return (
     <div className="space-y-4 sm:space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-foreground">API Keys</h1>
+        <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">API Keys</h1>
         <button
           onClick={() => setCreateModalOpen(true)}
           aria-label="New API key"

--- a/dashboard/src/pages/ApprovalsPage.tsx
+++ b/dashboard/src/pages/ApprovalsPage.tsx
@@ -176,7 +176,7 @@ export default function ApprovalsPage() {
   if (error) {
     return (
       <div>
-        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold tracking-tight text-foreground">Approval Gates</h1>
+        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">Approval Gates</h1>
         <div className="rounded-xl border border-error/30 bg-error/5 p-4">
           <p className="text-sm text-error">{error}</p>
           <button
@@ -194,7 +194,7 @@ export default function ApprovalsPage() {
     <div className="space-y-4 sm:space-y-6">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-foreground">Approval Gates</h1>
+          <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">Approval Gates</h1>
           {pendingCount > 0 && (
             <span className="flex h-6 min-w-6 items-center justify-center rounded-full bg-warning px-2 text-xs font-semibold text-white">
               {pendingCount}

--- a/dashboard/src/pages/AutoPilotPage.tsx
+++ b/dashboard/src/pages/AutoPilotPage.tsx
@@ -165,7 +165,7 @@ export default function AutoPilotPage() {
   if (error) {
     return (
       <div>
-        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold tracking-tight text-foreground">AutoPilot</h1>
+        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">AutoPilot</h1>
         <div className="rounded-xl border border-error/30 bg-error/5 p-4">
           <p className="text-sm text-error">{error}</p>
           <button
@@ -181,7 +181,7 @@ export default function AutoPilotPage() {
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-foreground">AutoPilot</h1>
+      <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">AutoPilot</h1>
 
       {/* Stats cards */}
       {stats && (

--- a/dashboard/src/pages/CompliancePage.tsx
+++ b/dashboard/src/pages/CompliancePage.tsx
@@ -153,7 +153,7 @@ export default function CompliancePage() {
   if (error) {
     return (
       <div>
-        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold tracking-tight text-foreground">Compliance</h1>
+        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">Compliance</h1>
         <div className="rounded-xl border border-error/30 bg-error/5 p-4">
           <p className="text-sm text-error">{error}</p>
           <button
@@ -175,7 +175,7 @@ export default function CompliancePage() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <Shield className="h-6 w-6 text-muted" />
-          <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-foreground">
+          <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">
             Compliance
           </h1>
           <span

--- a/dashboard/src/pages/DeadLetterPage.tsx
+++ b/dashboard/src/pages/DeadLetterPage.tsx
@@ -140,7 +140,7 @@ export default function DeadLetterPage() {
   if (error) {
     return (
       <div>
-        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold tracking-tight text-foreground">Dead Letter Queue</h1>
+        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">Dead Letter Queue</h1>
         <div className="rounded-xl border border-error/30 bg-error/5 p-4">
           <p className="text-sm text-error">{error}</p>
           <button
@@ -158,7 +158,7 @@ export default function DeadLetterPage() {
     <div className="space-y-4 sm:space-y-6">
       {/* Header row */}
       <div className="flex items-center justify-between">
-        <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-foreground">
+        <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">
           Dead Letter Queue
         </h1>
 

--- a/dashboard/src/pages/EvaluationsPage.tsx
+++ b/dashboard/src/pages/EvaluationsPage.tsx
@@ -166,7 +166,7 @@ export default function EvaluationsPage() {
   return (
     <div className="space-y-4 sm:space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-foreground">
+        <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">
           Evaluations
         </h1>
         <button

--- a/dashboard/src/pages/EvolutionPage.tsx
+++ b/dashboard/src/pages/EvolutionPage.tsx
@@ -909,7 +909,7 @@ export default function EvolutionPage() {
   if (error) {
     return (
       <div>
-        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold tracking-tight text-foreground">
+        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">
           Workflow Evolution
         </h1>
         <div className="rounded-xl border border-error/30 bg-error/5 p-4">
@@ -935,7 +935,7 @@ export default function EvolutionPage() {
     <div className="space-y-4 sm:space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-foreground">
+        <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">
           Workflow Evolution
         </h1>
         <button

--- a/dashboard/src/pages/IntegrationsPage.tsx
+++ b/dashboard/src/pages/IntegrationsPage.tsx
@@ -187,7 +187,7 @@ export default function IntegrationsPage() {
     <div className="space-y-4 sm:space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-foreground">Integrations</h1>
+        <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">Integrations</h1>
         <p className="mt-1 text-sm text-muted">
           Connect your workflows to external services and APIs.
         </p>

--- a/dashboard/src/pages/MemoryPage.tsx
+++ b/dashboard/src/pages/MemoryPage.tsx
@@ -157,7 +157,7 @@ export default function MemoryPage() {
   if (error) {
     return (
       <div>
-        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold tracking-tight text-foreground">
+        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">
           Agent Memory
         </h1>
         <div className="rounded-xl border border-error/30 bg-error/5 p-4">
@@ -181,7 +181,7 @@ export default function MemoryPage() {
       {/* Header */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-foreground">
+          <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">
             Agent Memory
           </h1>
           <p className="mt-1 text-sm text-muted">

--- a/dashboard/src/pages/OptimizerPage.tsx
+++ b/dashboard/src/pages/OptimizerPage.tsx
@@ -130,7 +130,7 @@ export default function OptimizerPage() {
   if (error) {
     return (
       <div>
-        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold tracking-tight text-foreground">Cost-Latency Optimizer</h1>
+        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">Cost-Latency Optimizer</h1>
         <div className="rounded-xl border border-error/30 bg-error/5 p-4">
           <p className="text-sm text-error">{error}</p>
           <button
@@ -150,7 +150,7 @@ export default function OptimizerPage() {
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-foreground">Cost-Latency Optimizer</h1>
+      <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">Cost-Latency Optimizer</h1>
 
       {stats && stats.estimated_savings_30d_usd > 1 && (
         <ContextBanner variant="info" icon={Coins}>

--- a/dashboard/src/pages/OverviewBento.tsx
+++ b/dashboard/src/pages/OverviewBento.tsx
@@ -57,7 +57,7 @@ export default function OverviewBento() {
             <div className="flex items-center justify-center w-8 h-8 rounded-xl bg-accent">
               <Castle className="h-4 w-4 text-accent-foreground" />
             </div>
-            <h1 className="text-xl font-bold tracking-tight text-foreground">Overview</h1>
+            <h1 className="text-xl font-bold font-display tracking-tight text-foreground">Overview</h1>
           </div>
         </div>
 
@@ -91,7 +91,7 @@ export default function OverviewBento() {
           <div className="flex items-center justify-center w-8 h-8 rounded-xl bg-accent">
             <Castle className="h-4 w-4 text-accent-foreground" />
           </div>
-          <h1 className="text-xl font-bold tracking-tight text-foreground">Overview</h1>
+          <h1 className="text-xl font-bold font-display tracking-tight text-foreground">Overview</h1>
         </div>
       </div>
 

--- a/dashboard/src/pages/OverviewFocus.tsx
+++ b/dashboard/src/pages/OverviewFocus.tsx
@@ -165,7 +165,7 @@ function FocusStatCard({
       <div className="flex items-end justify-between gap-2">
         <div>
           <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1">{label}</p>
-          <p className="text-3xl font-bold text-foreground tracking-tight leading-none">{value}</p>
+          <p className="font-display text-3xl font-bold text-foreground tracking-tight leading-none">{value}</p>
         </div>
         {spark && spark.values.length >= 2 && (
           <Sparkline values={spark.values} />

--- a/dashboard/src/pages/RunComparePage.tsx
+++ b/dashboard/src/pages/RunComparePage.tsx
@@ -504,7 +504,7 @@ export default function RunComparePage() {
 
       {/* Header + Run Selectors */}
       <div className="rounded-xl border border-border bg-surface p-4 sm:p-5 shadow-sm">
-        <h1 className="text-xl font-semibold tracking-tight text-foreground mb-4">
+        <h1 className="text-xl font-semibold font-display tracking-tight text-foreground mb-4">
           Replay Studio
         </h1>
 

--- a/dashboard/src/pages/RunDetailPage.tsx
+++ b/dashboard/src/pages/RunDetailPage.tsx
@@ -519,7 +519,7 @@ export default function RunDetailPage() {
       <div className="rounded-xl border border-border bg-surface p-3 sm:p-5 shadow-sm">
         <div className="flex flex-wrap items-start justify-between gap-3 sm:gap-4">
           <div className="min-w-0 flex-1">
-            <h1 className="text-lg sm:text-xl font-semibold tracking-tight text-foreground">
+            <h1 className="text-lg sm:text-xl font-semibold font-display tracking-tight text-foreground">
               {run.workflow_name}
             </h1>
             <p className="mt-1 flex items-center gap-1 font-mono text-xs text-muted truncate">

--- a/dashboard/src/pages/Runs.tsx
+++ b/dashboard/src/pages/Runs.tsx
@@ -208,7 +208,7 @@ export default function Runs() {
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-foreground">Runs</h1>
+      <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">Runs</h1>
 
       {/* Failure rate banner */}
       {successRate != null && successRate < 0.9 && (

--- a/dashboard/src/pages/ScheduleMonitorPage.tsx
+++ b/dashboard/src/pages/ScheduleMonitorPage.tsx
@@ -174,7 +174,7 @@ export default function ScheduleMonitorPage() {
   if (error) {
     return (
       <div>
-        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold tracking-tight text-foreground">
+        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">
           Schedule Monitor
         </h1>
         <div className="rounded-xl border border-error/30 bg-error/5 p-4">
@@ -194,7 +194,7 @@ export default function ScheduleMonitorPage() {
     <div className="space-y-4 sm:space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-foreground">
+        <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">
           Schedule Monitor
         </h1>
         <button

--- a/dashboard/src/pages/Schedules.tsx
+++ b/dashboard/src/pages/Schedules.tsx
@@ -129,7 +129,7 @@ export default function Schedules() {
   if (error) {
     return (
       <div>
-        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold tracking-tight text-foreground">Schedules</h1>
+        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">Schedules</h1>
         <div className="rounded-xl border border-error/30 bg-error/5 p-4">
           <p className="text-sm text-error">{error}</p>
           <button
@@ -146,7 +146,7 @@ export default function Schedules() {
   return (
     <div className="space-y-4 sm:space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-foreground">Schedules</h1>
+        <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">Schedules</h1>
         <button
           onClick={() => setModalOpen(true)}
           aria-label="New schedule"

--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -480,7 +480,7 @@ export default function SettingsPage() {
     <div className="space-y-4 sm:space-y-6">
       <div className="flex items-center gap-3">
         <Settings className="h-6 w-6 text-muted" />
-        <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-foreground">
+        <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">
           Settings
         </h1>
       </div>

--- a/dashboard/src/pages/SystemHealthPage.tsx
+++ b/dashboard/src/pages/SystemHealthPage.tsx
@@ -241,7 +241,7 @@ export default function SystemHealthPage() {
   if (error) {
     return (
       <div>
-        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold tracking-tight text-foreground">System Health</h1>
+        <h1 className="mb-4 sm:mb-6 text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">System Health</h1>
         <div className="rounded-xl border border-error/30 bg-error/5 p-4">
           <p className="text-sm text-error">{error}</p>
           <button
@@ -261,7 +261,7 @@ export default function SystemHealthPage() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <HeartPulse className="h-6 w-6 text-muted" />
-          <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-foreground">
+          <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">
             System Health
           </h1>
           {/* Overall status badge */}

--- a/dashboard/src/pages/TemplatesPage.tsx
+++ b/dashboard/src/pages/TemplatesPage.tsx
@@ -731,7 +731,7 @@ export default function TemplatesPage() {
             <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-accent/15">
               <Layers className="h-5 w-5 text-accent" />
             </div>
-            <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-foreground">
+            <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">
               Template Hub
             </h1>
           </div>

--- a/dashboard/src/pages/ViolationsPage.tsx
+++ b/dashboard/src/pages/ViolationsPage.tsx
@@ -105,7 +105,7 @@ export default function ViolationsPage() {
   return (
     <div className="space-y-4 sm:space-y-6">
       <div className="flex items-center gap-3">
-        <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-foreground">Policy Violations</h1>
+        <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">Policy Violations</h1>
       </div>
 
       {/* Critical violations banner */}

--- a/dashboard/src/pages/WorkflowBuilderPage.tsx
+++ b/dashboard/src/pages/WorkflowBuilderPage.tsx
@@ -135,7 +135,7 @@ export default function WorkflowBuilderPage() {
 
   return (
     <div className="space-y-3 sm:space-y-4">
-      <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-foreground">Workflow Builder</h1>
+      <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">Workflow Builder</h1>
       <WorkflowBuilder
         onSave={handleSave}
         onRun={handleRunClick}

--- a/dashboard/src/pages/WorkflowDetailPage.tsx
+++ b/dashboard/src/pages/WorkflowDetailPage.tsx
@@ -155,7 +155,7 @@ export default function WorkflowDetailPage() {
       <div className="rounded-xl border border-border bg-surface p-4 sm:p-5 shadow-sm">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h1 className="flex items-center gap-1 text-xl font-semibold tracking-tight text-foreground">
+            <h1 className="flex items-center gap-1 text-xl font-semibold font-display tracking-tight text-foreground">
               {data.workflow_name}
               <CopyButton value={data.workflow_name} label="workflow name" />
             </h1>

--- a/dashboard/src/pages/Workflows.tsx
+++ b/dashboard/src/pages/Workflows.tsx
@@ -170,7 +170,7 @@ export default function Workflows() {
   return (
     <div className="space-y-4 sm:space-y-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <h1 className="text-xl sm:text-2xl font-semibold tracking-tight text-foreground">Workflows</h1>
+        <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">Workflows</h1>
         <div className="flex flex-1 items-center gap-2 sm:flex-none">
           <div className="relative flex-1 sm:flex-none">
             <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted" />


### PR DESCRIPTION
**Visual revamp 1/5 — the foundation.** Replaces the cold neutral grayscale with an ownable "Sand & Ink" world:

- Light mode "paper & sand": warm sand background `#F7F3EC`, warm off-white surfaces, ink-black foreground `#1C1814`, warm taupe muted tones
- Dark mode "midnight control room": warm near-black `#0E0C09`, amber as glowing phosphor accent
- Display typography: self-hosted **Bricolage Grotesque** (`@fontsource`, no CDN — local-first) via `--font-display`, applied to page titles and hero stat numbers
- Token-level polish: amber-on-ink selection, warm scrollbars, re-tinted `.glow-accent`/`.bg-grid`, fixed a latent focus-ring bug (`var(--accent)` → `var(--color-ring)`)
- Contrast verified WCAG AA in both modes (fg/bg 15.95 light, 17.05 dark; accent-foreground ink-on-amber 8.22, up from 2.15)

Stacked on #255. The other four visual PRs (`panels`, `status-lights`, `brand-moments`, `motion`) are based on this branch.

Tests: vitest 805/805, lint zero new errors, build green.