### PR TITLE
feat(positioning): sovereign agent infrastructure for Europe — homepage + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sandcastle
 
-**Describe what you want. Go home. Sandcastle ships it.** Production-ready workflow orchestrator for AI agents. 7 AI providers with auto-failover, 22 step types including Claude Managed Agents, 15 agent templates, 4 OCR engines, EU AI Act compliance, and a full-featured dashboard. Define workflows in YAML or let AI design them for you.
+**Your box. Your brains. Your data.** Sandcastle is sovereign agent infrastructure: an open-source, production-ready workflow orchestrator that runs AI agents entirely on hardware you control - local models at $0/run, hard data-residency enforcement, and a tamper-evident audit trail. When you want the cloud, it's there too: 7 AI providers with auto-failover, 22 step types including Claude Managed Agents, 15 agent templates, 4 OCR engines, EU AI Act compliance features, and a full-featured dashboard. Define workflows in YAML or let AI design them for you. European-built.
 
 [![PyPI](https://img.shields.io/badge/PyPI-v0.33.0-blue?style=flat-square)](https://pypi.org/project/sandcastle-ai/0.33.0/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
@@ -86,7 +86,16 @@
 
 ## Why Sandcastle?
 
-AI agent frameworks give you building blocks - LLM calls, tool use, maybe a graph. But when you start building real products, the glue code piles up fast:
+**Sovereignty first.** Every mainstream agent stack assumes your data goes to someone else's cloud and your costs scale with someone else's token meter. Sandcastle inverts that default:
+
+- **Local-first execution.** NVIDIA NIM, Ollama, and oMLX are first-class providers at `region=local`. Spark Mode auto-detects an NVIDIA DGX Spark and flips to local-first defaults with no flags. Air-gap friendly by design.
+- **$0 runs on your hardware.** Inference on your own silicon is metered at `$0.00/run`. No egress, no per-token bill.
+- **Hard data-residency enforcement.** Set `data_residency=local` (or `eu`) and the engine raises before any step could route data off-box - enforcement in the executor, not a policy PDF.
+- **Replayable, auditable runs.** SHA-256 hash-chained audit trail on every run, plus deterministic cassettes: record once, replay offline at $0, identically, with a tamper-evident signature. Audit-ready for the EU AI Act era.
+
+If your workloads live in regulated or sovereignty-sensitive environments - public sector, healthcare, finance - this is the difference between "we have a policy" and "the runtime physically cannot leak."
+
+**And it's a complete orchestrator, not just a residency gate.** AI agent frameworks give you building blocks - LLM calls, tool use, maybe a graph. But when you start building real products, the glue code piles up fast:
 
 - **"Step A scrapes, step B enriches, step C scores."** - You need workflow orchestration.
 - **"Fan out over 50 leads in parallel, then merge."** - You need a DAG engine.

--- a/site/index.html
+++ b/site/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Sandcastle - Stop building AI infrastructure. Start shipping AI products.</title>
-  <meta name="description" content="Sandcastle - production AI workflow orchestrator. 7 AI providers, EU data residency, smart failover, cost intelligence, SLO routing, 22 step types, 236 templates. European-built, open source. pip install sandcastle-ai">
-  <meta name="keywords" content="AI workflow orchestrator, AI agent orchestration, EU AI Act compliance, AI audit trail, PII redaction, LLM orchestration, AI pipeline, workflow automation, AI compliance, GDPR AI, AI governance, AI risk management, Claude API, GPT orchestration, AI sandbox, multi-model routing, AI cost tracking, AI approval gates, OpenTelemetry AI, AI observability, workflow YAML, AI dashboard, sandcastle, sandcastle-ai">
+  <title>Sandcastle - Sovereign agent infrastructure for Europe. Your box. Your brains. Your data.</title>
+  <meta name="description" content="Sandcastle - sovereign agent infrastructure. Open-source AI workflow orchestrator that runs entirely on your own hardware: local models (NVIDIA NIM, Ollama, oMLX), $0 local runs, hard data-residency enforcement, tamper-evident audit trail. European-built. pip install sandcastle-ai">
+  <meta name="keywords" content="sovereign AI, digital sovereignty, sovereign agent infrastructure, AI workflow orchestrator, AI agent orchestration, local AI, on-premise AI agents, air-gapped AI, EU AI Act compliance, AI audit trail, PII redaction, LLM orchestration, AI pipeline, workflow automation, AI compliance, GDPR AI, AI governance, AI risk management, data residency, NVIDIA NIM, DGX Spark, Claude API, GPT orchestration, AI sandbox, multi-model routing, AI cost tracking, AI approval gates, OpenTelemetry AI, AI observability, workflow YAML, AI dashboard, sandcastle, sandcastle-ai">
   <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
   <meta name="author" content="Tomas Pflanzer">
   <link rel="canonical" href="https://sandcastle-ai.eu">
@@ -13,8 +13,8 @@
   <link rel="alternate" hreflang="x-default" href="https://sandcastle-ai.eu">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Sandcastle - Stop building AI infrastructure. Start shipping AI products.">
-  <meta property="og:description" content="Any model, any provider, your rules. 7 AI providers, EU data residency, smart failover, cost intelligence, 22 step types, 236 templates. pip install sandcastle-ai.">
+  <meta property="og:title" content="Sandcastle - Sovereign agent infrastructure for Europe">
+  <meta property="og:description" content="Your box. Your brains. Your data. Run AI agents entirely on your own hardware - local models, $0 local runs, hard data-residency enforcement, tamper-evident audit trail. European-built, open source.">
   <meta property="og:image" content="https://raw.githubusercontent.com/gizmax/Sandcastle/main/site/og-image.jpeg">
   <meta property="og:url" content="https://sandcastle-ai.eu">
   <meta property="og:type" content="website">
@@ -23,8 +23,8 @@
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Sandcastle - Stop building AI infrastructure. Start shipping AI products.">
-  <meta name="twitter:description" content="Any model, any provider, your rules. 7 AI providers, EU data residency, smart failover, cost intelligence. European-built, open source. pip install sandcastle-ai">
+  <meta name="twitter:title" content="Sandcastle - Sovereign agent infrastructure for Europe">
+  <meta name="twitter:description" content="Your box. Your brains. Your data. AI agents on your own hardware - local models, $0 local runs, data-residency enforcement, auditable runs. European-built, open source. pip install sandcastle-ai">
   <meta name="twitter:image" content="https://raw.githubusercontent.com/gizmax/Sandcastle/main/site/og-image.jpeg">
   <meta name="twitter:creator" content="@iuditg">
 
@@ -53,7 +53,7 @@
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     "name": "Sandcastle",
-    "description": "Production-ready AI agent workflow orchestrator with EU AI Act compliance, tamper-evident audit trail, PII redaction, 62 integrations, and real-time dashboard.",
+    "description": "Sovereign agent infrastructure: open-source AI workflow orchestrator that runs entirely on your own hardware. Local model providers (NVIDIA NIM, Ollama, oMLX), $0 local runs, hard data-residency enforcement, EU AI Act compliance features, tamper-evident audit trail, PII redaction, 62 integrations, and real-time dashboard.",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Cross-platform",
     "url": "https://sandcastle-ai.eu",
@@ -1764,11 +1764,11 @@
         v0.33.0 - Your Box, Your Brains
       </div>
       <h1>
-        Describe what you want. Go home.<br>
-        <span class="accent">Sandcastle ships it.</span>
+        Your box. Your brains.<br>
+        <span class="accent">Your data.</span>
       </h1>
       <p>
-        Which provider. Which model. Which agent. What happens when it fails. What it costs. Where the data lives. Who approves what. You used to build all of that yourself. Now you describe what you want and go home. European-built, open source.
+        Sandcastle is sovereign agent infrastructure: an open-source orchestrator that runs AI agents entirely on hardware you control. Local models, $0 per run, hard data-residency enforcement, and a tamper-evident audit trail for every run. Built in Europe, for the EU AI Act era.
       </p>
       <div class="hero-ctas">
         <a href="https://github.com/gizmax/Sandcastle" target="_blank" rel="noopener" class="btn btn-primary" aria-label="View Sandcastle on GitHub">
@@ -1818,6 +1818,39 @@
       </div>
     </div>
   </header>
+
+  <!-- Sovereignty Pillars -->
+  <section class="sovereignty" style="border-top: 1px solid var(--border); padding: 80px 0;">
+    <div class="container fade-in">
+      <span class="section-label">Sovereign by Design</span>
+      <h2 class="section-title">AI infrastructure that answers to you</h2>
+      <p class="section-subtitle">
+        Europe is building sovereign compute and sovereign models. Sandcastle is the missing layer: the sovereign runtime that puts agents on your own silicon, under your own rules, with evidence you can hand to an auditor.
+      </p>
+      <div class="pain-grid">
+        <div class="pain-card">
+          <div class="pain-card-icon">🖥️</div>
+          <div class="pain-card-title">Local-first execution</div>
+          <span class="pain-card-desc">NVIDIA NIM, Ollama, and oMLX run as first-class providers at <code>region=local</code>. Spark Mode auto-detects an NVIDIA DGX Spark and flips to local-first defaults - no flags, no config. Air-gap friendly.</span>
+        </div>
+        <div class="pain-card">
+          <div class="pain-card-icon">0️⃣</div>
+          <div class="pain-card-title">$0 runs on your hardware</div>
+          <span class="pain-card-desc">Inference on your own silicon is metered at $0.00 per run. No token meter, no egress, no invoice surprise. You pay for electricity, not tokens.</span>
+        </div>
+        <div class="pain-card">
+          <div class="pain-card-icon">🔏</div>
+          <div class="pain-card-title">Replayable, auditable runs</div>
+          <span class="pain-card-desc">Every run writes a SHA-256 hash-chained audit trail. Deterministic cassettes record a run once and replay it offline, identically, with a tamper-evident signature.</span>
+        </div>
+        <div class="pain-card">
+          <div class="pain-card-icon">🇪🇺</div>
+          <div class="pain-card-title">Built in Europe</div>
+          <span class="pain-card-desc">EU-built, open source, self-hosted. Set <code>data_residency=local</code> and the engine refuses any step that would leave the box - hard enforcement at the routing layer, built for the EU AI Act era.</span>
+        </div>
+      </div>
+    </div>
+  </section>
 
   <!-- Social Proof (C4) -->
   <section class="social-proof">


### PR DESCRIPTION
Repositions Sandcastle from "workflow tool" to **sovereign agent infrastructure for Europe** — leaning on the real building blocks (local execution, \$0 local runs, `data_residency` gate, replayable audit trail, EU-built).

- **Homepage** (`site/index.html`): new hero "Your box. Your brains. Your data." + "Sovereign by Design" section (4 proof pillars: local-first execution, \$0 on-your-hardware runs, replayable/auditable runs, EU-built). Existing design system, GA tag, terminal animation, and factual feature sections kept intact; updated meta/OG/JSON-LD.
- **README**: "Why Sandcastle?" now leads with sovereignty + local-first; nothing factual deleted.

Copy rules honored: confident, no defensive disclaimers; no false claims (no "Certified for NVIDIA"/"DGX-Ready"/"Tested on Spark" — "designed/built for" only; "built for the EU AI Act era"/"audit-ready", not a compliance guarantee; no invented customers/revenue/team).

Internal GTM docs (NVIDIA Inception draft + positioning one-pager) live **outside the repo** in `~/Documents/Sandcastle-GTM/` and are intentionally not part of this PR.

Stacked on #255 (gui-experiment).