### PR TITLE
feat(training): real GPU LoRA trainer for Overnight Self-Tune

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,12 @@ OLLAMA_HOST=http://localhost:11434 sandcastle serve   # Spark Mode auto-detects 
 Override detection anytime with `SANDCASTLE_SPARK_MODE=on|off`. On any non-Spark machine nothing
 changes — detection is fail-closed.
 
+**Overnight Self-Tune** goes one step further: with `pip install 'sandcastle-ai[training]'`,
+`TRAINER_BACKEND=gpu`, and `EVOLUTION_AUTO_FINETUNE=true`, the evolution loop fine-tunes a real
+LoRA adapter (transformers + peft) on the workflow's own eval data and routes the workflow to it —
+served by your local vLLM/Ollama/NIM at $0/run. See
+[docs/overnight-self-tune-spark.md](docs/overnight-self-tune-spark.md).
+
 > Spark Mode auto-configures Sandcastle for NVIDIA DGX Spark and local NVIDIA GPU inference. It is
 > **not** an official NVIDIA certification or endorsement. "NVIDIA", "DGX", and "DGX Spark" are
 > trademarks of NVIDIA Corporation, used here only to describe compatibility.

--- a/docs/overnight-self-tune-spark.md
+++ b/docs/overnight-self-tune-spark.md
@@ -1,0 +1,84 @@
+# Overnight Self-Tune on a DGX Spark — real LoRA training
+
+Sandcastle's evolution loop can fine-tune a **task-specific LoRA adapter** on a workflow's
+own eval data and route the workflow to it — for $0, entirely on-box. This page covers the
+real GPU path on an NVIDIA DGX Spark (GB10 Grace-Blackwell, ~128 GB unified memory).
+
+## The loop
+
+```
+nightly evolution run (mutate_finetune, every 5th iteration)
+        │ builds (input, output) pairs from the workflow's eval results
+        ▼
+GPUTrainer — LoRA SFT with transformers + peft (bf16, prompt-masked loss)
+        │ writes adapter weights + dataset.jsonl + training_metadata.json
+        ▼
+AdapterRegistry — ~/.sandcastle/adapters/<adapter_id>/ (metadata.json)
+        │ resolve_model("adapter/<id>") → local, $0.00/run
+        ▼
+local model server (vLLM / Ollama / NIM) serves base model + adapter
+        │
+        ▼
+workflow steps now call adapter/<id>; next eval scores feed the next night
+```
+
+Sandcastle **trains and registers** adapters; it does **not serve** them. Serving is the
+local OpenAI-compatible server's job.
+
+## Enable it
+
+```bash
+pip install 'sandcastle-ai[training]'    # torch, transformers, peft, datasets, accelerate
+
+export TRAINER_BACKEND=gpu               # default "mock" = deterministic, no GPU needed
+export EVOLUTION_AUTO_FINETUNE=true      # opt-in: every 5th evolution iteration fine-tunes
+export LORA_BASE_MODEL_ID="Qwen/Qwen2.5-7B-Instruct"   # HF model actually fine-tuned
+```
+
+Key knobs (all `settings.lora_*`, env-overridable): `LORA_R`, `LORA_ALPHA`, `LORA_DROPOUT`,
+`LORA_LR`, `LORA_EPOCHS`, `LORA_MAX_STEPS` (0 = epochs decide), `LORA_SEED`,
+`LORA_BATCH_SIZE`, `LORA_GRAD_ACCUM`, `LORA_MAX_SEQ_LEN`, `LORA_QUANTIZE`,
+`LORA_OUTPUT_DIR` (empty = `~/.sandcastle/adapters`).
+
+## Serving the adapter (vLLM example)
+
+The adapter must be loaded over the **same base model** it was trained on
+(`base_model` in the adapter's `metadata.json`):
+
+```bash
+ADAPTER=~/.sandcastle/adapters/<adapter_id>
+vllm serve Qwen/Qwen2.5-7B-Instruct \
+  --enable-lora \
+  --lora-modules <adapter_id>=$ADAPTER
+```
+
+Then requests with `"model": "<adapter_id>"` hit the tuned adapter. Point Sandcastle's
+local provider at the server (e.g. `NIM_BASE_URL=http://localhost:8000`). Ollama
+alternatively accepts a `Modelfile` with an `ADAPTER` directive; NVIDIA NIM supports
+multi-LoRA via `NIM_PEFT_SOURCE`.
+
+## Sizing & quantization tradeoff
+
+- **Default: bf16 base + LoRA, Qwen2.5-7B-Instruct.** ~15 GB weights + optimizer/activations
+  fits trivially in 128 GB unified memory and avoids any aarch64 wheel roulette.
+- **70B-class bases need quantization**: bf16 weights alone are ~140 GB. Set
+  `LORA_QUANTIZE=4bit` (QLoRA via bitsandbytes) and install `bitsandbytes` yourself —
+  it is *not* part of the `[training]` extra because CUDA aarch64 wheels are not
+  universally published; verify it imports on your DGX OS image first.
+- On the Spark, install torch per NVIDIA's instructions for CUDA-on-aarch64 if the
+  default PyPI wheel lacks CUDA support.
+
+## Validate on the Spark
+
+One command (trains Qwen2.5-0.5B for 5 steps, registers + resolves the adapter):
+
+```bash
+pip install -e '.[training]' && bash scripts/validate_training_on_spark.sh
+```
+
+## Reproducibility
+
+The adapter id is a pure hash of (base model, hyperparameters, dataset sha256) —
+re-training on unchanged data is idempotent. Each adapter dir contains `dataset.jsonl`
+(the exact chat-format training set, one `{"messages": [...]}` per line) and
+`training_metadata.json` (hyperparams, dataset hash, eval loss, library versions).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,16 @@ mcp = [
 security = [
     "cryptography>=43.0",
 ]
+# Real GPU LoRA training (Overnight Self-Tune, trainer_backend="gpu"). Needs a CUDA
+# GPU; on a DGX Spark (aarch64) install torch from NVIDIA's index. bitsandbytes is
+# intentionally NOT pinned here - 4/8-bit quantization is opt-in (lora_quantize).
+training = [
+    "torch>=2.4",
+    "transformers>=4.45",
+    "peft>=0.13",
+    "datasets>=3.0",
+    "accelerate>=1.0",
+]
 telemetry = [
     "sentry-sdk[fastapi]>=2.0",
 ]

--- a/scripts/validate_training_on_spark.sh
+++ b/scripts/validate_training_on_spark.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Smoke-validate the real GPU LoRA trainer on a DGX Spark (or any CUDA host).
+#
+# Trains Qwen/Qwen2.5-0.5B-Instruct for 5 steps on a tiny synthetic dataset, then
+# verifies the adapter lands in the registry and resolves as a local $0 model.
+# Run from the repo root on the Spark:
+#
+#   pip install -e '.[training]'
+#   bash scripts/validate_training_on_spark.sh
+#
+# Expected runtime: a few minutes (model download dominates the first run).
+set -euo pipefail
+
+python - <<'PY'
+import asyncio
+import time
+from types import SimpleNamespace
+
+from sandcastle.engine.adapter_registry import AdapterRegistry
+from sandcastle.engine.providers import resolve_model
+from sandcastle.engine.training.gpu_trainer import GPUTrainer
+
+config = SimpleNamespace(
+    lora_base_model_id="Qwen/Qwen2.5-0.5B-Instruct",
+    lora_r=8,
+    lora_alpha=16,
+    lora_dropout=0.05,
+    lora_lr=1e-4,
+    lora_epochs=1,
+    lora_max_steps=5,
+    lora_seed=42,
+    lora_batch_size=1,
+    lora_grad_accum=1,
+    lora_max_seq_len=512,
+    lora_quantize="none",
+    lora_output_dir="",  # -> ~/.sandcastle/adapters
+)
+pairs = [{"input": f"What is {i} + {i}?", "output": str(i + i)} for i in range(16)]
+
+result = asyncio.run(GPUTrainer().train("spark-validation", pairs, config))
+print(f"trained: {result.adapter_id}  metrics={result.metrics}")
+
+reg = AdapterRegistry()
+reg.register(
+    result.adapter_id, result.base_model, result.metrics,
+    result.samples, result.lora_config, created_at=time.time(),
+)
+assert reg.get(result.adapter_id) is not None, "adapter not registered"
+adapter_dir = reg.get_path(result.adapter_id)
+assert (adapter_dir / "adapter_model.safetensors").exists(), "no adapter weights written"
+
+info = resolve_model(f"adapter/{result.adapter_id}")
+assert info.region == "local" and info.input_price_per_m == 0.0
+
+print(f"OK: adapter registered at {adapter_dir}")
+print(f"Serve it:  vllm serve {result.base_model} --enable-lora "
+      f"--lora-modules {result.adapter_id}={adapter_dir}")
+PY

--- a/src/sandcastle/config.py
+++ b/src/sandcastle/config.py
@@ -54,8 +54,9 @@ class Settings(BaseSettings):
 
     # Overnight Self-Tune: the evolution loop may add a LoRA fine-tune mutation that
     # trains a local adapter on a workflow's own eval data and A/B-promotes it. Off by
-    # default; the trainer is a deterministic mock unless trainer_backend="gpu" (which
-    # needs torch/peft + a GPU and is a stub today). See engine/training/.
+    # default; the trainer is a deterministic mock unless trainer_backend="gpu" (real
+    # SFT - needs the [training] extras + a CUDA GPU, e.g. a DGX Spark). See
+    # engine/training/ and docs/overnight-self-tune-spark.md.
     evolution_auto_finetune: bool = False
     evolution_finetune_min_samples: int = 10
     trainer_backend: str = "mock"  # "mock" | "gpu"
@@ -63,6 +64,19 @@ class Settings(BaseSettings):
     lora_alpha: int = 16
     lora_lr: float = 1e-4
     lora_epochs: int = 3
+    lora_dropout: float = 0.05
+    lora_max_steps: int = 0  # 0 = no step cap (epochs decide)
+    lora_seed: int = 42
+    lora_batch_size: int = 1
+    lora_grad_accum: int = 8
+    lora_max_seq_len: int = 2048
+    # HF model the GPU trainer actually fine-tunes (the adapter must be served over the
+    # same base by vLLM/NIM). Default is small enough for bf16 LoRA on a 128 GB Spark;
+    # for 70B-class bases set lora_quantize="4bit"/"8bit" (needs bitsandbytes with
+    # CUDA aarch64 wheels - not guaranteed on DGX OS, hence opt-in).
+    lora_base_model_id: str = "Qwen/Qwen2.5-7B-Instruct"
+    lora_quantize: str = "none"  # "none" | "8bit" | "4bit"
+    lora_output_dir: str = ""  # empty = the adapter registry dir (~/.sandcastle/adapters)
 
     # E2B custom template (pre-built sandbox with SDK installed)
     e2b_template: str = ""  # e.g. "sandcastle-runner"

--- a/src/sandcastle/engine/adapter_registry.py
+++ b/src/sandcastle/engine/adapter_registry.py
@@ -32,7 +32,7 @@ class AdapterRegistry:
         lora_config: dict[str, Any],
         created_at: float = 0.0,
     ) -> Path:
-        """Persist an adapter's metadata + a stub weights file; return its directory."""
+        """Persist an adapter's metadata (+ a stub weights file when none exist)."""
         d = self.root / adapter_id
         d.mkdir(parents=True, exist_ok=True)
         meta = {
@@ -44,7 +44,10 @@ class AdapterRegistry:
             "created_at": created_at,
         }
         (d / "metadata.json").write_text(json.dumps(meta, indent=2, sort_keys=True))
-        (d / "adapter_model.safetensors.stub").write_text(adapter_id)
+        # Real weights (GPUTrainer writes adapter_model.safetensors before registering)
+        # win; the stub only marks mock-trained adapters so the layout stays uniform.
+        if not (d / "adapter_model.safetensors").exists():
+            (d / "adapter_model.safetensors.stub").write_text(adapter_id)
         return d
 
     def get(self, adapter_id: str) -> dict | None:

--- a/src/sandcastle/engine/training/__init__.py
+++ b/src/sandcastle/engine/training/__init__.py
@@ -2,6 +2,7 @@
 
 The evolution loop's ``mutate_finetune`` trains a task-specific LoRA adapter on a
 workflow's own eval data. Training is pluggable: a deterministic ``MockTrainer``
-(default, no GPU - powers all tests/CI) or a ``GPUTrainer`` stub that needs
-torch/peft + a CUDA GPU (e.g. a DGX Spark). Pick via ``settings.trainer_backend``.
+(default, no GPU - powers all tests/CI) or the real ``GPUTrainer`` (SFT via
+transformers + peft) that needs the ``[training]`` extras + a CUDA GPU (e.g. a
+DGX Spark). Pick via ``settings.trainer_backend``.
 """

--- a/src/sandcastle/engine/training/gpu_trainer.py
+++ b/src/sandcastle/engine/training/gpu_trainer.py
@@ -1,35 +1,319 @@
-"""Real GPU LoRA trainer - STUB. Needs torch + peft + transformers and a CUDA GPU.
+"""Real GPU LoRA trainer - SFT with torch + transformers + peft (Overnight Self-Tune).
 
-The training kernel is hardware-gated and intentionally not implemented here: the rest
-of Overnight Self-Tune (mutation, scoring, registry, A/B promotion) is exercised with
-the deterministic MockTrainer. On a real DGX Spark, implement ``train`` with
-``peft.LoraConfig`` over the locally-served base model and write the adapter weights to
-the registry path. torch/peft are imported lazily so importing this module never
-requires them.
+Trains a LoRA adapter over a Hugging Face base model on the workflow's own eval pairs
+and writes it where the adapter registry (and the local vLLM/NIM server) can pick it up.
+Heavy deps (torch/transformers/peft/datasets) are imported lazily inside ``train`` so
+importing this module never requires them; missing deps and missing CUDA both raise a
+clear, actionable ``RuntimeError``. Use ``trainer_backend="mock"`` everywhere else.
+
+Dataset format: each training pair is ``{"input": .., "output": ..}`` (the shape
+``evolution.mutate_finetune`` builds and MockTrainer hashes); ``prompt``/``completion``
+aliases and pre-built ``{"messages": [..]}`` chat rows are accepted too. On disk the
+trainer persists the normalized chat JSONL (one ``{"messages": [...]}`` per line)
+next to the adapter weights for full reproducibility.
+
+Quantization: defaults to **bf16** full-precision base + LoRA with a small default base
+model (Qwen2.5-7B-Instruct) - this is guaranteed to work on the DGX Spark's aarch64
+(GB10, ~128 GB unified memory). bitsandbytes 4-bit/8-bit (``lora_quantize``) is opt-in
+for 70B-class bases because aarch64 CUDA wheels are not universally available.
 """
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
+import json
+import logging
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 from sandcastle.engine.training.trainer import TrainingResult
 
+logger = logging.getLogger(__name__)
+
+_INSTALL_HINT = (
+    "GPUTrainer needs torch + transformers + peft + datasets + accelerate. "
+    "Install the training extras with: pip install 'sandcastle-ai[training]' "
+    "- or set trainer_backend='mock' to run the Self-Tune loop without a GPU."
+)
+
+# Default HF base model for real fine-tunes. Small enough to train comfortably in bf16
+# on a 128 GB DGX Spark; for 70B-class bases set lora_base_model_id + lora_quantize.
+_DEFAULT_BASE_MODEL_ID = "Qwen/Qwen2.5-7B-Instruct"
+
+# Fraction of pairs held out for eval loss (only when there are enough samples).
+_EVAL_HOLDOUT = 0.1
+_MIN_SAMPLES_FOR_HOLDOUT = 10
+
+
+@dataclass(frozen=True)
+class TrainParams:
+    """Resolved hyperparameters of one GPU LoRA run - hashed into the adapter id."""
+
+    base_model_id: str
+    source_model: str  # the Sandcastle model the adapter replaces (e.g. "sonnet")
+    r: int
+    alpha: int
+    dropout: float
+    lr: float
+    epochs: int
+    max_steps: int  # 0 = no cap (epochs decide)
+    seed: int
+    batch_size: int
+    grad_accum: int
+    max_seq_len: int
+    quantize: str  # "none" | "8bit" | "4bit"
+
+
+def normalize_pairs(training_pairs: list[dict]) -> list[dict]:
+    """Normalize raw training pairs into chat rows: ``{"messages": [user, assistant]}``.
+
+    Accepts ``input``/``output`` (the mutate_finetune shape), ``prompt``/``completion``
+    aliases, or pass-through ``messages`` rows. Unusable entries are silently skipped.
+    """
+    rows: list[dict] = []
+    for p in training_pairs or []:
+        if not isinstance(p, dict):
+            continue
+        if isinstance(p.get("messages"), list) and p["messages"]:
+            rows.append({"messages": p["messages"]})
+            continue
+        prompt = p.get("input") or p.get("prompt")
+        completion = p.get("output") or p.get("completion")
+        if prompt and completion:
+            rows.append(
+                {
+                    "messages": [
+                        {"role": "user", "content": str(prompt)},
+                        {"role": "assistant", "content": str(completion)},
+                    ]
+                }
+            )
+    return rows
+
+
+def dataset_sha256(rows: list[dict]) -> str:
+    """Stable sha256 of the normalized chat dataset (canonical JSONL)."""
+    canonical = "\n".join(json.dumps(r, sort_keys=True, ensure_ascii=True) for r in rows)
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def compute_adapter_id(params: TrainParams, rows: list[dict]) -> str:
+    """Deterministic adapter id: pure function of (hyperparams, dataset).
+
+    Same base model + same data + same hyperparams always yields the same id, so
+    re-running a nightly tune on unchanged data is idempotent for the registry.
+    """
+    canonical = json.dumps(
+        {"params": asdict(params), "dataset_sha256": dataset_sha256(rows)}, sort_keys=True
+    )
+    digest = hashlib.sha256(canonical.encode()).hexdigest()
+    base = params.base_model_id.replace("/", "_")
+    return f"lora-{base}-{digest[:12]}"
+
 
 class GPUTrainer:
-    """Hardware-gated LoRA trainer. Raises until implemented on real GPU hardware."""
+    """Real LoRA SFT trainer. Needs the ``[training]`` extras and a CUDA device."""
 
     async def train(
         self, base_model: str, training_pairs: list[dict], config: Any
     ) -> TrainingResult:
-        try:
-            import peft  # noqa: F401
-            import torch  # noqa: F401
-        except ImportError as e:
-            raise RuntimeError(
-                "GPUTrainer needs torch + peft (and a CUDA GPU). Install the training "
-                "extras and run on a GPU host, or use trainer_backend='mock'."
-            ) from e
-        raise NotImplementedError(
-            "Real LoRA training is not yet implemented - run on a DGX Spark with the "
-            "training extras. Use trainer_backend='mock' to exercise the Self-Tune loop."
+        """Train a LoRA adapter on ``training_pairs``; blocking work runs in a thread."""
+        params = self._resolve_params(base_model, config)
+        rows = normalize_pairs(training_pairs)
+        if not rows:
+            raise ValueError("no usable training pairs (need input/output or messages)")
+        adapter_id = compute_adapter_id(params, rows)
+        out_dir = self._output_dir(config) / adapter_id
+
+        deps = self._load_deps()
+        self._require_cuda(deps.torch)
+        logger.info(
+            "GPU LoRA train start: adapter=%s base=%s samples=%d",
+            adapter_id, params.base_model_id, len(rows),
         )
+        return await asyncio.to_thread(self._train_sync, deps, params, rows, adapter_id, out_dir)
+
+    # ---- pure / cheap helpers (no heavy deps) --------------------------------
+
+    def _resolve_params(self, base_model: str, config: Any) -> TrainParams:
+        """Read hyperparameters off ``config`` (settings) with sensible defaults."""
+        return TrainParams(
+            base_model_id=getattr(config, "lora_base_model_id", _DEFAULT_BASE_MODEL_ID)
+            or _DEFAULT_BASE_MODEL_ID,
+            source_model=base_model,
+            r=int(getattr(config, "lora_r", 8)),
+            alpha=int(getattr(config, "lora_alpha", 16)),
+            dropout=float(getattr(config, "lora_dropout", 0.05)),
+            lr=float(getattr(config, "lora_lr", 1e-4)),
+            epochs=int(getattr(config, "lora_epochs", 3)),
+            max_steps=int(getattr(config, "lora_max_steps", 0)),
+            seed=int(getattr(config, "lora_seed", 42)),
+            batch_size=int(getattr(config, "lora_batch_size", 1)),
+            grad_accum=int(getattr(config, "lora_grad_accum", 8)),
+            max_seq_len=int(getattr(config, "lora_max_seq_len", 2048)),
+            quantize=str(getattr(config, "lora_quantize", "none") or "none"),
+        )
+
+    def _output_dir(self, config: Any) -> Path:
+        """Adapter output root: ``lora_output_dir`` override or the adapter registry."""
+        override = getattr(config, "lora_output_dir", "") or ""
+        if override:
+            return Path(override)
+        from sandcastle.engine.adapter_registry import default_adapters_dir
+
+        return default_adapters_dir()
+
+    def _load_deps(self) -> SimpleNamespace:
+        """Lazily import the heavy training stack; actionable error when missing."""
+        try:
+            import datasets
+            import peft
+            import torch
+            import transformers
+        except ImportError as e:
+            raise RuntimeError(_INSTALL_HINT) from e
+        return SimpleNamespace(
+            torch=torch, transformers=transformers, peft=peft, datasets=datasets
+        )
+
+    def _require_cuda(self, torch: Any) -> None:
+        """Raise unless a CUDA device is visible (DGX Spark / any NVIDIA GPU)."""
+        if not torch.cuda.is_available():
+            raise RuntimeError(
+                "GPUTrainer needs a CUDA device and none is available. Run on a GPU "
+                "host (e.g. a DGX Spark), or set trainer_backend='mock'."
+            )
+
+    # ---- the blocking training kernel ----------------------------------------
+
+    def _train_sync(
+        self,
+        deps: SimpleNamespace,
+        params: TrainParams,
+        rows: list[dict],
+        adapter_id: str,
+        out_dir: Path,
+    ) -> TrainingResult:
+        """SFT a LoRA adapter and write weights + dataset + metadata to ``out_dir``."""
+        torch, tf, peft, datasets = deps.torch, deps.transformers, deps.peft, deps.datasets
+        tf.set_seed(params.seed)
+
+        tokenizer = tf.AutoTokenizer.from_pretrained(params.base_model_id)
+        if getattr(tokenizer, "pad_token", None) is None:
+            tokenizer.pad_token = tokenizer.eos_token
+
+        model_kwargs: dict[str, Any] = {"torch_dtype": torch.bfloat16, "device_map": "auto"}
+        if params.quantize in ("4bit", "8bit"):
+            # Opt-in: needs bitsandbytes with CUDA aarch64 support on a Spark.
+            model_kwargs["quantization_config"] = tf.BitsAndBytesConfig(
+                load_in_4bit=params.quantize == "4bit",
+                load_in_8bit=params.quantize == "8bit",
+                bnb_4bit_compute_dtype=torch.bfloat16,
+                bnb_4bit_quant_type="nf4",
+            )
+        model = tf.AutoModelForCausalLM.from_pretrained(params.base_model_id, **model_kwargs)
+        if params.quantize in ("4bit", "8bit"):
+            model = peft.prepare_model_for_kbit_training(model)
+        lora_cfg = peft.LoraConfig(
+            r=params.r,
+            lora_alpha=params.alpha,
+            lora_dropout=params.dropout,
+            task_type="CAUSAL_LM",
+            target_modules="all-linear",
+        )
+        model = peft.get_peft_model(model, lora_cfg)
+
+        def _tokenize(row: dict) -> dict:
+            # Loss only on the assistant completion: prompt tokens get label -100.
+            msgs = row["messages"]
+            full = list(tokenizer.apply_chat_template(msgs, tokenize=True))
+            prompt = tokenizer.apply_chat_template(
+                msgs[:-1], tokenize=True, add_generation_prompt=True
+            )
+            full = full[: params.max_seq_len]
+            plen = min(len(prompt), len(full))
+            labels = [-100] * plen + full[plen:]
+            return {"input_ids": full, "attention_mask": [1] * len(full), "labels": labels}
+
+        ds = datasets.Dataset.from_list(rows).map(_tokenize, remove_columns=["messages"])
+        eval_ds = None
+        if len(rows) >= _MIN_SAMPLES_FOR_HOLDOUT:
+            split = ds.train_test_split(test_size=_EVAL_HOLDOUT, seed=params.seed)
+            ds, eval_ds = split["train"], split["test"]
+
+        out_dir.mkdir(parents=True, exist_ok=True)
+        args = tf.TrainingArguments(
+            output_dir=str(out_dir / "hf_runs"),
+            num_train_epochs=params.epochs,
+            max_steps=params.max_steps if params.max_steps > 0 else -1,
+            learning_rate=params.lr,
+            per_device_train_batch_size=params.batch_size,
+            gradient_accumulation_steps=params.grad_accum,
+            bf16=True,
+            seed=params.seed,
+            logging_steps=10,
+            save_strategy="no",
+            report_to=[],
+        )
+        collator = tf.DataCollatorForSeq2Seq(tokenizer, padding=True, label_pad_token_id=-100)
+        trainer = tf.Trainer(
+            model=model,
+            args=args,
+            train_dataset=ds,
+            eval_dataset=eval_ds,
+            data_collator=collator,
+        )
+        train_out = trainer.train()
+        train_loss = round(float(getattr(train_out, "training_loss", 0.0)), 6)
+        eval_loss = train_loss
+        if eval_ds is not None:
+            eval_loss = round(float(trainer.evaluate().get("eval_loss", train_loss)), 6)
+        # Bounded 0..0.99 score so registry comparisons match MockTrainer's scale.
+        eval_score = round(max(0.0, min(0.99, 1.0 / (1.0 + eval_loss))), 4)
+
+        model.save_pretrained(str(out_dir))  # adapter_model.safetensors + adapter_config.json
+        tokenizer.save_pretrained(str(out_dir))
+
+        lora_config = {**asdict(params), "dataset_sha256": dataset_sha256(rows)}
+        metrics = {"loss": train_loss, "eval_loss": eval_loss, "eval_score": eval_score}
+        self._write_artifacts(out_dir, adapter_id, params, rows, metrics, deps)
+        logger.info("GPU LoRA train done: adapter=%s eval_loss=%s", adapter_id, eval_loss)
+        return TrainingResult(
+            adapter_id=adapter_id,
+            base_model=params.base_model_id,
+            samples=len(rows),
+            metrics=metrics,
+            lora_config=lora_config,
+        )
+
+    def _write_artifacts(
+        self,
+        out_dir: Path,
+        adapter_id: str,
+        params: TrainParams,
+        rows: list[dict],
+        metrics: dict[str, float],
+        deps: SimpleNamespace,
+    ) -> None:
+        """Persist the training dataset + a reproducibility metadata json beside weights."""
+        (out_dir / "dataset.jsonl").write_text(
+            "\n".join(json.dumps(r, ensure_ascii=True) for r in rows) + "\n"
+        )
+        meta = {
+            "adapter_id": adapter_id,
+            "base_model": params.base_model_id,
+            "source_model": params.source_model,
+            "dataset_sha256": dataset_sha256(rows),
+            "samples": len(rows),
+            "hyperparams": asdict(params),
+            "metrics": metrics,
+            "versions": {
+                "torch": getattr(deps.torch, "__version__", "?"),
+                "transformers": getattr(deps.transformers, "__version__", "?"),
+                "peft": getattr(deps.peft, "__version__", "?"),
+            },
+        }
+        (out_dir / "training_metadata.json").write_text(json.dumps(meta, indent=2, sort_keys=True))

--- a/src/sandcastle/engine/training/trainer.py
+++ b/src/sandcastle/engine/training/trainer.py
@@ -28,7 +28,7 @@ class Trainer(Protocol):
 
 
 def get_trainer(backend: str | None = None) -> Trainer:
-    """Return the configured trainer: ``"mock"`` (default) or ``"gpu"`` (stub).
+    """Return the configured trainer: ``"mock"`` (default) or ``"gpu"`` (real LoRA SFT).
 
     The backend defaults to ``settings.trainer_backend`` so the whole Self-Tune
     loop runs deterministically (mock) unless a real GPU trainer is requested.

--- a/tests/test_gpu_trainer.py
+++ b/tests/test_gpu_trainer.py
@@ -1,0 +1,286 @@
+"""Tests for the real GPU LoRA trainer - torch/transformers/peft fully mocked, no GPU.
+
+The heavy stack is injected through ``GPUTrainer._load_deps`` (the single lazy-import
+seam), so these tests exercise the full ``train()`` path - normalization, prompt-masked
+tokenization, holdout split, artifact writing, registry handoff - on any machine.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from sandcastle.engine.adapter_registry import AdapterRegistry
+from sandcastle.engine.training.gpu_trainer import (
+    GPUTrainer,
+    TrainParams,
+    compute_adapter_id,
+    dataset_sha256,
+    normalize_pairs,
+)
+from sandcastle.engine.training.trainer import TrainingResult
+
+PAIRS = [{"input": f"q{i}", "output": f"a{i}"} for i in range(12)]
+
+
+def _config(tmp_path: Path, **overrides) -> SimpleNamespace:
+    base = dict(
+        lora_base_model_id="acme/tiny-1b",
+        lora_r=4,
+        lora_alpha=8,
+        lora_dropout=0.1,
+        lora_lr=2e-4,
+        lora_epochs=1,
+        lora_max_steps=3,
+        lora_seed=7,
+        lora_batch_size=1,
+        lora_grad_accum=2,
+        lora_max_seq_len=64,
+        lora_quantize="none",
+        lora_output_dir=str(tmp_path / "adapters"),
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _params(**overrides) -> TrainParams:
+    base = dict(
+        base_model_id="acme/tiny-1b", source_model="sonnet", r=4, alpha=8, dropout=0.1,
+        lr=2e-4, epochs=1, max_steps=3, seed=7, batch_size=1, grad_accum=2,
+        max_seq_len=64, quantize="none",
+    )
+    base.update(overrides)
+    return TrainParams(**base)
+
+
+# ---- fakes -------------------------------------------------------------------
+
+
+class _FakeTokenizer:
+    pad_token = "<pad>"
+    eos_token = "<eos>"
+
+    def apply_chat_template(self, msgs, tokenize=True, add_generation_prompt=False):
+        n = sum(len(str(m.get("content", ""))) for m in msgs) + len(msgs)
+        return list(range(n + (1 if add_generation_prompt else 0)))
+
+    def save_pretrained(self, path):
+        Path(path, "tokenizer_config.json").write_text("{}")
+
+
+class _FakeModel:
+    def save_pretrained(self, path):
+        Path(path, "adapter_model.safetensors").write_bytes(b"fake-lora-weights")
+        Path(path, "adapter_config.json").write_text("{}")
+
+
+class _FakeDataset:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def map(self, fn, remove_columns=None):
+        return _FakeDataset([fn(r) for r in self.rows])
+
+    def train_test_split(self, test_size, seed):
+        k = max(1, int(len(self.rows) * test_size))
+        return {"train": _FakeDataset(self.rows[:-k]), "test": _FakeDataset(self.rows[-k:])}
+
+    def __len__(self):
+        return len(self.rows)
+
+
+class _FakeHFTrainer:
+    last = None
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        _FakeHFTrainer.last = self
+
+    def train(self):
+        return SimpleNamespace(training_loss=0.5)
+
+    def evaluate(self):
+        return {"eval_loss": 0.25}
+
+
+def _fake_deps() -> SimpleNamespace:
+    torch = SimpleNamespace(
+        bfloat16="bf16",
+        cuda=SimpleNamespace(is_available=lambda: True),
+        __version__="2.0-fake",
+    )
+    transformers = SimpleNamespace(
+        set_seed=MagicMock(),
+        AutoTokenizer=SimpleNamespace(from_pretrained=lambda mid: _FakeTokenizer()),
+        AutoModelForCausalLM=SimpleNamespace(
+            from_pretrained=MagicMock(return_value=_FakeModel())
+        ),
+        TrainingArguments=MagicMock(),
+        BitsAndBytesConfig=MagicMock(),
+        DataCollatorForSeq2Seq=MagicMock(),
+        Trainer=_FakeHFTrainer,
+        __version__="4.0-fake",
+    )
+    peft = SimpleNamespace(
+        LoraConfig=MagicMock(),
+        get_peft_model=MagicMock(side_effect=lambda model, cfg: model),
+        prepare_model_for_kbit_training=MagicMock(side_effect=lambda model: model),
+        __version__="0.1-fake",
+    )
+    datasets = SimpleNamespace(
+        Dataset=SimpleNamespace(from_list=lambda rows: _FakeDataset(rows))
+    )
+    return SimpleNamespace(torch=torch, transformers=transformers, peft=peft, datasets=datasets)
+
+
+# ---- happy path ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_happy_path_trains_writes_artifacts_and_registers(tmp_path, monkeypatch):
+    deps = _fake_deps()
+    monkeypatch.setattr(GPUTrainer, "_load_deps", lambda self: deps)
+    cfg = _config(tmp_path)
+
+    result = await GPUTrainer().train("sonnet", PAIRS, cfg)
+
+    assert isinstance(result, TrainingResult)
+    assert result.adapter_id.startswith("lora-acme_tiny-1b-")
+    assert result.base_model == "acme/tiny-1b"
+    assert result.samples == 12
+    assert result.metrics == {"loss": 0.5, "eval_loss": 0.25, "eval_score": 0.8}
+    assert result.lora_config["r"] == 4
+    assert result.lora_config["source_model"] == "sonnet"
+    assert result.lora_config["dataset_sha256"] == dataset_sha256(normalize_pairs(PAIRS))
+
+    # Hyperparams reached the HF TrainingArguments unchanged.
+    args_kwargs = deps.transformers.TrainingArguments.call_args.kwargs
+    assert args_kwargs["max_steps"] == 3 and args_kwargs["seed"] == 7
+    assert args_kwargs["learning_rate"] == 2e-4 and args_kwargs["bf16"] is True
+
+    # 12 samples -> a holdout eval split exists; labels are prompt-masked.
+    hf = _FakeHFTrainer.last
+    assert hf.kwargs["eval_dataset"] is not None
+    row = hf.kwargs["train_dataset"].rows[0]
+    assert row["labels"][0] == -100 and row["labels"][-1] != -100
+    assert len(row["input_ids"]) == len(row["labels"]) <= cfg.lora_max_seq_len
+
+    # Artifacts: weights + dataset JSONL + reproducibility metadata.
+    out = Path(cfg.lora_output_dir) / result.adapter_id
+    assert (out / "adapter_model.safetensors").exists()
+    assert (out / "dataset.jsonl").read_text().count("\n") == 12
+    meta = json.loads((out / "training_metadata.json").read_text())
+    assert meta["base_model"] == "acme/tiny-1b"
+    assert meta["metrics"]["eval_loss"] == 0.25
+    assert meta["dataset_sha256"] == result.lora_config["dataset_sha256"]
+    assert meta["hyperparams"]["seed"] == 7
+
+    # Registry handoff: register() keeps real weights and skips the stub file.
+    reg = AdapterRegistry(cfg.lora_output_dir)
+    reg.register(
+        result.adapter_id, result.base_model, result.metrics, result.samples,
+        result.lora_config, created_at=1.0,
+    )
+    got = reg.get(result.adapter_id)
+    assert got is not None and got["base_model"] == "acme/tiny-1b"
+    assert got["metrics"]["eval_score"] == 0.8
+    assert not (out / "adapter_model.safetensors.stub").exists()
+
+
+@pytest.mark.asyncio
+async def test_small_dataset_skips_holdout(tmp_path, monkeypatch):
+    deps = _fake_deps()
+    monkeypatch.setattr(GPUTrainer, "_load_deps", lambda self: deps)
+
+    result = await GPUTrainer().train("sonnet", PAIRS[:4], _config(tmp_path))
+
+    assert _FakeHFTrainer.last.kwargs["eval_dataset"] is None
+    assert result.metrics["eval_loss"] == result.metrics["loss"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_quantize_4bit_wires_bitsandbytes(tmp_path, monkeypatch):
+    deps = _fake_deps()
+    monkeypatch.setattr(GPUTrainer, "_load_deps", lambda self: deps)
+
+    await GPUTrainer().train("sonnet", PAIRS, _config(tmp_path, lora_quantize="4bit"))
+
+    bnb_kwargs = deps.transformers.BitsAndBytesConfig.call_args.kwargs
+    assert bnb_kwargs["load_in_4bit"] is True and bnb_kwargs["load_in_8bit"] is False
+    deps.peft.prepare_model_for_kbit_training.assert_called_once()
+
+
+# ---- gating errors --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_deps_raise_actionable_error(tmp_path, monkeypatch):
+    # None in sys.modules makes `import X` raise ImportError even if X is installed.
+    for mod in ("torch", "transformers", "peft", "datasets"):
+        monkeypatch.setitem(sys.modules, mod, None)
+    with pytest.raises(RuntimeError, match=r"sandcastle-ai\[training\]"):
+        await GPUTrainer().train("sonnet", PAIRS, _config(tmp_path))
+
+
+@pytest.mark.asyncio
+async def test_no_cuda_raises_clear_error(tmp_path, monkeypatch):
+    deps = _fake_deps()
+    deps.torch.cuda = SimpleNamespace(is_available=lambda: False)
+    monkeypatch.setattr(GPUTrainer, "_load_deps", lambda self: deps)
+    with pytest.raises(RuntimeError, match="CUDA"):
+        await GPUTrainer().train("sonnet", PAIRS, _config(tmp_path))
+
+
+@pytest.mark.asyncio
+async def test_no_usable_pairs_raises_before_deps_load():
+    # ValueError fires before any heavy import is attempted.
+    with pytest.raises(ValueError, match="no usable training pairs"):
+        await GPUTrainer().train("sonnet", [{"junk": 1}], SimpleNamespace())
+
+
+# ---- deterministic config hashing ------------------------------------------------
+
+
+def test_adapter_id_is_deterministic():
+    rows = normalize_pairs(PAIRS)
+    assert compute_adapter_id(_params(), rows) == compute_adapter_id(_params(), rows)
+
+
+def test_adapter_id_changes_with_params_or_data():
+    rows = normalize_pairs(PAIRS)
+    base = compute_adapter_id(_params(), rows)
+    assert compute_adapter_id(_params(r=8), rows) != base
+    assert compute_adapter_id(_params(seed=8), rows) != base
+    assert compute_adapter_id(_params(), normalize_pairs(PAIRS[:6])) != base
+
+
+def test_dataset_sha256_order_sensitive_and_stable():
+    rows = normalize_pairs(PAIRS)
+    assert dataset_sha256(rows) == dataset_sha256(list(rows))
+    assert dataset_sha256(rows) != dataset_sha256(list(reversed(rows)))
+
+
+# ---- pair normalization -----------------------------------------------------------
+
+
+def test_normalize_pairs_accepts_all_documented_shapes():
+    rows = normalize_pairs(
+        [
+            {"input": "q", "output": "a"},
+            {"prompt": "p", "completion": "c"},
+            {"messages": [{"role": "user", "content": "m"}]},
+            {"junk": 1},
+            "not-a-dict",  # type: ignore[list-item]
+            {"input": "", "output": "a"},  # empty prompt -> skipped
+        ]
+    )
+    assert len(rows) == 3
+    assert rows[0]["messages"][0] == {"role": "user", "content": "q"}
+    assert rows[0]["messages"][1] == {"role": "assistant", "content": "a"}
+    assert rows[1]["messages"][1] == {"role": "assistant", "content": "c"}
+    assert rows[2]["messages"] == [{"role": "user", "content": "m"}]

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -26,11 +26,13 @@ def test_get_trainer_unknown_raises():
 
 
 @pytest.mark.asyncio
-async def test_gpu_trainer_is_a_stub():
+async def test_gpu_trainer_is_gated():
     from sandcastle.engine.training.gpu_trainer import GPUTrainer
 
-    # Without torch/peft this raises RuntimeError; with them, NotImplementedError.
-    with pytest.raises((RuntimeError, NotImplementedError)):
+    # Without the [training] extras this raises (deps); with them but no GPU (CUDA).
+    # Either way GPUTrainer never silently no-ops on a dev box. Full coverage of the
+    # real path (with mocked deps) lives in tests/test_gpu_trainer.py.
+    with pytest.raises(RuntimeError):
         await GPUTrainer().train("sonnet", PAIRS, settings)
 
 


### PR DESCRIPTION
Replaces the GPUTrainer stub with a real LoRA SFT implementation (transformers + peft), completing the Overnight Self-Tune loop for NVIDIA DGX Spark.

- **Real LoRA training** (`engine/training/gpu_trainer.py`): bf16 + LoRA, prompt-masked labels, 10% eval holdout, deterministic adapter id from hyperparams + dataset hash; writes adapter + tokenizer + `training_metadata.json` into the existing adapter registry so `adapter/<id>` resolution works unchanged
- **`[training]` optional extra**: torch/transformers/peft/datasets/accelerate; all heavy imports lazy with actionable errors (missing deps → `pip install 'sandcastle-ai[training]'`; no CUDA → clear runtime error)
- Optional QLoRA path (bitsandbytes 4/8-bit) wired but opt-in (aarch64 wheel caveat documented)
- `docs/overnight-self-tune-spark.md` + `scripts/validate_training_on_spark.sh` (trains Qwen2.5-0.5B for 5 steps as a smoke test)

⚠️ **Unvalidated on silicon** — no CUDA on the dev machine; GPU path exercised via fully-mocked tests (10 new). Validate on a Spark with: `pip install -e '.[training]' && bash scripts/validate_training_on_spark.sh`. Full suite + ruff green.

Stacked on #255 (gui-experiment).