### PR TITLE
feat(dashboard): brand signature moments — illustrated empty states, sand skeletons, 404 (visual 4/5)

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -9,6 +9,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { AuthGate } from "@/components/auth/AuthGate";
 import { usePageTracking } from "@/hooks/usePageTracking";
 import { lazyWithRetry } from "@/lib/lazyWithRetry";
+import { SandcastleRuin, DuneContours, BuildingLoader } from "@/components/brand";
 
 // Lazy-loaded page components for code splitting. lazyWithRetry recovers from a
 // stale-deploy chunk miss (open tab + new deploy = 404 on the old hashed chunk)
@@ -77,14 +78,20 @@ function LiteGuard({ children }: { children: React.ReactNode }) {
 
 function NotFound() {
   return (
-    <div className="flex flex-col items-center justify-center py-24 gap-4">
-      <h1 className="text-4xl font-bold text-foreground">404</h1>
-      <p className="text-muted">Page not found</p>
+    <div className="relative flex flex-col items-center justify-center gap-3 overflow-hidden py-24 text-center">
+      <DuneContours className="absolute inset-x-0 bottom-0 h-40 w-full text-foreground opacity-[0.05]" />
+      <SandcastleRuin title="A crumbled sandcastle" className="h-36 w-48 text-muted-foreground" />
+      <h1 className="font-display text-3xl font-bold tracking-tight text-foreground">
+        This castle washed away.
+      </h1>
+      <p className="max-w-sm text-sm text-muted">
+        404 - the page you're looking for isn't here. The tide got it.
+      </p>
       <Link
         to="/"
-        className="text-sm font-medium text-accent hover:text-accent/80 transition-colors"
+        className="relative mt-3 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground shadow-sm transition-all hover:bg-accent-hover hover:shadow-md"
       >
-        Back to Overview
+        Back to solid ground
       </Link>
     </div>
   );
@@ -120,7 +127,7 @@ export default function App() {
         <Suspense
           fallback={
             <div className="flex h-screen items-center justify-center">
-              <LoadingSpinner size="lg" />
+              <BuildingLoader />
             </div>
           }
         >

--- a/dashboard/src/__tests__/EmptyState.test.tsx
+++ b/dashboard/src/__tests__/EmptyState.test.tsx
@@ -15,20 +15,45 @@ describe("EmptyState", () => {
     expect(screen.getByText("Create your first workflow to get started.")).toBeInTheDocument();
   });
 
-  it("renders without icon", () => {
+  it("renders the sandcastle illustration by default (no icon, no variant)", () => {
     const { container } = render(
       <EmptyState title="Empty" description="Nothing here" />
     );
-    // No icon container should be present
+    // No legacy icon container, brand illustration instead
+    expect(container.querySelector(".rounded-2xl")).toBeNull();
+    const svg = container.querySelector('[data-illustration="sandcastle-empty"]');
+    expect(svg).not.toBeNull();
+    // Decorative: hidden from the accessibility tree
+    expect(svg).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it.each([
+    ["castle", "sandcastle-empty"],
+    ["building", "sandcastle-building"],
+    ["ruin", "sandcastle-ruin"],
+    ["tide", "tide-chart"],
+  ] as const)("renders the %s variant illustration", (variant, illustration) => {
+    const { container } = render(
+      <EmptyState variant={variant} title="Empty" description="Nothing here" />
+    );
+    expect(container.querySelector(`[data-illustration="${illustration}"]`)).not.toBeNull();
+  });
+
+  it("variant wins over a legacy icon", () => {
+    const { container } = render(
+      <EmptyState variant="ruin" icon={Inbox} title="Empty" description="Nothing here" />
+    );
+    expect(container.querySelector('[data-illustration="sandcastle-ruin"]')).not.toBeNull();
     expect(container.querySelector(".rounded-2xl")).toBeNull();
   });
 
-  it("renders with icon", () => {
+  it("renders a legacy lucide icon when no variant is given", () => {
     const { container } = render(
       <EmptyState icon={Inbox} title="Empty" description="Nothing here" />
     );
-    // Icon container should be present
+    // Icon container should be present, no brand illustration
     expect(container.querySelector(".rounded-2xl")).not.toBeNull();
+    expect(container.querySelector("[data-illustration]")).toBeNull();
   });
 
   it("renders action button when provided", () => {

--- a/dashboard/src/__tests__/pages-hooks-wave9.test.tsx
+++ b/dashboard/src/__tests__/pages-hooks-wave9.test.tsx
@@ -247,7 +247,7 @@ describe("ApprovalsPage", () => {
     render(<ApprovalsPage />);
     await waitFor(() => {
       expect(screen.getByText("No approvals")).toBeInTheDocument();
-      expect(screen.getByText("Workflow steps requiring human review will appear here.")).toBeInTheDocument();
+      expect(screen.getByText("Nothing waiting on you. Steps that need human sign-off surface here.")).toBeInTheDocument();
     });
   });
 

--- a/dashboard/src/__tests__/v27-regression.test.tsx
+++ b/dashboard/src/__tests__/v27-regression.test.tsx
@@ -943,7 +943,7 @@ describe("MemoryPage", () => {
       expect(screen.getByText("No memories yet")).toBeInTheDocument();
     });
 
-    expect(screen.getByText(/Memories are created automatically/)).toBeInTheDocument();
+    expect(screen.getByText(/Agents write memories here/)).toBeInTheDocument();
   });
 
   it("Search returns filtered results and shows clear button", async () => {

--- a/dashboard/src/components/brand/BuildingLoader.tsx
+++ b/dashboard/src/components/brand/BuildingLoader.tsx
@@ -1,0 +1,25 @@
+import { cn } from "@/lib/utils";
+import { SandcastleBuilding } from "./SandcastleBuilding";
+
+/**
+ * BuildingLoader - branded first-load moment: sandcastle under construction
+ * plus a "Building..." line. Use judiciously for full-page / section first
+ * loads; tables and inline refreshes keep plain skeletons.
+ */
+interface Props {
+  label?: string;
+  className?: string;
+}
+
+export function BuildingLoader({ label = "Building...", className }: Props) {
+  return (
+    <div
+      role="status"
+      aria-label={label}
+      className={cn("flex flex-col items-center justify-center gap-4 py-16", className)}
+    >
+      <SandcastleBuilding className="h-30 w-40 text-muted-foreground" />
+      <p className="font-display text-sm font-semibold tracking-wide text-muted">{label}</p>
+    </div>
+  );
+}

--- a/dashboard/src/components/brand/DuneContours.tsx
+++ b/dashboard/src/components/brand/DuneContours.tsx
@@ -1,0 +1,41 @@
+/**
+ * DuneContours - abstract layered dune contour lines. Purely decorative
+ * background art: always aria-hidden, very low contrast (the consumer sets
+ * opacity via className, e.g. "opacity-[0.06]").
+ *
+ * preserveAspectRatio="none" so it stretches edge-to-edge as a backdrop;
+ * give it an explicit height via className.
+ */
+interface Props {
+  className?: string;
+}
+
+export function DuneContours({ className }: Props) {
+  return (
+    <svg
+      viewBox="0 0 600 220"
+      preserveAspectRatio="none"
+      data-illustration="dune-contours"
+      aria-hidden="true"
+      className={`brand-backdrop ${className ?? ""}`}
+      fill="none"
+    >
+      <g stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+        <path d="M0 40 C 90 18, 180 55, 300 38 S 510 20, 600 42" />
+        <path d="M0 84 C 120 60, 240 96, 360 78 S 540 64, 600 84" opacity="0.8" />
+        <path d="M0 126 C 100 104, 220 138, 340 120 S 520 108, 600 128" opacity="0.6" />
+        <path d="M0 168 C 140 148, 260 180, 380 162 S 540 152, 600 170" opacity="0.45" />
+        <path d="M0 204 C 110 188, 230 216, 350 200 S 530 192, 600 206" opacity="0.3" />
+      </g>
+      {/* One beaded accent contour between the ink lines */}
+      <path
+        d="M0 105 C 110 84, 230 116, 350 100 S 530 88, 600 106"
+        stroke="var(--color-accent)"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeDasharray="1 7"
+        opacity="0.5"
+      />
+    </svg>
+  );
+}

--- a/dashboard/src/components/brand/SandcastleBuilding.tsx
+++ b/dashboard/src/components/brand/SandcastleBuilding.tsx
@@ -1,0 +1,73 @@
+/**
+ * SandcastleBuilding - a sandcastle under construction with bucket & shovel.
+ * The right tower is unfinished (dashed outline) and the flag pole is bare:
+ * the flag goes up when the build is done.
+ *
+ * Use for loading / in-progress / first-load contexts.
+ */
+interface Props {
+  className?: string;
+  /** Accessible label. Omit to render as purely decorative (aria-hidden). */
+  title?: string;
+}
+
+export function SandcastleBuilding({ className, title }: Props) {
+  return (
+    <svg
+      viewBox="0 0 160 120"
+      data-illustration="sandcastle-building"
+      role={title ? "img" : undefined}
+      aria-label={title}
+      aria-hidden={title ? undefined : true}
+      className={className}
+      fill="none"
+    >
+      <g stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        {/* Sand mound + secondary contour */}
+        <path d="M12 96 C 38 89, 62 93, 80 92 C 102 91, 126 88, 148 96" />
+        <path d="M30 103 C 58 99, 100 101, 130 102" opacity="0.35" />
+
+        {/* Central keep */}
+        <path d="M63 40 L67 92 M97 40 L93 92" />
+        <path d="M61 40 v-8 h7.2 v5 h7.2 v-5 h7.2 v5 h7.2 v-5 h7.2 v8" />
+        <path d="M75 92 v-11 a5 5.5 0 0 1 10 0 v11" />
+        <path d="M68.3 64 h23.4 M69 76 h22" opacity="0.3" />
+
+        {/* Left tower (complete) */}
+        <path d="M36 62 L40 92 M58 62 L54 92" />
+        <path d="M34 62 v-6 h5.2 v3.5 h5.2 v-3.5 h5.2 v3.5 h5.2 v-3.5 h5.2 v6" />
+        <path d="M38 74 h17 M39 84 h15.5" opacity="0.3" />
+
+        {/* Right tower: only the base is built... */}
+        <path d="M103.5 80 L106 92 M122.5 80 L120 92" />
+        <path d="M40 92 H120" />
+
+        {/* ...the rest is still a plan (dashed) */}
+        <g strokeDasharray="3 3" opacity="0.5">
+          <path d="M102 68 L103.5 80 M124 68 L122.5 80" />
+          <path d="M100 68 v-5.5 h5.2 v3.5 h5.2 v-3.5 h5.2 v3.5 h5.2 v-3.5 h5.2 v5.5" />
+        </g>
+
+        {/* Bare flag pole - the flag goes up when the build is done */}
+        <path d="M79 32 V18" />
+
+        {/* Bucket (left) */}
+        <path d="M23 76 L26 93 L40 93 L43 76" />
+        <path d="M21 76 h24" />
+        <path d="M24.5 76 A 8.7 8 0 0 1 41.5 76" />
+
+        {/* Shovel (right) */}
+        <path d="M137 66 L131 92" />
+        <path d="M134.5 65 l5.5 1.8" />
+
+        {/* Fresh sand pile */}
+        <path d="M112 93 q 8 -10 17 0" />
+        <path d="M117 89 l-2.5 4 M122.5 88.5 l-2.5 4.5" opacity="0.4" />
+      </g>
+
+      {/* Amber details: bucket band + shovel blade */}
+      <path d="M25.4 82 h13.2" stroke="var(--color-accent)" strokeWidth="2.5" strokeLinecap="round" opacity="0.9" />
+      <path d="M128.5 89 L135 91.5 L130.5 98 Z" fill="var(--color-accent)" opacity="0.9" />
+    </svg>
+  );
+}

--- a/dashboard/src/components/brand/SandcastleEmpty.tsx
+++ b/dashboard/src/components/brand/SandcastleEmpty.tsx
@@ -1,0 +1,66 @@
+/**
+ * SandcastleEmpty - a small proud sandcastle with a tiny amber flag.
+ * Fine line-art in currentColor so it adapts to both themes; amber
+ * accent details come from the --color-accent token.
+ *
+ * Default usage is the generic "nothing here yet" empty state.
+ */
+interface Props {
+  className?: string;
+  /** Accessible label. Omit to render as purely decorative (aria-hidden). */
+  title?: string;
+}
+
+export function SandcastleEmpty({ className, title }: Props) {
+  return (
+    <svg
+      viewBox="0 0 160 120"
+      data-illustration="sandcastle-empty"
+      role={title ? "img" : undefined}
+      aria-label={title}
+      aria-hidden={title ? undefined : true}
+      className={className}
+      fill="none"
+    >
+      <g stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        {/* Sand mound + secondary contour */}
+        <path d="M12 96 C 38 89, 62 93, 80 92 C 102 91, 126 88, 148 96" />
+        <path d="M30 103 C 58 99, 100 101, 130 102" opacity="0.35" />
+
+        {/* Central keep (bucket taper: wider at top) */}
+        <path d="M63 40 L67 92 M97 40 L93 92" />
+        <path d="M61 40 v-8 h7.2 v5 h7.2 v-5 h7.2 v5 h7.2 v-5 h7.2 v8" />
+        {/* Door arch */}
+        <path d="M75 92 v-11 a5 5.5 0 0 1 10 0 v11" />
+        {/* Sand ridges (texture) */}
+        <path d="M68.3 64 h23.4 M69 76 h22" opacity="0.3" />
+
+        {/* Left tower */}
+        <path d="M36 62 L40 92 M58 62 L54 92" />
+        <path d="M34 62 v-6 h5.2 v3.5 h5.2 v-3.5 h5.2 v3.5 h5.2 v-3.5 h5.2 v6" />
+        <path d="M38 74 h17 M39 84 h15.5" opacity="0.3" />
+
+        {/* Right tower */}
+        <path d="M102 68 L106 92 M124 68 L120 92" />
+        <path d="M100 68 v-5.5 h5.2 v3.5 h5.2 v-3.5 h5.2 v3.5 h5.2 v-3.5 h5.2 v5.5" />
+        <path d="M104 78 h18 M105 86 h16" opacity="0.3" />
+
+        {/* Baseline between towers and keep */}
+        <path d="M40 92 H120" />
+
+        {/* Flag pole */}
+        <path d="M79 32 V15" />
+      </g>
+
+      {/* Amber details: pennant, window, tiny shells */}
+      <path
+        d="M79 15 L93 19 L79 23.5 Z"
+        fill="var(--color-accent)"
+        className="brand-flag"
+      />
+      <path d="M77.5 56 v-2.5 a2.5 2.5 0 0 1 5 0 V56 Z" fill="var(--color-accent)" opacity="0.7" />
+      <circle cx="40" cy="99" r="1.3" fill="var(--color-accent)" opacity="0.5" />
+      <circle cx="122" cy="98.5" r="1.3" fill="var(--color-accent)" opacity="0.5" />
+    </svg>
+  );
+}

--- a/dashboard/src/components/brand/SandcastleRuin.tsx
+++ b/dashboard/src/components/brand/SandcastleRuin.tsx
@@ -1,0 +1,58 @@
+/**
+ * SandcastleRuin - a partially crumbled sandcastle: broken keep, collapsed
+ * tower, drooping flag. For errors, failures, and 404s.
+ */
+interface Props {
+  className?: string;
+  /** Accessible label. Omit to render as purely decorative (aria-hidden). */
+  title?: string;
+}
+
+export function SandcastleRuin({ className, title }: Props) {
+  return (
+    <svg
+      viewBox="0 0 160 120"
+      data-illustration="sandcastle-ruin"
+      role={title ? "img" : undefined}
+      aria-label={title}
+      aria-hidden={title ? undefined : true}
+      className={className}
+      fill="none"
+    >
+      <g stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        {/* Sand mound + receding tide line */}
+        <path d="M12 96 C 38 90, 62 94, 80 93 C 102 92, 126 89, 148 96" />
+        <path d="M126 102 q 5 -3 10 0 q 5 3 10 0" opacity="0.35" />
+        <path d="M26 104 C 50 100, 80 102, 104 103" opacity="0.35" />
+
+        {/* Keep: left half stands, right side broken away */}
+        <path d="M61 44 v-8 h7.2 v5 h7.2 v-5 h7.2 v8 l3 9 l-6 4 l8 7 l-4 8 l4.4 20 H64 Z" />
+        {/* Broken door arch */}
+        <path d="M73 92 v-7 a4.5 4.5 0 0 1 4.5 -4.5" />
+        {/* Crack */}
+        <path d="M76 72 l2.5 -5 l-2 -4 l3 -4" opacity="0.6" />
+        {/* Sand ridge */}
+        <path d="M66 82 h16" opacity="0.3" />
+
+        {/* Collapsed left tower: rubble mound + tumbled stones */}
+        <path d="M28 92 q 7 -10 14 -4 q 6 -6 12 4" />
+        <circle cx="38" cy="88.5" r="2" />
+        <circle cx="48.5" cy="90" r="1.6" />
+
+        {/* Right tower stub with jagged break */}
+        <path d="M104 92 V78 l4.5 2 l3 -5.5 l4.5 3.5 V92" />
+        <path d="M106 86 h8" opacity="0.3" />
+
+        {/* Baseline */}
+        <path d="M28 92 H120" />
+
+        {/* Tilted flag pole */}
+        <path d="M70 36 L74 20" />
+      </g>
+
+      {/* Amber details: drooping flag, half-buried shell */}
+      <path d="M74 20 q 7 1.5 8.5 7 l-7.5 -2.5 Z" fill="var(--color-accent)" opacity="0.85" />
+      <circle cx="118" cy="98" r="1.3" fill="var(--color-accent)" opacity="0.5" />
+    </svg>
+  );
+}

--- a/dashboard/src/components/brand/TideChart.tsx
+++ b/dashboard/src/components/brand/TideChart.tsx
@@ -1,0 +1,43 @@
+/**
+ * TideChart - minimal wave/tide line motif for waiting, scheduled, and
+ * filtered-to-nothing contexts. Works as a divider or a light empty-state
+ * illustration.
+ */
+interface Props {
+  className?: string;
+  /** Accessible label. Omit to render as purely decorative (aria-hidden). */
+  title?: string;
+}
+
+export function TideChart({ className, title }: Props) {
+  return (
+    <svg
+      viewBox="0 0 240 48"
+      data-illustration="tide-chart"
+      role={title ? "img" : undefined}
+      aria-label={title}
+      aria-hidden={title ? undefined : true}
+      className={className}
+      fill="none"
+    >
+      {/* Main tide line */}
+      <path
+        d="M6 26 C 20 12, 36 12, 50 26 S 78 40, 92 26 S 120 12, 134 26 S 162 40, 176 26 S 204 12, 218 26"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      {/* Beaded echo wave, slightly offset */}
+      <path
+        d="M14 33 C 28 21, 44 21, 58 33 S 86 45, 100 33 S 128 21, 142 33 S 170 45, 184 33 S 212 21, 226 33"
+        stroke="var(--color-accent)"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeDasharray="1 6"
+        opacity="0.6"
+      />
+      {/* High-tide marker */}
+      <circle cx="134" cy="26" r="2.4" fill="var(--color-accent)" />
+    </svg>
+  );
+}

--- a/dashboard/src/components/brand/index.ts
+++ b/dashboard/src/components/brand/index.ts
@@ -1,0 +1,6 @@
+export { SandcastleEmpty } from "./SandcastleEmpty";
+export { SandcastleBuilding } from "./SandcastleBuilding";
+export { SandcastleRuin } from "./SandcastleRuin";
+export { DuneContours } from "./DuneContours";
+export { TideChart } from "./TideChart";
+export { BuildingLoader } from "./BuildingLoader";

--- a/dashboard/src/components/overview/BentoEmptyState.tsx
+++ b/dashboard/src/components/overview/BentoEmptyState.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { ArrowRight, Castle, Check, CheckCircle, Loader2, Rocket } from "lucide-react";
 import { api } from "@/api/client";
 import { cn } from "@/lib/utils";
+import { DuneContours } from "@/components/brand";
 
 const CHECKLIST_KEY = "sandcastle_getting_started";
 
@@ -151,7 +152,8 @@ export function BentoEmptyState() {
   return (
     <div className="space-y-4">
       {!cls.dismissed && (
-        <div className="bg-surface rounded-2xl shadow-sm border border-border p-6">
+        <div className="relative overflow-hidden bg-surface rounded-2xl shadow-sm border border-border p-6">
+          <DuneContours className="absolute inset-x-0 bottom-0 h-28 w-full text-foreground opacity-[0.05]" />
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-3">
               <div className="flex items-center justify-center w-10 h-10 rounded-xl bg-accent/10">

--- a/dashboard/src/components/overview/CostForecast.tsx
+++ b/dashboard/src/components/overview/CostForecast.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { TrendingUp, TrendingDown, AlertTriangle, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { api } from "@/api/client";
+import { TideChart } from "@/components/brand";
 
 interface DayData {
   date: string;
@@ -80,7 +81,10 @@ export function CostForecast() {
           </div>
           <h3 className="text-sm font-medium text-foreground">Cost Forecast</h3>
         </div>
-        <p className="text-xs text-muted text-center py-8">{error || "No data"}</p>
+        <div className="flex flex-col items-center gap-2 py-6">
+          <TideChart className="h-8 w-36 text-muted-foreground" />
+          <p className="text-xs text-muted text-center">{error || "No cost data yet"}</p>
+        </div>
       </div>
     );
   }

--- a/dashboard/src/components/shared/EmptyState.tsx
+++ b/dashboard/src/components/shared/EmptyState.tsx
@@ -1,7 +1,30 @@
 import { cn } from "@/lib/utils";
 import type { LucideIcon } from "lucide-react";
+import { SandcastleEmpty } from "@/components/brand/SandcastleEmpty";
+import { SandcastleBuilding } from "@/components/brand/SandcastleBuilding";
+import { SandcastleRuin } from "@/components/brand/SandcastleRuin";
+import { TideChart } from "@/components/brand/TideChart";
+
+/**
+ * Brand illustration variants:
+ * - "castle"   - proud sandcastle: generic "nothing here yet" (default)
+ * - "building" - castle under construction: something is being set up
+ * - "ruin"     - crumbled castle: errors and failures
+ * - "tide"     - wave motif: waiting, scheduled, or filtered-to-nothing
+ */
+export type EmptyStateVariant = "castle" | "building" | "ruin" | "tide";
+
+const ILLUSTRATIONS: Record<EmptyStateVariant, (props: { className?: string }) => React.JSX.Element> = {
+  castle: SandcastleEmpty,
+  building: SandcastleBuilding,
+  ruin: SandcastleRuin,
+  tide: TideChart,
+};
 
 interface EmptyStateProps {
+  /** Brand illustration. Defaults to the sandcastle unless a legacy icon is given. */
+  variant?: EmptyStateVariant;
+  /** @deprecated Legacy lucide icon - only rendered when no variant is set. */
   icon?: LucideIcon;
   title: string;
   description: string;
@@ -12,15 +35,27 @@ interface EmptyStateProps {
   className?: string;
 }
 
-export function EmptyState({ icon: Icon, title, description, action, className }: EmptyStateProps) {
+export function EmptyState({ variant, icon: Icon, title, description, action, className }: EmptyStateProps) {
+  // Brand illustration wins; the lucide icon remains only as a legacy escape
+  // hatch. With neither prop, the sandcastle is the house default.
+  const Illustration = variant ? ILLUSTRATIONS[variant] : Icon ? null : SandcastleEmpty;
+  const isTide = variant === "tide";
+
   return (
     <div className={cn("flex flex-col items-center justify-center py-16 text-center", className)}>
-      {Icon && (
+      {Illustration ? (
+        <Illustration
+          className={cn(
+            "text-muted-foreground",
+            isTide ? "mb-4 h-12 w-48" : "mb-5 h-27 w-36"
+          )}
+        />
+      ) : Icon ? (
         <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-accent/10">
           <Icon className="h-8 w-8 text-accent" />
         </div>
-      )}
-      <h3 className="mb-1 text-lg font-semibold text-foreground">{title}</h3>
+      ) : null}
+      <h3 className="mb-1 font-display text-lg font-semibold tracking-tight text-foreground">{title}</h3>
       <p className="mb-6 max-w-sm text-sm text-muted">{description}</p>
       {action && (
         <button

--- a/dashboard/src/components/ui/Skeleton.tsx
+++ b/dashboard/src/components/ui/Skeleton.tsx
@@ -1,21 +1,15 @@
 /**
- * Skeleton loader with animated shimmer effect.
- * Uses the skeleton-shimmer keyframe defined in index.css.
+ * Skeleton loader with a warm sand shimmer sweep.
+ * Base tint + sweep gradient live in styles/brand.css (token-based,
+ * adapts to both themes).
  */
 export function Skeleton({ className = "" }: { className?: string }) {
   return (
     <div
-      className={`relative overflow-hidden rounded-md bg-border/50 ${className}`}
+      className={`skeleton-sand relative overflow-hidden rounded-md ${className}`}
       aria-hidden="true"
     >
-      <div
-        className="absolute inset-0"
-        style={{
-          background:
-            "linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.08) 50%, transparent 100%)",
-          animation: "skeleton-shimmer 1.8s ease-in-out infinite",
-        }}
-      />
+      <div className="skeleton-sand-sweep absolute inset-0" />
     </div>
   );
 }

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "sonner";
 import "@fontsource/bricolage-grotesque/600.css";
 import "@fontsource/bricolage-grotesque/700.css";
 import "./index.css";
+import "./styles/brand.css";
 import App from "./App.tsx";
 
 // Apply the theme immediately to prevent a flash. Dark-first: a stored preference

--- a/dashboard/src/pages/ApiKeysPage.tsx
+++ b/dashboard/src/pages/ApiKeysPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Key, Plus, Loader2, Sparkles, Server } from "lucide-react";
+import { Plus, Loader2, Sparkles, Server } from "lucide-react";
 import { toast } from "sonner";
 import { api } from "@/api/client";
 import { ApiKeyTable, type ApiKeyItem } from "@/components/api-keys/ApiKeyTable";
@@ -227,9 +227,9 @@ export default function ApiKeysPage() {
 
       {keys.length === 0 ? (
         <EmptyState
-          icon={Key}
+          variant="castle"
           title="No API keys yet"
-          description="Create your first API key to authenticate requests."
+          description="Mint your first key to authenticate API requests."
           action={{ label: "Create API Key", onClick: () => setCreateModalOpen(true) }}
         />
       ) : (

--- a/dashboard/src/pages/ApprovalsPage.tsx
+++ b/dashboard/src/pages/ApprovalsPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { ShieldCheck, Clock, CheckCircle2, XCircle, SkipForward, RefreshCw, MessageSquare, Loader2 } from "lucide-react";
+import { Clock, CheckCircle2, XCircle, SkipForward, RefreshCw, MessageSquare, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { api } from "@/api/client";
 import { EmptyState } from "@/components/shared/EmptyState";
@@ -224,9 +224,9 @@ export default function ApprovalsPage() {
 
       {items.length === 0 ? (
         <EmptyState
-          icon={ShieldCheck}
+          variant="tide"
           title="No approvals"
-          description="Workflow steps requiring human review will appear here."
+          description="Nothing waiting on you. Steps that need human sign-off surface here."
         />
       ) : (
         <div className="space-y-3">

--- a/dashboard/src/pages/AutoPilotPage.tsx
+++ b/dashboard/src/pages/AutoPilotPage.tsx
@@ -214,9 +214,9 @@ export default function AutoPilotPage() {
       {/* Experiments */}
       {experiments.length === 0 ? (
         <EmptyState
-          icon={FlaskConical}
+          variant="building"
           title="No experiments yet"
-          description="Add autopilot config to any workflow step to start optimizing automatically."
+          description="Add autopilot config to any workflow step and Sandcastle starts optimizing on its own."
         />
       ) : (
         <div className="space-y-4">

--- a/dashboard/src/pages/DeadLetterPage.tsx
+++ b/dashboard/src/pages/DeadLetterPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Inbox, AlertTriangle, Layers, List } from "lucide-react";
+import { AlertTriangle, Layers, List } from "lucide-react";
 import { toast } from "sonner";
 import { api } from "@/api/client";
 import { DeadLetterTable, type DLQItem } from "@/components/dead-letter/DeadLetterTable";
@@ -200,9 +200,9 @@ export default function DeadLetterPage() {
 
       {items.length === 0 ? (
         <EmptyState
-          icon={Inbox}
+          variant="castle"
           title="No dead letters"
-          description="Failed steps that exceed retry limits will appear here."
+          description="Nothing washed up. Steps that exhaust their retries land here."
         />
       ) : viewMode === "clustered" ? (
         <ErrorClusters

--- a/dashboard/src/pages/EvaluationsPage.tsx
+++ b/dashboard/src/pages/EvaluationsPage.tsx
@@ -297,7 +297,7 @@ export default function EvaluationsPage() {
       {/* Eval runs list */}
       {runs.length === 0 ? (
         <EmptyState
-          icon={ClipboardCheck}
+          variant="castle"
           title="No evaluations yet"
           description="Run your first eval suite via CLI (sandcastle eval suite.yaml) or the API."
         />

--- a/dashboard/src/pages/EvolutionPage.tsx
+++ b/dashboard/src/pages/EvolutionPage.tsx
@@ -1253,9 +1253,9 @@ export default function EvolutionPage() {
       {/* Empty state */}
       {evolutions.length === 0 && (
         <EmptyState
-          icon={Sparkles}
+          variant="building"
           title="No evolutions yet"
-          description="Start an evolution to automatically discover better prompts, models, and configurations for your workflows."
+          description="Start an evolution and let it discover better prompts, models, and configurations for your workflows."
         />
       )}
 

--- a/dashboard/src/pages/IntegrationsPage.tsx
+++ b/dashboard/src/pages/IntegrationsPage.tsx
@@ -5,7 +5,6 @@ import {
   AlertTriangle,
   Link2,
   Blocks,
-  Plug,
   KeyRound,
 } from "lucide-react";
 import { api } from "@/api/client";
@@ -337,9 +336,9 @@ export default function IntegrationsPage() {
       ) : (
         <section>
           <EmptyState
-            icon={Plug}
+            variant="castle"
             title="No integrations configured yet"
-            description="Connect your workflows to external services."
+            description="Connect your workflows to the world outside the castle walls."
           />
           {/* Popular quick-start cards */}
           <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4 max-w-3xl mx-auto">

--- a/dashboard/src/pages/MemoryPage.tsx
+++ b/dashboard/src/pages/MemoryPage.tsx
@@ -267,12 +267,12 @@ export default function MemoryPage() {
       {/* Memory list */}
       {memories.length === 0 ? (
         <EmptyState
-          icon={Brain}
+          variant={searchQuery ? "tide" : "castle"}
           title={searchQuery ? "No matching memories" : "No memories yet"}
           description={
             searchQuery
               ? "Try a different search query or clear the filter."
-              : "Memories are created automatically as agents learn from workflow runs."
+              : "Agents write memories here as they learn from workflow runs."
           }
           action={
             searchQuery

--- a/dashboard/src/pages/Onboarding.tsx
+++ b/dashboard/src/pages/Onboarding.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { OnboardingWizard } from "@/components/onboarding/OnboardingWizard";
+import { DuneContours } from "@/components/brand";
 
 /**
  * Full-screen onboarding page - renders outside the Layout wrapper.
@@ -22,7 +23,10 @@ export default function Onboarding() {
   }, [navigate]);
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-background bg-grid p-4 sm:p-6">
+    <div className="relative flex min-h-screen flex-col items-center justify-center bg-background bg-grid p-4 sm:p-6">
+      {/* Dune contours along the bottom - quiet brand backdrop */}
+      <DuneContours className="fixed inset-x-0 bottom-0 h-44 w-full text-foreground opacity-[0.06] sm:h-56" />
+
       {/* Subtle brand in top-left */}
       <div className="fixed top-4 left-4 flex items-center gap-2 text-sm font-semibold text-foreground/60">
         <span className="text-lg">🏰</span>
@@ -30,7 +34,7 @@ export default function Onboarding() {
       </div>
 
       {/* Centered wizard container */}
-      <div className="w-full max-w-[720px]">
+      <div className="relative w-full max-w-[720px]">
         <OnboardingWizard onFinish={handleFinish} />
       </div>
     </div>

--- a/dashboard/src/pages/OptimizerPage.tsx
+++ b/dashboard/src/pages/OptimizerPage.tsx
@@ -254,9 +254,9 @@ export default function OptimizerPage() {
       {/* Decisions */}
       {decisions.length === 0 ? (
         <EmptyState
-          icon={Gauge}
+          variant="castle"
           title="No optimizer decisions"
-          description="When the optimizer selects models for workflow steps, decisions will appear here."
+          description="When the optimizer picks models for workflow steps, its reasoning shows up here."
         />
       ) : (
         <div className="space-y-3">

--- a/dashboard/src/pages/RunComparePage.tsx
+++ b/dashboard/src/pages/RunComparePage.tsx
@@ -4,7 +4,6 @@ import {
   ArrowDown,
   ArrowUp,
   Minus,
-  GitCompareArrows,
   ArrowLeftRight,
   ChevronDown,
   Clock,
@@ -569,7 +568,7 @@ export default function RunComparePage() {
         {(!runA || !runB) && !data && (
           <div className="py-12">
             <EmptyState
-              icon={GitCompareArrows}
+              variant="tide"
               title="Select two runs to compare"
               description="Choose Run A and Run B from the dropdowns above to see a side-by-side comparison."
             />
@@ -579,7 +578,7 @@ export default function RunComparePage() {
         {error && (
           <div className="py-12">
             <EmptyState
-              icon={GitCompareArrows}
+              variant="ruin"
               title="Cannot compare runs"
               description={error}
             />

--- a/dashboard/src/pages/Runs.tsx
+++ b/dashboard/src/pages/Runs.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
-import { PlayCircle, Trash2, XCircle, Search, AlertTriangle, BookmarkPlus, X, Bookmark, Zap, Download, GitCompareArrows } from "lucide-react";
+import { Trash2, XCircle, Search, AlertTriangle, BookmarkPlus, X, Bookmark, Zap, Download, GitCompareArrows } from "lucide-react";
 import { toast } from "sonner";
 import { api } from "@/api/client";
 import { useRuns } from "@/hooks/useRuns";
@@ -521,12 +521,12 @@ export default function Runs() {
         </div>
       ) : filteredRuns.length === 0 ? (
         <EmptyState
-          icon={PlayCircle}
+          variant={statusFilter !== "all" || workflowFilter || searchTerm ? "tide" : "castle"}
           title={statusFilter !== "all" || workflowFilter || searchTerm ? "No runs match your filters" : "No runs yet"}
           description={
             statusFilter !== "all" || workflowFilter || searchTerm
-              ? "Try adjusting your filters."
-              : "Run a workflow to see execution history here."
+              ? "The tide turned up nothing. Try loosening your filters."
+              : "Run a workflow and its history lands here. Build something."
           }
           action={
             statusFilter !== "all" || workflowFilter || searchTerm

--- a/dashboard/src/pages/ScheduleMonitorPage.tsx
+++ b/dashboard/src/pages/ScheduleMonitorPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import {
-  Calendar, Clock, Play, Pause, AlertTriangle, CheckCircle2,
+  Clock, Play, Pause, AlertTriangle, CheckCircle2,
   Loader2, RefreshCw, RotateCcw,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -212,7 +212,7 @@ export default function ScheduleMonitorPage() {
 
       {schedules.length === 0 ? (
         <EmptyState
-          icon={Calendar}
+          variant="tide"
           title="No schedules configured"
           description="Create a schedule from the Schedules page to start monitoring automated workflow runs."
         />

--- a/dashboard/src/pages/Schedules.tsx
+++ b/dashboard/src/pages/Schedules.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Calendar, Plus, Loader2 } from "lucide-react";
+import { Plus, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { api } from "@/api/client";
 import { ScheduleTable } from "@/components/schedules/ScheduleTable";
@@ -163,9 +163,9 @@ export default function Schedules() {
 
       {schedules.length === 0 ? (
         <EmptyState
-          icon={Calendar}
+          variant="tide"
           title="No schedules yet"
-          description="No schedules configured. Create a schedule to run workflows on a cron timer."
+          description="Put a workflow on a cron timer and let the tide do the work."
           action={{ label: "New Schedule", onClick: () => setModalOpen(true) }}
         />
       ) : (

--- a/dashboard/src/pages/TemplatesPage.tsx
+++ b/dashboard/src/pages/TemplatesPage.tsx
@@ -974,14 +974,14 @@ export default function TemplatesPage() {
             </div>
           ) : communityError ? (
             <EmptyState
-              icon={Globe}
+              variant="ruin"
               title="Could not load community workflows"
               description="Check your connection and try again."
               action={{ label: "Retry", onClick: handleCommunityRetry }}
             />
           ) : communityFiltered.length === 0 ? (
             <EmptyState
-              icon={Globe}
+              variant={communitySearch ? "tide" : "castle"}
               title={communitySearch ? "No matching workflows" : "No community workflows yet"}
               description={communitySearch ? "Try adjusting your search." : "Be the first to contribute!"}
               action={
@@ -1567,7 +1567,7 @@ function PacksView({
         {searchResults.length === 0 ? (
           <>
             <EmptyState
-              icon={Layers}
+              variant="tide"
               title="No templates found"
               description="Try adjusting your search query."
             />
@@ -2002,7 +2002,7 @@ function AllTemplatesEmpty({
   return (
     <>
       <EmptyState
-        icon={Layers}
+        variant="tide"
         title="No templates found"
         description={
           isInstalledFilter
@@ -2067,7 +2067,7 @@ function IntegrationView({
   if (filteredGroups.length === 0) {
     return (
       <EmptyState
-        icon={Plug}
+        variant={search ? "tide" : "castle"}
         title={search ? "No matching integrations" : "No integrations found"}
         description={search ? "Try adjusting your search query." : "Template packs with tool integrations will appear here."}
       />

--- a/dashboard/src/pages/ViolationsPage.tsx
+++ b/dashboard/src/pages/ViolationsPage.tsx
@@ -160,9 +160,9 @@ export default function ViolationsPage() {
 
       {items.length === 0 ? (
         <EmptyState
-          icon={ShieldAlert}
+          variant="castle"
           title="No violations"
-          description="Policy violations from workflow runs will appear here."
+          description="A clean record. Policy violations from runs would land here."
         />
       ) : (
         <div className="space-y-3">

--- a/dashboard/src/pages/Workflows.tsx
+++ b/dashboard/src/pages/Workflows.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { GitBranch, LayoutGrid, Network, Plus, Search, Star, Trash2, X, Loader2 } from "lucide-react";
+import { LayoutGrid, Network, Plus, Search, Star, Trash2, X, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { api } from "@/api/client";
 import { WorkflowList } from "@/components/workflows/WorkflowList";
@@ -276,9 +276,9 @@ export default function Workflows() {
       {viewMode === "graph" ? (
         workflows.length === 0 ? (
           <EmptyState
-            icon={GitBranch}
+            variant="castle"
             title="No workflows found"
-            description="No workflows found. Add YAML files to your workflows directory to get started."
+            description="Drop YAML files into your workflows directory, or build one right here."
             action={{ label: "Create Workflow", onClick: () => navigate("/workflows/builder") }}
           />
         ) : (
@@ -330,14 +330,14 @@ export default function Workflows() {
 
           {workflows.length === 0 ? (
             <EmptyState
-              icon={GitBranch}
+              variant="castle"
               title="No workflows found"
-              description="No workflows found. Add YAML files to your workflows directory to get started."
+              description="Drop YAML files into your workflows directory, or build one right here."
               action={{ label: "Create Workflow", onClick: () => navigate("/workflows/builder") }}
             />
           ) : filteredWorkflows.length === 0 ? (
             <EmptyState
-              icon={Search}
+              variant="tide"
               title="No matching workflows"
               description={`No workflows match "${searchQuery}".`}
               action={{ label: "Clear search", onClick: () => setSearchQuery("") }}

--- a/dashboard/src/styles/brand.css
+++ b/dashboard/src/styles/brand.css
@@ -1,0 +1,58 @@
+/* ────────────────────────────────────────────────────────────────────
+   Sandcastle brand signature moments (visual revamp PR 4)
+   Flag wave, warm sand skeleton shimmer, dune backdrop helpers.
+   All colors derive from the theme tokens defined in index.css.
+   ──────────────────────────────────────────────────────────────────── */
+
+/* ──── Gentle flag wave on the empty-state sandcastle ──── */
+
+@keyframes brand-flag-wave {
+  0%, 100% { transform: skewY(0deg) scaleX(1); }
+  50%      { transform: skewY(-5deg) scaleX(0.96); }
+}
+
+.brand-flag {
+  transform-box: fill-box;
+  transform-origin: left center;
+  animation: brand-flag-wave 3.4s ease-in-out infinite;
+}
+
+/* ──── Warm sand skeleton shimmer (replaces the cold gray pulse) ──── */
+
+@keyframes brand-sand-sweep {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(200%); }
+}
+
+.skeleton-sand {
+  background: color-mix(in srgb, var(--color-border) 60%, var(--color-background));
+}
+
+.skeleton-sand-sweep {
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    color-mix(in srgb, var(--color-accent) 9%, transparent) 40%,
+    color-mix(in srgb, var(--color-accent) 16%, transparent) 50%,
+    color-mix(in srgb, var(--color-accent) 9%, transparent) 60%,
+    transparent 100%
+  );
+  animation: brand-sand-sweep 1.8s ease-in-out infinite;
+}
+
+/* ──── Decorative dune backdrop ──── */
+
+.brand-backdrop {
+  pointer-events: none;
+  user-select: none;
+}
+
+/* ──── Accessibility: respect reduced motion
+        (mirrors the exclusion-list pattern in index.css) ──── */
+
+@media (prefers-reduced-motion: reduce) {
+  .brand-flag,
+  .skeleton-sand-sweep {
+    animation: none !important;
+  }
+}


### PR DESCRIPTION
**Visual revamp 4/5.** The moments where every generic dashboard shows "icon + No data yet" become ownable artwork — one consistent style: fine 1.5px line-art in `currentColor` + amber accents, inline SVG React components (themeable, accessible):

- Illustration set: `SandcastleEmpty` (proud castle, amber flag), `SandcastleBuilding` (bucket & shovel — loading), `SandcastleRuin` (error/404), `DuneContours` (low-contrast backdrop), `TideChart` (waiting/scheduled motif)
- Shared `EmptyState` with `variant` prop, swept across 17 pages (Runs, Workflows, Templates, Schedules, Evaluations, Memory, DeadLetter, Approvals, Violations, Evolution, Optimizer, AutoPilot, Integrations, ApiKeys, RunCompare…) with tightened copy
- 404 rebuilt: SandcastleRuin + "This castle washed away." + "Back to solid ground"
- Skeletons re-tinted to warm sand shimmer; `BuildingLoader` for route-level first loads
- DuneContours backdrops on Onboarding + Getting Started (5-6% opacity)

Stacked on #256 (Sand & Ink). Tests: vitest 810/810 (6 new), lint zero new, build green.