### PR TITLE
feat(dashboard): instrument-panel layout language (visual 2/5)

### DIFF
--- a/dashboard/src/__tests__/pages-hooks-wave9.test.tsx
+++ b/dashboard/src/__tests__/pages-hooks-wave9.test.tsx
@@ -769,7 +769,7 @@ describe("SystemHealthPage", () => {
     setupHealthyApi();
     render(<SystemHealthPage />);
     await waitFor(() => {
-      expect(screen.getByText("Total Runs (today)")).toBeInTheDocument();
+      expect(screen.getByText("Total Runs · Today")).toBeInTheDocument();
     });
     // Quick stats values - some numbers may appear in multiple places
     expect(screen.getAllByText("42").length).toBeGreaterThanOrEqual(1);

--- a/dashboard/src/components/overview/BentoActivityFeed.tsx
+++ b/dashboard/src/components/overview/BentoActivityFeed.tsx
@@ -23,8 +23,8 @@ export function BentoActivityFeed({ events, loading }: { events: AuditEvent[]; l
         "hover:border-accent/30 transition-all duration-300",
         "overflow-hidden",
       )}>
-        <div className="px-5 py-4 border-b border-border">
-          <h3 className="text-sm font-semibold text-foreground">Activity Feed</h3>
+        <div className="px-4 py-2.5 border-b border-border">
+          <h3 className="panel-label text-muted-foreground">Activity Feed</h3>
         </div>
         <div className="flex items-center justify-center h-40">
           <Skeleton className="h-4 w-32 rounded-lg" />
@@ -40,8 +40,8 @@ export function BentoActivityFeed({ events, loading }: { events: AuditEvent[]; l
         "hover:border-accent/30 transition-all duration-300",
         "overflow-hidden",
       )}>
-        <div className="px-5 py-4 border-b border-border">
-          <h3 className="text-sm font-semibold text-foreground">Activity Feed</h3>
+        <div className="px-4 py-2.5 border-b border-border">
+          <h3 className="panel-label text-muted-foreground">Activity Feed</h3>
         </div>
         <div className="flex items-center justify-center h-24">
           <p className="text-xs text-muted-foreground">No recent events</p>
@@ -56,9 +56,9 @@ export function BentoActivityFeed({ events, loading }: { events: AuditEvent[]; l
       "hover:border-accent/30 transition-all duration-300",
       "overflow-hidden",
     )}>
-      <div className="px-5 py-4 border-b border-border flex items-center justify-between">
-        <h3 className="text-sm font-semibold text-foreground">Activity Feed</h3>
-        <span className="text-[10px] text-muted-foreground">{events.length} events</span>
+      <div className="px-4 py-2.5 border-b border-border flex items-center justify-between">
+        <h3 className="panel-label text-muted-foreground">Activity Feed</h3>
+        <span className="font-data text-[10px] text-muted-foreground">{events.length} events</span>
       </div>
       <div className="max-h-80 overflow-y-auto divide-y divide-border">
         {events.map((event) => {
@@ -72,7 +72,7 @@ export function BentoActivityFeed({ events, loading }: { events: AuditEvent[]; l
               key={event.id}
               onClick={() => event.run_id ? navigate(`/runs/${event.run_id}`) : undefined}
               className={cn(
-                "flex w-full items-center gap-3 px-5 py-3 text-left",
+                "flex w-full items-center gap-3 px-4 py-2 text-left",
                 "hover:bg-background transition-colors duration-150",
                 event.run_id ? "cursor-pointer" : "cursor-default",
               )}
@@ -88,7 +88,7 @@ export function BentoActivityFeed({ events, loading }: { events: AuditEvent[]; l
                 </p>
               </div>
               {costUsd != null && costUsd > 0 && (
-                <span className="text-[10px] font-mono text-muted-foreground shrink-0">
+                <span className="font-data text-[10px] text-muted-foreground shrink-0 text-right">
                   {formatCost(costUsd)}
                 </span>
               )}

--- a/dashboard/src/components/overview/BentoHealthHero.tsx
+++ b/dashboard/src/components/overview/BentoHealthHero.tsx
@@ -28,9 +28,9 @@ export function BentoHealthHero({
 
   return (
     <div className={cn(
-      "bg-surface rounded-2xl shadow-sm border border-border",
-      "hover:border-accent/30 transition-all duration-300",
-      "p-6 flex flex-col gap-4 h-full relative",
+      "bg-surface rounded-md border border-border",
+      "hover:border-accent/30 transition-colors duration-200",
+      "p-5 flex flex-col gap-3.5 h-full relative",
     )}>
       <div className="absolute top-5 right-5">
         {loading ? (
@@ -51,8 +51,8 @@ export function BentoHealthHero({
       </div>
 
       <div>
-        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1">
-          Workflow Command Center
+        <p className="panel-label text-muted-foreground mb-1.5">
+          Command Center · Today
         </p>
         <p className="font-display text-5xl font-bold text-foreground tracking-tight leading-none">
           {totalRuns}
@@ -96,7 +96,7 @@ export function BentoHealthHero({
               key={insight.id}
               to={insight.link}
               className={cn(
-                "flex items-center gap-2.5 rounded-xl px-3 py-2",
+                "flex items-center gap-2.5 rounded-md px-3 py-1.5",
                 "bg-background border border-border",
                 "hover:border-accent/30 hover:bg-surface",
                 "transition-colors duration-150 text-sm",

--- a/dashboard/src/components/overview/BentoHeatmap.tsx
+++ b/dashboard/src/components/overview/BentoHeatmap.tsx
@@ -100,7 +100,7 @@ export function BentoHeatmap({ cells }: { cells: HeatmapCell[] }) {
     >
       <div className="mb-4 flex items-end justify-between gap-3">
         <div>
-          <h3 className="text-sm font-semibold text-foreground">Run activity</h3>
+          <h3 className="panel-label text-muted-foreground">Run activity</h3>
           <p className="mt-0.5 text-[11px] text-muted-foreground">
             {total.toLocaleString()} runs · last 52 weeks
             {busiest && busiest.count > 0 && (

--- a/dashboard/src/components/overview/BentoProviderCosts.tsx
+++ b/dashboard/src/components/overview/BentoProviderCosts.tsx
@@ -39,7 +39,7 @@ export function BentoProviderCosts({
       "p-5 flex flex-col gap-3",
     )}>
       <div className="flex items-center justify-between">
-        <h3 className="text-sm font-semibold text-foreground">Cost by Provider</h3>
+        <h3 className="panel-label text-muted-foreground">Cost by Provider</h3>
         <span className="text-xs text-muted-foreground">Last {period_days} days</span>
       </div>
 
@@ -102,7 +102,7 @@ export function BentoSavingsOpportunities({ savings }: { savings: ProviderSaving
       "hover:border-accent/30 transition-all duration-300",
       "p-5 flex flex-col gap-3",
     )}>
-      <h3 className="text-sm font-semibold text-foreground">Savings Opportunities</h3>
+      <h3 className="panel-label text-muted-foreground">Savings Opportunities</h3>
       <div className="space-y-3">
         {savings.alternatives.slice(0, 3).map((alt) => (
           <div key={alt.provider} className="flex items-start justify-between gap-2">

--- a/dashboard/src/components/overview/BentoRecentRuns.tsx
+++ b/dashboard/src/components/overview/BentoRecentRuns.tsx
@@ -22,23 +22,23 @@ export function BentoRecentRuns({ runs }: { runs: RunItem[] }) {
       "hover:border-accent/30 transition-all duration-300",
       "overflow-hidden",
     )}>
-      <div className="px-5 py-4 border-b border-border">
-        <h3 className="text-sm font-semibold text-foreground">Recent Runs</h3>
+      <div className="px-4 py-2.5 border-b border-border">
+        <h3 className="panel-label text-muted-foreground">Recent Runs</h3>
       </div>
       <div className="divide-y divide-border">
         {runs.slice(0, 5).map((run) => (
           <button
             key={run.run_id}
             onClick={() => navigate(`/runs/${run.run_id}`)}
-            className="flex w-full items-center gap-3 px-5 py-3.5 text-left hover:bg-background transition-colors duration-150"
+            className="flex w-full items-center gap-3 px-4 py-2 text-left hover:bg-background transition-colors duration-150"
           >
             <div className="min-w-0 flex-1">
               <p className="truncate text-sm font-medium text-foreground">{run.workflow_name}</p>
-              <p className="text-xs text-muted-foreground mt-0.5">
+              <p className="text-xs text-muted-foreground">
                 {run.started_at ? formatRelativeTime(run.started_at) : "queued"}
               </p>
             </div>
-            <span className="text-xs font-mono text-muted-foreground shrink-0">
+            <span className="font-data text-xs text-muted-foreground shrink-0 text-right">
               {formatCost(run.total_cost_usd)}
             </span>
             <span className={cn(

--- a/dashboard/src/components/overview/BentoStats.tsx
+++ b/dashboard/src/components/overview/BentoStats.tsx
@@ -47,34 +47,31 @@ interface StatCardProps {
   label: string;
   value: string;
   icon: React.ElementType;
-  iconBg: string;
   iconColor: string;
   spark?: SparklineData;
   positiveIsGood?: boolean;
 }
 
 export function BentoStatCard({
-  label, value, icon: Icon, iconBg, iconColor,
+  label, value, icon: Icon, iconColor,
   spark, positiveIsGood = true,
 }: StatCardProps) {
   return (
     <div className={cn(
-      "bg-surface rounded-2xl shadow-sm border border-border",
-      "p-6",
-      "hover:border-accent/30 transition-all duration-300",
-      "flex flex-col gap-3",
+      "bg-surface rounded-md border border-border",
+      "p-4",
+      "hover:border-accent/30 transition-colors duration-200",
+      "flex flex-col gap-2.5",
     )}>
-      <div className="flex items-start justify-between">
-        <div className={cn("h-9 w-9 rounded-xl flex items-center justify-center", iconBg)}>
-          <Icon className={cn("shrink-0", iconColor)} style={{ height: "18px", width: "18px" }} />
-        </div>
+      <div className="flex items-center justify-between gap-2">
+        <span className="flex min-w-0 items-center gap-1.5">
+          <Icon className={cn("shrink-0", iconColor)} style={{ height: "13px", width: "13px" }} />
+          <span className="panel-label text-muted-foreground truncate">{label}</span>
+        </span>
         {spark && <TrendBadge percent={spark.trendPercent} positiveIsGood={positiveIsGood} />}
       </div>
       <div className="flex items-end justify-between gap-2">
-        <div>
-          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-0.5">{label}</p>
-          <p className="font-display text-3xl font-bold text-foreground tracking-tight leading-none">{value}</p>
-        </div>
+        <p className="font-display text-3xl font-bold text-foreground tracking-tight leading-none">{value}</p>
         {spark && spark.values.length >= 2 && <Sparkline values={spark.values} />}
       </div>
     </div>
@@ -104,7 +101,6 @@ export function BentoStatsRow({
         value={String(totalRuns)}
         icon={Activity}
         iconColor="text-accent"
-        iconBg="bg-accent/10"
         spark={sparklines?.runs}
         positiveIsGood={true}
       />
@@ -113,7 +109,6 @@ export function BentoStatsRow({
         value={`${successRate}%`}
         icon={CheckCircle}
         iconColor="text-success"
-        iconBg="bg-success/10"
         spark={sparklines?.rate}
         positiveIsGood={true}
       />
@@ -122,7 +117,6 @@ export function BentoStatsRow({
         value={formatCost(totalCost)}
         icon={DollarSign}
         iconColor="text-running"
-        iconBg="bg-running/10"
         spark={sparklines?.cost}
         positiveIsGood={false}
       />
@@ -131,7 +125,6 @@ export function BentoStatsRow({
         value={avgDuration > 0 ? `${Math.round(avgDuration)}s` : "n/a"}
         icon={Timer}
         iconColor="text-muted-foreground"
-        iconBg="bg-border"
         spark={sparklines?.duration}
         positiveIsGood={false}
       />

--- a/dashboard/src/components/overview/CostChart.tsx
+++ b/dashboard/src/components/overview/CostChart.tsx
@@ -29,7 +29,7 @@ export function CostChart({ data }: CostChartProps) {
 
   return (
     <div className={cn("rounded-xl border border-border bg-surface p-5 shadow-sm")}>
-      <h3 className="mb-4 text-sm font-semibold text-foreground">Cost by Workflow (7 Days)</h3>
+      <h3 className="mb-3 panel-label text-muted-foreground">Cost by Workflow · 7 Days</h3>
       <ResponsiveContainer width="100%" height={240}>
         <BarChart data={data}>
           <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />

--- a/dashboard/src/components/overview/RunsChart.tsx
+++ b/dashboard/src/components/overview/RunsChart.tsx
@@ -32,7 +32,7 @@ export function RunsChart({ data }: RunsChartProps) {
 
   return (
     <div className={cn("rounded-xl border border-border bg-surface p-5 shadow-sm")}>
-      <h3 className="mb-4 text-sm font-semibold text-foreground">Runs (Last 30 Days)</h3>
+      <h3 className="mb-3 panel-label text-muted-foreground">Runs · Last 30 Days</h3>
       <ResponsiveContainer width="100%" height={240}>
         <LineChart data={data}>
           <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />

--- a/dashboard/src/components/runs/RunsTable.tsx
+++ b/dashboard/src/components/runs/RunsTable.tsx
@@ -51,7 +51,7 @@ export function RunsTable({ runs, allRuns, total, limit, offset, onPageChange, s
   }, [runs, pool]);
 
   return (
-    <div className="rounded-xl border border-border bg-surface shadow-sm overflow-hidden">
+    <div className="rounded-md border border-border bg-surface overflow-hidden">
       <div
         className="overflow-x-auto"
         style={{
@@ -67,7 +67,7 @@ export function RunsTable({ runs, allRuns, total, limit, offset, onPageChange, s
           <thead>
             <tr className="border-b border-border bg-background/50">
               {selectable && (
-                <th className="w-10 px-3 py-3" scope="col">
+                <th className="w-10 px-3 py-2" scope="col">
                   <input
                     type="checkbox"
                     checked={allSelected}
@@ -83,11 +83,11 @@ export function RunsTable({ runs, allRuns, total, limit, offset, onPageChange, s
                   />
                 </th>
               )}
-              <th scope="col" className="hidden sm:table-cell px-3 sm:px-5 py-3 text-left font-medium text-muted">Workflow</th>
-              <th scope="col" className="px-3 sm:px-5 py-3 text-left font-medium text-muted">Status</th>
-              <th scope="col" className="px-3 sm:px-5 py-3 text-left font-medium text-muted">Started</th>
-              <th scope="col" className="hidden md:table-cell px-3 sm:px-5 py-3 text-left font-medium text-muted">Duration</th>
-              <th scope="col" className="px-3 sm:px-5 py-3 text-right font-medium text-muted">Cost</th>
+              <th scope="col" className="hidden sm:table-cell px-3 sm:px-4 py-2 text-left panel-label text-muted-foreground">Workflow</th>
+              <th scope="col" className="px-3 sm:px-4 py-2 text-left panel-label text-muted-foreground">Status</th>
+              <th scope="col" className="px-3 sm:px-4 py-2 text-left panel-label text-muted-foreground">Started</th>
+              <th scope="col" className="hidden md:table-cell px-3 sm:px-4 py-2 text-right panel-label text-muted-foreground">Duration</th>
+              <th scope="col" className="px-3 sm:px-4 py-2 text-right panel-label text-muted-foreground">Cost</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-border">
@@ -110,7 +110,7 @@ export function RunsTable({ runs, allRuns, total, limit, offset, onPageChange, s
                 )}
               >
                 {selectable && (
-                  <td className="w-10 px-3 py-3" onClick={(e) => e.stopPropagation()}>
+                  <td className="w-10 px-3 py-2" onClick={(e) => e.stopPropagation()}>
                     <input
                       type="checkbox"
                       checked={selectedIds?.has(run.run_id) ?? false}
@@ -128,12 +128,12 @@ export function RunsTable({ runs, allRuns, total, limit, offset, onPageChange, s
                     />
                   </td>
                 )}
-                <td className="hidden sm:table-cell px-3 sm:px-5 py-3 font-medium text-foreground">
+                <td className="hidden sm:table-cell px-3 sm:px-4 py-2 font-medium text-foreground">
                   <span title={run.workflow_name}>{run.workflow_name}</span>
                   <span className="ml-2 font-data text-[11px] text-muted-foreground" title={run.run_id}>{run.run_id.slice(0, 8)}</span>
                   <CopyButton value={run.run_id} label="run ID" />
                 </td>
-                <td className="px-3 sm:px-5 py-3">
+                <td className="px-3 sm:px-4 py-2">
                   <span className="inline-flex items-center gap-1.5 flex-wrap">
                     <RunStatusBadge status={run.status} />
                     {run.risk_level && run.risk_level !== "minimal" && (
@@ -142,11 +142,11 @@ export function RunsTable({ runs, allRuns, total, limit, offset, onPageChange, s
                     <AnomalyBadge anomalies={anomalyMap.get(run.run_id) ?? []} />
                   </span>
                 </td>
-                <td className="px-3 sm:px-5 py-3 text-muted">
+                <td className="px-3 sm:px-4 py-2 text-muted">
                   {run.started_at ? formatRelativeTime(run.started_at) : "queued"}
                 </td>
-                <td className="hidden md:table-cell px-3 sm:px-5 py-3 text-muted">{getDuration(run)}</td>
-                <td className="px-3 sm:px-5 py-3 text-right font-data text-muted">
+                <td className="hidden md:table-cell px-3 sm:px-4 py-2 text-right font-data text-muted">{getDuration(run)}</td>
+                <td className="px-3 sm:px-4 py-2 text-right font-data text-muted">
                   {formatCost(run.total_cost_usd)}
                 </td>
               </tr>
@@ -157,7 +157,7 @@ export function RunsTable({ runs, allRuns, total, limit, offset, onPageChange, s
 
       {/* Pagination */}
       {totalPages > 1 && (
-        <div className="flex items-center justify-between border-t border-border px-3 sm:px-5 py-3">
+        <div className="flex items-center justify-between border-t border-border px-3 sm:px-4 py-2.5">
           <p className="text-xs text-muted">
             Showing {total > 0 ? offset + 1 : 0}-{Math.min(offset + limit, total)} of {total}
           </p>

--- a/dashboard/src/components/schedules/ScheduleTable.tsx
+++ b/dashboard/src/components/schedules/ScheduleTable.tsx
@@ -21,25 +21,25 @@ interface ScheduleTableProps {
 
 export function ScheduleTable({ schedules, togglingId, onToggle, onDelete, onEdit }: ScheduleTableProps) {
   return (
-    <div className="rounded-xl border border-border bg-surface shadow-sm overflow-hidden">
+    <div className="rounded-md border border-border bg-surface overflow-hidden">
       <div className="overflow-x-auto">
         <table className="w-full text-sm" aria-label="Schedules">
           <thead>
             <tr className="border-b border-border bg-background/50">
-              <th scope="col" className="px-3 sm:px-5 py-3 text-left font-medium text-muted">Workflow</th>
-              <th scope="col" className="px-3 sm:px-5 py-3 text-left font-medium text-muted">Schedule</th>
-              <th scope="col" className="hidden md:table-cell px-3 sm:px-5 py-3 text-left font-medium text-muted">Created</th>
-              <th scope="col" className="px-3 sm:px-5 py-3 text-center font-medium text-muted">Enabled</th>
-              <th scope="col" className="px-3 sm:px-5 py-3 text-right font-medium text-muted">Actions</th>
+              <th scope="col" className="px-3 sm:px-4 py-2 text-left panel-label text-muted-foreground">Workflow</th>
+              <th scope="col" className="px-3 sm:px-4 py-2 text-left panel-label text-muted-foreground">Schedule</th>
+              <th scope="col" className="hidden md:table-cell px-3 sm:px-4 py-2 text-left panel-label text-muted-foreground">Created</th>
+              <th scope="col" className="px-3 sm:px-4 py-2 text-center panel-label text-muted-foreground">Enabled</th>
+              <th scope="col" className="px-3 sm:px-4 py-2 text-right panel-label text-muted-foreground">Actions</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-border">
             {schedules.map((schedule) => (
               <tr key={schedule.id}>
-                <td className="px-3 sm:px-5 py-3 font-medium text-foreground">
+                <td className="px-3 sm:px-4 py-2 font-medium text-foreground">
                   {schedule.workflow_name}
                 </td>
-                <td className="px-3 sm:px-5 py-3">
+                <td className="px-3 sm:px-4 py-2">
                   <span className="text-foreground text-xs">
                     {cronToHuman(schedule.cron_expression)}
                   </span>
@@ -47,10 +47,10 @@ export function ScheduleTable({ schedules, togglingId, onToggle, onDelete, onEdi
                     {schedule.cron_expression}
                   </span>
                 </td>
-                <td className="hidden md:table-cell px-3 sm:px-5 py-3 text-muted">
+                <td className="hidden md:table-cell px-3 sm:px-4 py-2 font-data text-muted">
                   {schedule.created_at ? formatRelativeTime(schedule.created_at) : "-"}
                 </td>
-                <td className="px-3 sm:px-5 py-3 text-center">
+                <td className="px-3 sm:px-4 py-2 text-center">
                   {togglingId === schedule.id ? (
                     <Loader2 className="inline h-4 w-4 animate-spin text-muted" />
                   ) : (
@@ -75,7 +75,7 @@ export function ScheduleTable({ schedules, togglingId, onToggle, onDelete, onEdi
                     </button>
                   )}
                 </td>
-                <td className="px-3 sm:px-5 py-3 text-right">
+                <td className="px-3 sm:px-4 py-2 text-right">
                   <div className="flex items-center justify-end gap-3">
                     <button
                       onClick={() => onEdit(schedule)}

--- a/dashboard/src/components/ui/PageHeader.tsx
+++ b/dashboard/src/components/ui/PageHeader.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@/lib/utils";
+
+interface PageHeaderProps {
+  /** Mono uppercase micro-label rendered above the title, e.g. "OPERATIONS · RUN HISTORY". */
+  eyebrow: string;
+  title: string;
+  /** Right-aligned slot for status badges, refresh buttons, primary actions. */
+  actions?: React.ReactNode;
+  className?: string;
+}
+
+/** Compact instrument-panel page header: mono eyebrow over a display-face
+ *  title, optional right-aligned status/actions, minimal dead vertical space. */
+export function PageHeader({ eyebrow, title, actions, className }: PageHeaderProps) {
+  return (
+    <div className={cn("flex flex-wrap items-end justify-between gap-x-3 gap-y-2", className)}>
+      <div className="min-w-0">
+        <p className="panel-label text-muted-foreground">{eyebrow}</p>
+        <h1 className="mt-0.5 text-xl sm:text-2xl font-semibold font-display tracking-tight leading-none text-foreground">
+          {title}
+        </h1>
+      </div>
+      {actions && <div className="flex items-center gap-2">{actions}</div>}
+    </div>
+  );
+}

--- a/dashboard/src/components/ui/SectionCard.tsx
+++ b/dashboard/src/components/ui/SectionCard.tsx
@@ -17,37 +17,30 @@ export function SectionCard({
   return (
     <div
       className={cn(
-        "rounded-xl border p-5 sm:p-6 shadow-sm",
+        "rounded-md border overflow-hidden",
         readOnly
           ? "border-dashed border-border/70 bg-surface/60"
           : "border-border bg-surface"
       )}
     >
-      <div className="flex items-center gap-3 mb-4">
-        <div
+      <div className="flex items-start gap-2.5 border-b border-border px-4 py-3 sm:px-5">
+        <Icon
           className={cn(
-            "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
-            readOnly ? "bg-muted/40" : "bg-accent/10"
+            "mt-px h-3.5 w-3.5 shrink-0",
+            readOnly ? "text-muted-foreground" : "text-accent"
           )}
-        >
-          <Icon
-            className={cn(
-              "h-[18px] w-[18px]",
-              readOnly ? "text-muted-foreground" : "text-accent"
-            )}
-          />
-        </div>
-        <div className="flex-1">
+        />
+        <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+            <h2 className="panel-label text-foreground">{title}</h2>
             {readOnly && (
-              <span className="inline-flex items-center gap-1 rounded-md border border-border bg-muted/50 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+              <span className="inline-flex items-center gap-1 rounded-sm border border-border bg-muted/50 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
                 <Lock className="h-2.5 w-2.5" />
                 Read-only
               </span>
             )}
           </div>
-          <p className="text-sm text-muted-foreground mt-0.5">{description}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">{description}</p>
           {readOnly && (
             <p className="text-xs text-muted-foreground/70 mt-0.5">
               Configured via environment variables
@@ -55,7 +48,7 @@ export function SectionCard({
           )}
         </div>
       </div>
-      {children}
+      <div className="p-4 sm:p-5">{children}</div>
     </div>
   );
 }

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "sonner";
 import "@fontsource/bricolage-grotesque/600.css";
 import "@fontsource/bricolage-grotesque/700.css";
 import "./index.css";
+import "./styles/panels.css";
 import App from "./App.tsx";
 
 // Apply the theme immediately to prevent a flash. Dark-first: a stored preference

--- a/dashboard/src/pages/OverviewBento.tsx
+++ b/dashboard/src/pages/OverviewBento.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
-import { Castle } from "lucide-react";
 import { SectionErrorBoundary } from "@/components/shared/ErrorBoundary";
+import { PageHeader } from "@/components/ui/PageHeader";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { BentoActivityFeed } from "@/components/overview/BentoActivityFeed";
 import { BentoAnomalies } from "@/components/overview/BentoAnomalies";
@@ -52,14 +52,7 @@ export default function OverviewBento() {
   if (isEmpty) {
     return (
       <div className="space-y-4 sm:space-y-5">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2.5">
-            <div className="flex items-center justify-center w-8 h-8 rounded-xl bg-accent">
-              <Castle className="h-4 w-4 text-accent-foreground" />
-            </div>
-            <h1 className="text-xl font-bold font-display tracking-tight text-foreground">Overview</h1>
-          </div>
-        </div>
+        <PageHeader eyebrow="Sandcastle · Command Deck" title="Overview" />
 
         <SectionErrorBoundary section="health">
           <BentoHealthHero
@@ -86,14 +79,7 @@ export default function OverviewBento() {
 
   return (
     <div className="space-y-4 sm:space-y-5">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2.5">
-          <div className="flex items-center justify-center w-8 h-8 rounded-xl bg-accent">
-            <Castle className="h-4 w-4 text-accent-foreground" />
-          </div>
-          <h1 className="text-xl font-bold font-display tracking-tight text-foreground">Overview</h1>
-        </div>
-      </div>
+      <PageHeader eyebrow="Sandcastle · Command Deck" title="Overview" />
 
       {!d.recDismissed && (d.advisorRecs.length > 0 || (d.topRecommendation && d.showProviderCosts)) && (
         <SectionErrorBoundary section="recommendations">

--- a/dashboard/src/pages/Runs.tsx
+++ b/dashboard/src/pages/Runs.tsx
@@ -9,6 +9,7 @@ import { RunsTable } from "@/components/runs/RunsTable";
 import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 import { EmptyState } from "@/components/shared/EmptyState";
 import { ContextBanner } from "@/components/shared/ContextBanner";
+import { PageHeader } from "@/components/ui/PageHeader";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { cn, formatCost, formatDuration, parseUTC } from "@/lib/utils";
 import { exportToCsv } from "@/lib/exportCsv";
@@ -207,8 +208,18 @@ export default function Runs() {
   }, [filteredRuns]);
 
   return (
-    <div className="space-y-4 sm:space-y-6">
-      <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">Runs</h1>
+    <div className="space-y-4 sm:space-y-5">
+      <PageHeader
+        eyebrow="Operations · Run History"
+        title="Runs"
+        actions={
+          successRate != null && (
+            <span className="panel-label text-muted-foreground">
+              {Math.round(successRate * 100)}% success · today
+            </span>
+          )
+        }
+      />
 
       {/* Failure rate banner */}
       {successRate != null && successRate < 0.9 && (

--- a/dashboard/src/pages/SystemHealthPage.tsx
+++ b/dashboard/src/pages/SystemHealthPage.tsx
@@ -8,10 +8,10 @@ import {
   Container,
   HardDrive,
   RefreshCw,
-  HeartPulse,
 } from "lucide-react";
 import { api } from "@/api/client";
 import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { PageHeader } from "@/components/ui/PageHeader";
 import { cn } from "@/lib/utils";
 
 // -- Types ------------------------------------------------------------------
@@ -256,55 +256,50 @@ export default function SystemHealthPage() {
   }
 
   return (
-    <div className="space-y-4 sm:space-y-6">
+    <div className="space-y-4 sm:space-y-5">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <HeartPulse className="h-6 w-6 text-muted" />
-          <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">
-            System Health
-          </h1>
-          {/* Overall status badge */}
-          <span
-            className={cn(
-              "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium",
-              overallStatus === "healthy" && "bg-success/15 border-success/30 text-success",
-              overallStatus === "degraded" && "bg-warning/15 border-warning/30 text-warning",
-              overallStatus === "unhealthy" && "bg-error/15 border-error/30 text-error"
-            )}
-          >
-            <span className={cn("h-1.5 w-1.5 rounded-full", statusDot(overallStatus))} />
-            {overallStatus === "healthy" ? "All Systems Operational" : overallStatus === "degraded" ? "Degraded" : "Issues Detected"}
-          </span>
-        </div>
-        <button
-          onClick={() => void fetchData(true)}
-          disabled={refreshing}
-          className={cn(
-            "flex items-center gap-2 rounded-lg border border-border px-3 py-1.5 text-sm font-medium",
-            "text-foreground hover:bg-border/40 transition-colors",
-            refreshing && "opacity-50 cursor-not-allowed"
-          )}
-        >
-          <RefreshCw className={cn("h-3.5 w-3.5", refreshing && "animate-spin")} />
-          Refresh
-        </button>
-      </div>
+      <PageHeader
+        eyebrow="Diagnostics · Live"
+        title="System Health"
+        actions={
+          <>
+            <span
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium",
+                overallStatus === "healthy" && "bg-success/15 border-success/30 text-success",
+                overallStatus === "degraded" && "bg-warning/15 border-warning/30 text-warning",
+                overallStatus === "unhealthy" && "bg-error/15 border-error/30 text-error"
+              )}
+            >
+              <span className={cn("h-1.5 w-1.5 rounded-full", statusDot(overallStatus))} />
+              {overallStatus === "healthy" ? "All Systems Operational" : overallStatus === "degraded" ? "Degraded" : "Issues Detected"}
+            </span>
+            <button
+              onClick={() => void fetchData(true)}
+              disabled={refreshing}
+              className={cn(
+                "flex items-center gap-2 rounded-md border border-border px-3 py-1.5 text-sm font-medium",
+                "text-foreground hover:bg-border/40 transition-colors",
+                refreshing && "opacity-50 cursor-not-allowed"
+              )}
+            >
+              <RefreshCw className={cn("h-3.5 w-3.5", refreshing && "animate-spin")} />
+              Refresh
+            </button>
+          </>
+        }
+      />
 
       {/* Top row: Server Status + Runtime Info */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         {/* Server Status card */}
-        <div className="rounded-xl border border-border bg-surface p-5 sm:p-6 shadow-sm">
-          <div className="flex items-center gap-3 mb-4">
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent/10">
-              <Activity className="h-[18px] w-[18px] text-accent" />
-            </div>
-            <div>
-              <h2 className="text-lg font-semibold text-foreground">Server Status</h2>
-              <p className="text-sm text-muted-foreground mt-0.5">API health check</p>
-            </div>
+        <div className="rounded-md border border-border bg-surface overflow-hidden">
+          <div className="flex items-center gap-2 border-b border-border px-4 py-2.5 sm:px-5">
+            <Activity className="h-3.5 w-3.5 text-accent shrink-0" />
+            <h2 className="panel-label text-foreground">Server Status</h2>
+            <span className="panel-label text-muted-foreground/70 ml-auto">API health check</span>
           </div>
-          <div className="space-y-3">
+          <div className="space-y-2.5 p-4 sm:p-5">
             <div className="flex items-center justify-between">
               <span className="text-sm text-muted-foreground">Status</span>
               <span
@@ -338,17 +333,13 @@ export default function SystemHealthPage() {
         </div>
 
         {/* Runtime Info card */}
-        <div className="rounded-xl border border-border bg-surface p-5 sm:p-6 shadow-sm">
-          <div className="flex items-center gap-3 mb-4">
-            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent/10">
-              <Server className="h-[18px] w-[18px] text-accent" />
-            </div>
-            <div>
-              <h2 className="text-lg font-semibold text-foreground">Runtime Info</h2>
-              <p className="text-sm text-muted-foreground mt-0.5">Sandbox and infrastructure</p>
-            </div>
+        <div className="rounded-md border border-border bg-surface overflow-hidden">
+          <div className="flex items-center gap-2 border-b border-border px-4 py-2.5 sm:px-5">
+            <Server className="h-3.5 w-3.5 text-accent shrink-0" />
+            <h2 className="panel-label text-foreground">Runtime Info</h2>
+            <span className="panel-label text-muted-foreground/70 ml-auto">Sandbox and infrastructure</span>
           </div>
-          <div className="space-y-3">
+          <div className="space-y-2.5 p-4 sm:p-5">
             <div className="flex items-center justify-between">
               <span className="text-sm text-muted-foreground">Mode</span>
               <span
@@ -391,9 +382,9 @@ export default function SystemHealthPage() {
       </div>
 
       {/* Service Checks */}
-      <div className="rounded-xl border border-border bg-surface shadow-sm overflow-hidden">
-        <div className="px-5 py-4 border-b border-border">
-          <h2 className="text-sm font-semibold text-foreground uppercase tracking-wider">
+      <div className="rounded-md border border-border bg-surface overflow-hidden">
+        <div className="px-4 py-2.5 border-b border-border">
+          <h2 className="panel-label text-muted-foreground">
             Service Checks
           </h2>
         </div>
@@ -403,7 +394,7 @@ export default function SystemHealthPage() {
             return (
               <div
                 key={check.name}
-                className="flex items-center gap-4 px-5 py-3.5 hover:bg-border/10 transition-colors"
+                className="flex items-center gap-4 px-4 py-2.5 hover:bg-border/10 transition-colors"
               >
                 {/* Status dot */}
                 <span className={cn("h-2.5 w-2.5 rounded-full shrink-0", statusDot(check.status))} />
@@ -434,27 +425,27 @@ export default function SystemHealthPage() {
       {/* Quick Stats */}
       {quickStats && (
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-          <div className="rounded-xl border border-border bg-surface p-4 shadow-sm">
-            <p className="text-xs font-medium text-muted-foreground">Total Runs (today)</p>
-            <p className="mt-1 text-xl sm:text-2xl font-semibold text-foreground font-mono">
+          <div className="rounded-md border border-border bg-surface p-4">
+            <p className="panel-label text-muted-foreground">Total Runs · Today</p>
+            <p className="mt-1.5 font-display text-2xl sm:text-3xl font-bold tracking-tight leading-none text-foreground">
               {quickStats.runs}
             </p>
           </div>
-          <div className="rounded-xl border border-border bg-surface p-4 shadow-sm">
-            <p className="text-xs font-medium text-muted-foreground">Workflows</p>
-            <p className="mt-1 text-xl sm:text-2xl font-semibold text-foreground font-mono">
+          <div className="rounded-md border border-border bg-surface p-4">
+            <p className="panel-label text-muted-foreground">Workflows</p>
+            <p className="mt-1.5 font-display text-2xl sm:text-3xl font-bold tracking-tight leading-none text-foreground">
               {quickStats.workflows}
             </p>
           </div>
-          <div className="rounded-xl border border-border bg-surface p-4 shadow-sm">
-            <p className="text-xs font-medium text-muted-foreground">Templates</p>
-            <p className="mt-1 text-xl sm:text-2xl font-semibold text-foreground font-mono">
+          <div className="rounded-md border border-border bg-surface p-4">
+            <p className="panel-label text-muted-foreground">Templates</p>
+            <p className="mt-1.5 font-display text-2xl sm:text-3xl font-bold tracking-tight leading-none text-foreground">
               {quickStats.templates}
             </p>
           </div>
-          <div className="rounded-xl border border-border bg-surface p-4 shadow-sm">
-            <p className="text-xs font-medium text-muted-foreground">API Keys</p>
-            <p className="mt-1 text-xl sm:text-2xl font-semibold text-foreground font-mono">
+          <div className="rounded-md border border-border bg-surface p-4">
+            <p className="panel-label text-muted-foreground">API Keys</p>
+            <p className="mt-1.5 font-display text-2xl sm:text-3xl font-bold tracking-tight leading-none text-foreground">
               {quickStats.apiKeys}
             </p>
           </div>
@@ -462,19 +453,13 @@ export default function SystemHealthPage() {
       )}
 
       {/* Environment card */}
-      <div className="rounded-xl border border-border bg-surface p-5 sm:p-6 shadow-sm">
-        <div className="flex items-center gap-3 mb-4">
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent/10">
-            <CheckCircle2 className="h-[18px] w-[18px] text-accent" />
-          </div>
-          <div>
-            <h2 className="text-lg font-semibold text-foreground">Environment</h2>
-            <p className="text-sm text-muted-foreground mt-0.5">
-              System configuration overview
-            </p>
-          </div>
+      <div className="rounded-md border border-border bg-surface overflow-hidden">
+        <div className="flex items-center gap-2 border-b border-border px-4 py-2.5 sm:px-5">
+          <CheckCircle2 className="h-3.5 w-3.5 text-accent shrink-0" />
+          <h2 className="panel-label text-foreground">Environment</h2>
+          <span className="panel-label text-muted-foreground/70 ml-auto">System configuration</span>
         </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-4 p-4 sm:p-5">
           <div>
             <p className="text-xs font-medium text-muted-foreground mb-1">Sandcastle Version</p>
             <p className="text-sm font-mono text-foreground">

--- a/dashboard/src/styles/panels.css
+++ b/dashboard/src/styles/panels.css
@@ -1,0 +1,43 @@
+/* ──── Instrument-panel language (visual revamp PR 2) ────
+   Panels, not bento cards: flat surfaces, 1px hairline borders, sharp radii,
+   mono uppercase micro-labels, dense tabular readouts.
+   Imported after index.css from main.tsx. Rules here are intentionally
+   unlayered so they win over Tailwind's @layer utilities. */
+
+/* Sharper radii: xl/2xl data surfaces collapse to the md step.
+   Buttons and chips keep their own smaller radii from the theme scale. */
+:root {
+  --radius-xl: 0.375rem;
+  --radius-2xl: 0.375rem;
+}
+
+/* Panels are flat — hairline borders carry the structure, not drop shadows.
+   Larger shadows (lg/xl) stay for true floating layers: popovers, modals. */
+.shadow-xs,
+.shadow-sm,
+.hover\:shadow-md:hover {
+  box-shadow: none;
+}
+
+/* Mono uppercase micro-label for section headers, page eyebrows and table
+   heads — `RUNS · LAST 24H` style. Color is left to the caller (pair with
+   text-muted-foreground or text-foreground) so Tailwind color utilities
+   keep working next to it. */
+.panel-label {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem; /* 11px */
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+/* Hairline divider between panel sections — use instead of gaps between
+   floating cards. */
+.panel-divider {
+  border-top: 1px solid var(--color-border);
+}
+
+/* Numbers line up like instrument readouts in every table. */
+table {
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
**Visual revamp 2/5.** Kills the generic rounded-shadowed-card-grid look in favor of a dense instrument-panel language:

- `styles/panels.css`: collapses `--radius-xl/2xl` on data surfaces, zeroes small shadows (hairline 1px borders carry structure; modals keep depth), global `tabular-nums` on tables
- `.panel-label`: IBM Plex Mono 11px uppercase micro-labels (`RUNS · LAST 30 DAYS` style) across all panel headers
- Shared `PageHeader` component: mono eyebrow + display-font title + right-aligned actions
- Density pass: RunsTable/ScheduleTable tighter rows, right-aligned mono numerics; SectionCard → flat panel with hairline header bar
- Showcase pages hand-tuned: Overview (`SANDCASTLE · COMMAND DECK`), Runs (live success-rate readout), SystemHealth (`DIAGNOSTICS · LIVE`)

Stacked on #256 (Sand & Ink). Tests: vitest 805/805, lint zero new, build green.