### PR TITLE
feat(dashboard): control-room status lights replace pill badges (visual 3/5)

### DIFF
--- a/dashboard/src/__tests__/RunStatusBadge.test.tsx
+++ b/dashboard/src/__tests__/RunStatusBadge.test.tsx
@@ -26,23 +26,24 @@ describe("RunStatusBadge", () => {
     expect(screen.getByText("unknown_status")).toBeInTheDocument();
   });
 
-  it("renders with small size by default", () => {
+  it("renders with small size by default (small LED)", () => {
     const { container } = render(<RunStatusBadge status="completed" />);
-    const badge = container.querySelector("span");
-    expect(badge?.className).toContain("text-xs");
+    const led = container.querySelector(".led");
+    expect(led?.classList.contains("h-2")).toBe(true);
   });
 
-  it("renders with medium size when specified", () => {
+  it("renders with medium size when specified (larger LED)", () => {
     const { container } = render(<RunStatusBadge status="completed" size="md" />);
-    const badge = container.querySelector("span");
-    expect(badge?.className).toContain("text-sm");
+    const led = container.querySelector(".led");
+    expect(led?.classList.contains("h-2.5")).toBe(true);
   });
 
-  it("renders the status dot", () => {
+  it("renders the indicator light", () => {
     const { container } = render(<RunStatusBadge status="running" />);
     const dot = container.querySelector("span > span");
     expect(dot).not.toBeNull();
     expect(dot?.className).toContain("rounded-full");
+    expect(dot?.className).toContain("led--breathing");
   });
 
   it("applies custom className", () => {

--- a/dashboard/src/__tests__/StatusLed.test.tsx
+++ b/dashboard/src/__tests__/StatusLed.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StatusLed } from "@/components/ui/StatusLed";
+import { getLedConfig } from "@/lib/statusLed";
+
+describe("getLedConfig state mapping", () => {
+  it("maps running to a breathing light in the running color", () => {
+    expect(getLedConfig("running")).toEqual({
+      state: "breathing",
+      color: "var(--color-running)",
+    });
+  });
+
+  it("maps completed/succeeded to a steady green light", () => {
+    expect(getLedConfig("completed")).toEqual({
+      state: "on",
+      color: "var(--color-success)",
+    });
+    expect(getLedConfig("succeeded")).toEqual({
+      state: "on",
+      color: "var(--color-success)",
+    });
+  });
+
+  it("maps failed to a flicker-then-steady red light", () => {
+    expect(getLedConfig("failed")).toEqual({
+      state: "flicker",
+      color: "var(--color-error)",
+    });
+  });
+
+  it("maps queued and pending to dim lights", () => {
+    expect(getLedConfig("queued").state).toBe("dim");
+    expect(getLedConfig("queued").color).toBe("var(--color-queued)");
+    expect(getLedConfig("pending").state).toBe("dim");
+  });
+
+  it("maps cancelled and skipped to hollow rings", () => {
+    expect(getLedConfig("cancelled").state).toBe("hollow");
+    expect(getLedConfig("skipped").state).toBe("hollow");
+  });
+
+  it("maps awaiting_approval to a breathing warning light", () => {
+    expect(getLedConfig("awaiting_approval")).toEqual({
+      state: "breathing",
+      color: "var(--color-warning)",
+    });
+  });
+
+  it("maps health states to indicator semantics", () => {
+    expect(getLedConfig("healthy").state).toBe("on");
+    expect(getLedConfig("unhealthy").state).toBe("flicker");
+    expect(getLedConfig("degraded").state).toBe("breathing");
+    expect(getLedConfig("unconfigured").state).toBe("hollow");
+  });
+
+  it("maps version lifecycle states", () => {
+    expect(getLedConfig("production").state).toBe("on");
+    expect(getLedConfig("staging").state).toBe("on");
+    expect(getLedConfig("staging").color).toBe("var(--color-warning)");
+    expect(getLedConfig("draft").state).toBe("dim");
+    expect(getLedConfig("archived").state).toBe("hollow");
+  });
+
+  it("falls back to a dim muted light for unknown statuses", () => {
+    expect(getLedConfig("does_not_exist")).toEqual({
+      state: "dim",
+      color: "var(--color-muted)",
+    });
+    expect(getLedConfig("")).toEqual({
+      state: "dim",
+      color: "var(--color-muted)",
+    });
+  });
+});
+
+describe("StatusLed", () => {
+  it("renders the raw status as label by default", () => {
+    render(<StatusLed status="completed" />);
+    expect(screen.getByText("completed")).toBeInTheDocument();
+  });
+
+  it("renders a custom label when provided", () => {
+    render(<StatusLed status="failed" label="Failing" />);
+    expect(screen.getByText("Failing")).toBeInTheDocument();
+    expect(screen.queryByText("failed")).not.toBeInTheDocument();
+  });
+
+  it("hides the label when showLabel is false", () => {
+    const { container } = render(<StatusLed status="running" showLabel={false} />);
+    expect(screen.queryByText("running")).not.toBeInTheDocument();
+    expect(container.querySelector(".led")).not.toBeNull();
+  });
+
+  it("applies the LED state class for each status", () => {
+    const cases: Array<[string, string]> = [
+      ["running", "led--breathing"],
+      ["completed", "led--on"],
+      ["failed", "led--flicker"],
+      ["queued", "led--dim"],
+      ["cancelled", "led--hollow"],
+    ];
+    for (const [status, cls] of cases) {
+      const { container, unmount } = render(<StatusLed status={status} />);
+      expect(container.querySelector(".led")?.classList.contains(cls)).toBe(true);
+      unmount();
+    }
+  });
+
+  it("exposes the status and led state as data attributes", () => {
+    const { container } = render(<StatusLed status="running" />);
+    const root = container.querySelector("span[data-status]");
+    expect(root?.getAttribute("data-status")).toBe("running");
+    expect(root?.getAttribute("data-led-state")).toBe("breathing");
+  });
+
+  it("renders a small light by default and a larger one for md", () => {
+    const { container: sm } = render(<StatusLed status="completed" />);
+    expect(sm.querySelector(".led")?.classList.contains("h-2")).toBe(true);
+
+    const { container: md } = render(<StatusLed status="completed" size="md" />);
+    expect(md.querySelector(".led")?.classList.contains("h-2.5")).toBe(true);
+  });
+
+  it("uses the mono micro label style", () => {
+    render(<StatusLed status="completed" />);
+    expect(screen.getByText("completed").classList.contains("led-label")).toBe(true);
+  });
+
+  it("merges a custom className on the root element", () => {
+    const { container } = render(<StatusLed status="completed" className="ml-2" />);
+    expect(container.querySelector("span[data-status]")?.className).toContain("ml-2");
+  });
+});

--- a/dashboard/src/__tests__/dashboard-wave8.test.tsx
+++ b/dashboard/src/__tests__/dashboard-wave8.test.tsx
@@ -1349,20 +1349,20 @@ describe("RunStatusBadge", () => {
     expect(badge).toBeInTheDocument();
   });
 
-  it("applies sm size by default (uses px-2)", () => {
+  it("applies sm size by default (small LED)", () => {
     render(<RunStatusBadge status="completed" />);
-    const badge = screen.getByText("completed").closest("span.inline-flex");
+    const badge = screen.getByText("completed").closest("span[data-status]");
     expect(badge).toBeInTheDocument();
-    // sm size adds px-2 class
-    expect(badge!.className).toContain("px-2");
+    // sm size renders an h-2 light
+    expect(badge!.querySelector(".led")!.classList.contains("h-2")).toBe(true);
   });
 
-  it("applies md size when specified (uses px-3)", () => {
+  it("applies md size when specified (larger LED)", () => {
     render(<RunStatusBadge status="completed" size="md" />);
-    const badge = screen.getByText("completed").closest("span.inline-flex");
+    const badge = screen.getByText("completed").closest("span[data-status]");
     expect(badge).toBeInTheDocument();
-    // md size adds px-3 class
-    expect(badge!.className).toContain("px-3");
+    // md size renders an h-2.5 light
+    expect(badge!.querySelector(".led")!.classList.contains("h-2.5")).toBe(true);
   });
 
   it("renders all known statuses", () => {

--- a/dashboard/src/components/overview/BentoHealthHero.tsx
+++ b/dashboard/src/components/overview/BentoHealthHero.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
-import { ArrowRight, CheckCircle2, DollarSign } from "lucide-react";
+import { ArrowRight, DollarSign } from "lucide-react";
 import { cn, formatCost } from "@/lib/utils";
+import { StatusLed } from "@/components/ui/StatusLed";
 import type { Insight, Severity } from "@/lib/insights";
 
 const SEVERITY_DOT: Record<Severity, string> = {
@@ -77,15 +78,11 @@ export function BentoHealthHero({
 
       {!loading && actionable.length === 0 && (
         <div className="flex items-center gap-2">
-          <span className={cn(
-            "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-semibold",
-            score >= 80
-              ? "bg-success/10 border border-success/20 text-success"
-              : "bg-warning/10 border border-warning/20 text-warning",
-          )}>
-            <CheckCircle2 className="h-3.5 w-3.5" />
-            {score >= 80 ? "All systems healthy" : scoreLabel}
-          </span>
+          <StatusLed
+            status={score >= 80 ? "healthy" : "degraded"}
+            label={score >= 80 ? "All systems healthy" : scoreLabel}
+            size="md"
+          />
         </div>
       )}
 

--- a/dashboard/src/components/overview/BentoProviderStatusBanner.tsx
+++ b/dashboard/src/components/overview/BentoProviderStatusBanner.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Key, Wifi, X } from "lucide-react";
 import { api } from "@/api/client";
 import { cn } from "@/lib/utils";
+import { StatusLed } from "@/components/ui/StatusLed";
 import type { ProviderInfo } from "./bentoTypes";
 
 const PROVIDER_BANNER_DISMISSED_KEY = "sandcastle_provider_banner_dismissed";
@@ -70,21 +71,17 @@ export function BentoProviderStatusBanner() {
                 <span
                   key={p.id}
                   className={cn(
-                    "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium",
-                    isActive
-                      ? "bg-success/10 text-success"
-                      : "bg-muted text-muted-foreground",
+                    "inline-flex items-center gap-1.5 px-1 text-xs font-medium",
+                    isActive ? "text-success" : "text-muted-foreground",
                   )}
                 >
-                  <span
-                    className={cn(
-                      "h-1.5 w-1.5 rounded-full shrink-0",
-                      isActive ? "bg-success" : "bg-muted-foreground/40",
-                    )}
+                  <StatusLed
+                    status={isActive ? "healthy" : "unconfigured"}
+                    showLabel={false}
                   />
                   {p.name}
                   {p.status === "running" && p.latency_ms != null && (
-                    <span className="text-[10px] text-success/70">{p.latency_ms}ms</span>
+                    <span className="font-mono text-[10px] text-success/70">{p.latency_ms}ms</span>
                   )}
                 </span>
               );

--- a/dashboard/src/components/runs/RunStatusBadge.tsx
+++ b/dashboard/src/components/runs/RunStatusBadge.tsx
@@ -1,5 +1,4 @@
-import { cn } from "@/lib/utils";
-import { STATUS_COLORS, STATUS_DOT_COLORS } from "@/lib/constants";
+import { StatusLed } from "@/components/ui/StatusLed";
 
 interface RunStatusBadgeProps {
   status: string;
@@ -7,21 +6,8 @@ interface RunStatusBadgeProps {
   size?: "sm" | "md";
 }
 
+/* Thin wrapper kept for API compatibility: every run status surface
+   now renders the StatusLed indicator-light language instead of a pill. */
 export function RunStatusBadge({ status, className, size = "sm" }: RunStatusBadgeProps) {
-  const colors = STATUS_COLORS[status] || STATUS_COLORS.pending;
-  const dotColor = STATUS_DOT_COLORS[status] || STATUS_DOT_COLORS.pending;
-
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1.5 rounded-full border font-medium capitalize",
-        colors,
-        size === "sm" ? "px-2 py-0.5 text-xs" : "px-3 py-1 text-sm",
-        className
-      )}
-    >
-      <span className={cn("h-1.5 w-1.5 rounded-full", dotColor)} />
-      {status}
-    </span>
-  );
+  return <StatusLed status={status} size={size} className={className} />;
 }

--- a/dashboard/src/components/runs/StepTimeline.tsx
+++ b/dashboard/src/components/runs/StepTimeline.tsx
@@ -1,5 +1,6 @@
+import type { CSSProperties } from "react";
 import { StepCard } from "@/components/runs/StepCard";
-import { STATUS_DOT_COLORS } from "@/lib/constants";
+import { getLedConfig } from "@/lib/statusLed";
 import { cn } from "@/lib/utils";
 
 interface Step {
@@ -40,9 +41,10 @@ export function StepTimeline({ steps, runId, onReplay, onFork }: StepTimelinePro
           <div className="flex flex-col items-center">
             <div
               className={cn(
-                "mt-4 h-3 w-3 rounded-full border-2 border-surface",
-                STATUS_DOT_COLORS[step.status] || "bg-muted"
+                "led mt-4 h-2.5 w-2.5 rounded-full",
+                `led--${getLedConfig(step.status).state}`
               )}
+              style={{ "--led-color": getLedConfig(step.status).color } as CSSProperties}
             />
             {i < steps.length - 1 && (
               <div className="w-px flex-1 bg-border" />

--- a/dashboard/src/components/ui/StatusLed.tsx
+++ b/dashboard/src/components/ui/StatusLed.tsx
@@ -1,0 +1,60 @@
+import type { CSSProperties } from "react";
+import { cn } from "@/lib/utils";
+import { getLedConfig } from "@/lib/statusLed";
+
+/* Control-room indicator light. Replaces pill badges app-wide:
+   status reads as a physical LED + lowercase mono micro-label.
+   Physics live in styles/status-lights.css; the status → state/color
+   mapping lives in lib/statusLed.ts. */
+
+interface StatusLedProps {
+  status: string;
+  /** Display text; defaults to the raw status string. */
+  label?: string;
+  /** Hide the text and show only the light. */
+  showLabel?: boolean;
+  /** sm for lists/tables, md for detail headers. */
+  size?: "sm" | "md";
+  className?: string;
+}
+
+export function StatusLed({
+  status,
+  label,
+  showLabel = true,
+  size = "sm",
+  className,
+}: StatusLedProps) {
+  const { state, color } = getLedConfig(status);
+  const text = label ?? status;
+
+  return (
+    <span
+      data-status={status}
+      data-led-state={state}
+      className={cn(
+        "inline-flex items-center",
+        size === "sm" ? "gap-1.5" : "gap-2",
+        className
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "led rounded-full shrink-0",
+          `led--${state}`,
+          size === "sm" ? "h-2 w-2" : "h-2.5 w-2.5"
+        )}
+        style={{ "--led-color": color } as CSSProperties}
+      />
+      {showLabel && (
+        <span
+          className={cn("led-label", size === "sm" ? "text-[10px]" : "text-xs")}
+          style={{ color }}
+        >
+          {text}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/dashboard/src/components/workflows/DagGraph.tsx
+++ b/dashboard/src/components/workflows/DagGraph.tsx
@@ -88,15 +88,40 @@ export function DagGraph({ steps, className }: DagGraphProps) {
       };
     });
 
+    // Light-trail edges: without statuses (planning view) keep neutral accent
+    // wiring; with statuses, edges read as light traces between indicators.
+    const hasStatuses = steps.some((s) => s.status);
+
     const edges: Edge[] = [];
     steps.forEach((s) => {
       (s.depends_on || []).forEach((dep) => {
+        if (!hasStatuses) {
+          edges.push({
+            id: `${dep}-${s.id}`,
+            source: dep,
+            target: s.id,
+            style: { stroke: "var(--color-accent)", strokeWidth: 2 },
+          });
+          return;
+        }
+
+        const sourceStatus = stepMap.get(dep)?.status;
+        let className = "dag-edge-idle";
+        if (s.status === "running") {
+          // flowing light into the step that is executing right now
+          className = "dag-edge-active";
+        } else if (s.status === "failed") {
+          className = "dag-edge-failed";
+        } else if (sourceStatus === "completed") {
+          // trail left behind by a finished step
+          className = "dag-edge-trail";
+        }
+
         edges.push({
           id: `${dep}-${s.id}`,
           source: dep,
           target: s.id,
-          animated: s.status === "running",
-          style: { stroke: "var(--color-accent)", strokeWidth: 2 },
+          className,
         });
       });
     });

--- a/dashboard/src/components/workflows/StepNode.tsx
+++ b/dashboard/src/components/workflows/StepNode.tsx
@@ -1,8 +1,9 @@
 import { memo } from "react";
 import { Handle, Position, type NodeProps, type Node } from "@xyflow/react";
 import { Bell, Brain, Code, Cpu, ExternalLink, FileSpreadsheet, FileText, FlaskConical, Gauge, GitBranch, Globe, MessageSquare, Monitor, Radio, RefreshCw, Repeat, ShieldCheck, Shuffle, Tag, Wrench, Zap } from "lucide-react";
+import type { CSSProperties } from "react";
 import { cn } from "@/lib/utils";
-import { STATUS_DOT_COLORS } from "@/lib/constants";
+import { getLedConfig } from "@/lib/statusLed";
 import type { StepType } from "@/components/workflows/StepConfigPanel";
 
 type StepNodeData = {
@@ -84,7 +85,7 @@ const STEP_TYPE_RAW_COLORS: Record<string, string> = {
 
 function StepNodeComponent({ data, selected }: NodeProps<StepNodeType>) {
   const status = data.status || "pending";
-  const dotColor = STATUS_DOT_COLORS[status] || "bg-muted";
+  const led = getLedConfig(status);
   const showBadges = data.hasRetry || data.hasApproval || data.hasAutoPilot || data.hasCsvOutput || data.hasPdfReport || data.hasSlo || data.hasTools;
   const stepType = data.stepType || "standard";
   const TypeIcon = STEP_TYPE_ICONS[stepType] || Cpu;
@@ -115,7 +116,10 @@ function StepNodeComponent({ data, selected }: NodeProps<StepNodeType>) {
       />
 
       <div className="flex items-center gap-2">
-        <div className={cn("h-2 w-2 rounded-full", dotColor)} />
+        <div
+          className={cn("led h-2 w-2 rounded-full shrink-0", `led--${led.state}`)}
+          style={{ "--led-color": led.color } as CSSProperties}
+        />
         <TypeIcon className={cn("h-3.5 w-3.5", iconColor)} />
         <span className="font-mono text-xs font-medium text-foreground">{data.label}</span>
       </div>

--- a/dashboard/src/components/workflows/VersionStatusBadge.tsx
+++ b/dashboard/src/components/workflows/VersionStatusBadge.tsx
@@ -1,24 +1,7 @@
-import { cn } from "@/lib/utils";
+import { StatusLed } from "@/components/ui/StatusLed";
 
-const STATUS_STYLES: Record<string, { badge: string; dot: string }> = {
-  draft: { badge: "bg-muted/15 text-muted border-muted/30", dot: "bg-muted" },
-  staging: { badge: "bg-warning/15 text-warning border-warning/30", dot: "bg-warning" },
-  production: { badge: "bg-success/15 text-success border-success/30", dot: "bg-success" },
-  archived: { badge: "bg-muted/10 text-muted/60 border-muted/20", dot: "bg-muted/60" },
-};
-
+/* Version lifecycle as indicator lights:
+   draft = dim, staging = amber on, production = green on, archived = hollow. */
 export function VersionStatusBadge({ status, className }: { status: string; className?: string }) {
-  const style = STATUS_STYLES[status] || STATUS_STYLES.draft;
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium capitalize",
-        style.badge,
-        className
-      )}
-    >
-      <span className={cn("h-1.5 w-1.5 rounded-full", style.dot)} />
-      {status}
-    </span>
-  );
+  return <StatusLed status={status} className={className} />;
 }

--- a/dashboard/src/components/workflows/WorkflowCard.tsx
+++ b/dashboard/src/components/workflows/WorkflowCard.tsx
@@ -1,7 +1,8 @@
 import { memo, useState } from "react";
-import { GitBranch, Play, Pencil, Eye, History, Check, Clock, CheckCircle, XCircle, Star, Layers } from "lucide-react";
+import { GitBranch, Play, Pencil, Eye, History, Check, Clock, Star, Layers } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DoctorBadge } from "./DoctorBadge";
+import { StatusLed } from "@/components/ui/StatusLed";
 
 /** Per-workflow runtime stats — populated by WorkflowList once the
  *  backend exposes a per-workflow stats endpoint. Cards render without
@@ -22,10 +23,10 @@ function deriveHealth(successRate: number): HealthLevel {
   return "failing";
 }
 
-const healthConfig: Record<HealthLevel, { dot: string; label: string; text: string }> = {
-  healthy:  { dot: "bg-success",  label: "Healthy",  text: "text-success" },
-  degraded: { dot: "bg-warning",  label: "Degraded", text: "text-warning" },
-  failing:  { dot: "bg-error",    label: "Failing",  text: "text-error" },
+const healthConfig: Record<HealthLevel, { label: string }> = {
+  healthy:  { label: "Healthy" },
+  degraded: { label: "Degraded" },
+  failing:  { label: "Failing" },
 };
 // --- End mock stats ---
 
@@ -129,14 +130,13 @@ export const WorkflowCard = memo(function WorkflowCard({
         </button>
       )}
 
-      {/* Health badge - top right, offset from checkbox */}
-      {hc && (
+      {/* Health light - top right, offset from checkbox */}
+      {health && hc && (
         <div className={cn(
-          "absolute top-3 flex items-center gap-1.5",
+          "absolute top-3 flex items-center",
           onSelect ? "right-10" : "right-3"
         )}>
-          <span className={cn("h-2 w-2 rounded-full", hc.dot)} />
-          <span className={cn("text-[10px] font-medium", hc.text)}>{hc.label}</span>
+          <StatusLed status={health} label={hc.label} />
         </div>
       )}
 
@@ -164,15 +164,7 @@ export const WorkflowCard = memo(function WorkflowCard({
       <div className="mb-3 flex items-center gap-1.5 text-xs text-muted">
         {stats && stats.lastRunStatus ? (
           <>
-            {stats.lastRunStatus === "completed" && (
-              <CheckCircle className="h-3 w-3 text-success" />
-            )}
-            {stats.lastRunStatus === "failed" && (
-              <XCircle className="h-3 w-3 text-error" />
-            )}
-            {stats.lastRunStatus === "running" && (
-              <Clock className="h-3 w-3 text-running" />
-            )}
+            <StatusLed status={stats.lastRunStatus} showLabel={false} />
             <span>
               Last run: {stats.lastRunAgo} -{" "}
               <span className={cn(
@@ -198,16 +190,7 @@ export const WorkflowCard = memo(function WorkflowCard({
           <>
             <span className="text-border">|</span>
             <span className="font-mono">v{version}</span>
-            {versionStatus && (
-              <span className={cn(
-                "rounded-full px-1.5 py-0.5 text-[10px] font-medium capitalize",
-                versionStatus === "production" ? "bg-success/15 text-success" :
-                versionStatus === "staging" ? "bg-warning/15 text-warning" :
-                "bg-muted/15 text-muted"
-              )}>
-                {versionStatus}
-              </span>
-            )}
+            {versionStatus && <StatusLed status={versionStatus} />}
           </>
         )}
         {totalVersions != null && totalVersions > 1 && (

--- a/dashboard/src/lib/statusLed.ts
+++ b/dashboard/src/lib/statusLed.ts
@@ -1,0 +1,51 @@
+/* Status → indicator-light mapping for the control-room LED language.
+   Kept outside the component file so non-component consumers (StepNode,
+   StepTimeline, pages) can share it without breaking fast refresh. */
+
+export type LedState = "on" | "breathing" | "flicker" | "dim" | "hollow";
+
+export interface LedConfig {
+  state: LedState;
+  color: string;
+}
+
+const LED_MAP: Record<string, LedConfig> = {
+  // run / step lifecycle
+  queued: { state: "dim", color: "var(--color-queued)" },
+  pending: { state: "dim", color: "var(--color-muted)" },
+  running: { state: "breathing", color: "var(--color-running)" },
+  completed: { state: "on", color: "var(--color-success)" },
+  succeeded: { state: "on", color: "var(--color-success)" },
+  failed: { state: "flicker", color: "var(--color-error)" },
+  partial: { state: "on", color: "var(--color-warning)" },
+  cancelled: { state: "hollow", color: "var(--color-muted)" },
+  skipped: { state: "hollow", color: "var(--color-muted)" },
+  budget_exceeded: { state: "on", color: "var(--color-warning)" },
+  awaiting_approval: { state: "breathing", color: "var(--color-warning)" },
+  // approvals
+  approved: { state: "on", color: "var(--color-success)" },
+  rejected: { state: "flicker", color: "var(--color-error)" },
+  timed_out: { state: "hollow", color: "var(--color-muted)" },
+  // health / schedules / workflows
+  healthy: { state: "on", color: "var(--color-success)" },
+  degraded: { state: "breathing", color: "var(--color-warning)" },
+  unhealthy: { state: "flicker", color: "var(--color-error)" },
+  failing: { state: "flicker", color: "var(--color-error)" },
+  unconfigured: { state: "hollow", color: "var(--color-muted)" },
+  active: { state: "on", color: "var(--color-success)" },
+  paused: { state: "hollow", color: "var(--color-muted)" },
+  // runtime mode
+  local: { state: "on", color: "var(--color-accent)" },
+  // workflow versions
+  draft: { state: "dim", color: "var(--color-muted)" },
+  staging: { state: "on", color: "var(--color-warning)" },
+  production: { state: "on", color: "var(--color-success)" },
+  archived: { state: "hollow", color: "var(--color-muted)" },
+};
+
+const FALLBACK: LedConfig = { state: "dim", color: "var(--color-muted)" };
+
+/** Resolve a status string to its LED state + color (fallback: dim muted). */
+export function getLedConfig(status: string): LedConfig {
+  return LED_MAP[status] || FALLBACK;
+}

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "sonner";
 import "@fontsource/bricolage-grotesque/600.css";
 import "@fontsource/bricolage-grotesque/700.css";
 import "./index.css";
+import "./styles/status-lights.css";
 import App from "./App.tsx";
 
 // Apply the theme immediately to prevent a flash. Dark-first: a stored preference

--- a/dashboard/src/pages/ApprovalsPage.tsx
+++ b/dashboard/src/pages/ApprovalsPage.tsx
@@ -3,6 +3,7 @@ import { ShieldCheck, Clock, CheckCircle2, XCircle, SkipForward, RefreshCw, Mess
 import { toast } from "sonner";
 import { api } from "@/api/client";
 import { EmptyState } from "@/components/shared/EmptyState";
+import { StatusLed } from "@/components/ui/StatusLed";
 import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
 import { formatRelativeTime, cn, isSafeUrl } from "@/lib/utils";
 import { useNavigate } from "react-router-dom";
@@ -296,17 +297,12 @@ export default function ApprovalsPage() {
                     </div>
                   </div>
 
-                  {/* Status badge */}
-                  <span
-                    className={cn(
-                      "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium",
-                      style.bg,
-                      style.text
-                    )}
-                  >
-                    <span className={cn("h-1.5 w-1.5 rounded-full", style.dot)} />
-                    {style.label}
-                  </span>
+                  {/* Status light: pending approval breathes amber, like awaiting_approval runs */}
+                  <StatusLed
+                    status={item.status === "pending" ? "awaiting_approval" : item.status}
+                    label={style.label}
+                    className="shrink-0"
+                  />
 
                   {/* Action buttons (only for pending) */}
                   {isPending && (

--- a/dashboard/src/pages/ScheduleMonitorPage.tsx
+++ b/dashboard/src/pages/ScheduleMonitorPage.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import { api } from "@/api/client";
 import { EmptyState } from "@/components/shared/EmptyState";
 import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { StatusLed } from "@/components/ui/StatusLed";
 import { cronToHuman, getNextRuns } from "@/lib/cron";
 import { cn, formatRelativeTime } from "@/lib/utils";
 
@@ -35,13 +36,13 @@ interface ScheduleMonitorItem {
 function statusBadge(status: string) {
   switch (status) {
     case "active":
-      return { label: "Active", bg: "bg-success/10 border-success/30 text-success" };
+      return { label: "Active" };
     case "paused":
-      return { label: "Paused", bg: "bg-muted-foreground/10 border-border text-muted-foreground" };
+      return { label: "Paused" };
     case "failing":
-      return { label: "Failing", bg: "bg-error/10 border-error/30 text-error" };
+      return { label: "Failing" };
     default:
-      return { label: status, bg: "bg-border text-muted-foreground" };
+      return { label: status };
   }
 }
 
@@ -219,7 +220,8 @@ export default function ScheduleMonitorPage() {
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 sm:gap-5">
           {schedules.map((schedule) => {
-            const badge = statusBadge(schedule.status ?? (schedule.enabled ? "active" : "paused"));
+            const scheduleStatus = schedule.status ?? (schedule.enabled ? "active" : "paused");
+            const badge = statusBadge(scheduleStatus);
             const successPct = Math.round((schedule.success_rate ?? 0) * 100);
             const isToggling = togglingId === schedule.id;
             const isTriggering = triggeringId === schedule.id;
@@ -243,12 +245,7 @@ export default function ScheduleMonitorPage() {
                       {cronToHuman(schedule.cron_expression)}
                     </p>
                   </div>
-                  <span className={cn(
-                    "shrink-0 text-[10px] font-semibold rounded-full px-2.5 py-1 border",
-                    badge.bg
-                  )}>
-                    {badge.label}
-                  </span>
+                  <StatusLed status={scheduleStatus} label={badge.label} className="shrink-0" />
                 </div>
 
                 {/* Stats row */}

--- a/dashboard/src/pages/SystemHealthPage.tsx
+++ b/dashboard/src/pages/SystemHealthPage.tsx
@@ -12,6 +12,8 @@ import {
 } from "lucide-react";
 import { api } from "@/api/client";
 import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { StatusLed } from "@/components/ui/StatusLed";
+import { getLedConfig } from "@/lib/statusLed";
 import { cn } from "@/lib/utils";
 
 // -- Types ------------------------------------------------------------------
@@ -58,29 +60,16 @@ interface ServiceCheck {
 
 // -- Helpers ----------------------------------------------------------------
 
-function statusDot(status: ServiceStatus) {
+function statusLabel(status: ServiceStatus): string {
   switch (status) {
     case "healthy":
-      return "bg-success";
+      return "Healthy";
     case "unhealthy":
-      return "bg-error animate-pulse";
+      return "Unhealthy";
     case "degraded":
-      return "bg-warning animate-pulse";
+      return "Degraded";
     case "unconfigured":
-      return "bg-muted";
-  }
-}
-
-function statusLabel(status: ServiceStatus) {
-  switch (status) {
-    case "healthy":
-      return { text: "Healthy", className: "text-success" };
-    case "unhealthy":
-      return { text: "Unhealthy", className: "text-error" };
-    case "degraded":
-      return { text: "Degraded", className: "text-warning" };
-    case "unconfigured":
-      return { text: "Not Configured", className: "text-muted" };
+      return "Not Configured";
   }
 }
 
@@ -264,18 +253,12 @@ export default function SystemHealthPage() {
           <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">
             System Health
           </h1>
-          {/* Overall status badge */}
-          <span
-            className={cn(
-              "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium",
-              overallStatus === "healthy" && "bg-success/15 border-success/30 text-success",
-              overallStatus === "degraded" && "bg-warning/15 border-warning/30 text-warning",
-              overallStatus === "unhealthy" && "bg-error/15 border-error/30 text-error"
-            )}
-          >
-            <span className={cn("h-1.5 w-1.5 rounded-full", statusDot(overallStatus))} />
-            {overallStatus === "healthy" ? "All Systems Operational" : overallStatus === "degraded" ? "Degraded" : "Issues Detected"}
-          </span>
+          {/* Overall status light */}
+          <StatusLed
+            status={overallStatus}
+            size="md"
+            label={overallStatus === "healthy" ? "All Systems Operational" : overallStatus === "degraded" ? "Degraded" : "Issues Detected"}
+          />
         </div>
         <button
           onClick={() => void fetchData(true)}
@@ -351,16 +334,10 @@ export default function SystemHealthPage() {
           <div className="space-y-3">
             <div className="flex items-center justify-between">
               <span className="text-sm text-muted-foreground">Mode</span>
-              <span
-                className={cn(
-                  "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium",
-                  runtime?.mode === "local"
-                    ? "bg-accent/15 border border-accent/30 text-accent"
-                    : "bg-success/15 border border-success/30 text-success"
-                )}
-              >
-                {runtime?.mode === "local" ? "Local" : "Production"}
-              </span>
+              <StatusLed
+                status={runtime?.mode === "local" ? "local" : "production"}
+                label={runtime?.mode === "local" ? "Local" : "Production"}
+              />
             </div>
             <div className="flex items-center justify-between">
               <span className="text-sm text-muted-foreground">Sandbox Backend</span>
@@ -390,44 +367,47 @@ export default function SystemHealthPage() {
         </div>
       </div>
 
-      {/* Service Checks */}
+      {/* Service Checks: indicator board */}
       <div className="rounded-xl border border-border bg-surface shadow-sm overflow-hidden">
-        <div className="px-5 py-4 border-b border-border">
+        <div className="px-5 py-4 border-b border-border flex items-center justify-between">
           <h2 className="text-sm font-semibold text-foreground uppercase tracking-wider">
             Service Checks
           </h2>
+          <span className="font-mono text-[10px] tracking-widest text-muted uppercase">
+            {serviceChecks.filter((c) => c.status === "healthy").length}/{serviceChecks.length} nominal
+          </span>
         </div>
         <div className="divide-y divide-border">
-          {serviceChecks.map((check) => {
-            const label = statusLabel(check.status);
-            return (
-              <div
-                key={check.name}
-                className="flex items-center gap-4 px-5 py-3.5 hover:bg-border/10 transition-colors"
+          {serviceChecks.map((check) => (
+            <div
+              key={check.name}
+              className="indicator-board-row flex items-center gap-4 px-5 py-3.5"
+            >
+              {/* Indicator light */}
+              <StatusLed status={check.status} showLabel={false} size="md" />
+
+              {/* Icon */}
+              <check.icon className="h-4 w-4 text-muted shrink-0" />
+
+              {/* Name */}
+              <span className="font-mono text-xs tracking-wide text-foreground min-w-[140px]">
+                {check.name}
+              </span>
+
+              {/* Detail */}
+              <span className="text-sm font-mono text-muted flex-1 truncate">
+                {check.detail}
+              </span>
+
+              {/* Status readout */}
+              <span
+                className="led-label text-[10px] shrink-0"
+                style={{ color: getLedConfig(check.status).color }}
               >
-                {/* Status dot */}
-                <span className={cn("h-2.5 w-2.5 rounded-full shrink-0", statusDot(check.status))} />
-
-                {/* Icon */}
-                <check.icon className="h-4 w-4 text-muted shrink-0" />
-
-                {/* Name */}
-                <span className="text-sm font-medium text-foreground min-w-[140px]">
-                  {check.name}
-                </span>
-
-                {/* Detail */}
-                <span className="text-sm font-mono text-muted flex-1 truncate">
-                  {check.detail}
-                </span>
-
-                {/* Status label */}
-                <span className={cn("text-xs font-medium shrink-0", label.className)}>
-                  {label.text}
-                </span>
-              </div>
-            );
-          })}
+                {statusLabel(check.status)}
+              </span>
+            </div>
+          ))}
         </div>
       </div>
 

--- a/dashboard/src/styles/status-lights.css
+++ b/dashboard/src/styles/status-lights.css
@@ -1,0 +1,147 @@
+/* ──── Status lights: control-room indicator language ────
+   Statuses render as physical indicator LEDs instead of pill badges.
+   Color comes in via --led-color (set inline by StatusLed / StepNode);
+   glow strength is theme-scoped: phosphor glow in dark, subtle halo in light. */
+
+:root {
+  /* glow opacity (0-100, used as a percentage inside color-mix) */
+  --led-glow: 45;
+}
+
+.dark {
+  --led-glow: 80;
+}
+
+.led {
+  --led-color: var(--color-muted);
+  display: inline-block;
+  border-radius: 9999px;
+  background-color: var(--led-color);
+}
+
+/* steady on: solid dot with a quiet halo (completed / healthy / production) */
+.led--on,
+.led--flicker {
+  box-shadow:
+    0 0 4px color-mix(in srgb, var(--led-color) calc(var(--led-glow) * 0.7%), transparent),
+    0 0 10px color-mix(in srgb, var(--led-color) calc(var(--led-glow) * 0.35%), transparent);
+}
+
+/* breathing: slow 2s pulse with a soft outer glow (running / awaiting input) */
+.led--breathing {
+  animation: led-breathe 2s ease-in-out infinite;
+}
+
+@keyframes led-breathe {
+  0%,
+  100% {
+    opacity: 1;
+    box-shadow:
+      0 0 5px color-mix(in srgb, var(--led-color) calc(var(--led-glow) * 0.8%), transparent),
+      0 0 14px color-mix(in srgb, var(--led-color) calc(var(--led-glow) * 0.45%), transparent);
+  }
+  50% {
+    opacity: 0.45;
+    box-shadow:
+      0 0 2px color-mix(in srgb, var(--led-color) calc(var(--led-glow) * 0.4%), transparent),
+      0 0 6px color-mix(in srgb, var(--led-color) calc(var(--led-glow) * 0.15%), transparent);
+  }
+}
+
+/* flicker: a single brief stutter on mount, then steady (failed). No infinite blink. */
+.led--flicker {
+  animation: led-flicker 0.65s linear 1;
+}
+
+@keyframes led-flicker {
+  0% { opacity: 1; }
+  12% { opacity: 0.15; }
+  24% { opacity: 1; }
+  38% { opacity: 0.3; }
+  52% { opacity: 1; }
+  68% { opacity: 0.2; }
+  82% { opacity: 0.9; }
+  100% { opacity: 1; }
+}
+
+/* dim: light is wired but barely lit (queued / pending / draft) */
+.led--dim {
+  opacity: 0.4;
+  box-shadow: none;
+}
+
+/* hollow: empty socket ring (cancelled / skipped / paused / archived) */
+.led--hollow {
+  background-color: transparent;
+  border: 1.5px solid color-mix(in srgb, var(--led-color) 70%, transparent);
+  box-shadow: none;
+}
+
+/* mono micro label next to the light (lowercase, consistent app-wide) */
+.led-label {
+  font-family: var(--font-mono);
+  text-transform: lowercase;
+  letter-spacing: 0.05em;
+  line-height: 1;
+}
+
+/* ──── DAG light trails (xyflow edges) ──── */
+
+/* trail out of a completed step: steady success glow */
+.react-flow__edge.dag-edge-trail .react-flow__edge-path {
+  stroke: var(--color-success);
+  stroke-width: 2;
+  filter: drop-shadow(0 0 3px color-mix(in srgb, var(--color-success) calc(var(--led-glow) * 1%), transparent));
+}
+
+/* edge feeding the currently running step: flowing light */
+.react-flow__edge.dag-edge-active .react-flow__edge-path {
+  stroke: var(--color-running);
+  stroke-width: 2.5;
+  stroke-dasharray: 7 7;
+  animation: dag-flow 0.8s linear infinite;
+  filter: drop-shadow(0 0 4px color-mix(in srgb, var(--color-running) calc(var(--led-glow) * 1%), transparent));
+}
+
+@keyframes dag-flow {
+  to {
+    stroke-dashoffset: -14;
+  }
+}
+
+/* edge into a failed step: red-tinted, no flow */
+.react-flow__edge.dag-edge-failed .react-flow__edge-path {
+  stroke: color-mix(in srgb, var(--color-error) 75%, transparent);
+  stroke-width: 2;
+  filter: drop-shadow(0 0 3px color-mix(in srgb, var(--color-error) calc(var(--led-glow) * 0.8%), transparent));
+}
+
+/* unlit wiring between idle steps */
+.react-flow__edge.dag-edge-idle .react-flow__edge-path {
+  stroke: var(--color-border);
+  stroke-width: 2;
+}
+
+/* ──── Indicator board (System Health) ──── */
+
+.indicator-board-row {
+  transition: background-color 150ms ease;
+}
+
+.indicator-board-row:hover {
+  background-color: color-mix(in srgb, var(--color-border) 12%, transparent);
+}
+
+/* Accessibility: stop indicator animations for users who prefer reduced motion
+   (mirrors the exclusion-list pattern in index.css) */
+@media (prefers-reduced-motion: reduce) {
+  .led--breathing,
+  .led--flicker {
+    animation: none !important;
+    opacity: 1;
+  }
+  .react-flow__edge.dag-edge-active .react-flow__edge-path {
+    animation: none !important;
+    stroke-dasharray: none;
+  }
+}


### PR DESCRIPTION
**Visual revamp 3/5.** Status becomes a physical light, not a colored pill:

- New `StatusLed` (+ `lib/statusLed.ts` mapping): running = 2s breathing glow, completed = steady green, failed = single flicker on mount then steady red (never infinite blinking), queued = dim, cancelled/skipped = hollow ring; sm/md sizes, lowercase mono labels, theme-scoped glow (phosphor in dark)
- Swept the whole app: runs table, run detail/compare, step timeline, workflow cards, versions, approvals, schedule monitor, provider banner, overview hero
- DAG light trails: completed edges glow steady green, the edge into the running step flows as animated light, failed edges red-tinted; StepNode dots are LEDs
- SystemHealth as an indicator board: LED rows, mono service names, "n/5 nominal" counter
- Full `prefers-reduced-motion` support

Stacked on #256 (Sand & Ink). Tests: vitest 822/822 (15 new), lint zero new, build green.