### PR TITLE
feat(audit): Black Box — tamper-evident signed audit trail + compliance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
 - [Cost Estimation API](#cost-estimation-api)
 - [EU AI Act Compliance](#eu-ai-act-compliance)
 - [Tamper-Evident Audit Trail](#tamper-evident-audit-trail)
+- [Black Box Flight Recorder](#black-box-flight-recorder)
 - [OpenTelemetry](#opentelemetry)
 - [Agent Memory](#agent-memory)
 - [Evaluations](#evaluations)
@@ -1303,6 +1304,56 @@ Every significant event in Sandcastle is appended to a tamper-evident audit log.
 curl http://localhost:8080/api/audit/verify/run_abc123
 # Returns: { "valid": true, "chain_length": 12, "broken_at": null }
 ```
+
+---
+
+## Black Box Flight Recorder
+
+A flight recorder for AI agents: every run becomes a signed, tamper-evident, replayable audit
+artifact. Built for teams that need to show exactly what their AI did, with cryptographic proof
+that the record has not been altered since the run - the kind of traceable, replayable record
+the EU AI Act expects from production AI systems.
+
+Each recorded step is appended to a hash chain (`record_hash` = SHA-256 over the canonical
+record + `prev_hash`), and the chain head is signed with your audit key (HMAC-SHA256). Editing,
+removing, or reordering a single record breaks every hash after it - and verification points to
+the exact record that changed. The same file is a deterministic cassette, so any audited run
+can be replayed offline, byte-for-byte, at zero cost.
+
+```bash
+# .env
+COMPLIANCE_MODE=black_box        # enable the flight recorder
+DATA_RESIDENCY=local             # required: the audit trail never leaves your infra
+SANDCASTLE_AUDIT_KEY=<secret>    # signs every chain head
+```
+
+With `COMPLIANCE_MODE=black_box`, Sandcastle enforces at runtime:
+
+- **Every run is recorded** - a signed cassette is written for each run, automatically
+- **Every chain head is signed** - runs refuse to start without an audit key
+- **Local data residency** - runs refuse to start unless `DATA_RESIDENCY=local`
+- **Attested run API** - `GET /api/runs/{id}` returns `signed: true` plus the chain head hash
+
+Verify any run or cassette file offline:
+
+```bash
+sandcastle audit verify <run-id>            # resolves the run's cassette under the data dir
+sandcastle audit verify run.cassette.json   # or verify a file directly
+# PASS - hash chain intact, every record verifies
+# FAIL - first broken record: chain index 2 (record was modified)
+```
+
+Or from Python:
+
+```python
+from sandcastle.engine.cassette import verify_cassette
+
+result = verify_cassette("run.cassette.json")
+print(result.status, result.chain_head, result.first_broken_index)
+```
+
+Signatures embed their algorithm (`hmac-sha256` today), so asymmetric backends like Ed25519
+can be added without invalidating existing cassettes.
 
 ---
 

--- a/src/sandcastle/__main__.py
+++ b/src/sandcastle/__main__.py
@@ -4530,6 +4530,51 @@ def _cmd_owners(args: argparse.Namespace) -> None:
         print(f"  {owner}: {steps_str}")
 
 
+def _cmd_audit_verify(args: argparse.Namespace) -> None:
+    """Verify a run cassette's tamper-evident hash chain and keyed signature.
+
+    The target is either a path to a ``.cassette.json`` file or a run ID,
+    which is resolved to the auto-recorded cassette under the data dir
+    (black box compliance mode). Exits 1 on FAIL.
+    """
+    from pathlib import Path
+
+    from sandcastle.engine.cassette import default_cassette_path, verify_cassette
+
+    path = Path(args.target)
+    if not path.exists():
+        path = default_cassette_path(args.target)
+    if not path.exists():
+        print(
+            _color(f"No cassette found for '{args.target}' (looked at {path})", _C.RED),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    v = verify_cassette(path, key=args.key)
+
+    print(f"Cassette:   {path}")
+    print(f"Records:    {v.chain_length}")
+    print(f"Chain head: {v.chain_head}")
+    if v.signature_ok is None:
+        print("Signature:  not checked (unsigned cassette or no audit key configured)")
+    elif v.signature_ok:
+        print(f"Signature:  {_color('valid', _C.GREEN)}")
+    else:
+        print(f"Signature:  {_color('INVALID', _C.RED)}")
+    print()
+
+    if v.valid:
+        print(_color("PASS", _C.GREEN) + " - hash chain intact, every record verifies")
+        return
+    print(_color("FAIL", _C.RED) + " - the audit trail does not verify")
+    if v.first_broken_index is not None:
+        print(f"  First broken record: chain index {v.first_broken_index}")
+    if v.reason:
+        print(f"  Reason: {v.reason}")
+    sys.exit(1)
+
+
 # ---------------------------------------------------------------------------
 # Argument parser
 # ---------------------------------------------------------------------------
@@ -4885,6 +4930,22 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     _add_connection_args(p_violations_list)
 
+    # --- audit (black box flight recorder) ---
+    p_audit = subparsers.add_parser("audit", help="Signed audit trail (black box)")
+    audit_sub = p_audit.add_subparsers(dest="audit_action")
+
+    p_audit_verify = audit_sub.add_parser(
+        "verify", help="Verify a run's signed cassette: hash chain + signature"
+    )
+    p_audit_verify.add_argument(
+        "target", help="Run ID (resolved under the data dir) or path to a .cassette.json file"
+    )
+    p_audit_verify.add_argument(
+        "--key",
+        default=None,
+        help="Audit key to verify the signature with (default: AUDIT_KEY from env/.env)",
+    )
+
     # --- tools ---
     p_tools = subparsers.add_parser("tools", help="Tool/connector management")
     tools_sub = p_tools.add_subparsers(dest="tools_action")
@@ -5038,6 +5099,15 @@ def main() -> None:
             _cmd_db_migrate(args)
         else:
             print("Usage: sandcastle db migrate", file=sys.stderr)
+            sys.exit(1)
+        return
+
+    # --- audit ---
+    if args.command == "audit":
+        if getattr(args, "audit_action", None) == "verify":
+            _cmd_audit_verify(args)
+        else:
+            print("Usage: sandcastle audit verify <run-id-or-cassette-path>", file=sys.stderr)
             sys.exit(1)
         return
 

--- a/src/sandcastle/api/routes.py
+++ b/src/sandcastle/api/routes.py
@@ -5416,6 +5416,19 @@ async def get_run(run_id: str, req: Request) -> ApiResponse:
         # Return outputs without the internal metadata key
         outputs = {k: v for k, v in outputs.items() if k != "_token_report"}
 
+    # Black box compliance mode: attest the run's signed cassette (if present)
+    signed = False
+    audit_chain_head: str | None = None
+    try:
+        from sandcastle.engine.cassette import default_cassette_path, read_attestation
+
+        attestation = read_attestation(default_cassette_path(str(run.id)))
+        if attestation is not None:
+            signed = attestation["signed"]
+            audit_chain_head = attestation["chain_head"]
+    except Exception:  # pragma: no cover - attestation must never break get_run
+        logger.warning("Failed to read cassette attestation for run %s", run.id, exc_info=True)
+
     return ApiResponse(
         data=RunStatusResponse(
             run_id=str(run.id),
@@ -5447,6 +5460,8 @@ async def get_run(run_id: str, req: Request) -> ApiResponse:
             else None,
             risk_level=run.risk_level or "minimal",
             token_report=token_report,
+            signed=signed,
+            audit_chain_head=audit_chain_head,
         )
     )
 
@@ -12305,7 +12320,7 @@ async def get_annex_iv(name: str, req: Request) -> ApiResponse:
 async def get_compliance_status() -> ApiResponse:
     """Return the current compliance mode status and active features."""
     mode = settings.compliance_mode or ""
-    active = mode == "eu_ai_act"
+    active = mode in ("eu_ai_act", "black_box")
 
     features = {
         "audit_trail": True,  # Always enabled - tamper-evident hash chain
@@ -12313,6 +12328,8 @@ async def get_compliance_status() -> ApiResponse:
         "privacy_router": settings.privacy_enabled,
         "emergency_stop": True,  # Always available
         "input_prompt_logging": True,  # Always captured in RunStep.input_prompt
+        # Black box mode: every run recorded to a signed cassette
+        "signed_cassettes": mode == "black_box" and bool(settings.audit_key),
     }
 
     return ApiResponse(

--- a/src/sandcastle/api/schemas.py
+++ b/src/sandcastle/api/schemas.py
@@ -452,6 +452,10 @@ class RunStatusResponse(BaseModel):
     sub_runs: list[dict[str, Any]] | None = None
     risk_level: str = "minimal"
     token_report: dict[str, Any] | None = None
+    # Black box compliance mode: True when the run's cassette carries a keyed
+    # chain signature that verifies; audit_chain_head is the hash-chain head.
+    signed: bool = False
+    audit_chain_head: str | None = None
 
 
 class StepStatusResponse(BaseModel):

--- a/src/sandcastle/config.py
+++ b/src/sandcastle/config.py
@@ -4,7 +4,7 @@ import logging
 import os
 from pathlib import Path
 
-from pydantic import computed_field, field_validator
+from pydantic import AliasChoices, Field, computed_field, field_validator
 from pydantic_settings import BaseSettings
 
 from sandcastle.engine.spark import get_spark_info
@@ -183,8 +183,21 @@ class Settings(BaseSettings):
     privacy_entities: str = "email,phone,ssn,credit_card"  # comma-separated entity types
     privacy_apply_to: str = "outputs,webhooks"  # comma-separated apply_to targets
 
-    # Compliance mode: "" = disabled, "eu_ai_act" = EU AI Act enforcement
+    # Compliance mode:
+    #   ""          - disabled
+    #   "eu_ai_act" - EU AI Act enforcement (high-risk approval gates, etc.)
+    #   "black_box" - flight-recorder mode: every run is recorded to a signed,
+    #                 tamper-evident cassette; requires data_residency=local and
+    #                 a configured audit_key, and run responses expose the
+    #                 signed chain head. Verify with `sandcastle audit verify`.
     compliance_mode: str = ""
+
+    # Secret key for signing audit chains (HMAC-SHA256). Set via the
+    # SANDCASTLE_AUDIT_KEY (or AUDIT_KEY) env var - never hardcode it.
+    audit_key: str = Field(
+        default="",
+        validation_alias=AliasChoices("SANDCASTLE_AUDIT_KEY", "AUDIT_KEY", "audit_key"),
+    )
 
     # Data residency: "" = no restriction, "eu" = EU only, "local" = local/on-prem only
     data_residency: str = ""  # "", "eu", "local"
@@ -530,7 +543,7 @@ class Settings(BaseSettings):
     _SENSITIVE_FIELDS: frozenset[str] = frozenset({
         "anthropic_api_key", "e2b_api_key", "openai_api_key",
         "openrouter_api_key", "minimax_api_key", "mistral_api_key", "sentry_dsn",
-        "admin_api_key", "webhook_secret", "credential_encryption_key",
+        "admin_api_key", "webhook_secret", "credential_encryption_key", "audit_key",
         "aws_access_key_id", "aws_secret_access_key",
         "database_url", "redis_url", "license_key",
         "tool_slack_bot_token", "tool_jira_api_token",

--- a/src/sandcastle/engine/cassette.py
+++ b/src/sandcastle/engine/cassette.py
@@ -319,6 +319,20 @@ def verify_cassette(path: str | Path, key: str | None = None) -> CassetteVerific
     store.chain = data.get("chain", [])
     store.meta = data.get("meta", {})
 
+    # Legacy v1 cassette (recorded before the hash chain existed): no chain to
+    # walk, so fall back to the whole-file signature it was recorded with.
+    if not store.chain and store.records and "chain" not in data:
+        chain_ok = store.verify()
+        return CassetteVerification(
+            valid=chain_ok,
+            chain_ok=chain_ok,
+            signature_ok=None,
+            chain_length=0,
+            chain_head=CHAIN_GENESIS,
+            first_broken_index=None,
+            reason=None if chain_ok else "legacy cassette signature mismatch (v1, no chain)",
+        )
+
     chain_ok, broken_idx, reason = store.verify_chain()
     stored_head = store.meta.get("chain_head")
     if chain_ok and stored_head is not None and stored_head != store.chain_head():

--- a/src/sandcastle/engine/cassette.py
+++ b/src/sandcastle/engine/cassette.py
@@ -26,12 +26,42 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
-CASSETTE_VERSION = 1
+CASSETTE_VERSION = 2
+
+# Sentinel prev_hash for the first record in a chain (matches the audit trail).
+CHAIN_GENESIS = "genesis"
+
+
+def compute_record_hash(cache_key: str, record: dict[str, Any], prev_hash: str) -> str:
+    """SHA-256 over the canonical JSON of a record plus its predecessor's hash.
+
+    Including ``prev_hash`` links every record to the one before it, so any
+    edit, removal, or reordering breaks every hash downstream of the change.
+    """
+    canonical = json.dumps(
+        {"cache_key": cache_key, "record": record, "prev_hash": prev_hash},
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def default_cassette_path(run_id: str) -> Path:
+    """Canonical on-disk location of a run's auto-recorded cassette.
+
+    Used by black-box compliance mode (auto-record) and by
+    ``sandcastle audit verify <run-id>``.
+    """
+    from sandcastle.config import settings
+
+    return Path(settings.data_dir) / "cassettes" / f"{run_id}.cassette.json"
 
 
 class CassetteStore:
@@ -48,6 +78,9 @@ class CassetteStore:
         self.path = Path(path)
         self.mode = mode
         self.records: dict[str, dict[str, Any]] = {}
+        # Ordered hash chain: one entry per recorded step, each linking to the
+        # previous via prev_hash (tamper-evident, see compute_record_hash).
+        self.chain: list[dict[str, Any]] = []
         self.meta: dict[str, Any] = {}
         self._signature_ok: bool | None = None
         self.replay_hits = 0
@@ -61,6 +94,7 @@ class CassetteStore:
             raise FileNotFoundError(f"cassette not found for replay: {self.path}")
         data = json.loads(self.path.read_text())
         self.records = data.get("records", {})
+        self.chain = data.get("chain", [])
         self.meta = data.get("meta", {})
         self._signature_ok = self.verify()
         if self._signature_ok is False:
@@ -91,15 +125,45 @@ class CassetteStore:
 
     # -- record --------------------------------------------------------------
     def put(self, cache_key: str, output: Any, cost_usd: float, model: str, step_id: str) -> None:
-        """Record a step output under its cache key (record mode only)."""
+        """Record a step output under its cache key (record mode only).
+
+        Every put also appends a hash-chain entry: record_hash = SHA-256 over
+        the canonical record + the previous entry's hash. Re-recording an
+        existing key (rare: same cache key hit twice) rebuilds the chain so
+        hashes always match the stored records.
+        """
         if self.mode != "record" or not cache_key:
             return
+        rerecord = cache_key in self.records
         self.records[cache_key] = {
             "output": output,
             "cost_usd": cost_usd,
             "model": model,
             "step_id": step_id,
         }
+        if rerecord:
+            self._rebuild_chain()
+            return
+        prev_hash = self.chain[-1]["record_hash"] if self.chain else CHAIN_GENESIS
+        self.chain.append(
+            {
+                "index": len(self.chain),
+                "cache_key": cache_key,
+                "step_id": step_id,
+                "prev_hash": prev_hash,
+                "record_hash": compute_record_hash(cache_key, self.records[cache_key], prev_hash),
+            }
+        )
+
+    def _rebuild_chain(self) -> None:
+        """Recompute every chain hash in append order (after a re-record)."""
+        prev_hash = CHAIN_GENESIS
+        for entry in self.chain:
+            entry["prev_hash"] = prev_hash
+            entry["record_hash"] = compute_record_hash(
+                entry["cache_key"], self.records.get(entry["cache_key"], {}), prev_hash
+            )
+            prev_hash = entry["record_hash"]
 
     def _canonical(self) -> str:
         return json.dumps(self.records, sort_keys=True, default=str)
@@ -112,21 +176,185 @@ class CassetteStore:
         """True if the loaded file's stored signature matches its records."""
         return self.meta.get("signature") == self.signature()
 
+    # -- hash chain + keyed signature ------------------------------------------
+    def chain_head(self) -> str:
+        """The last record_hash in the chain (CHAIN_GENESIS when empty)."""
+        return self.chain[-1]["record_hash"] if self.chain else CHAIN_GENESIS
+
+    def _signing_payload(self) -> bytes:
+        """Canonical bytes the keyed signature covers: chain head + length."""
+        return json.dumps(
+            {
+                "chain_head": self.chain_head(),
+                "record_count": len(self.chain),
+                "version": CASSETTE_VERSION,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+
+    def verify_chain(self) -> tuple[bool, int | None, str | None]:
+        """Re-walk the hash chain and recompute every record hash.
+
+        Returns (valid, first_broken_index, reason). first_broken_index is the
+        chain index of the first entry that fails, or None when intact.
+        """
+        chain_keys = {e.get("cache_key") for e in self.chain}
+        expected_prev = CHAIN_GENESIS
+        for idx, entry in enumerate(self.chain):
+            cache_key = entry.get("cache_key", "")
+            if entry.get("prev_hash") != expected_prev:
+                return False, idx, "prev_hash does not match the previous record_hash"
+            record = self.records.get(cache_key)
+            if record is None:
+                return False, idx, f"chained record '{cache_key}' is missing from records"
+            computed = compute_record_hash(cache_key, record, expected_prev)
+            if computed != entry.get("record_hash"):
+                return False, idx, "record_hash mismatch (record was modified)"
+            expected_prev = entry["record_hash"]
+        extra = set(self.records) - chain_keys
+        if extra:
+            return False, len(self.chain), f"records not covered by the chain: {sorted(extra)}"
+        return True, None, None
+
+    def verify_signature(self, key: str | None = None) -> bool | None:
+        """Check the keyed signature over the chain head.
+
+        Returns True/False for a signed cassette, or None when the file has
+        no chain signature or no key is available to verify it.
+        """
+        from sandcastle.engine.signing import get_verifier
+
+        sig = self.meta.get("chain_signature") or {}
+        if not sig.get("value"):
+            return None
+        verifier = get_verifier(sig.get("alg", ""), key=key)
+        if verifier is None:
+            return None
+        return verifier.verify(self._signing_payload(), sig["value"])
+
     def save(self) -> None:
-        """Write the signed cassette file (record mode)."""
+        """Write the signed cassette file (record mode).
+
+        The file always carries the hash chain and its head; when an audit
+        key is configured (``AUDIT_KEY`` / ``SANDCASTLE_AUDIT_KEY``), the
+        chain head is additionally signed so the whole file is bound to the
+        key holder, not just internally consistent.
+        """
         if self.mode != "record":
             return
-        payload = {
-            "meta": {
-                "version": CASSETTE_VERSION,
-                "step_count": len(self.records),
-                "total_cost_usd": round(
-                    sum(float(r.get("cost_usd", 0.0) or 0.0) for r in self.records.values()), 6
-                ),
-                "signature": self.signature(),
-            },
-            "records": self.records,
+        from sandcastle.engine.signing import get_signer
+
+        meta: dict[str, Any] = {
+            "version": CASSETTE_VERSION,
+            "step_count": len(self.records),
+            "total_cost_usd": round(
+                sum(float(r.get("cost_usd", 0.0) or 0.0) for r in self.records.values()), 6
+            ),
+            "signature": self.signature(),
+            "chain_head": self.chain_head(),
         }
+        signer = get_signer()
+        if signer is not None:
+            meta["chain_signature"] = {
+                "alg": signer.alg,
+                "value": signer.sign(self._signing_payload()),
+            }
+        payload = {"meta": meta, "records": self.records, "chain": self.chain}
+        self.meta = meta
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self.path.write_text(json.dumps(payload, indent=2, default=str))
         logger.info("Recorded cassette %s (%d steps)", self.path, len(self.records))
+
+
+@dataclass
+class CassetteVerification:
+    """Result of verifying a cassette's hash chain and keyed signature."""
+
+    valid: bool
+    chain_ok: bool
+    signature_ok: bool | None  # None = unsigned or no key available
+    chain_length: int
+    chain_head: str
+    first_broken_index: int | None
+    reason: str | None
+
+    @property
+    def status(self) -> str:
+        return "PASS" if self.valid else "FAIL"
+
+
+def verify_cassette(path: str | Path, key: str | None = None) -> CassetteVerification:
+    """Verify a cassette file: re-walk the hash chain and check the signature.
+
+    The Python API behind ``sandcastle audit verify``. A cassette is valid
+    when the chain recomputes cleanly AND the keyed signature (if present
+    and a key is available) verifies. *key* overrides the configured
+    ``audit_key``.
+    """
+    store = CassetteStore.__new__(CassetteStore)  # bypass mode validation/load
+    store.path = Path(path)
+    store.mode = "replay"
+    store.records = {}
+    store.chain = []
+    store.meta = {}
+    store._signature_ok = None
+    store.replay_hits = 0
+    store.replay_misses = 0
+    if not store.path.exists():
+        return CassetteVerification(
+            valid=False, chain_ok=False, signature_ok=None, chain_length=0,
+            chain_head=CHAIN_GENESIS, first_broken_index=None,
+            reason=f"cassette not found: {path}",
+        )
+    try:
+        data = json.loads(store.path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        return CassetteVerification(
+            valid=False, chain_ok=False, signature_ok=None, chain_length=0,
+            chain_head=CHAIN_GENESIS, first_broken_index=None,
+            reason=f"unreadable cassette: {exc}",
+        )
+    store.records = data.get("records", {})
+    store.chain = data.get("chain", [])
+    store.meta = data.get("meta", {})
+
+    chain_ok, broken_idx, reason = store.verify_chain()
+    stored_head = store.meta.get("chain_head")
+    if chain_ok and stored_head is not None and stored_head != store.chain_head():
+        chain_ok = False
+        broken_idx = len(store.chain)
+        reason = "stored chain_head does not match the recomputed chain head"
+    signature_ok = store.verify_signature(key=key)
+    if signature_ok is False and reason is None:
+        reason = "chain signature does not verify (wrong key or tampered head)"
+    valid = chain_ok and signature_ok is not False
+    return CassetteVerification(
+        valid=valid,
+        chain_ok=chain_ok,
+        signature_ok=signature_ok,
+        chain_length=len(store.chain),
+        chain_head=store.chain_head(),
+        first_broken_index=broken_idx,
+        reason=reason,
+    )
+
+
+def read_attestation(path: str | Path) -> dict[str, Any] | None:
+    """Lightweight attestation for API responses: {signed, chain_head} or None.
+
+    ``signed`` is True only when the cassette carries a keyed chain signature
+    that verifies with the currently configured audit key.
+    """
+    p = Path(path)
+    if not p.exists():
+        return None
+    try:
+        verification = verify_cassette(p)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Failed to read cassette attestation %s: %s", p, exc)
+        return None
+    return {
+        "signed": verification.signature_ok is True and verification.chain_ok,
+        "chain_head": verification.chain_head,
+    }

--- a/src/sandcastle/engine/executor.py
+++ b/src/sandcastle/engine/executor.py
@@ -7993,6 +7993,33 @@ async def execute_workflow(
     if compliance_mode == "eu_ai_act":
         logger.info("EU AI Act compliance mode active")
 
+    # Black box compliance mode: refuse to start unless the flight-recorder
+    # preconditions hold - local data residency and a configured signing key.
+    if compliance_mode == "black_box":
+        if (getattr(settings, "data_residency", "") or "") != "local":
+            return WorkflowResult(
+                run_id=run_id or str(uuid.uuid4()),
+                outputs={},
+                total_cost_usd=0.0,
+                status="failed",
+                error=(
+                    "Black box compliance mode requires data_residency=local "
+                    "(set DATA_RESIDENCY=local) so the signed audit trail never "
+                    "leaves your infrastructure."
+                ),
+            )
+        if not (getattr(settings, "audit_key", "") or ""):
+            return WorkflowResult(
+                run_id=run_id or str(uuid.uuid4()),
+                outputs={},
+                total_cost_usd=0.0,
+                status="failed",
+                error=(
+                    "Black box compliance mode requires a signing key: set the "
+                    "SANDCASTLE_AUDIT_KEY environment variable."
+                ),
+            )
+
     # EU AI Act: warn (or fail in compliance mode) if high-risk workflow has no approval step
     if risk_level == "high":
         has_approval = any(s.type == "approval" for s in workflow.steps)
@@ -8017,6 +8044,15 @@ async def execute_workflow(
 
     if run_id is None:
         run_id = str(uuid.uuid4())
+
+    # Black box compliance mode: every top-level run is recorded to a signed
+    # cassette (the finally-block below persists it on any outcome).
+    if compliance_mode == "black_box" and cassette is None and depth == 0:
+        from sandcastle.engine.cassette import CassetteStore, default_cassette_path
+
+        cassette = CassetteStore(default_cassette_path(run_id), "record")
+        cassette_mode = "record"
+        logger.info("Black box mode: recording signed cassette for run %s", run_id)
 
     if storage is None:
         storage = create_storage()

--- a/src/sandcastle/engine/signing.py
+++ b/src/sandcastle/engine/signing.py
@@ -1,0 +1,97 @@
+"""Pluggable signing backends for the black-box audit trail.
+
+The default backend is HMAC-SHA256 keyed by the ``audit_key`` setting
+(``SANDCASTLE_AUDIT_KEY`` / ``AUDIT_KEY`` env var) - stdlib only, no extra
+dependencies. The ``AuditSigner`` interface is deliberately minimal so an
+asymmetric backend (e.g. Ed25519 via the optional ``cryptography`` extra)
+can be registered later without touching any caller: signatures embed the
+``alg`` identifier, and verification dispatches on it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+from abc import ABC, abstractmethod
+
+logger = logging.getLogger(__name__)
+
+
+class AuditSigner(ABC):
+    """A signing backend: produces and verifies detached signatures.
+
+    Implementations must set ``alg`` to a stable identifier that is stored
+    alongside every signature, so files remain verifiable after new
+    backends are added.
+    """
+
+    alg: str
+
+    @abstractmethod
+    def sign(self, message: bytes) -> str:
+        """Return a hex-encoded detached signature over *message*."""
+
+    @abstractmethod
+    def verify(self, message: bytes, signature: str) -> bool:
+        """True if *signature* is a valid signature over *message*."""
+
+
+class HmacSigner(AuditSigner):
+    """HMAC-SHA256 signer keyed by a shared secret (stdlib only)."""
+
+    alg = "hmac-sha256"
+
+    def __init__(self, key: str) -> None:
+        if not key:
+            raise ValueError("HmacSigner requires a non-empty key")
+        self._key = key.encode("utf-8")
+
+    def sign(self, message: bytes) -> str:
+        return hmac.new(self._key, message, hashlib.sha256).hexdigest()
+
+    def verify(self, message: bytes, signature: str) -> bool:
+        if not signature:
+            return False
+        return hmac.compare_digest(self.sign(message), signature)
+
+
+# Registry of available backends by algorithm identifier. An asymmetric
+# backend registers itself here (alg -> constructor taking the key material).
+_BACKENDS: dict[str, type[AuditSigner]] = {
+    HmacSigner.alg: HmacSigner,
+}
+
+
+def get_signer(key: str | None = None) -> AuditSigner | None:
+    """Return the configured signer, or None when no audit key is set.
+
+    *key* overrides the ``audit_key`` setting (used by the verify CLI's
+    ``--key`` flag and by tests).
+    """
+    if key is None:
+        from sandcastle.config import settings
+
+        key = getattr(settings, "audit_key", "") or ""
+    if not key:
+        return None
+    return HmacSigner(key)
+
+
+def get_verifier(alg: str, key: str | None = None) -> AuditSigner | None:
+    """Return a verifier for *alg*, or None when the backend or key is missing."""
+    backend = _BACKENDS.get(alg)
+    if backend is None:
+        logger.warning("Unknown audit signature algorithm: %s", alg)
+        return None
+    if key is None:
+        from sandcastle.config import settings
+
+        key = getattr(settings, "audit_key", "") or ""
+    if not key:
+        return None
+    try:
+        return backend(key)
+    except Exception as exc:
+        logger.error("Failed to initialize %s verifier: %s", alg, exc)
+        return None

--- a/tests/test_blackbox_audit.py
+++ b/tests/test_blackbox_audit.py
@@ -1,0 +1,350 @@
+"""Tests for the black box flight recorder - signed, tamper-evident cassette chains.
+
+Every recorded step gets a hash-chain entry (record_hash = SHA-256 over the canonical
+record + prev_hash) and the chain head is signed with the configured audit key
+(HMAC-SHA256). These tests prove: the chain is built correctly, any tampering is
+detected at the exact record, compliance_mode="black_box" enforces its preconditions
+and auto-records every run, and `sandcastle audit verify` reports PASS/FAIL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sandcastle.__main__ import _cmd_audit_verify
+from sandcastle.config import settings
+from sandcastle.engine.cassette import (
+    CHAIN_GENESIS,
+    CassetteStore,
+    compute_record_hash,
+    default_cassette_path,
+    read_attestation,
+    verify_cassette,
+)
+from sandcastle.engine.signing import HmacSigner, get_signer, get_verifier
+
+KEY = "test-audit-key"
+
+
+def _record_cassette(path, n: int = 3) -> CassetteStore:
+    """Record *n* steps into a cassette and save it."""
+    store = CassetteStore(path, "record")
+    for i in range(n):
+        store.put(f"key-{i}", output=f"out-{i}", cost_usd=0.01, model="sonnet", step_id=f"s{i}")
+    store.save()
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Chain building
+# ---------------------------------------------------------------------------
+
+
+class TestChainBuilding:
+    def test_put_appends_linked_chain_entries(self, tmp_path):
+        store = _record_cassette(tmp_path / "c.cassette.json", n=3)
+        assert len(store.chain) == 3
+        assert store.chain[0]["prev_hash"] == CHAIN_GENESIS
+        for i, entry in enumerate(store.chain):
+            assert entry["index"] == i
+            prev = CHAIN_GENESIS if i == 0 else store.chain[i - 1]["record_hash"]
+            assert entry["prev_hash"] == prev
+            assert entry["record_hash"] == compute_record_hash(
+                entry["cache_key"], store.records[entry["cache_key"]], prev
+            )
+        assert store.chain_head() == store.chain[-1]["record_hash"]
+
+    def test_saved_file_carries_chain_and_head(self, tmp_path):
+        path = tmp_path / "c.cassette.json"
+        store = _record_cassette(path)
+        data = json.loads(path.read_text())
+        assert data["meta"]["chain_head"] == store.chain_head()
+        assert len(data["chain"]) == 3
+        assert data["meta"]["version"] == 2
+
+    def test_empty_cassette_head_is_genesis(self, tmp_path):
+        store = CassetteStore(tmp_path / "e.cassette.json", "record")
+        assert store.chain_head() == CHAIN_GENESIS
+        store.save()
+        assert verify_cassette(tmp_path / "e.cassette.json").valid
+
+    def test_rerecording_a_key_rebuilds_a_valid_chain(self, tmp_path):
+        path = tmp_path / "r.cassette.json"
+        store = CassetteStore(path, "record")
+        store.put("k", output="v1", cost_usd=0.01, model="m", step_id="s")
+        store.put("k2", output="v2", cost_usd=0.01, model="m", step_id="s2")
+        store.put("k", output="v1-again", cost_usd=0.01, model="m", step_id="s")
+        store.save()
+        v = verify_cassette(path)
+        assert v.valid and v.chain_ok
+        assert v.chain_length == 2
+
+    def test_signature_written_when_audit_key_set(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(settings, "audit_key", KEY)
+        path = tmp_path / "signed.cassette.json"
+        _record_cassette(path)
+        sig = json.loads(path.read_text())["meta"]["chain_signature"]
+        assert sig["alg"] == "hmac-sha256"
+        assert len(sig["value"]) == 64  # hex SHA-256
+
+    def test_no_signature_without_audit_key(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(settings, "audit_key", "")
+        path = tmp_path / "unsigned.cassette.json"
+        _record_cassette(path)
+        assert "chain_signature" not in json.loads(path.read_text())["meta"]
+
+
+# ---------------------------------------------------------------------------
+# Verification + tamper detection
+# ---------------------------------------------------------------------------
+
+
+class TestTamperDetection:
+    def test_intact_signed_cassette_passes(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(settings, "audit_key", KEY)
+        path = tmp_path / "ok.cassette.json"
+        _record_cassette(path)
+        v = verify_cassette(path)
+        assert v.valid and v.chain_ok and v.signature_ok is True
+        assert v.first_broken_index is None and v.reason is None
+        assert v.status == "PASS"
+
+    def test_flipped_byte_fails_at_correct_index(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(settings, "audit_key", KEY)
+        path = tmp_path / "t.cassette.json"
+        _record_cassette(path, n=3)
+        data = json.loads(path.read_text())
+        data["records"]["key-1"]["output"] = "out-1!"  # flip a byte in record 1
+        path.write_text(json.dumps(data))
+        v = verify_cassette(path)
+        assert not v.valid and not v.chain_ok
+        assert v.first_broken_index == 1
+        assert "modified" in v.reason
+        assert v.status == "FAIL"
+
+    def test_deleted_chain_entry_breaks_linkage(self, tmp_path):
+        path = tmp_path / "d.cassette.json"
+        _record_cassette(path, n=3)
+        data = json.loads(path.read_text())
+        del data["chain"][1]
+        path.write_text(json.dumps(data))
+        v = verify_cassette(path)
+        assert not v.valid
+        assert v.first_broken_index == 1
+        assert "prev_hash" in v.reason
+
+    def test_record_injected_outside_chain_is_detected(self, tmp_path):
+        path = tmp_path / "i.cassette.json"
+        _record_cassette(path, n=2)
+        data = json.loads(path.read_text())
+        data["records"]["forged"] = {"output": "evil", "cost_usd": 0, "model": "m", "step_id": "x"}
+        path.write_text(json.dumps(data))
+        v = verify_cassette(path)
+        assert not v.valid
+        assert "not covered by the chain" in v.reason
+
+    def test_wrong_key_fails_signature(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(settings, "audit_key", KEY)
+        path = tmp_path / "w.cassette.json"
+        _record_cassette(path)
+        v = verify_cassette(path, key="wrong-key")
+        assert v.chain_ok is True
+        assert v.signature_ok is False
+        assert not v.valid
+
+    def test_unsigned_cassette_with_intact_chain_passes_without_signature(self, tmp_path):
+        path = tmp_path / "u.cassette.json"
+        _record_cassette(path)
+        v = verify_cassette(path)
+        assert v.valid and v.signature_ok is None
+
+    def test_missing_file_fails_cleanly(self, tmp_path):
+        v = verify_cassette(tmp_path / "nope.cassette.json")
+        assert not v.valid
+        assert "not found" in v.reason
+
+    def test_read_attestation(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(settings, "audit_key", KEY)
+        path = tmp_path / "a.cassette.json"
+        store = _record_cassette(path)
+        att = read_attestation(path)
+        assert att == {"signed": True, "chain_head": store.chain_head()}
+        assert read_attestation(tmp_path / "missing.json") is None
+
+
+# ---------------------------------------------------------------------------
+# Signing backends
+# ---------------------------------------------------------------------------
+
+
+class TestSigningBackends:
+    def test_hmac_sign_and_verify_roundtrip(self):
+        signer = HmacSigner(KEY)
+        sig = signer.sign(b"chain-head")
+        assert signer.verify(b"chain-head", sig)
+        assert not signer.verify(b"different", sig)
+        assert not HmacSigner("other").verify(b"chain-head", sig)
+
+    def test_get_signer_none_without_key(self, monkeypatch):
+        monkeypatch.setattr(settings, "audit_key", "")
+        assert get_signer() is None
+        assert get_signer(KEY) is not None
+
+    def test_get_verifier_dispatches_on_alg(self):
+        assert get_verifier("hmac-sha256", key=KEY).alg == "hmac-sha256"
+        assert get_verifier("ed25519", key=KEY) is None  # not registered (yet)
+
+
+# ---------------------------------------------------------------------------
+# compliance_mode = "black_box" enforcement
+# ---------------------------------------------------------------------------
+
+BLACKBOX_WORKFLOW = """name: blackbox-test
+description: A single local-model step for black box recording.
+default_model: omlx/gemma-3
+input_schema:
+  required: []
+  properties:
+    q: { type: string, default: "hi" }
+steps:
+  - id: think
+    prompt: "Answer: {input.q}"
+"""
+
+
+class TestBlackBoxComplianceMode:
+    def _mock_settings(self, **overrides):
+        mock = MagicMock()
+        mock.compliance_mode = "black_box"
+        mock.data_residency = "local"
+        mock.audit_key = KEY
+        mock.max_workflow_depth = 5
+        for k, v in overrides.items():
+            setattr(mock, k, v)
+        return mock
+
+    def test_refuses_without_local_data_residency(self):
+        import asyncio
+
+        from sandcastle.engine.dag import build_plan, parse_yaml_string
+        from sandcastle.engine.executor import execute_workflow
+
+        wf = parse_yaml_string(BLACKBOX_WORKFLOW)
+        plan = build_plan(wf)
+        with patch("sandcastle.config.settings", self._mock_settings(data_residency="eu")):
+            result = asyncio.run(execute_workflow(wf, plan, {}))
+        assert result.status == "failed"
+        assert "data_residency=local" in result.error
+
+    def test_refuses_without_audit_key(self):
+        import asyncio
+
+        from sandcastle.engine.dag import build_plan, parse_yaml_string
+        from sandcastle.engine.executor import execute_workflow
+
+        wf = parse_yaml_string(BLACKBOX_WORKFLOW)
+        plan = build_plan(wf)
+        with patch("sandcastle.config.settings", self._mock_settings(audit_key="")):
+            result = asyncio.run(execute_workflow(wf, plan, {}))
+        assert result.status == "failed"
+        assert "SANDCASTLE_AUDIT_KEY" in result.error
+
+    @pytest.mark.asyncio
+    async def test_run_is_auto_recorded_and_signed(self, tmp_path, monkeypatch):
+        """In black_box mode a run with no --record flag still produces a signed,
+        verifiable cassette at the canonical path, and the attestation reports it."""
+        from sandcastle.engine.dag import build_plan, parse_yaml_string
+        from sandcastle.engine.executor import execute_workflow
+        from sandcastle.engine.sandshore import SandshoreResult, SandshoreRuntime
+
+        monkeypatch.setattr(settings, "compliance_mode", "black_box")
+        monkeypatch.setattr(settings, "data_residency", "local")
+        monkeypatch.setattr(settings, "audit_key", KEY)
+        monkeypatch.setattr(settings, "data_dir", str(tmp_path))
+
+        wf = parse_yaml_string(BLACKBOX_WORKFLOW)
+        plan = build_plan(wf)
+        sandbox = MagicMock(spec=SandshoreRuntime)
+
+        async def _query(request):
+            return SandshoreResult(
+                text="FLIGHT RECORDED", structured_output=None, total_cost_usd=0.0,
+                input_tokens=5, output_tokens=5,
+            )
+
+        sandbox.query = _query
+        with patch("sandcastle.engine.executor.get_sandshore_runtime", return_value=sandbox):
+            result = await execute_workflow(wf, plan, {"q": "hi"}, admin_trusted=True)
+
+        assert result.status == "completed"
+        cassette_file = default_cassette_path(result.run_id)
+        assert cassette_file.exists(), "black box mode must auto-record every run"
+
+        v = verify_cassette(cassette_file)
+        assert v.valid and v.chain_ok and v.signature_ok is True
+        assert v.chain_length == 1
+
+        att = read_attestation(cassette_file)
+        assert att["signed"] is True
+        assert att["chain_head"] == v.chain_head
+
+
+# ---------------------------------------------------------------------------
+# `sandcastle audit verify` CLI
+# ---------------------------------------------------------------------------
+
+
+class TestAuditVerifyCli:
+    def _args(self, target: str, key: str | None = None) -> argparse.Namespace:
+        return argparse.Namespace(target=target, key=key)
+
+    def test_verify_pass(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(settings, "audit_key", KEY)
+        path = tmp_path / "ok.cassette.json"
+        _record_cassette(path)
+        _cmd_audit_verify(self._args(str(path)))
+        out = capsys.readouterr().out
+        assert "PASS" in out
+        assert "Signature:" in out and "valid" in out
+
+    def test_verify_fail_exits_1_with_broken_index(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(settings, "audit_key", KEY)
+        path = tmp_path / "bad.cassette.json"
+        _record_cassette(path, n=3)
+        data = json.loads(path.read_text())
+        data["records"]["key-2"]["output"] = "tampered"
+        path.write_text(json.dumps(data))
+        with pytest.raises(SystemExit) as exc_info:
+            _cmd_audit_verify(self._args(str(path)))
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "FAIL" in out
+        assert "chain index 2" in out
+
+    def test_verify_resolves_run_id_under_data_dir(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(settings, "audit_key", KEY)
+        monkeypatch.setattr(settings, "data_dir", str(tmp_path))
+        run_id = "11111111-2222-3333-4444-555555555555"
+        _record_cassette(default_cassette_path(run_id))
+        _cmd_audit_verify(self._args(run_id))
+        assert "PASS" in capsys.readouterr().out
+
+    def test_verify_unknown_target_exits_1(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(settings, "data_dir", str(tmp_path))
+        with pytest.raises(SystemExit) as exc_info:
+            _cmd_audit_verify(self._args("no-such-run"))
+        assert exc_info.value.code == 1
+        assert "No cassette found" in capsys.readouterr().err
+
+    def test_verify_with_explicit_key_flag(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(settings, "audit_key", KEY)
+        path = tmp_path / "k.cassette.json"
+        _record_cassette(path)
+        with pytest.raises(SystemExit) as exc_info:
+            _cmd_audit_verify(self._args(str(path), key="wrong-key"))
+        assert exc_info.value.code == 1
+        assert "INVALID" in capsys.readouterr().out

--- a/tests/test_blackbox_audit.py
+++ b/tests/test_blackbox_audit.py
@@ -348,3 +348,29 @@ class TestAuditVerifyCli:
             _cmd_audit_verify(self._args(str(path), key="wrong-key"))
         assert exc_info.value.code == 1
         assert "INVALID" in capsys.readouterr().out
+
+
+class TestLegacyCassettes:
+    def test_v1_cassette_without_chain_verifies_via_legacy_signature(self, tmp_path):
+        """Cassettes recorded before the hash chain existed still verify (and still
+        flag tampering) via their original whole-file signature."""
+        import hashlib
+
+        path = tmp_path / "v1.cassette.json"
+        records = {"k": {"output": "old", "cost_usd": 0.01, "model": "m", "step_id": "s"}}
+        signature = hashlib.sha256(
+            json.dumps(records, sort_keys=True, default=str).encode()
+        ).hexdigest()
+        path.write_text(json.dumps({
+            "meta": {"version": 1, "step_count": 1, "signature": signature},
+            "records": records,
+        }))
+        v = verify_cassette(path)
+        assert v.valid and v.chain_length == 0 and v.signature_ok is None
+
+        data = json.loads(path.read_text())
+        data["records"]["k"]["output"] = "tampered"
+        path.write_text(json.dumps(data))
+        v2 = verify_cassette(path)
+        assert not v2.valid
+        assert "legacy" in v2.reason


### PR DESCRIPTION
**The Black Box: a flight recorder for AI agents.** Builds on the existing cassette record/replay system to make every run a tamper-evident, replayable artifact.

- **Hash-chain signing** (`engine/signing.py`, `engine/cassette.py`): each step/event record carries `prev_hash` + `record_hash` (SHA-256 over canonical JSON), the chain head is keyed-signed (HMAC-SHA256 via stdlib; `alg`-dispatched so Ed25519 can be added later without invalidating files)
- **`compliance_mode="black_box"`** (`engine/executor.py`): when on, refuses to start unless `data_residency=local` + `audit_key` set; auto-records every depth-0 run; run API exposes `signed` + `audit_chain_head`
- **`sandcastle audit verify <run-id-or-path>`**: re-walks the chain, recomputes hashes, checks the signature, prints PASS/FAIL with the first broken record index
- README "Black Box Flight Recorder" section (tamper-evident/replayable framing — no certification claims)

Tests: 26 new in `test_blackbox_audit.py` (chain build, tamper detection, mode gates, verify CLI); ruff clean. Defensive feature only — no exploit content.

Stacked on #255 (gui-experiment).