### PR TITLE
feat(dashboard): settle motion identity — easing tokens, odometers, live-surface scanlines (visual 5/5)

### DIFF
--- a/dashboard/src/__tests__/Odometer.test.tsx
+++ b/dashboard/src/__tests__/Odometer.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { Odometer } from "@/components/ui/Odometer";
+import { easeSettle } from "@/lib/motion";
+
+/** Manually steppable rAF + performance.now mock. */
+function installRafMock() {
+  let now = 0;
+  let nextId = 1;
+  const queue = new Map<number, FrameRequestCallback>();
+
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    const id = nextId++;
+    queue.set(id, cb);
+    return id;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+    queue.delete(id);
+  });
+  vi.spyOn(performance, "now").mockImplementation(() => now);
+
+  return {
+    /** Advance the clock and flush one frame batch. */
+    step(ms: number) {
+      now += ms;
+      const callbacks = [...queue.values()];
+      queue.clear();
+      for (const cb of callbacks) cb(now);
+    },
+    /** Run frames until the queue drains (animation finished). */
+    finish(frameMs = 16, maxFrames = 200) {
+      let frames = 0;
+      while (queue.size > 0 && frames < maxFrames) {
+        this.step(frameMs);
+        frames++;
+      }
+    },
+    get pending() {
+      return queue.size;
+    },
+  };
+}
+
+function setReducedMotion(matches: boolean) {
+  vi.stubGlobal("matchMedia", (query: string) => ({
+    matches: query.includes("prefers-reduced-motion") ? matches : false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }));
+}
+
+/** The visible (animated overlay) text node — the second aria-hidden span. */
+function visibleText(container: HTMLElement): string {
+  const spans = container.querySelectorAll("span[aria-hidden]");
+  return spans[spans.length - 1].textContent ?? "";
+}
+
+describe("Odometer", () => {
+  let raf: ReturnType<typeof installRafMock>;
+
+  beforeEach(() => {
+    setReducedMotion(false);
+    raf = installRafMock();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the final value immediately for width reservation (no layout shift)", () => {
+    const { container } = render(<Odometer value={1234} duration={400} />);
+    // First aria-hidden span is the invisible width reserver with the final value.
+    const reserver = container.querySelector("span.invisible");
+    expect(reserver).not.toBeNull();
+    expect(reserver!.textContent).toBe("1,234");
+  });
+
+  it("starts at 0 on first mount and eases up to the target", () => {
+    const { container } = render(<Odometer value={100} duration={400} />);
+    expect(visibleText(container)).toBe("0");
+
+    // Halfway: value follows the settle curve (monotonic, past linear midpoint).
+    act(() => raf.step(200));
+    const mid = Number(visibleText(container).replace(/,/g, ""));
+    expect(mid).toBeGreaterThan(50);
+    expect(mid).toBeLessThan(100);
+    expect(mid).toBe(Math.round(100 * easeSettle(0.5)));
+
+    act(() => raf.finish());
+    expect(visibleText(container)).toBe("100");
+  });
+
+  it("eases from the previous value on update, not from 0", () => {
+    const { container, rerender } = render(<Odometer value={100} duration={400} />);
+    act(() => raf.finish());
+    expect(visibleText(container)).toBe("100");
+
+    rerender(<Odometer value={200} duration={400} />);
+    act(() => raf.step(40)); // 10% in
+    const v = Number(visibleText(container).replace(/,/g, ""));
+    expect(v).toBeGreaterThanOrEqual(100); // never dips back toward 0
+    expect(v).toBeLessThan(200);
+
+    act(() => raf.finish());
+    expect(visibleText(container)).toBe("200");
+  });
+
+  it("applies the format function every frame", () => {
+    const format = (v: number) => `$${v.toFixed(2)}`;
+    const { container } = render(<Odometer value={5} format={format} duration={400} />);
+    expect(visibleText(container)).toBe("$0.00");
+    act(() => raf.finish());
+    expect(visibleText(container)).toBe("$5.00");
+  });
+
+  it("jumps instantly when prefers-reduced-motion is set", () => {
+    setReducedMotion(true);
+    const { container } = render(<Odometer value={4321} duration={400} />);
+    expect(visibleText(container)).toBe("4,321");
+    expect(raf.pending).toBe(0); // no animation scheduled
+  });
+
+  it("jumps instantly on update under reduced motion", () => {
+    setReducedMotion(true);
+    const { container, rerender } = render(<Odometer value={10} duration={400} />);
+    rerender(<Odometer value={99} duration={400} />);
+    expect(visibleText(container)).toBe("99");
+    expect(raf.pending).toBe(0);
+  });
+
+  it("exposes the final value as an accessible label", () => {
+    render(<Odometer value={777} duration={400} />);
+    expect(screen.getByLabelText("777")).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/__tests__/dashboard-wave8.test.tsx
+++ b/dashboard/src/__tests__/dashboard-wave8.test.tsx
@@ -100,10 +100,11 @@ describe("StatsCards", () => {
     render(
       <StatsCards totalRuns={0} successRate={0} totalCost={0} avgDuration={0} />
     );
-    expect(screen.getByText("0")).toBeInTheDocument();
-    expect(screen.getByText("0%")).toBeInTheDocument();
-    expect(screen.getByText("$0.00")).toBeInTheDocument();
-    expect(screen.getByText("0s")).toBeInTheDocument();
+    // Odometer renders the value twice (invisible width reserver + overlay)
+    expect(screen.getAllByText("0")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("0%")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("$0.00")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("0s")[0]).toBeInTheDocument();
   });
 
   it("handles NaN success rate gracefully (displays 0%)", () => {
@@ -111,7 +112,7 @@ describe("StatsCards", () => {
       <StatsCards totalRuns={0} successRate={NaN} totalCost={0} avgDuration={0} />
     );
     // After the bug fix, NaN should show as 0%
-    expect(screen.getByText("0%")).toBeInTheDocument();
+    expect(screen.getAllByText("0%")[0]).toBeInTheDocument();
   });
 
   it("handles Infinity cost gracefully", () => {
@@ -119,7 +120,7 @@ describe("StatsCards", () => {
       <StatsCards totalRuns={0} successRate={0} totalCost={Infinity} avgDuration={0} />
     );
     // formatCost handles non-finite -> "$0.00"
-    expect(screen.getByText("$0.00")).toBeInTheDocument();
+    expect(screen.getAllByText("$0.00")[0]).toBeInTheDocument();
   });
 
   it("handles NaN duration gracefully", () => {
@@ -127,14 +128,14 @@ describe("StatsCards", () => {
       <StatsCards totalRuns={0} successRate={0} totalCost={0} avgDuration={NaN} />
     );
     // formatDuration handles non-finite -> "0s"
-    expect(screen.getByText("0s")).toBeInTheDocument();
+    expect(screen.getAllByText("0s")[0]).toBeInTheDocument();
   });
 
   it("handles negative duration gracefully", () => {
     render(
       <StatsCards totalRuns={0} successRate={0} totalCost={0} avgDuration={-10} />
     );
-    expect(screen.getByText("0s")).toBeInTheDocument();
+    expect(screen.getAllByText("0s")[0]).toBeInTheDocument();
   });
 
   it("renders 100% success rate", () => {
@@ -588,7 +589,7 @@ describe("RunsTable", () => {
         onPageChange={vi.fn()}
       />
     );
-    expect(screen.getByText("$0.00")).toBeInTheDocument();
+    expect(screen.getAllByText("$0.00")[0]).toBeInTheDocument();
   });
 
   it("has proper aria-label on table", () => {

--- a/dashboard/src/components/api-keys/CreateApiKeyModal.tsx
+++ b/dashboard/src/components/api-keys/CreateApiKeyModal.tsx
@@ -126,7 +126,7 @@ export function CreateApiKeyModal({ open, loading, onClose, onSubmit }: CreateAp
                 disabled={loading}
                 className={cn(
                   "flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground",
-                  "hover:bg-accent-hover transition-all duration-200",
+                  "hover:bg-accent-hover transition-settle",
                   "shadow-sm hover:shadow-md",
                   "disabled:opacity-50 disabled:cursor-not-allowed"
                 )}

--- a/dashboard/src/components/api-keys/KeyRevealModal.tsx
+++ b/dashboard/src/components/api-keys/KeyRevealModal.tsx
@@ -77,7 +77,7 @@ export function KeyRevealModal({ apiKey, onClose }: KeyRevealModalProps) {
               onClick={onClose}
               className={cn(
                 "rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground",
-                "hover:bg-accent-hover transition-all duration-200",
+                "hover:bg-accent-hover transition-settle",
                 "shadow-sm hover:shadow-md"
               )}
             >

--- a/dashboard/src/components/layout/ActivityFeed.tsx
+++ b/dashboard/src/components/layout/ActivityFeed.tsx
@@ -132,7 +132,7 @@ export function ActivityFeed() {
         aria-haspopup="true"
         className={cn(
           "relative flex h-9 w-9 items-center justify-center rounded-lg",
-          "hover:bg-border/50 transition-all duration-200",
+          "hover:bg-border/50 transition-settle",
           "text-muted hover:text-foreground",
           shaking && "animate-bell-shake",
         )}

--- a/dashboard/src/components/layout/Header.tsx
+++ b/dashboard/src/components/layout/Header.tsx
@@ -221,7 +221,7 @@ export function Header({
           className={cn(
             "ml-auto hidden h-9 w-full max-w-sm items-center gap-2 rounded-lg border border-border bg-background px-3 text-sm sm:flex lg:ml-8",
             "text-muted-foreground/50 hover:border-accent/30 hover:text-muted-foreground",
-            "transition-all duration-200"
+            "transition-settle"
           )}
         >
           <Search className="h-4 w-4 shrink-0" />

--- a/dashboard/src/components/layout/NotificationCenter.tsx
+++ b/dashboard/src/components/layout/NotificationCenter.tsx
@@ -75,7 +75,7 @@ export function NotificationCenter({
         aria-haspopup="true"
         className={cn(
           "relative flex h-9 w-9 items-center justify-center rounded-lg",
-          "hover:bg-border/50 transition-all duration-200",
+          "hover:bg-border/50 transition-settle",
           "text-muted hover:text-foreground",
         )}
       >

--- a/dashboard/src/components/layout/Sidebar.tsx
+++ b/dashboard/src/components/layout/Sidebar.tsx
@@ -209,7 +209,7 @@ export function Sidebar({ open, onClose, dlqCount = 0, approvalsCount = 0 }: Sid
                     className={({ isActive }) =>
                       cn(
                         "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium",
-                        "transition-all duration-200",
+                        "transition-settle",
                         isActive
                           ? "bg-accent/10 text-accent"
                           : "text-muted hover:bg-border/40 hover:text-foreground"
@@ -303,7 +303,7 @@ export function Sidebar({ open, onClose, dlqCount = 0, approvalsCount = 0 }: Sid
                           className={({ isActive }) =>
                             cn(
                               "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium",
-                              "transition-all duration-200",
+                              "transition-settle",
                               isActive
                                 ? "bg-accent/10 text-accent"
                                 : "text-muted hover:bg-border/40 hover:text-foreground"

--- a/dashboard/src/components/onboarding/ProgressBar.tsx
+++ b/dashboard/src/components/onboarding/ProgressBar.tsx
@@ -26,7 +26,7 @@ export function ProgressBar({ steps, currentStep }: ProgressBarProps) {
               <div className="flex flex-col items-center gap-1.5">
                 <div
                   className={cn(
-                    "flex h-8 w-8 items-center justify-center rounded-full text-xs font-semibold transition-all duration-300",
+                    "flex h-8 w-8 items-center justify-center rounded-full text-xs font-semibold transition-settle",
                     isCompleted && "bg-accent text-accent-foreground scale-in-bounce",
                     isCurrent && "bg-accent text-accent-foreground glow-accent ring-2 ring-accent/30 step-indicator-pulse",
                     isFuture && "bg-border text-muted"

--- a/dashboard/src/components/onboarding/StepApiKeysCheck.tsx
+++ b/dashboard/src/components/onboarding/StepApiKeysCheck.tsx
@@ -199,7 +199,7 @@ export function StepApiKeysCheck({ onNext, onBack }: StepApiKeysCheckProps) {
           disabled={loading}
           className={cn(
             "inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground",
-            "hover:bg-accent/5 transition-all duration-200",
+            "hover:bg-accent/5 transition-settle",
             "disabled:opacity-60 disabled:cursor-not-allowed"
           )}
         >
@@ -228,7 +228,7 @@ export function StepApiKeysCheck({ onNext, onBack }: StepApiKeysCheckProps) {
             onClick={onNext}
             className={cn(
               "inline-flex items-center gap-2 rounded-lg bg-accent px-5 py-2 text-sm font-medium text-accent-foreground",
-              "hover:bg-accent-hover transition-all duration-200 shadow-sm"
+              "hover:bg-accent-hover transition-settle shadow-sm"
             )}
           >
             Continue

--- a/dashboard/src/components/onboarding/StepChooseTemplate.tsx
+++ b/dashboard/src/components/onboarding/StepChooseTemplate.tsx
@@ -179,7 +179,7 @@ export function StepChooseTemplate({
                 key={template.name}
                 onClick={() => handleSelect(template)}
                 className={cn(
-                  "relative flex flex-col items-start gap-3 rounded-xl border p-4 text-left transition-all duration-200",
+                  "relative flex flex-col items-start gap-3 rounded-xl border p-4 text-left transition-settle",
                   isSelected
                     ? "border-accent bg-accent/5 glow-accent card-selected"
                     : "border-border hover:border-accent/40 hover:bg-accent/[0.02] card-hover-lift"
@@ -254,7 +254,7 @@ export function StepChooseTemplate({
           disabled={!selected}
           className={cn(
             "inline-flex items-center gap-2 rounded-lg bg-accent px-5 py-2 text-sm font-medium text-accent-foreground",
-            "hover:bg-accent-hover transition-all duration-200 shadow-sm",
+            "hover:bg-accent-hover transition-settle shadow-sm",
             "disabled:opacity-60 disabled:cursor-not-allowed"
           )}
         >

--- a/dashboard/src/components/onboarding/StepConfigureInputs.tsx
+++ b/dashboard/src/components/onboarding/StepConfigureInputs.tsx
@@ -52,7 +52,7 @@ export function StepConfigureInputs({
   const inputClass = cn(
     "h-9 w-full rounded-lg border border-border bg-background px-3 text-sm",
     "focus-visible:border-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
-    "transition-all duration-200"
+    "transition-settle"
   );
 
   return (
@@ -156,7 +156,7 @@ export function StepConfigureInputs({
                     className={cn(
                       "w-full rounded-lg border border-border bg-background px-3 py-2 text-sm resize-y",
                       "focus-visible:border-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
-                      "transition-all duration-200"
+                      "transition-settle"
                     )}
                   />
                 ) : isNumber ? (
@@ -213,7 +213,7 @@ export function StepConfigureInputs({
           title={missingRequired ? "Fill the required fields first" : undefined}
           className={cn(
             "inline-flex items-center gap-2 rounded-lg bg-accent px-5 py-2 text-sm font-medium text-accent-foreground",
-            "hover:bg-accent-hover transition-all duration-200 shadow-sm",
+            "hover:bg-accent-hover transition-settle shadow-sm",
             "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-accent"
           )}
         >

--- a/dashboard/src/components/onboarding/StepLaunch.tsx
+++ b/dashboard/src/components/onboarding/StepLaunch.tsx
@@ -108,7 +108,7 @@ export function StepLaunch({
           disabled={!template || launching}
           className={cn(
             "w-full inline-flex items-center justify-center gap-2 rounded-xl bg-accent px-6 py-3 text-sm font-medium text-accent-foreground btn-shimmer",
-            "hover:bg-accent-hover transition-all duration-200 shadow-sm hover:shadow-md",
+            "hover:bg-accent-hover transition-settle shadow-sm hover:shadow-md",
             "disabled:opacity-60 disabled:cursor-not-allowed"
           )}
         >

--- a/dashboard/src/components/onboarding/StepWelcome.tsx
+++ b/dashboard/src/components/onboarding/StepWelcome.tsx
@@ -66,7 +66,7 @@ export function StepWelcome({ onNext, onSkip }: StepWelcomeProps) {
           onClick={onNext}
           className={cn(
             "inline-flex items-center gap-2 rounded-lg bg-accent px-6 py-2.5 text-sm font-medium text-accent-foreground btn-shimmer",
-            "hover:bg-accent-hover transition-all duration-200 shadow-sm hover:shadow-md"
+            "hover:bg-accent-hover transition-settle shadow-sm hover:shadow-md"
           )}
         >
           Get Started

--- a/dashboard/src/components/overview/BentoActivityFeed.tsx
+++ b/dashboard/src/components/overview/BentoActivityFeed.tsx
@@ -20,7 +20,7 @@ export function BentoActivityFeed({ events, loading }: { events: AuditEvent[]; l
     return (
       <div className={cn(
         "bg-surface rounded-2xl shadow-sm border border-border",
-        "hover:border-accent/30 transition-all duration-300",
+        "hover:border-accent/30 transition-settle",
         "overflow-hidden",
       )}>
         <div className="px-5 py-4 border-b border-border">
@@ -37,7 +37,7 @@ export function BentoActivityFeed({ events, loading }: { events: AuditEvent[]; l
     return (
       <div className={cn(
         "bg-surface rounded-2xl shadow-sm border border-border",
-        "hover:border-accent/30 transition-all duration-300",
+        "hover:border-accent/30 transition-settle",
         "overflow-hidden",
       )}>
         <div className="px-5 py-4 border-b border-border">
@@ -53,7 +53,7 @@ export function BentoActivityFeed({ events, loading }: { events: AuditEvent[]; l
   return (
     <div className={cn(
       "bg-surface rounded-2xl shadow-sm border border-border",
-      "hover:border-accent/30 transition-all duration-300",
+      "hover:border-accent/30 transition-settle",
       "overflow-hidden",
     )}>
       <div className="px-5 py-4 border-b border-border flex items-center justify-between">

--- a/dashboard/src/components/overview/BentoAnomalies.tsx
+++ b/dashboard/src/components/overview/BentoAnomalies.tsx
@@ -9,7 +9,7 @@ export function BentoAnomalies({ anomalies }: { anomalies: AnomalyItem[] }) {
   return (
     <div className={cn(
       "bg-surface rounded-2xl shadow-sm border border-border",
-      "hover:border-accent/30 transition-all duration-300",
+      "hover:border-accent/30 transition-settle",
       "p-6 flex flex-col gap-3",
     )}>
       <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">

--- a/dashboard/src/components/overview/BentoCharts.tsx
+++ b/dashboard/src/components/overview/BentoCharts.tsx
@@ -9,14 +9,14 @@ export function BentoCharts({ stats }: { stats: Stats }) {
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-5">
       <div className={cn(
         "bg-surface rounded-2xl shadow-sm border border-border",
-        "hover:border-accent/30 transition-all duration-300",
+        "hover:border-accent/30 transition-settle",
         "[&>div]:rounded-2xl [&>div]:border-0 [&>div]:shadow-none [&>div]:bg-transparent",
       )}>
         <RunsChart data={stats.runs_by_day} />
       </div>
       <div className={cn(
         "bg-surface rounded-2xl shadow-sm border border-border",
-        "hover:border-accent/30 transition-all duration-300",
+        "hover:border-accent/30 transition-settle",
         "[&>div]:rounded-2xl [&>div]:border-0 [&>div]:shadow-none [&>div]:bg-transparent",
       )}>
         {stats.cost_by_workflow && <CostChart data={stats.cost_by_workflow} />}

--- a/dashboard/src/components/overview/BentoEmptyState.tsx
+++ b/dashboard/src/components/overview/BentoEmptyState.tsx
@@ -326,7 +326,7 @@ export function BentoEmptyState() {
               className={cn(
                 "text-left rounded-xl border border-border p-4",
                 "hover:border-accent/40 hover:bg-accent/5",
-                "transition-all duration-200 active:scale-[0.98] cursor-pointer group",
+                "transition-settle active:scale-[0.98] cursor-pointer group",
               )}
             >
               <span className="text-2xl">{qr.icon}</span>

--- a/dashboard/src/components/overview/BentoFailoverEvents.tsx
+++ b/dashboard/src/components/overview/BentoFailoverEvents.tsx
@@ -19,7 +19,7 @@ export function BentoFailoverEvents({ data }: { data: FailoverEventsData }) {
   return (
     <div className={cn(
       "bg-surface rounded-2xl shadow-sm border border-border",
-      "hover:border-accent/30 transition-all duration-300",
+      "hover:border-accent/30 transition-settle",
       "p-5 flex flex-col gap-3",
     )}>
       <div className="flex items-center justify-between">

--- a/dashboard/src/components/overview/BentoForecast.tsx
+++ b/dashboard/src/components/overview/BentoForecast.tsx
@@ -6,7 +6,7 @@ export function BentoForecast() {
   return (
     <div className={cn(
       "bg-surface rounded-2xl shadow-sm border border-border",
-      "hover:border-accent/30 transition-all duration-300",
+      "hover:border-accent/30 transition-settle",
       "[&>div]:rounded-2xl [&>div]:border-0 [&>div]:shadow-none [&>div]:bg-transparent",
     )}>
       <CostForecast />

--- a/dashboard/src/components/overview/BentoHealthHero.tsx
+++ b/dashboard/src/components/overview/BentoHealthHero.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { ArrowRight, CheckCircle2, DollarSign } from "lucide-react";
+import { Odometer } from "@/components/ui/Odometer";
 import { cn, formatCost } from "@/lib/utils";
 import type { Insight, Severity } from "@/lib/insights";
 
@@ -29,7 +30,7 @@ export function BentoHealthHero({
   return (
     <div className={cn(
       "bg-surface rounded-2xl shadow-sm border border-border",
-      "hover:border-accent/30 transition-all duration-300",
+      "hover:border-accent/30 transition-settle",
       "p-6 flex flex-col gap-4 h-full relative",
     )}>
       <div className="absolute top-5 right-5">
@@ -55,7 +56,7 @@ export function BentoHealthHero({
           Workflow Command Center
         </p>
         <p className="font-display text-5xl font-bold text-foreground tracking-tight leading-none">
-          {totalRuns}
+          <Odometer value={totalRuns} />
         </p>
         <p className="mt-1 text-sm text-muted-foreground">workflows ran today</p>
       </div>
@@ -67,7 +68,7 @@ export function BentoHealthHero({
         </span>
         <span className="inline-flex items-center gap-1.5 rounded-full bg-accent/10 border border-accent/20 px-3 py-1.5 text-xs font-semibold text-accent">
           <DollarSign className="h-3 w-3" />
-          {formatCost(totalCost)} cost
+          <Odometer value={totalCost} format={formatCost} /> cost
         </span>
         <span className="inline-flex items-center gap-1.5 rounded-full bg-running/10 border border-running/20 px-3 py-1.5 text-xs font-semibold text-running">
           <span className="h-1.5 w-1.5 rounded-full bg-running" />

--- a/dashboard/src/components/overview/BentoHeatmap.tsx
+++ b/dashboard/src/components/overview/BentoHeatmap.tsx
@@ -94,7 +94,7 @@ export function BentoHeatmap({ cells }: { cells: HeatmapCell[] }) {
     <div
       className={cn(
         "bg-surface rounded-2xl shadow-sm border border-border",
-        "hover:border-accent/30 transition-all duration-300",
+        "hover:border-accent/30 transition-settle",
         "p-6",
       )}
     >

--- a/dashboard/src/components/overview/BentoProviderCosts.tsx
+++ b/dashboard/src/components/overview/BentoProviderCosts.tsx
@@ -35,7 +35,7 @@ export function BentoProviderCosts({
   return (
     <div className={cn(
       "rounded-2xl border border-border bg-surface shadow-sm",
-      "hover:border-accent/30 transition-all duration-300",
+      "hover:border-accent/30 transition-settle",
       "p-5 flex flex-col gap-3",
     )}>
       <div className="flex items-center justify-between">
@@ -99,7 +99,7 @@ export function BentoSavingsOpportunities({ savings }: { savings: ProviderSaving
   return (
     <div className={cn(
       "rounded-2xl border border-border bg-surface shadow-sm",
-      "hover:border-accent/30 transition-all duration-300",
+      "hover:border-accent/30 transition-settle",
       "p-5 flex flex-col gap-3",
     )}>
       <h3 className="text-sm font-semibold text-foreground">Savings Opportunities</h3>

--- a/dashboard/src/components/overview/BentoQuickActions.tsx
+++ b/dashboard/src/components/overview/BentoQuickActions.tsx
@@ -10,7 +10,7 @@ export function BentoQuickActions() {
   return (
     <div className={cn(
       "bg-surface rounded-2xl shadow-sm border border-border",
-      "hover:border-accent/30 transition-all duration-300",
+      "hover:border-accent/30 transition-settle",
       "p-6 flex flex-col gap-3 h-full",
     )}>
       <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1">

--- a/dashboard/src/components/overview/BentoRecentRuns.tsx
+++ b/dashboard/src/components/overview/BentoRecentRuns.tsx
@@ -19,7 +19,7 @@ export function BentoRecentRuns({ runs }: { runs: RunItem[] }) {
   return (
     <div className={cn(
       "bg-surface rounded-2xl shadow-sm border border-border",
-      "hover:border-accent/30 transition-all duration-300",
+      "hover:border-accent/30 transition-settle",
       "overflow-hidden",
     )}>
       <div className="px-5 py-4 border-b border-border">

--- a/dashboard/src/components/overview/BentoStats.tsx
+++ b/dashboard/src/components/overview/BentoStats.tsx
@@ -1,4 +1,5 @@
 import { Activity, CheckCircle, DollarSign, Timer } from "lucide-react";
+import { Odometer } from "@/components/ui/Odometer";
 import { cn, formatCost } from "@/lib/utils";
 import type { SparklineData } from "./bentoTypes";
 
@@ -45,7 +46,7 @@ export function TrendBadge({ percent, positiveIsGood }: { percent: number; posit
 
 interface StatCardProps {
   label: string;
-  value: string;
+  value: React.ReactNode;
   icon: React.ElementType;
   iconBg: string;
   iconColor: string;
@@ -61,7 +62,7 @@ export function BentoStatCard({
     <div className={cn(
       "bg-surface rounded-2xl shadow-sm border border-border",
       "p-6",
-      "hover:border-accent/30 transition-all duration-300",
+      "hover:border-accent/30 transition-settle",
       "flex flex-col gap-3",
     )}>
       <div className="flex items-start justify-between">
@@ -101,7 +102,7 @@ export function BentoStatsRow({
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-5">
       <BentoStatCard
         label="Runs Today"
-        value={String(totalRuns)}
+        value={<Odometer value={totalRuns} />}
         icon={Activity}
         iconColor="text-accent"
         iconBg="bg-accent/10"
@@ -110,7 +111,7 @@ export function BentoStatsRow({
       />
       <BentoStatCard
         label="Success Rate"
-        value={`${successRate}%`}
+        value={<Odometer value={successRate} format={(v) => `${Math.round(v)}%`} />}
         icon={CheckCircle}
         iconColor="text-success"
         iconBg="bg-success/10"
@@ -119,7 +120,7 @@ export function BentoStatsRow({
       />
       <BentoStatCard
         label="Cost Today"
-        value={formatCost(totalCost)}
+        value={<Odometer value={totalCost} format={formatCost} />}
         icon={DollarSign}
         iconColor="text-running"
         iconBg="bg-running/10"
@@ -128,7 +129,7 @@ export function BentoStatsRow({
       />
       <BentoStatCard
         label="Avg Duration"
-        value={avgDuration > 0 ? `${Math.round(avgDuration)}s` : "n/a"}
+        value={avgDuration > 0 ? <Odometer value={avgDuration} format={(v) => `${Math.round(v)}s`} /> : "n/a"}
         icon={Timer}
         iconColor="text-muted-foreground"
         iconBg="bg-border"

--- a/dashboard/src/components/overview/LayoutSwitcher.tsx
+++ b/dashboard/src/components/overview/LayoutSwitcher.tsx
@@ -42,7 +42,7 @@ export function LayoutSwitcher({ layout, setLayout }: LayoutSwitcherProps) {
             localStorage.setItem("sandcastle_overview_layout", opt.id);
           }}
           className={cn(
-            "flex items-center justify-center rounded-lg w-7 h-7 transition-all duration-150",
+            "flex items-center justify-center rounded-lg w-7 h-7 transition-settle",
             layout === opt.id
               ? "bg-accent text-accent-foreground shadow-sm"
               : "text-muted-foreground hover:text-foreground",

--- a/dashboard/src/components/overview/StatsCards.tsx
+++ b/dashboard/src/components/overview/StatsCards.tsx
@@ -1,4 +1,5 @@
 import { Activity, CheckCircle, DollarSign, Timer, TrendingUp, TrendingDown } from "lucide-react";
+import { Odometer } from "@/components/ui/Odometer";
 import { cn } from "@/lib/utils";
 import { formatCost, formatDuration } from "@/lib/utils";
 
@@ -148,7 +149,7 @@ export function StatsCards({
             key={card.key}
             className={cn(
               "rounded-xl border border-border bg-surface p-5",
-              "shadow-sm transition-all duration-200 hover:shadow-md"
+              "shadow-sm transition-settle hover:shadow-md"
             )}
           >
             <div className="flex items-center gap-3">
@@ -167,7 +168,7 @@ export function StatsCards({
                 </div>
                 <div className="flex items-center justify-between gap-2">
                   <p className="font-data text-xl font-semibold tracking-tight text-foreground">
-                    {card.format(values[card.key])}
+                    <Odometer value={values[card.key]} format={card.format} />
                   </p>
                   {spark && spark.values.length >= 2 && (
                     <Sparkline values={spark.values} color={card.sparkColor} />

--- a/dashboard/src/components/runs/LiveStream.tsx
+++ b/dashboard/src/components/runs/LiveStream.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSSE } from "@/hooks/useSSE";
 import { cn } from "@/lib/utils";
 
@@ -10,6 +10,15 @@ export function LiveStream({ runId }: LiveStreamProps) {
   const { events, connected } = useSSE(`/runs/${runId}/stream`);
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // "Data flowing" indicator: true while events arrived in the last ~2s.
+  const [flowing, setFlowing] = useState(false);
+  useEffect(() => {
+    if (events.length === 0) return;
+    setFlowing(true);
+    const timer = setTimeout(() => setFlowing(false), 2000);
+    return () => clearTimeout(timer);
+  }, [events]);
+
   useEffect(() => {
     if (containerRef.current) {
       containerRef.current.scrollTop = containerRef.current.scrollHeight;
@@ -17,7 +26,12 @@ export function LiveStream({ runId }: LiveStreamProps) {
   }, [events]);
 
   return (
-    <div className="rounded-xl border border-border bg-background shadow-sm overflow-hidden">
+    <div
+      className={cn(
+        "relative rounded-xl border border-border bg-background shadow-sm overflow-hidden",
+        flowing && "surface-flowing"
+      )}
+    >
       <div className="flex items-center gap-2 border-b border-border px-4 py-2">
         <div
           className={cn(
@@ -31,7 +45,7 @@ export function LiveStream({ runId }: LiveStreamProps) {
       </div>
       <div
         ref={containerRef}
-        className="max-h-96 overflow-y-auto p-4 font-mono text-xs leading-relaxed"
+        className="surface-live max-h-96 overflow-y-auto p-4 font-mono text-xs leading-relaxed"
       >
         {events.length === 0 ? (
           <p className="text-muted">Waiting for events...</p>
@@ -44,6 +58,11 @@ export function LiveStream({ runId }: LiveStreamProps) {
               </span>
             </div>
           ))
+        )}
+        {connected && (
+          <span className="surface-live-cursor" aria-hidden="true">
+            ▊
+          </span>
         )}
       </div>
     </div>

--- a/dashboard/src/components/runs/PipelineViz.tsx
+++ b/dashboard/src/components/runs/PipelineViz.tsx
@@ -116,7 +116,7 @@ function PipelineNode({
         onMouseLeave={onLeave}
         className={cn(
           "relative h-7 w-7 rounded-full border-2 border-surface",
-          "transition-all duration-200 cursor-pointer",
+          "transition-settle cursor-pointer",
           "hover:scale-125 hover:shadow-md",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
           isRunning && "pipeline-node-pulse"

--- a/dashboard/src/components/runs/ReplayForkModal.tsx
+++ b/dashboard/src/components/runs/ReplayForkModal.tsx
@@ -183,7 +183,7 @@ export function ReplayForkModal({
             disabled={submitting}
             className={cn(
               "flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground",
-              "hover:bg-accent-hover transition-all duration-200",
+              "hover:bg-accent-hover transition-settle",
               "shadow-sm hover:shadow-md",
               "disabled:opacity-50 disabled:cursor-not-allowed"
             )}

--- a/dashboard/src/components/runs/RunTree.tsx
+++ b/dashboard/src/components/runs/RunTree.tsx
@@ -30,7 +30,7 @@ function RunTreeCard({
     <button
       onClick={() => !isCurrent && navigate(`/runs/${run.run_id}`)}
       className={cn(
-        "flex items-center gap-3 rounded-lg border px-3 py-2 text-left text-sm transition-all duration-200",
+        "flex items-center gap-3 rounded-lg border px-3 py-2 text-left text-sm transition-settle",
         isCurrent
           ? "border-accent bg-accent/10 cursor-default"
           : "border-border bg-surface hover:bg-border/20 hover:shadow-sm cursor-pointer"

--- a/dashboard/src/components/runs/StepFlamegraph.tsx
+++ b/dashboard/src/components/runs/StepFlamegraph.tsx
@@ -382,7 +382,7 @@ export function StepFlamegraph({ steps }: StepFlamegraphProps) {
               key={`${bar.step.step_id}-${bar.step.parallel_index ?? 0}-${idx}`}
               className={cn(
                 "absolute flex items-center justify-between rounded-md cursor-pointer",
-                "transition-all duration-200",
+                "transition-settle",
                 isHovered && "brightness-125 shadow-md z-10",
                 isDimmed && "opacity-50"
               )}

--- a/dashboard/src/components/runs/TerminalLog.tsx
+++ b/dashboard/src/components/runs/TerminalLog.tsx
@@ -195,6 +195,15 @@ export function TerminalLog({ logs, stepName, status, isLive = false }: Terminal
   const searchInputRef = useRef<HTMLInputElement>(null);
   const prevLogLength = useRef(logs.length);
 
+  // "Data flowing" indicator: true while new log data arrived in the last ~2s.
+  const [flowing, setFlowing] = useState(false);
+  useEffect(() => {
+    if (!isLive || logs.length === 0) return;
+    setFlowing(true);
+    const timer = setTimeout(() => setFlowing(false), 2000);
+    return () => clearTimeout(timer);
+  }, [logs, isLive]);
+
   const lines = useMemo(() => logs.split("\n"), [logs]);
   const lineTypes = useMemo(() => lines.map(classifyLine), [lines]);
 
@@ -295,7 +304,8 @@ export function TerminalLog({ logs, stepName, status, isLive = false }: Terminal
       data-terminal-log
       className={cn(
         "rounded-lg border border-gray-800 overflow-hidden",
-        expanded ? "fixed inset-4 z-50" : ""
+        expanded ? "fixed inset-4 z-50" : "relative",
+        isLive && status === "running" && flowing && "surface-flowing"
       )}
     >
       {/* Top bar */}
@@ -442,6 +452,7 @@ export function TerminalLog({ logs, stepName, status, isLive = false }: Terminal
         ref={scrollRef}
         className={cn(
           "bg-[#1a1a2e] overflow-y-auto overflow-x-auto font-mono text-xs leading-relaxed",
+          "surface-live surface-live-dark",
           expanded ? "h-full" : "max-h-[400px]"
         )}
         onScroll={() => {
@@ -487,6 +498,11 @@ export function TerminalLog({ logs, stepName, status, isLive = false }: Terminal
             })}
           </tbody>
         </table>
+        {isLive && status === "running" && (
+          <div className="pl-[52px] pb-1" aria-hidden="true">
+            <span className="surface-live-cursor">▊</span>
+          </div>
+        )}
       </div>
 
       {/* Fullscreen backdrop */}

--- a/dashboard/src/components/schedules/CreateScheduleModal.tsx
+++ b/dashboard/src/components/schedules/CreateScheduleModal.tsx
@@ -220,7 +220,7 @@ export function CreateScheduleModal({ open, onClose, onSubmit }: CreateScheduleM
                 disabled={!selectedWorkflow}
                 className={cn(
                   "rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground",
-                  "hover:bg-accent-hover transition-all duration-200",
+                  "hover:bg-accent-hover transition-settle",
                   "shadow-sm hover:shadow-md",
                   "disabled:opacity-50 disabled:cursor-not-allowed"
                 )}

--- a/dashboard/src/components/schedules/CronBuilder.tsx
+++ b/dashboard/src/components/schedules/CronBuilder.tsx
@@ -120,7 +120,7 @@ export function CronBuilder({ value, onChange }: CronBuilderProps) {
             type="button"
             onClick={() => setFrequency(f.value)}
             className={cn(
-              "rounded-lg px-2.5 py-1.5 text-xs font-medium transition-all duration-200",
+              "rounded-lg px-2.5 py-1.5 text-xs font-medium transition-settle",
               frequency === f.value
                 ? "bg-accent text-accent-foreground shadow-sm"
                 : "bg-surface border border-border text-muted hover:text-foreground hover:border-accent/30"
@@ -239,7 +239,7 @@ export function CronBuilder({ value, onChange }: CronBuilderProps) {
                     }
                   }}
                   className={cn(
-                    "rounded-lg px-3 py-1.5 text-xs font-medium transition-all duration-200",
+                    "rounded-lg px-3 py-1.5 text-xs font-medium transition-settle",
                     active
                       ? "bg-accent text-accent-foreground shadow-sm"
                       : "bg-surface border border-border text-muted hover:text-foreground hover:border-accent/30"
@@ -298,7 +298,7 @@ export function CronBuilder({ value, onChange }: CronBuilderProps) {
                     }
                   }}
                   className={cn(
-                    "rounded-lg py-1.5 text-xs font-medium transition-all duration-200",
+                    "rounded-lg py-1.5 text-xs font-medium transition-settle",
                     active
                       ? "bg-accent text-accent-foreground shadow-sm"
                       : "bg-surface border border-border text-muted hover:text-foreground hover:border-accent/30"

--- a/dashboard/src/components/schedules/EditScheduleModal.tsx
+++ b/dashboard/src/components/schedules/EditScheduleModal.tsx
@@ -101,7 +101,7 @@ export function EditScheduleModal({ open, schedule, onClose, onSubmit }: EditSch
                 type="submit"
                 className={cn(
                   "rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground",
-                  "hover:bg-accent-hover transition-all duration-200",
+                  "hover:bg-accent-hover transition-settle",
                   "shadow-sm hover:shadow-md"
                 )}
               >

--- a/dashboard/src/components/shared/EmptyState.tsx
+++ b/dashboard/src/components/shared/EmptyState.tsx
@@ -27,7 +27,7 @@ export function EmptyState({ icon: Icon, title, description, action, className }
           onClick={action.onClick}
           className={cn(
             "rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground",
-            "hover:bg-accent-hover transition-all duration-200",
+            "hover:bg-accent-hover transition-settle",
             "shadow-sm hover:shadow-md"
           )}
         >

--- a/dashboard/src/components/shared/ErrorBoundary.tsx
+++ b/dashboard/src/components/shared/ErrorBoundary.tsx
@@ -93,7 +93,7 @@ export class ErrorBoundary extends Component<Props, State> {
             </div>
             <button
               onClick={this.handleHardReload}
-              className="flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground hover:bg-accent-hover transition-all duration-200"
+              className="flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground hover:bg-accent-hover transition-settle"
             >
               <RotateCcw className="w-4 h-4" />
               Reload
@@ -131,7 +131,7 @@ export class ErrorBoundary extends Component<Props, State> {
           </div>
           <button
             onClick={this.handleReset}
-            className="flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground hover:bg-accent-hover transition-all duration-200"
+            className="flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground hover:bg-accent-hover transition-settle"
           >
             <RotateCcw className="w-4 h-4" />
             Try Again

--- a/dashboard/src/components/shared/JsonEditor.tsx
+++ b/dashboard/src/components/shared/JsonEditor.tsx
@@ -42,7 +42,7 @@ export function JsonEditor({ value, onChange, placeholder, className, rows = 8 }
           "w-full rounded-lg border bg-surface px-3 py-2 font-mono text-sm",
           "placeholder:text-muted-foreground/50",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
-          "transition-all duration-200 resize-y",
+          "transition-settle resize-y",
           error ? "border-error" : "border-border"
         )}
       />

--- a/dashboard/src/components/shared/ThemeToggle.tsx
+++ b/dashboard/src/components/shared/ThemeToggle.tsx
@@ -10,20 +10,20 @@ export function ThemeToggle() {
       onClick={toggleTheme}
       className={cn(
         "relative flex h-9 w-9 items-center justify-center rounded-lg",
-        "hover:bg-border/50 transition-all duration-200",
+        "hover:bg-border/50 transition-settle",
         "text-muted hover:text-foreground"
       )}
       aria-label="Toggle theme"
     >
       <Sun
         className={cn(
-          "h-[18px] w-[18px] transition-all duration-300",
+          "h-[18px] w-[18px] transition-settle",
           theme === "dark" ? "rotate-90 scale-0 opacity-0" : "rotate-0 scale-100 opacity-100"
         )}
       />
       <Moon
         className={cn(
-          "absolute h-[18px] w-[18px] transition-all duration-300",
+          "absolute h-[18px] w-[18px] transition-settle",
           theme === "dark" ? "rotate-0 scale-100 opacity-100" : "-rotate-90 scale-0 opacity-0"
         )}
       />

--- a/dashboard/src/components/templates/CommunityCard.tsx
+++ b/dashboard/src/components/templates/CommunityCard.tsx
@@ -66,7 +66,7 @@ export function CommunityCard({ template, installed, onInstall, onPreview }: Com
     <div
       className={cn(
         "group rounded-xl border border-border bg-surface p-4 text-left",
-        "transition-all duration-200 hover:shadow-md hover:border-accent/30"
+        "transition-settle hover:shadow-md hover:border-accent/30"
       )}
     >
       {/* Top row: category dot + source badge */}
@@ -215,7 +215,7 @@ export function CommunityCard({ template, installed, onInstall, onPreview }: Com
           }}
           className={cn(
             "flex flex-1 items-center justify-center gap-1.5 rounded-lg px-3 py-1.5",
-            "text-xs font-medium transition-all duration-200 shadow-sm",
+            "text-xs font-medium transition-settle shadow-sm",
             installed
               ? "border border-success/30 text-success hover:bg-success/10 bg-transparent"
               : "bg-accent text-accent-foreground hover:bg-accent-hover"

--- a/dashboard/src/components/templates/InstallModal.tsx
+++ b/dashboard/src/components/templates/InstallModal.tsx
@@ -107,7 +107,7 @@ export function InstallModal({
           aria-label={phase === "done" ? `${pack.name} Installed` : `Installing ${pack.name}`}
           className={cn(
             "w-full max-w-md rounded-xl border bg-surface shadow-xl",
-            "transition-all duration-300",
+            "transition-settle",
             phase === "done" ? "border-accent/30 glow-accent" : "border-border"
           )}
         >
@@ -148,7 +148,7 @@ export function InstallModal({
             <div className="px-5 pt-4">
               <div className="h-1.5 w-full overflow-hidden rounded-full bg-border/40">
                 <div
-                  className="h-full rounded-full bg-accent transition-all duration-300 ease-out"
+                  className="h-full rounded-full bg-accent transition-settle ease-out"
                   style={{ width: `${progressPct}%` }}
                 />
               </div>
@@ -162,7 +162,7 @@ export function InstallModal({
                 <div
                   key={item.name}
                   className={cn(
-                    "flex items-center gap-3 rounded-lg px-3 py-2 transition-all duration-200",
+                    "flex items-center gap-3 rounded-lg px-3 py-2 transition-settle",
                     item.status === "installing" && "bg-accent/5",
                     item.status === "done" && "opacity-80"
                   )}
@@ -218,7 +218,7 @@ export function InstallModal({
                   className={cn(
                     "flex flex-1 items-center justify-center gap-2 rounded-lg bg-accent px-4 py-2.5",
                     "text-sm font-medium text-accent-foreground",
-                    "hover:bg-accent-hover transition-all duration-200 shadow-sm"
+                    "hover:bg-accent-hover transition-settle shadow-sm"
                   )}
                 >
                   <ArrowRight className="h-4 w-4" />

--- a/dashboard/src/components/templates/PackCard.tsx
+++ b/dashboard/src/components/templates/PackCard.tsx
@@ -22,9 +22,9 @@ export function PackCard({ pack, count, onClick, onInstall }: PackCardProps) {
       type="button"
       onClick={onClick}
       className={cn(
-        "group rounded-xl border p-5 text-left transition-all duration-200",
+        "group rounded-xl border p-5 text-left transition-settle",
         "border-border bg-surface hover:shadow-md",
-        "hover:scale-[1.02]",
+        "hover:-translate-y-px",
         `hover:${pack.color.border}`
       )}
     >
@@ -74,7 +74,7 @@ export function PackCard({ pack, count, onClick, onInstall }: PackCardProps) {
                 "flex items-center gap-1 rounded-md border border-border px-2 py-1",
                 "text-[11px] font-medium text-muted-foreground",
                 "hover:text-foreground hover:border-accent/40 hover:bg-accent/5",
-                "transition-all duration-150"
+                "transition-settle"
               )}
             >
               <Download className="h-3 w-3" />

--- a/dashboard/src/components/templates/RunModal.tsx
+++ b/dashboard/src/components/templates/RunModal.tsx
@@ -122,7 +122,7 @@ export function RunModal({
                 disabled={running}
                 className={cn(
                   "flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground",
-                  "hover:bg-accent-hover transition-all duration-200 shadow-sm",
+                  "hover:bg-accent-hover transition-settle shadow-sm",
                   running && "opacity-50 cursor-not-allowed"
                 )}
               >

--- a/dashboard/src/components/templates/TemplateCard.tsx
+++ b/dashboard/src/components/templates/TemplateCard.tsx
@@ -44,7 +44,7 @@ export function TemplateCard({ template, isSelected, onClick }: TemplateCardProp
       type="button"
       onClick={onClick}
       className={cn(
-        "group rounded-xl border p-4 text-left transition-all duration-200",
+        "group rounded-xl border p-4 text-left transition-settle",
         isSelected
           ? "border-accent ring-2 ring-accent/20 bg-accent/5"
           : `border-border bg-surface hover:shadow-md hover:bg-surface hover:${accentBorder}`

--- a/dashboard/src/components/templates/TemplateDetail.tsx
+++ b/dashboard/src/components/templates/TemplateDetail.tsx
@@ -128,7 +128,7 @@ export function TemplateDetail({
               className={cn(
                 "flex flex-1 items-center justify-center gap-2 rounded-lg bg-accent px-4 py-2",
                 "text-sm font-medium text-accent-foreground",
-                "hover:bg-accent-hover transition-all duration-200 shadow-sm"
+                "hover:bg-accent-hover transition-settle shadow-sm"
               )}
             >
               <Play className="h-4 w-4" />

--- a/dashboard/src/components/ui/Odometer.tsx
+++ b/dashboard/src/components/ui/Odometer.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+import { easeSettle, ODOMETER_DURATION, prefersReducedMotion } from "@/lib/motion";
+
+interface OdometerProps {
+  /** Target numeric value. On first mount the number rolls up from 0;
+   *  on later changes it eases from the previous value. */
+  value: number;
+  /** Formatter applied every frame (e.g. formatCost). Defaults to a
+   *  rounded, locale-formatted integer. */
+  format?: (v: number) => string;
+  /** Roll-up duration in ms. */
+  duration?: number;
+  className?: string;
+}
+
+const defaultFormat = (v: number) => Math.round(v).toLocaleString();
+
+/**
+ * Animated number roll-up with the "settle" easing.
+ *
+ * Zero layout shift by design: the final formatted value is rendered
+ * immediately (invisible) to reserve its width, while the eased value
+ * is painted on top. Uses tabular-nums so digits do not wobble.
+ * Respects prefers-reduced-motion (jumps straight to the value).
+ */
+export function Odometer({
+  value,
+  format = defaultFormat,
+  duration = ODOMETER_DURATION,
+  className,
+}: OdometerProps) {
+  const [displayValue, setDisplayValue] = useState<number>(() =>
+    prefersReducedMotion() ? value : 0
+  );
+  // Previous *settled or in-flight* value: the next animation starts here.
+  const currentRef = useRef(displayValue);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (prefersReducedMotion() || duration <= 0) {
+      currentRef.current = value;
+      setDisplayValue(value);
+      return;
+    }
+    const from = currentRef.current;
+    if (from === value) return;
+
+    const start = performance.now();
+    const tick = (now: number) => {
+      const t = (now - start) / duration;
+      if (t >= 1) {
+        currentRef.current = value;
+        setDisplayValue(value);
+        rafRef.current = null;
+        return;
+      }
+      const eased = from + (value - from) * easeSettle(t);
+      currentRef.current = eased;
+      setDisplayValue(eased);
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    };
+  }, [value, duration]);
+
+  const finalText = format(value);
+
+  return (
+    <span
+      className={cn("relative inline-block tabular-nums whitespace-nowrap", className)}
+      aria-label={finalText}
+    >
+      {/* Invisible final value reserves the final width immediately —
+          the layout never shifts while the number eases. */}
+      <span aria-hidden="true" className="invisible">
+        {finalText}
+      </span>
+      <span aria-hidden="true" className="absolute inset-0 text-right">
+        {format(displayValue)}
+      </span>
+    </span>
+  );
+}

--- a/dashboard/src/components/workflows/BatchRunModal.tsx
+++ b/dashboard/src/components/workflows/BatchRunModal.tsx
@@ -462,7 +462,7 @@ export function BatchRunModal({ open, workflowName, fileName, onClose }: BatchRu
                 disabled={cancelling}
                 className={cn(
                   "flex items-center gap-2 rounded-lg border border-error/30 px-4 py-2 text-sm font-medium text-error",
-                  "hover:bg-error/10 transition-all duration-200",
+                  "hover:bg-error/10 transition-settle",
                   "disabled:opacity-50 disabled:cursor-not-allowed"
                 )}
               >
@@ -481,7 +481,7 @@ export function BatchRunModal({ open, workflowName, fileName, onClose }: BatchRu
                 disabled={starting}
                 className={cn(
                   "flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground",
-                  "hover:bg-accent-hover transition-all duration-200 shadow-sm hover:shadow-md",
+                  "hover:bg-accent-hover transition-settle shadow-sm hover:shadow-md",
                   "disabled:opacity-50 disabled:cursor-not-allowed"
                 )}
               >

--- a/dashboard/src/components/workflows/DependencyGraph.tsx
+++ b/dashboard/src/components/workflows/DependencyGraph.tsx
@@ -415,7 +415,7 @@ export function DependencyGraph({ workflows }: DependencyGraphProps) {
               strokeWidth={highlighted ? 2 : 1.5}
               strokeOpacity={dimmed ? 0.15 : highlighted ? 0.8 : 0.4}
               markerEnd="url(#dep-arrow)"
-              className="transition-all duration-200"
+              className="transition-settle"
             />
           );
         })}
@@ -456,7 +456,7 @@ export function DependencyGraph({ workflows }: DependencyGraphProps) {
                 fill={fill}
                 stroke={stroke}
                 strokeWidth={isHovered ? 2.5 : 1.5}
-                className="transition-all duration-150"
+                className="transition-settle"
               />
               <text
                 x={pos.x}

--- a/dashboard/src/components/workflows/DirectoryBrowser.tsx
+++ b/dashboard/src/components/workflows/DirectoryBrowser.tsx
@@ -146,7 +146,7 @@ export function DirectoryBrowser({ open, initialPath, onSelect, onClose }: Direc
               onClick={() => onSelect(currentPath)}
               className={cn(
                 "rounded-lg bg-accent px-3 py-1.5 text-xs font-medium text-accent-foreground",
-                "hover:bg-accent-hover transition-all duration-200 shadow-sm"
+                "hover:bg-accent-hover transition-settle shadow-sm"
               )}
             >
               Select This Directory

--- a/dashboard/src/components/workflows/RunWorkflowModal.tsx
+++ b/dashboard/src/components/workflows/RunWorkflowModal.tsx
@@ -357,7 +357,7 @@ export function RunWorkflowModal({ open, workflowName, inputSchema, onClose, onR
                 type="submit"
                 className={cn(
                   "flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground",
-                  "hover:bg-accent-hover transition-all duration-200 shadow-sm hover:shadow-md"
+                  "hover:bg-accent-hover transition-settle shadow-sm hover:shadow-md"
                 )}
               >
                 <Play className="h-3.5 w-3.5" />

--- a/dashboard/src/components/workflows/StepNode.tsx
+++ b/dashboard/src/components/workflows/StepNode.tsx
@@ -96,7 +96,7 @@ function StepNodeComponent({ data, selected }: NodeProps<StepNodeType>) {
     <div
       className={cn(
         "rounded-lg border bg-surface px-4 py-3 shadow-sm min-w-[140px]",
-        "transition-all duration-200",
+        "transition-settle",
         isRunning && "step-running-glow border-accent/60",
         selected
           ? "border-accent ring-2 ring-accent/30 shadow-[0_0_16px_rgba(245,158,11,0.2)]"

--- a/dashboard/src/components/workflows/TemplateBrowser.tsx
+++ b/dashboard/src/components/workflows/TemplateBrowser.tsx
@@ -146,7 +146,7 @@ export function TemplateBrowser({ open, onClose, onSelect }: TemplateBrowserProp
                       setSelectedName(selectedName === t.name ? null : t.name)
                     }
                     className={cn(
-                      "rounded-lg border p-4 text-left transition-all duration-150",
+                      "rounded-lg border p-4 text-left transition-settle",
                       selectedName === t.name
                         ? "border-accent ring-2 ring-accent/20 bg-accent/5"
                         : "border-border hover:bg-border/40"
@@ -197,7 +197,7 @@ export function TemplateBrowser({ open, onClose, onSelect }: TemplateBrowserProp
               disabled={!selectedName || fetching}
               className={cn(
                 "flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground",
-                "hover:bg-accent-hover transition-all duration-200 shadow-sm",
+                "hover:bg-accent-hover transition-settle shadow-sm",
                 (!selectedName || fetching) && "opacity-50 cursor-not-allowed"
               )}
             >

--- a/dashboard/src/components/workflows/WorkflowBuilder.tsx
+++ b/dashboard/src/components/workflows/WorkflowBuilder.tsx
@@ -1210,7 +1210,7 @@ export function WorkflowBuilder({ onSave, onRun, initialWorkflow }: WorkflowBuil
       <div className="flex flex-1 min-w-0">
         {/* Canvas */}
         <div className={cn(
-          "flex-1 min-w-0 pt-8 lg:pt-0 transition-all duration-300",
+          "flex-1 min-w-0 pt-8 lg:pt-0 transition-settle",
           generateModalOpen ? "lg:w-[60%]" : "w-full"
         )}>
           <ErrorBoundary name="WorkflowBuilder-ReactFlow">
@@ -1286,7 +1286,7 @@ export function WorkflowBuilder({ onSave, onRun, initialWorkflow }: WorkflowBuil
             onClick={() => onRun(yaml)}
             className={cn(
               "flex items-center gap-1.5 rounded-lg bg-accent px-2 sm:px-3 py-1.5 text-xs font-medium text-accent-foreground",
-              "hover:bg-accent-hover transition-all duration-200 shadow-sm"
+              "hover:bg-accent-hover transition-settle shadow-sm"
             )}
           >
             <Play className="h-3.5 w-3.5" />
@@ -1331,7 +1331,7 @@ export function WorkflowBuilder({ onSave, onRun, initialWorkflow }: WorkflowBuil
                   }}
                   className={cn(
                     "rounded-lg bg-accent px-3 py-1.5 text-xs font-medium text-accent-foreground",
-                    "hover:bg-accent-hover transition-all duration-200 shadow-sm"
+                    "hover:bg-accent-hover transition-settle shadow-sm"
                   )}
                 >
                   Replace

--- a/dashboard/src/components/workflows/WorkflowCard.tsx
+++ b/dashboard/src/components/workflows/WorkflowCard.tsx
@@ -89,8 +89,8 @@ export const WorkflowCard = memo(function WorkflowCard({
     <div
       className={cn(
         "group/card relative rounded-xl border border-border bg-surface p-5 shadow-sm",
-        "transition-all duration-200",
-        "hover:shadow-md hover:border-accent/40 hover:-translate-y-0.5",
+        "transition-settle",
+        "hover:shadow-md hover:border-accent/40 hover:-translate-y-px",
         selected && "border-accent ring-2 ring-accent/20"
       )}
     >
@@ -101,7 +101,7 @@ export const WorkflowCard = memo(function WorkflowCard({
           onClick={handlePinClick}
           aria-label={pinned ? `Unpin ${name}` : `Pin ${name}`}
           className={cn(
-            "absolute left-3 top-3 flex h-5 w-5 items-center justify-center rounded transition-all duration-200",
+            "absolute left-3 top-3 flex h-5 w-5 items-center justify-center rounded transition-settle",
             pinned
               ? "text-accent"
               : "text-muted opacity-0 group-hover/card:opacity-100 hover:opacity-100 hover:text-accent/70"
@@ -240,7 +240,7 @@ export const WorkflowCard = memo(function WorkflowCard({
           onClick={onRun}
           className={cn(
             "flex items-center gap-1.5 rounded-lg bg-accent px-2.5 py-1.5 text-xs font-medium text-accent-foreground",
-            "hover:bg-accent-hover transition-all duration-200 shadow-sm"
+            "hover:bg-accent-hover transition-settle shadow-sm"
           )}
         >
           <Play className="h-3 w-3" />

--- a/dashboard/src/lib/motion.ts
+++ b/dashboard/src/lib/motion.ts
@@ -1,0 +1,36 @@
+/**
+ * Sandcastle motion tokens — JS mirror of src/styles/motion.css.
+ * Brand metaphor: sand settling — fast arrival, soft damped landing.
+ */
+
+/** Snappy-out, softly damped easing (CSS: var(--ease-settle)). */
+export const EASE_SETTLE = "cubic-bezier(0.22, 1, 0.36, 1)";
+
+/** Symmetric in-out variant (CSS: var(--ease-settle-inout)). */
+export const EASE_SETTLE_INOUT = "cubic-bezier(0.65, 0, 0.35, 1)";
+
+/** Duration scale in milliseconds (CSS: --motion-fast/base/slow). */
+export const MOTION_FAST = 120;
+export const MOTION_BASE = 180;
+export const MOTION_SLOW = 320;
+
+/** Default duration for odometer number roll-ups (ms). */
+export const ODOMETER_DURATION = 640;
+
+/**
+ * Numeric approximation of the settle curve for rAF-driven animation.
+ * Fast attack, long damped landing (matches EASE_SETTLE visually).
+ */
+export function easeSettle(t: number): number {
+  const clamped = Math.min(1, Math.max(0, t));
+  return 1 - Math.pow(1 - clamped, 4);
+}
+
+/** True when the user asked the OS for reduced motion. */
+export function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches === true
+  );
+}

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -5,6 +5,8 @@ import { Toaster } from "sonner";
 import "@fontsource/bricolage-grotesque/600.css";
 import "@fontsource/bricolage-grotesque/700.css";
 import "./index.css";
+// Motion identity: settle easing, odometers, live-surface kit (PR: visual-motion)
+import "./styles/motion.css";
 import App from "./App.tsx";
 
 // Apply the theme immediately to prevent a flash. Dark-first: a stored preference

--- a/dashboard/src/pages/ApprovalsPage.tsx
+++ b/dashboard/src/pages/ApprovalsPage.tsx
@@ -211,7 +211,7 @@ export default function ApprovalsPage() {
             onClick={() => setFilter(f.key)}
             aria-pressed={filter === f.key}
             className={cn(
-              "rounded-md px-3 py-1.5 text-sm font-medium transition-all duration-200",
+              "rounded-md px-3 py-1.5 text-sm font-medium transition-settle",
               filter === f.key
                 ? "bg-surface text-foreground shadow-sm"
                 : "text-muted hover:text-foreground"

--- a/dashboard/src/pages/CompliancePage.tsx
+++ b/dashboard/src/pages/CompliancePage.tsx
@@ -283,7 +283,7 @@ export default function CompliancePage() {
             className={cn(
               "inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium",
               "border border-border text-foreground bg-transparent",
-              "transition-all duration-200 hover:bg-surface hover:border-border/80 hover:shadow-sm",
+              "transition-settle hover:bg-surface hover:border-border/80 hover:shadow-sm",
               "active:scale-[0.98]"
             )}
           >
@@ -295,7 +295,7 @@ export default function CompliancePage() {
             className={cn(
               "inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium",
               "border border-border text-foreground bg-transparent",
-              "transition-all duration-200 hover:bg-surface hover:border-border/80 hover:shadow-sm",
+              "transition-settle hover:bg-surface hover:border-border/80 hover:shadow-sm",
               "active:scale-[0.98]"
             )}
           >
@@ -307,7 +307,7 @@ export default function CompliancePage() {
             className={cn(
               "inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium",
               "bg-error text-white border border-error",
-              "transition-all duration-200 hover:bg-error/90 hover:shadow-md",
+              "transition-settle hover:bg-error/90 hover:shadow-md",
               "active:scale-[0.98]"
             )}
           >

--- a/dashboard/src/pages/IntegrationsPage.tsx
+++ b/dashboard/src/pages/IntegrationsPage.tsx
@@ -280,7 +280,7 @@ export default function IntegrationsPage() {
                   onClick={() => setSelectedTool(tool)}
                   className={cn(
                     "relative flex items-start gap-4 rounded-xl border border-border bg-surface p-4",
-                    "text-left transition-all duration-200",
+                    "text-left transition-settle",
                     "hover:border-accent/40 hover:shadow-md hover:shadow-accent/5",
                     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
                   )}
@@ -355,7 +355,7 @@ export default function IntegrationsPage() {
                     onClick={() => setSelectedTool(tool)}
                     className={cn(
                       "flex flex-col items-center gap-2 rounded-xl border border-border bg-surface p-4",
-                      "transition-all duration-200",
+                      "transition-settle",
                       "hover:border-accent/40 hover:shadow-md hover:shadow-accent/5",
                       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
                     )}
@@ -440,7 +440,7 @@ export default function IntegrationsPage() {
                   onClick={() => setSelectedTool(tool)}
                   className={cn(
                     "flex items-start gap-3 rounded-xl border border-border bg-surface p-3",
-                    "text-left transition-all duration-200",
+                    "text-left transition-settle",
                     "hover:border-accent/40 hover:shadow-md hover:shadow-accent/5",
                     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
                   )}

--- a/dashboard/src/pages/MemoryPage.tsx
+++ b/dashboard/src/pages/MemoryPage.tsx
@@ -300,7 +300,7 @@ export default function MemoryPage() {
                 key={mem.id}
                 className={cn(
                   "rounded-xl border border-border bg-surface p-4 sm:p-5",
-                  "transition-all duration-200 hover:border-accent/30",
+                  "transition-settle hover:border-accent/30",
                   isDeleting && "opacity-50",
                 )}
               >

--- a/dashboard/src/pages/OverviewBento.tsx
+++ b/dashboard/src/pages/OverviewBento.tsx
@@ -51,7 +51,7 @@ export default function OverviewBento() {
 
   if (isEmpty) {
     return (
-      <div className="space-y-4 sm:space-y-5">
+      <div className="space-y-4 sm:space-y-5 settle-stagger">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2.5">
             <div className="flex items-center justify-center w-8 h-8 rounded-xl bg-accent">
@@ -85,7 +85,7 @@ export default function OverviewBento() {
   }
 
   return (
-    <div className="space-y-4 sm:space-y-5">
+    <div className="space-y-4 sm:space-y-5 settle-stagger">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2.5">
           <div className="flex items-center justify-center w-8 h-8 rounded-xl bg-accent">

--- a/dashboard/src/pages/OverviewFocus.tsx
+++ b/dashboard/src/pages/OverviewFocus.tsx
@@ -151,7 +151,7 @@ function FocusStatCard({
   return (
     <div className={cn(
       "bg-surface rounded-2xl shadow-sm border border-border",
-      "hover:border-accent/30 transition-all duration-300",
+      "hover:border-accent/30 transition-settle",
       "p-5 flex flex-col gap-3"
     )}>
       <div className="flex items-start justify-between">
@@ -191,7 +191,7 @@ function FocusCostBar({ spent, projected }: CostBarProps) {
   return (
     <div className={cn(
       "bg-surface rounded-2xl shadow-sm border border-border",
-      "hover:border-accent/30 transition-all duration-300",
+      "hover:border-accent/30 transition-settle",
       "p-5"
     )}>
       <div className="flex items-center gap-2 mb-3">
@@ -247,7 +247,7 @@ function FocusRecentRuns({ runs }: { runs: RunItem[] }) {
   return (
     <div className={cn(
       "bg-surface rounded-2xl shadow-sm border border-border",
-      "hover:border-accent/30 transition-all duration-300",
+      "hover:border-accent/30 transition-settle",
       "overflow-hidden"
     )}>
       <div className="flex items-center justify-between px-5 py-4 border-b border-border">
@@ -398,7 +398,7 @@ export default function OverviewFocus({
       {/* Section 1: Compact hero with inline CTA - PRIMARY ACTION ABOVE FOLD */}
       <div className={cn(
         "bg-surface rounded-2xl shadow-sm border border-border",
-        "hover:border-accent/30 transition-all duration-300",
+        "hover:border-accent/30 transition-settle",
         "p-5"
       )}>
         <div className="flex items-center justify-between gap-4">
@@ -446,7 +446,7 @@ export default function OverviewFocus({
               className={cn(
                 "flex items-center gap-2 rounded-xl px-4 py-2",
                 "bg-accent text-accent-foreground font-semibold text-sm",
-                "hover:bg-accent-hover transition-all duration-200 active:scale-[0.98]",
+                "hover:bg-accent-hover transition-settle active:scale-[0.98]",
                 "whitespace-nowrap"
               )}
             >
@@ -461,7 +461,7 @@ export default function OverviewFocus({
       {!advisor.loading && actionableInsights.length > 0 && (
         <div className={cn(
           "bg-surface rounded-2xl shadow-sm border border-border",
-          "hover:border-accent/30 transition-all duration-300",
+          "hover:border-accent/30 transition-settle",
           "overflow-hidden"
         )}>
           <div className="px-5 py-4 border-b border-border flex items-center gap-2">

--- a/dashboard/src/pages/RunDetailPage.tsx
+++ b/dashboard/src/pages/RunDetailPage.tsx
@@ -11,6 +11,7 @@ import { RiskLevelBadge } from "@/components/runs/RiskLevelBadge";
 import { AnomalyBadge } from "@/components/shared/AnomalyBadge";
 import { StepTimeline } from "@/components/runs/StepTimeline";
 import { LiveStream } from "@/components/runs/LiveStream";
+import { Odometer } from "@/components/ui/Odometer";
 import { RunTree } from "@/components/runs/RunTree";
 import { ReplayForkModal } from "@/components/runs/ReplayForkModal";
 import { PipelineViz } from "@/components/runs/PipelineViz";
@@ -508,7 +509,7 @@ export default function RunDetailPage() {
         : null;
 
   return (
-    <div className="space-y-4 sm:space-y-6">
+    <div className="space-y-4 sm:space-y-6 settle-stagger">
       <Breadcrumb items={[
         { label: "Overview", href: "/" },
         { label: "Runs", href: "/runs" },
@@ -621,7 +622,7 @@ export default function RunDetailPage() {
           )}
           <div>
             <span className="text-xs font-medium text-muted-foreground">Cost</span>
-            <p>{formatCost(run.total_cost_usd)}</p>
+            <p><Odometer value={run.total_cost_usd} format={formatCost} /></p>
           </div>
         </div>
 
@@ -750,7 +751,7 @@ export default function RunDetailPage() {
                 <button
                   onClick={() => setVizMode("pipeline")}
                   className={cn(
-                    "rounded-md px-2.5 py-1 text-[11px] font-medium transition-all duration-200",
+                    "rounded-md px-2.5 py-1 text-[11px] font-medium transition-settle",
                     vizMode === "pipeline"
                       ? "bg-accent text-accent-foreground shadow-sm"
                       : "text-muted hover:text-foreground"
@@ -761,7 +762,7 @@ export default function RunDetailPage() {
                 <button
                   onClick={() => setVizMode("flamegraph")}
                   className={cn(
-                    "rounded-md px-2.5 py-1 text-[11px] font-medium transition-all duration-200",
+                    "rounded-md px-2.5 py-1 text-[11px] font-medium transition-settle",
                     vizMode === "flamegraph"
                       ? "bg-accent text-accent-foreground shadow-sm"
                       : "text-muted hover:text-foreground"

--- a/dashboard/src/pages/Runs.tsx
+++ b/dashboard/src/pages/Runs.tsx
@@ -207,7 +207,7 @@ export default function Runs() {
   }, [filteredRuns]);
 
   return (
-    <div className="space-y-4 sm:space-y-6">
+    <div className="space-y-4 sm:space-y-6 settle-stagger">
       <h1 className="text-xl sm:text-2xl font-semibold font-display tracking-tight text-foreground">Runs</h1>
 
       {/* Failure rate banner */}
@@ -230,7 +230,7 @@ export default function Runs() {
               }}
               aria-pressed={statusFilter === s}
               className={cn(
-                "rounded-lg px-3 py-1.5 text-xs font-medium capitalize transition-all duration-200",
+                "rounded-lg px-3 py-1.5 text-xs font-medium capitalize transition-settle",
                 statusFilter === s
                   ? "bg-accent text-accent-foreground shadow-sm"
                   : "bg-border/40 text-muted hover:bg-border hover:text-foreground"
@@ -373,7 +373,7 @@ export default function Runs() {
                   key={sf.id}
                   className={cn(
                     "group relative inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs",
-                    "border cursor-pointer transition-all duration-200",
+                    "border cursor-pointer transition-settle",
                     isActive
                       ? "bg-accent/15 border-accent text-accent glow-accent"
                       : "bg-surface border-border text-foreground hover:border-accent/30 hover:bg-accent/5"
@@ -408,7 +408,7 @@ export default function Runs() {
               onClick={() => applyQuickFilter({ status: "failed" })}
               className={cn(
                 "rounded-full border border-border bg-surface px-3 py-1 text-xs",
-                "text-foreground hover:border-accent/30 hover:bg-accent/5 transition-all duration-200"
+                "text-foreground hover:border-accent/30 hover:bg-accent/5 transition-settle"
               )}
             >
               Failed Today
@@ -417,7 +417,7 @@ export default function Runs() {
               onClick={() => applyQuickFilter({ status: "running" })}
               className={cn(
                 "rounded-full border border-border bg-surface px-3 py-1 text-xs",
-                "text-foreground hover:border-accent/30 hover:bg-accent/5 transition-all duration-200"
+                "text-foreground hover:border-accent/30 hover:bg-accent/5 transition-settle"
               )}
             >
               Running Now
@@ -426,7 +426,7 @@ export default function Runs() {
               onClick={() => applyQuickFilter({ status: "completed" })}
               className={cn(
                 "rounded-full border border-border bg-surface px-3 py-1 text-xs",
-                "text-foreground hover:border-accent/30 hover:bg-accent/5 transition-all duration-200"
+                "text-foreground hover:border-accent/30 hover:bg-accent/5 transition-settle"
               )}
             >
               Expensive Runs

--- a/dashboard/src/pages/ScheduleMonitorPage.tsx
+++ b/dashboard/src/pages/ScheduleMonitorPage.tsx
@@ -202,7 +202,7 @@ export default function ScheduleMonitorPage() {
           aria-label="Refresh schedules"
           className={cn(
             "flex items-center gap-2 rounded-lg bg-surface border border-border px-3 py-2 text-sm font-medium text-foreground",
-            "hover:bg-background transition-all duration-200"
+            "hover:bg-background transition-settle"
           )}
         >
           <RefreshCw className="h-4 w-4" />
@@ -229,7 +229,7 @@ export default function ScheduleMonitorPage() {
                 key={schedule.id}
                 className={cn(
                   "bg-surface rounded-2xl shadow-sm border border-border",
-                  "hover:border-accent/30 transition-all duration-300",
+                  "hover:border-accent/30 transition-settle",
                   "p-5 flex flex-col gap-4"
                 )}
               >
@@ -315,7 +315,7 @@ export default function ScheduleMonitorPage() {
                     disabled={isToggling}
                     className={cn(
                       "flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium",
-                      "border transition-all duration-200",
+                      "border transition-settle",
                       schedule.enabled
                         ? "border-warning/30 bg-warning/5 text-warning hover:bg-warning/10"
                         : "border-success/30 bg-success/5 text-success hover:bg-success/10",
@@ -337,7 +337,7 @@ export default function ScheduleMonitorPage() {
                     className={cn(
                       "flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium",
                       "border border-accent/30 bg-accent/5 text-accent hover:bg-accent/10",
-                      "transition-all duration-200",
+                      "transition-settle",
                       (isTriggering || !schedule.enabled) && "opacity-50 cursor-not-allowed"
                     )}
                   >

--- a/dashboard/src/pages/Schedules.tsx
+++ b/dashboard/src/pages/Schedules.tsx
@@ -152,7 +152,7 @@ export default function Schedules() {
           aria-label="New schedule"
           className={cn(
             "flex items-center gap-2 rounded-lg bg-accent px-3 sm:px-4 py-2 text-sm font-medium text-accent-foreground",
-            "hover:bg-accent-hover transition-all duration-200",
+            "hover:bg-accent-hover transition-settle",
             "shadow-sm hover:shadow-md"
           )}
         >

--- a/dashboard/src/pages/SystemHealthPage.tsx
+++ b/dashboard/src/pages/SystemHealthPage.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { api } from "@/api/client";
 import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { Odometer } from "@/components/ui/Odometer";
 import { cn } from "@/lib/utils";
 
 // -- Types ------------------------------------------------------------------
@@ -437,25 +438,25 @@ export default function SystemHealthPage() {
           <div className="rounded-xl border border-border bg-surface p-4 shadow-sm">
             <p className="text-xs font-medium text-muted-foreground">Total Runs (today)</p>
             <p className="mt-1 text-xl sm:text-2xl font-semibold text-foreground font-mono">
-              {quickStats.runs}
+              <Odometer value={quickStats.runs} />
             </p>
           </div>
           <div className="rounded-xl border border-border bg-surface p-4 shadow-sm">
             <p className="text-xs font-medium text-muted-foreground">Workflows</p>
             <p className="mt-1 text-xl sm:text-2xl font-semibold text-foreground font-mono">
-              {quickStats.workflows}
+              <Odometer value={quickStats.workflows} />
             </p>
           </div>
           <div className="rounded-xl border border-border bg-surface p-4 shadow-sm">
             <p className="text-xs font-medium text-muted-foreground">Templates</p>
             <p className="mt-1 text-xl sm:text-2xl font-semibold text-foreground font-mono">
-              {quickStats.templates}
+              <Odometer value={quickStats.templates} />
             </p>
           </div>
           <div className="rounded-xl border border-border bg-surface p-4 shadow-sm">
             <p className="text-xs font-medium text-muted-foreground">API Keys</p>
             <p className="mt-1 text-xl sm:text-2xl font-semibold text-foreground font-mono">
-              {quickStats.apiKeys}
+              <Odometer value={quickStats.apiKeys} />
             </p>
           </div>
         </div>

--- a/dashboard/src/pages/TemplatesPage.tsx
+++ b/dashboard/src/pages/TemplatesPage.tsx
@@ -768,7 +768,7 @@ export default function TemplatesPage() {
                 key={tab.id}
                 onClick={() => setView(tab.id)}
                 className={cn(
-                  "flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-all duration-150",
+                  "flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-settle",
                   isActive
                     ? "bg-surface text-foreground shadow-sm"
                     : "text-muted hover:text-foreground"
@@ -924,7 +924,7 @@ export default function TemplatesPage() {
                   onClick={() => setCommunityCollection(col.id)}
                   className={cn(
                     "flex-shrink-0 w-48 rounded-xl border border-border bg-surface p-4 text-left",
-                    "transition-all duration-200 hover:shadow-md hover:border-accent/30"
+                    "transition-settle hover:shadow-md hover:border-accent/30"
                   )}
                 >
                   <span className="text-lg leading-none">{col.icon === "target" ? "\uD83C\uDFAF" : col.icon === "pen-tool" ? "\u270D\uFE0F" : col.icon === "terminal" ? "\uD83D\uDCBB" : col.icon === "headphones" ? "\uD83C\uDFA7" : col.icon === "users" ? "\uD83D\uDC65" : "\uD83D\uDCE6"}</span>
@@ -1497,7 +1497,7 @@ function HeroPack({
             className={cn(
               "flex items-center gap-2 rounded-lg bg-accent px-4 py-2.5",
               "text-sm font-medium text-accent-foreground",
-              "hover:bg-accent-hover transition-all duration-200 shadow-sm"
+              "hover:bg-accent-hover transition-settle shadow-sm"
             )}
           >
             <Download className="h-4 w-4" />
@@ -1708,7 +1708,7 @@ function PackDetailView({
               className={cn(
                 "flex items-center gap-2 rounded-lg bg-accent px-4 py-2",
                 "text-sm font-medium text-accent-foreground",
-                "hover:bg-accent-hover transition-all duration-200 shadow-sm",
+                "hover:bg-accent-hover transition-settle shadow-sm",
                 selectedCount === 0 && "opacity-50 cursor-not-allowed"
               )}
             >
@@ -1830,7 +1830,7 @@ function PackDetailView({
               className={cn(
                 "flex items-center gap-2 rounded-lg bg-accent px-4 py-2",
                 "text-sm font-medium text-accent-foreground",
-                "hover:bg-accent-hover transition-all duration-200 shadow-sm",
+                "hover:bg-accent-hover transition-settle shadow-sm",
                 selectedCount === 0 && "opacity-50 cursor-not-allowed"
               )}
             >

--- a/dashboard/src/pages/ViolationsPage.tsx
+++ b/dashboard/src/pages/ViolationsPage.tsx
@@ -147,7 +147,7 @@ export default function ViolationsPage() {
             onClick={() => setFilter(f.key)}
             aria-pressed={filter === f.key}
             className={cn(
-              "rounded-md px-3 py-1.5 text-sm font-medium transition-all duration-200",
+              "rounded-md px-3 py-1.5 text-sm font-medium transition-settle",
               filter === f.key
                 ? "bg-surface text-foreground shadow-sm"
                 : "text-muted hover:text-foreground"

--- a/dashboard/src/styles/motion.css
+++ b/dashboard/src/styles/motion.css
@@ -1,0 +1,158 @@
+/* ──── Sandcastle motion identity ────
+   Brand metaphor: sand settling — fast arrival, soft damped landing.
+   One easing, one duration scale, used everywhere. Keep in sync with
+   src/lib/motion.ts (JS mirror of these tokens). */
+
+:root {
+  /* Snappy-out, softly damped. Fast attack, long gentle settle. */
+  --ease-settle: cubic-bezier(0.22, 1, 0.36, 1);
+  /* Symmetric variant for elements that both leave and arrive (drawers, toggles). */
+  --ease-settle-inout: cubic-bezier(0.65, 0, 0.35, 1);
+
+  --motion-fast: 120ms;  /* hovers, presses, color shifts */
+  --motion-base: 180ms;  /* most UI state changes, entrances */
+  --motion-slow: 320ms;  /* drawers, modals, large surfaces */
+
+  /* Make Tailwind's transition-* utilities settle by default
+     (overrides the @theme defaults from the framework layer). */
+  --default-transition-timing-function: var(--ease-settle);
+  --default-transition-duration: var(--motion-base);
+}
+
+/* ──── Tokenized transition recipe ────
+   Replacement for ad-hoc `transition-all duration-200` sprinkles.
+   Property allowlist: never animate layout (width/height/margin). */
+.transition-settle {
+  transition-property: color, background-color, border-color, box-shadow,
+    opacity, transform, filter;
+  transition-duration: var(--motion-base);
+  transition-timing-function: var(--ease-settle);
+}
+
+/* Buttons: retune the global micro-interaction (defined in index.css)
+   onto the shared scale. Loaded after index.css, so this wins. */
+button, [role="button"], .btn {
+  transition: transform var(--motion-fast) var(--ease-settle),
+              box-shadow var(--motion-fast) var(--ease-settle),
+              background-color var(--motion-fast) var(--ease-settle),
+              border-color var(--motion-fast) var(--ease-settle),
+              color var(--motion-fast) var(--ease-settle),
+              opacity var(--motion-fast) var(--ease-settle);
+}
+
+/* Card hovers: settle easing, max 1px lift (no floaty cards). */
+.card-hover-lift {
+  transition: transform var(--motion-base) var(--ease-settle),
+              box-shadow var(--motion-base) var(--ease-settle);
+}
+.card-hover-lift:hover {
+  transform: translateY(-1px);
+}
+.card-hover-glow {
+  transition: box-shadow var(--motion-base) var(--ease-settle),
+              border-color var(--motion-base) var(--ease-settle);
+}
+
+/* ──── Entry choreography: "settle" ────
+   Page-level content entrance: 6px rise + fade with a soft landing.
+   Use .settle-enter on a single block, .settle-stagger on a container
+   whose direct children are top-level sections (NOT table rows). */
+
+@keyframes settle-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.settle-enter {
+  animation: settle-in var(--motion-base) var(--ease-settle) both;
+}
+
+.settle-stagger > * {
+  animation: settle-in var(--motion-base) var(--ease-settle) both;
+}
+/* Stagger siblings by 30ms, capped at 6 steps — later sections land together. */
+.settle-stagger > *:nth-child(1) { animation-delay: 0ms; }
+.settle-stagger > *:nth-child(2) { animation-delay: 30ms; }
+.settle-stagger > *:nth-child(3) { animation-delay: 60ms; }
+.settle-stagger > *:nth-child(4) { animation-delay: 90ms; }
+.settle-stagger > *:nth-child(5) { animation-delay: 120ms; }
+.settle-stagger > *:nth-child(n+6) { animation-delay: 150ms; }
+
+/* ──── Live-surface kit ────
+   For streaming surfaces (run logs, event feeds): a whisper of CRT.
+   .surface-live      → scanline texture on the log/stream body
+   .surface-flowing   → amber top-edge shimmer while data arrives
+                        (toggle on the relative/overflow-hidden wrapper
+                        when events landed in the last ~2s)
+   .surface-live-cursor → blinking block cursor for "stream alive" */
+
+.surface-live {
+  background-image: repeating-linear-gradient(
+    0deg,
+    rgba(28, 24, 20, 0.025) 0px,
+    rgba(28, 24, 20, 0.025) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+}
+.dark .surface-live,
+/* TerminalLog body is dark in both themes — same texture weight */
+.surface-live.surface-live-dark {
+  background-image: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.10) 0px,
+    rgba(0, 0, 0, 0.10) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+}
+
+@keyframes cursor-blink {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0; }
+}
+.surface-live-cursor {
+  display: inline-block;
+  color: var(--color-accent);
+  animation: cursor-blink 1.06s steps(1, end) infinite;
+  user-select: none;
+}
+
+@keyframes data-flow-shimmer {
+  from { transform: translateX(-100%); }
+  to   { transform: translateX(350%); }
+}
+.surface-flowing::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 2px;
+  width: 30%;
+  background: linear-gradient(90deg, transparent, var(--color-accent), transparent);
+  opacity: 0.7;
+  animation: data-flow-shimmer 1.4s var(--ease-settle-inout) infinite;
+  pointer-events: none;
+}
+
+/* ──── Reduced motion ────
+   Follows the exclusion-list pattern from index.css. The global
+   `*` rule there already clamps durations; this makes intent explicit:
+   entrances just appear, the cursor holds steady, surfaces go static. */
+@media (prefers-reduced-motion: reduce) {
+  .settle-enter,
+  .settle-stagger > *,
+  .surface-live-cursor,
+  .surface-flowing::after {
+    animation: none !important;
+  }
+  .surface-flowing::after {
+    content: none;
+  }
+  .surface-live-cursor {
+    opacity: 1;
+  }
+  .card-hover-lift:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
**Visual revamp 5/5.** One coherent motion system — the brand metaphor is sand settling: fast arrival, soft damped landing.

- Tokens: `--ease-settle: cubic-bezier(0.22, 1, 0.36, 1)`, durations 120/180/320ms, mirrored in `lib/motion.ts`; Tailwind default transition overridden so every `transition-*` utility settles; ~60 components swept off ad-hoc `transition-all duration-200`; hover lifts capped at 1px
- Shared `Odometer` (rAF-eased roll-up, tabular-nums, zero layout shift) applied to Overview stats, health hero, SystemHealth metrics, RunDetail cost total
- Entry choreography: single subtle settle (6px rise + fade, 30ms stagger, top-level sections only — never table rows) on Overview, Runs, RunDetail
- `.surface-live` kit for streaming surfaces: ultra-subtle CRT scanlines, blinking `▊` cursor while live, amber top-edge shimmer while data flows — applied to TerminalLog and LiveStream
- Everything respects `prefers-reduced-motion`

Stacked on #256 (Sand & Ink). Tests: vitest 812/812 (7 new), lint zero new, build green. No new dependencies.