### PR TITLE
feat(dashboard): ⌘K command palette + ✓ Proven verified-template badge

### DIFF
--- a/dashboard/src/__tests__/CommandPalette.test.tsx
+++ b/dashboard/src/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Command palette tests: fuzzy page matching, grouped results, keyboard
+ * navigation, theme toggle action, debounced API search and API-down behavior.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// jsdom does not implement scrollIntoView (used to keep the active item visible)
+Element.prototype.scrollIntoView = vi.fn();
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock("@/api/client", () => ({
+  api: {
+    get: vi.fn(),
+  },
+}));
+
+import { api } from "@/api/client";
+import { CommandPalette } from "@/components/layout/CommandPalette";
+import { fuzzyScore } from "@/lib/fuzzy";
+import { THEME_TOGGLE_EVENT } from "@/hooks/useTheme";
+
+const mockedGet = vi.mocked(api.get);
+
+function renderPalette(props: Partial<React.ComponentProps<typeof CommandPalette>> = {}) {
+  return render(
+    <CommandPalette open onClose={vi.fn()} recentItems={[]} {...props} />
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedGet.mockResolvedValue({ data: [], error: null });
+});
+
+describe("fuzzyScore", () => {
+  it("scores substrings highest", () => {
+    expect(fuzzyScore("temp", "Templates")).toBeGreaterThan(2);
+  });
+
+  it("matches subsequences in order", () => {
+    expect(fuzzyScore("wfb", "Workflow Builder")).toBeGreaterThan(0);
+    expect(fuzzyScore("schmon", "Schedule Monitor")).toBeGreaterThan(0);
+  });
+
+  it("rejects out-of-order or missing characters", () => {
+    expect(fuzzyScore("xyz", "Templates")).toBe(0);
+    expect(fuzzyScore("setalpmet", "Templates")).toBe(0);
+  });
+});
+
+describe("CommandPalette", () => {
+  it("shows all pages grouped under Pages when empty", () => {
+    renderPalette();
+    expect(screen.getByText("Pages")).toBeInTheDocument();
+    expect(screen.getByText("Templates")).toBeInTheDocument();
+    expect(screen.getByText("Memory")).toBeInTheDocument();
+    expect(screen.getByText("Compliance")).toBeInTheDocument();
+  });
+
+  it("fuzzy matches pages by name", async () => {
+    renderPalette();
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "tmplts" } });
+    await waitFor(() => {
+      expect(screen.getByText("Templates")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Memory")).not.toBeInTheDocument();
+  });
+
+  it("navigates to the active item on Enter", () => {
+    const onClose = vi.fn();
+    renderPalette({ onClose });
+    const input = screen.getByRole("combobox");
+    fireEvent.change(input, { target: { value: "templates" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(mockNavigate).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("moves the selection with arrow keys", () => {
+    renderPalette();
+    const input = screen.getByRole("combobox");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    const active = document.getElementById("cmd-item-1");
+    expect(active).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("closes on Escape", () => {
+    const onClose = vi.fn();
+    renderPalette({ onClose });
+    fireEvent.keyDown(screen.getByRole("combobox"), { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("dispatches the theme toggle event from the /theme action", () => {
+    const onClose = vi.fn();
+    const listener = vi.fn();
+    window.addEventListener(THEME_TOGGLE_EVENT, listener);
+    renderPalette({ onClose });
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "/theme" } });
+    fireEvent.click(screen.getByText("/theme"));
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+    window.removeEventListener(THEME_TOGGLE_EVENT, listener);
+  });
+
+  it("searches runs and workflows via the API, with a Run entry per workflow", async () => {
+    mockedGet.mockImplementation((path: string) => {
+      if (path === "/runs") {
+        return Promise.resolve({
+          data: [
+            { run_id: "abc12345-0000", workflow_name: "daily-digest", status: "completed" },
+          ],
+          error: null,
+        });
+      }
+      return Promise.resolve({
+        data: [{ name: "daily-digest", file_name: "daily_digest.yaml", steps_count: 3 }],
+        error: null,
+      });
+    });
+
+    renderPalette();
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "daily" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("Run daily-digest")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Runs")).toBeInTheDocument();
+    expect(screen.getByText("Workflows")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Run daily-digest"));
+    expect(mockNavigate).toHaveBeenCalledWith("/workflows?run=daily_digest");
+  });
+
+  it("still shows page matches when the API is down", async () => {
+    mockedGet.mockRejectedValue(new Error("connection refused"));
+    renderPalette();
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "settings" } });
+    await waitFor(() => {
+      expect(screen.getByText("Settings")).toBeInTheDocument();
+    });
+  });
+
+  it("traps focus inside the dialog on Tab", () => {
+    renderPalette();
+    const dialog = screen.getByRole("dialog");
+    const input = screen.getByRole("combobox");
+    input.focus();
+    // Shift+Tab from the first focusable wraps to the last
+    fireEvent.keyDown(dialog, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).not.toBe(document.body);
+    expect(dialog.contains(document.activeElement)).toBe(true);
+  });
+
+  it("renders nothing when closed", () => {
+    render(<CommandPalette open={false} onClose={vi.fn()} recentItems={[]} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/dashboard/src/__tests__/ProvenBadge.test.tsx
+++ b/dashboard/src/__tests__/ProvenBadge.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * Proven badge + proof modal tests: badge rendering and click isolation,
+ * modal manifest/checksum display, replay PASS/FAIL flow, and error states.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("@/api/client", () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+import { api } from "@/api/client";
+import { ProvenBadge } from "@/components/templates/ProvenBadge";
+import { ProvenModal } from "@/components/templates/ProvenModal";
+import { TemplateCard } from "@/components/templates/TemplateCard";
+
+const mockedGet = vi.mocked(api.get);
+const mockedPost = vi.mocked(api.post);
+
+const VERIFICATION = {
+  proven: true,
+  manifest: {
+    name: "bundle-test",
+    version: "1.0.0",
+    description: "A proven workflow",
+    author: "tester",
+    license: "MIT",
+    sandcastle_version: "0.33.0",
+    created_at: "2026-06-09T00:00:00+00:00",
+  },
+  workflow: { file: "workflow.yaml", sha256: "a".repeat(64), valid: true },
+  cassettes: [
+    {
+      file: "cassettes/proof.cassette.json",
+      sha256: "b".repeat(64),
+      valid: true,
+      step_count: 1,
+      recorded_cost_usd: 0.02,
+    },
+  ],
+  checksums_valid: true,
+  installed_workflow_matches: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ProvenBadge", () => {
+  it("renders the bold Proven label", () => {
+    render(<ProvenBadge />);
+    expect(screen.getByTestId("proven-badge")).toHaveTextContent("Proven");
+  });
+
+  it("fires onClick without triggering the parent", () => {
+    const onBadge = vi.fn();
+    const onParent = vi.fn();
+    render(
+      <button onClick={onParent}>
+        <ProvenBadge onClick={onBadge} />
+      </button>
+    );
+    fireEvent.click(screen.getByTestId("proven-badge"));
+    expect(onBadge).toHaveBeenCalledTimes(1);
+    expect(onParent).not.toHaveBeenCalled();
+  });
+});
+
+describe("TemplateCard proven badge", () => {
+  const baseTemplate = {
+    name: "bundle-test",
+    description: "desc",
+    tags: [],
+    step_count: 1,
+    source: "community" as const,
+  };
+
+  it("shows the badge for proven templates", () => {
+    render(
+      <TemplateCard
+        template={{ ...baseTemplate, proven: true }}
+        isSelected={false}
+        onClick={vi.fn()}
+        onProvenClick={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId("proven-badge")).toBeInTheDocument();
+  });
+
+  it("shows nothing for non-bundle templates", () => {
+    render(
+      <TemplateCard template={baseTemplate} isSelected={false} onClick={vi.fn()} />
+    );
+    expect(screen.queryByTestId("proven-badge")).not.toBeInTheDocument();
+  });
+
+  it("opens the proof instead of the card detail when the badge is clicked", () => {
+    const onCard = vi.fn();
+    const onProven = vi.fn();
+    render(
+      <TemplateCard
+        template={{ ...baseTemplate, proven: true }}
+        isSelected={false}
+        onClick={onCard}
+        onProvenClick={onProven}
+      />
+    );
+    fireEvent.click(screen.getByTestId("proven-badge"));
+    expect(onProven).toHaveBeenCalledTimes(1);
+    expect(onCard).not.toHaveBeenCalled();
+  });
+});
+
+describe("ProvenModal", () => {
+  it("loads and shows manifest details with checksum validity", async () => {
+    mockedGet.mockResolvedValue({ data: VERIFICATION, error: null });
+    render(<ProvenModal templateName="bundle-test" onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("tester")).toBeInTheDocument();
+    });
+    expect(mockedGet).toHaveBeenCalledWith("/templates/bundle-test/verification");
+    expect(screen.getByText("1.0.0")).toBeInTheDocument();
+    expect(screen.getByText("MIT")).toBeInTheDocument();
+    expect(screen.getByText("workflow.yaml")).toBeInTheDocument();
+    expect(screen.getByText("proof.cassette.json")).toBeInTheDocument();
+    expect(screen.getByText(/sha256: aaaaaaaaaaaa/)).toBeInTheDocument();
+  });
+
+  it("replays the proof and shows PASS per cassette", async () => {
+    mockedGet.mockResolvedValue({ data: VERIFICATION, error: null });
+    mockedPost.mockResolvedValue({
+      data: {
+        ok: true,
+        errors: [],
+        cassettes: [
+          {
+            file: "cassettes/proof.cassette.json",
+            passed: true,
+            detail: "1 step(s) replayed at $0",
+            replay_hits: 1,
+            replay_misses: 0,
+          },
+        ],
+      },
+      error: null,
+    });
+
+    render(<ProvenModal templateName="bundle-test" onClose={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText("Replay proof locally")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Replay proof locally"));
+    await waitFor(() => {
+      expect(screen.getByText("PASS")).toBeInTheDocument();
+    });
+    expect(mockedPost).toHaveBeenCalledWith("/templates/bundle-test/verify");
+    expect(
+      screen.getByText("Proof verified - every cassette replayed at $0.")
+    ).toBeInTheDocument();
+  });
+
+  it("shows FAIL and errors when the replay breaks", async () => {
+    mockedGet.mockResolvedValue({ data: VERIFICATION, error: null });
+    mockedPost.mockResolvedValue({
+      data: {
+        ok: false,
+        errors: ["cassette 'cassettes/proof.cassette.json' checksum mismatch"],
+        cassettes: [
+          {
+            file: "cassettes/proof.cassette.json",
+            passed: false,
+            detail: "checksum mismatch",
+            replay_hits: 0,
+            replay_misses: 0,
+          },
+        ],
+      },
+      error: null,
+    });
+
+    render(<ProvenModal templateName="bundle-test" onClose={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText("Replay proof locally")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Replay proof locally"));
+    await waitFor(() => {
+      expect(screen.getByText("FAIL")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Verification failed.")).toBeInTheDocument();
+    expect(screen.getAllByText(/checksum mismatch/).length).toBeGreaterThan(0);
+  });
+
+  it("warns when the installed workflow was edited after install", async () => {
+    mockedGet.mockResolvedValue({
+      data: { ...VERIFICATION, installed_workflow_matches: false },
+      error: null,
+    });
+    render(<ProvenModal templateName="bundle-test" onClose={vi.fn()} />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/edited after install/)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("handles an unreachable API gracefully", async () => {
+    mockedGet.mockRejectedValue(new Error("connection refused"));
+    render(<ProvenModal templateName="bundle-test" onClose={vi.fn()} />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Could not load the verification status/)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("closes from the header button", async () => {
+    mockedGet.mockResolvedValue({ data: VERIFICATION, error: null });
+    const onClose = vi.fn();
+    render(<ProvenModal templateName="bundle-test" onClose={onClose} />);
+    fireEvent.click(screen.getByLabelText("Close proof dialog"));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/dashboard/src/components/layout/CommandPalette.tsx
+++ b/dashboard/src/components/layout/CommandPalette.tsx
@@ -1,11 +1,21 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
+  Brain,
+  Dna,
+  FlaskConical,
+  Gauge,
   GitBranch,
+  Hammer,
   Key,
+  Layers,
   LayoutDashboard,
+  Moon,
+  Play,
   PlayCircle,
   Plug,
+  Rocket,
+  Scale,
   Search,
   Settings,
   ShieldCheck,
@@ -16,7 +26,9 @@ import {
   Clock,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { fuzzyScore } from "@/lib/fuzzy";
 import { api } from "@/api/client";
+import { THEME_TOGGLE_EVENT } from "@/hooks/useTheme";
 import type { RecentItem } from "@/hooks/useRecentItems";
 
 /* ------------------------------------------------------------------ */
@@ -24,7 +36,7 @@ import type { RecentItem } from "@/hooks/useRecentItems";
 /* ------------------------------------------------------------------ */
 
 interface SearchResult {
-  type: "run" | "workflow" | "tool";
+  type: "run" | "workflow" | "run-workflow" | "tool";
   label: string;
   sub: string;
   link: string;
@@ -39,7 +51,10 @@ interface CommandItem {
   /** Extra query params to append */
   search?: string;
   icon: React.ElementType;
+  /** Side-effect command (e.g. theme toggle) - runs instead of navigation */
+  perform?: () => void;
 }
+
 
 interface CommandPaletteProps {
   open: boolean;
@@ -60,19 +75,38 @@ const ACTION_COMMANDS: CommandItem[] = [
   { category: "action", label: "/health", description: "Go to system health", link: "/system-health", icon: HeartPulse },
   { category: "action", label: "/dlq", description: "Go to dead letter queue", link: "/dead-letter", icon: Inbox },
   { category: "action", label: "/schedules", description: "Go to schedules", link: "/schedules", icon: Calendar },
+  { category: "action", label: "/templates", description: "Go to Template Hub", link: "/templates", icon: Layers },
+  {
+    category: "action",
+    label: "/theme",
+    description: "Toggle light/dark theme",
+    link: "",
+    icon: Moon,
+    perform: () => window.dispatchEvent(new Event(THEME_TOGGLE_EVENT)),
+  },
 ];
 
 const PAGE_ITEMS: CommandItem[] = [
   { category: "page", label: "Overview", description: "Dashboard overview", link: "/", icon: LayoutDashboard },
   { category: "page", label: "Runs", description: "All workflow runs", link: "/runs", icon: PlayCircle },
   { category: "page", label: "Workflows", description: "Manage workflows", link: "/workflows", icon: GitBranch },
+  { category: "page", label: "Workflow Builder", description: "Visual workflow builder", link: "/workflows/builder", icon: Hammer },
+  { category: "page", label: "Templates", description: "Template Hub", link: "/templates", icon: Layers },
   { category: "page", label: "Approvals", description: "Pending approvals", link: "/approvals", icon: ShieldCheck },
   { category: "page", label: "Integrations", description: "Connected tools", link: "/integrations", icon: Plug },
+  { category: "page", label: "Evaluations", description: "Eval suites and results", link: "/evaluations", icon: FlaskConical },
+  { category: "page", label: "AutoPilot", description: "Autonomous optimization", link: "/autopilot", icon: Rocket },
+  { category: "page", label: "Evolution", description: "Workflow evolution", link: "/evolution", icon: Dna },
+  { category: "page", label: "Violations", description: "Policy violations", link: "/violations", icon: AlertTriangle },
+  { category: "page", label: "Optimizer", description: "Cost optimizer", link: "/optimizer", icon: Gauge },
   { category: "page", label: "API Keys", description: "Manage API keys", link: "/api-keys", icon: Key },
   { category: "page", label: "Settings", description: "Application settings", link: "/settings", icon: Settings },
   { category: "page", label: "System Health", description: "Health overview", link: "/system-health", icon: HeartPulse },
   { category: "page", label: "Dead Letter", description: "Dead letter queue", link: "/dead-letter", icon: Inbox },
   { category: "page", label: "Schedules", description: "Scheduled workflows", link: "/schedules", icon: Calendar },
+  { category: "page", label: "Schedule Monitor", description: "Schedule health", link: "/schedule-monitor", icon: Clock },
+  { category: "page", label: "Compliance", description: "EU AI Act compliance", link: "/compliance", icon: Scale },
+  { category: "page", label: "Memory", description: "Agent memory", link: "/memory", icon: Brain },
 ];
 
 const CATEGORY_ORDER = ["action", "recent", "run", "workflow", "page"] as const;
@@ -102,6 +136,7 @@ function iconForRecent(item: RecentItem): React.ElementType {
 export function CommandPalette({ open, onClose, recentItems }: CommandPaletteProps) {
   const navigate = useNavigate();
   const inputRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
@@ -176,13 +211,21 @@ export function CommandPalette({ open, onClose, recentItems }: CommandPalettePro
             type: "workflow",
             label: w.name,
             sub: `${w.steps_count} steps - ${w.file_name}`,
-            link: "/workflows",
+            link: `/workflows/${encodeURIComponent(w.name)}`,
+          });
+          // Companion entry that opens the run form straight away
+          const stem = w.file_name.replace(/\.ya?ml$/, "");
+          items.push({
+            type: "run-workflow",
+            label: `Run ${w.name}`,
+            sub: "Open the run form",
+            link: `/workflows?run=${encodeURIComponent(stem)}`,
           });
         }
       }
     }
 
-    setApiResults(items.slice(0, 10));
+    setApiResults(items.slice(0, 12));
   }, []);
 
   // Build the flat item list based on query
@@ -212,11 +255,23 @@ export function CommandPalette({ open, onClose, recentItems }: CommandPalettePro
       return [...recent, ...PAGE_ITEMS];
     }
 
-    // Search mode: combine API results + page matches
-    const matchedPages = PAGE_ITEMS.filter(
-      (p) =>
-        p.label.toLowerCase().includes(lower) ||
-        p.description.toLowerCase().includes(lower)
+    // Search mode: combine API results + fuzzy page/action matches
+    const matchedPages = PAGE_ITEMS
+      .map((p) => ({
+        item: p,
+        score: Math.max(
+          fuzzyScore(lower, p.label),
+          p.description.toLowerCase().includes(lower) ? 1.5 : 0
+        ),
+      }))
+      .filter(({ score }) => score > 0)
+      .sort((a, b) => b.score - a.score)
+      .map(({ item }) => item);
+
+    const matchedActions = ACTION_COMMANDS.filter(
+      (a) =>
+        fuzzyScore(lower, a.label.slice(1)) > 0 ||
+        a.description.toLowerCase().includes(lower)
     );
 
     const runItems: CommandItem[] = apiResults
@@ -230,16 +285,16 @@ export function CommandPalette({ open, onClose, recentItems }: CommandPalettePro
       }));
 
     const workflowItems: CommandItem[] = apiResults
-      .filter((r) => r.type === "workflow")
+      .filter((r) => r.type === "workflow" || r.type === "run-workflow")
       .map((r) => ({
         category: "workflow" as const,
         label: r.label,
         description: r.sub,
         link: r.link,
-        icon: GitBranch,
+        icon: r.type === "run-workflow" ? Play : GitBranch,
       }));
 
-    return [...runItems, ...workflowItems, ...matchedPages];
+    return [...matchedActions, ...runItems, ...workflowItems, ...matchedPages];
   }, [query, recentItems, apiResults]);
 
   // Group items by category, preserving order
@@ -275,6 +330,11 @@ export function CommandPalette({ open, onClose, recentItems }: CommandPalettePro
   }, [activeIndex]);
 
   function handleSelect(item: CommandItem) {
+    if (item.perform) {
+      item.perform();
+      onClose();
+      return;
+    }
     const url = item.link + (item.search ?? "");
     navigate(url);
     onClose();
@@ -284,6 +344,25 @@ export function CommandPalette({ open, onClose, recentItems }: CommandPalettePro
     if (e.key === "Escape") {
       e.preventDefault();
       onClose();
+      return;
+    }
+    if (e.key === "Tab") {
+      // Focus trap: Tab cycles inside the palette instead of escaping it
+      const root = dialogRef.current;
+      if (!root) return;
+      const focusables = root.querySelectorAll<HTMLElement>(
+        'input, button, [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
       return;
     }
     if (e.key === "ArrowDown") {
@@ -321,8 +400,11 @@ export function CommandPalette({ open, onClose, recentItems }: CommandPalettePro
       {/* Palette */}
       <div className="fixed inset-0 z-[61] flex items-start justify-center pt-[15vh] px-4">
         <div
+          ref={dialogRef}
           role="dialog"
+          aria-modal="true"
           aria-label="Command palette"
+          onKeyDown={handleKeyDown}
           className={cn(
             "w-full max-w-lg overflow-hidden rounded-xl border border-border bg-surface shadow-2xl",
             "animate-in fade-in slide-in-from-top-2 duration-150"
@@ -336,7 +418,6 @@ export function CommandPalette({ open, onClose, recentItems }: CommandPalettePro
               type="text"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
-              onKeyDown={handleKeyDown}
               placeholder='Search or type "/" for commands...'
               className={cn(
                 "h-12 flex-1 bg-transparent text-sm text-foreground outline-none",

--- a/dashboard/src/components/templates/ProvenBadge.tsx
+++ b/dashboard/src/components/templates/ProvenBadge.tsx
@@ -1,0 +1,33 @@
+import { BadgeCheck } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface ProvenBadgeProps {
+  /** Opens the proof modal. Rendered as a plain span when omitted. */
+  onClick?: (e: React.MouseEvent) => void;
+  className?: string;
+}
+
+/** Bold "✓ Proven" badge for templates installed from a verified .sctpl
+ *  bundle - the workflow ships with replayable proof-of-execution cassettes. */
+export function ProvenBadge({ onClick, className }: ProvenBadgeProps) {
+  return (
+    <span
+      data-testid="proven-badge"
+      title="Cassette-verified template - click to inspect and replay the proof"
+      onClick={(e) => {
+        if (!onClick) return;
+        e.stopPropagation();
+        onClick(e);
+      }}
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full bg-success/15 border border-success/40",
+        "px-1.5 py-0.5 text-[10px] font-bold text-success whitespace-nowrap",
+        onClick && "cursor-pointer hover:bg-success/25 transition-colors",
+        className
+      )}
+    >
+      <BadgeCheck className="h-2.5 w-2.5" />
+      Proven
+    </span>
+  );
+}

--- a/dashboard/src/components/templates/ProvenModal.tsx
+++ b/dashboard/src/components/templates/ProvenModal.tsx
@@ -1,0 +1,368 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  BadgeCheck,
+  CheckCircle2,
+  Loader2,
+  Play,
+  ShieldAlert,
+  X,
+  XCircle,
+} from "lucide-react";
+import { api } from "@/api/client";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { cn } from "@/lib/utils";
+
+// ---- API shapes ----
+
+interface ChecksumEntry {
+  file: string;
+  sha256: string;
+  valid: boolean;
+  step_count?: number | null;
+  recorded_cost_usd?: number | null;
+}
+
+interface VerificationData {
+  proven: boolean;
+  error?: string;
+  manifest?: {
+    name: string;
+    version: string;
+    description: string;
+    author: string;
+    license?: string;
+    sandcastle_version?: string;
+    created_at?: string;
+  };
+  workflow?: ChecksumEntry;
+  cassettes?: ChecksumEntry[];
+  checksums_valid?: boolean;
+  installed_workflow_matches?: boolean;
+}
+
+interface CassetteReplayResult {
+  file: string;
+  passed: boolean;
+  detail: string;
+  replay_hits: number;
+  replay_misses: number;
+}
+
+interface VerifyData {
+  ok: boolean;
+  errors: string[];
+  cassettes: CassetteReplayResult[];
+}
+
+interface ProvenModalProps {
+  templateName: string;
+  onClose: () => void;
+}
+
+function shortSha(sha: string): string {
+  return `${sha.slice(0, 12)}…`;
+}
+
+function cassetteLabel(file: string): string {
+  return file.replace(/^cassettes\//, "");
+}
+
+/** Proof inspector for a bundle-verified template: manifest details, payload
+ *  checksums, and a one-click strict replay of the bundled cassettes. */
+export function ProvenModal({ templateName, onClose }: ProvenModalProps) {
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [data, setData] = useState<VerificationData | null>(null);
+
+  const [replaying, setReplaying] = useState(false);
+  const [replayError, setReplayError] = useState<string | null>(null);
+  const [replay, setReplay] = useState<VerifyData | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setLoadError(false);
+    api
+      .get<VerificationData>(`/templates/${encodeURIComponent(templateName)}/verification`)
+      .then((res) => {
+        if (cancelled) return;
+        if (res.data) setData(res.data);
+        else setLoadError(true);
+      })
+      .catch(() => {
+        if (!cancelled) setLoadError(true);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [templateName]);
+
+  const handleReplay = useCallback(async () => {
+    setReplaying(true);
+    setReplayError(null);
+    setReplay(null);
+    try {
+      const res = await api.post<VerifyData>(
+        `/templates/${encodeURIComponent(templateName)}/verify`
+      );
+      if (res.data) setReplay(res.data);
+      else setReplayError(res.error?.message ?? "Verification request failed");
+    } catch {
+      setReplayError("Could not reach the API server");
+    } finally {
+      setReplaying(false);
+    }
+  }, [templateName]);
+
+  const manifest = data?.manifest;
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-[60] bg-black/40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={`Proof of execution for ${templateName}`}
+          className="w-full max-w-lg max-h-[85vh] overflow-y-auto rounded-xl border border-border bg-surface p-6 shadow-xl"
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
+              <BadgeCheck className="h-5 w-5 text-success" />
+              Proven Template
+            </h2>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close proof dialog"
+              className="rounded-lg p-1 text-muted hover:text-foreground"
+            >
+              <X aria-hidden="true" className="h-5 w-5" />
+            </button>
+          </div>
+
+          {loading ? (
+            <div className="flex h-32 items-center justify-center">
+              <LoadingSpinner size="md" />
+            </div>
+          ) : loadError || !data ? (
+            <div className="flex items-center gap-2 rounded-lg bg-error/10 border border-error/30 p-3">
+              <ShieldAlert className="h-5 w-5 text-error shrink-0" />
+              <p className="text-sm text-error">
+                Could not load the verification status. Check that the API
+                server is running and try again.
+              </p>
+            </div>
+          ) : !data.proven ? (
+            <p className="text-sm text-muted">
+              {data.error ??
+                "This template was not installed from a verified .sctpl bundle."}
+            </p>
+          ) : (
+            <div className="space-y-4">
+              <p className="text-sm text-muted">
+                Installed from a verified .sctpl bundle. The recorded cassettes
+                are the proof - replay them any time, offline and at $0.
+              </p>
+
+              {/* Manifest */}
+              {manifest && (
+                <div className="rounded-lg bg-background p-3 space-y-1.5">
+                  {[
+                    ["Name", manifest.name],
+                    ["Version", manifest.version],
+                    ["Author", manifest.author || "-"],
+                    ["License", manifest.license ?? "-"],
+                    ["Packed with", manifest.sandcastle_version ?? "-"],
+                    [
+                      "Created",
+                      manifest.created_at
+                        ? new Date(manifest.created_at).toLocaleDateString()
+                        : "-",
+                    ],
+                  ].map(([label, value]) => (
+                    <div
+                      key={label}
+                      className="flex items-center gap-2 text-xs text-muted-foreground"
+                    >
+                      <span className="w-24 shrink-0 font-medium">{label}:</span>
+                      <span className="font-mono text-foreground truncate">{value}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {/* Checksums */}
+              <div className="space-y-1.5">
+                <p className="text-xs font-semibold text-muted uppercase tracking-wider">
+                  Payload checksums
+                </p>
+                <div className="rounded-lg border border-border divide-y divide-border/60 overflow-hidden">
+                  {data.workflow && (
+                    <ChecksumRow
+                      label={data.workflow.file}
+                      sha={data.workflow.sha256}
+                      valid={data.workflow.valid}
+                    />
+                  )}
+                  {(data.cassettes ?? []).map((c) => (
+                    <ChecksumRow
+                      key={c.file}
+                      label={cassetteLabel(c.file)}
+                      sha={c.sha256}
+                      valid={c.valid}
+                    />
+                  ))}
+                </div>
+                {data.installed_workflow_matches === false && (
+                  <p className="flex items-center gap-1.5 text-xs text-warning">
+                    <ShieldAlert className="h-3.5 w-3.5 shrink-0" />
+                    The installed workflow was edited after install - it no
+                    longer matches the bundled proof.
+                  </p>
+                )}
+              </div>
+
+              {/* Replay proof */}
+              <div className="space-y-2">
+                <button
+                  type="button"
+                  onClick={handleReplay}
+                  disabled={replaying}
+                  className={cn(
+                    "flex w-full items-center justify-center gap-2 rounded-lg bg-accent px-4 py-2",
+                    "text-sm font-medium text-accent-foreground",
+                    "hover:bg-accent-hover transition-all shadow-sm",
+                    replaying && "opacity-70 cursor-not-allowed"
+                  )}
+                >
+                  {replaying ? (
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                      Replaying cassettes...
+                    </>
+                  ) : (
+                    <>
+                      <Play className="h-4 w-4" />
+                      Replay proof locally
+                    </>
+                  )}
+                </button>
+
+                {replayError && (
+                  <div className="flex items-center gap-2 rounded-lg bg-error/10 border border-error/30 p-3">
+                    <XCircle className="h-4 w-4 text-error shrink-0" />
+                    <p className="text-xs text-error">{replayError}</p>
+                  </div>
+                )}
+
+                {replay && (
+                  <div className="space-y-2" data-testid="replay-result">
+                    <div
+                      className={cn(
+                        "flex items-center gap-2 rounded-lg border p-3",
+                        replay.ok
+                          ? "bg-success/10 border-success/30"
+                          : "bg-error/10 border-error/30"
+                      )}
+                    >
+                      {replay.ok ? (
+                        <CheckCircle2 className="h-4 w-4 text-success shrink-0" />
+                      ) : (
+                        <XCircle className="h-4 w-4 text-error shrink-0" />
+                      )}
+                      <p
+                        className={cn(
+                          "text-xs font-medium",
+                          replay.ok ? "text-success" : "text-error"
+                        )}
+                      >
+                        {replay.ok
+                          ? "Proof verified - every cassette replayed at $0."
+                          : "Verification failed."}
+                      </p>
+                    </div>
+
+                    {replay.errors.length > 0 && (
+                      <ul className="space-y-1 rounded-lg bg-background p-3">
+                        {replay.errors.map((err) => (
+                          <li key={err} className="text-xs text-error font-mono">
+                            {err}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+
+                    {replay.cassettes.length > 0 && (
+                      <div className="rounded-lg border border-border divide-y divide-border/60 overflow-hidden">
+                        {replay.cassettes.map((c) => (
+                          <div
+                            key={c.file}
+                            className="flex items-center justify-between gap-3 px-3 py-2"
+                          >
+                            <div className="min-w-0">
+                              <p className="text-xs font-mono text-foreground truncate">
+                                {cassetteLabel(c.file)}
+                              </p>
+                              <p className="text-[11px] text-muted-foreground truncate">
+                                {c.detail}
+                              </p>
+                            </div>
+                            <span
+                              className={cn(
+                                "shrink-0 rounded-full px-2 py-0.5 text-[10px] font-bold",
+                                c.passed
+                                  ? "bg-success/15 text-success"
+                                  : "bg-error/15 text-error"
+                              )}
+                            >
+                              {c.passed ? "PASS" : "FAIL"}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+function ChecksumRow({
+  label,
+  sha,
+  valid,
+}: {
+  label: string;
+  sha: string;
+  valid: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 px-3 py-2">
+      <div className="min-w-0">
+        <p className="text-xs font-mono text-foreground truncate">{label}</p>
+        <p className="text-[11px] font-mono text-muted-foreground" title={sha}>
+          sha256: {shortSha(sha)}
+        </p>
+      </div>
+      {valid ? (
+        <CheckCircle2 className="h-4 w-4 shrink-0 text-success" />
+      ) : (
+        <XCircle className="h-4 w-4 shrink-0 text-error" />
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/templates/TemplateCard.tsx
+++ b/dashboard/src/components/templates/TemplateCard.tsx
@@ -1,6 +1,7 @@
 import { ArrowRight, Globe } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getPackById } from "@/lib/templatePacks";
+import { ProvenBadge } from "@/components/templates/ProvenBadge";
 
 interface Template {
   name: string;
@@ -10,6 +11,7 @@ interface Template {
   category?: string | null;
   source?: "community";
   author?: string;
+  proven?: boolean;
 }
 
 const TAG_COLORS = [
@@ -33,9 +35,11 @@ interface TemplateCardProps {
   template: Template;
   isSelected: boolean;
   onClick: () => void;
+  /** Opens the proof modal for bundle-verified templates */
+  onProvenClick?: () => void;
 }
 
-export function TemplateCard({ template, isSelected, onClick }: TemplateCardProps) {
+export function TemplateCard({ template, isSelected, onClick, onProvenClick }: TemplateCardProps) {
   const pack = template.category ? getPackById(template.category) : null;
   const accentBorder = pack ? pack.color.border : "border-border";
 
@@ -63,6 +67,9 @@ export function TemplateCard({ template, isSelected, onClick }: TemplateCardProp
               <Globe className="h-2.5 w-2.5" />
               Community
             </span>
+          )}
+          {template.proven && (
+            <ProvenBadge onClick={onProvenClick ? () => onProvenClick() : undefined} />
           )}
         </div>
         <ArrowRight className="h-4 w-4 text-muted opacity-0 group-hover:opacity-100 transition-opacity" />

--- a/dashboard/src/hooks/useTheme.ts
+++ b/dashboard/src/hooks/useTheme.ts
@@ -2,6 +2,10 @@ import { useState, useEffect, useCallback } from "react";
 
 type Theme = "light" | "dark";
 
+/** Window event that flips the theme from anywhere (e.g. the command palette).
+ *  Every mounted useTheme instance listens, so all toggles stay in sync. */
+export const THEME_TOGGLE_EVENT = "sandcastle:toggle-theme";
+
 function getInitialTheme(): Theme {
   try {
     const stored = localStorage.getItem("theme");
@@ -28,6 +32,14 @@ export function useTheme() {
       // be persisted (private browsing / quota exceeded).
     }
   }, [theme]);
+
+  // Global toggle event - lets the command palette (or anything else) flip the
+  // theme without holding a reference to this hook instance.
+  useEffect(() => {
+    const handler = () => setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+    window.addEventListener(THEME_TOGGLE_EVENT, handler);
+    return () => window.removeEventListener(THEME_TOGGLE_EVENT, handler);
+  }, []);
 
   const toggleTheme = useCallback(() => {
     setTheme((prev) => (prev === "dark" ? "light" : "dark"));

--- a/dashboard/src/lib/fuzzy.ts
+++ b/dashboard/src/lib/fuzzy.ts
@@ -1,0 +1,21 @@
+/** Subsequence fuzzy matcher: > 0 when every query character appears in order
+ *  inside the text. Substring hits score highest, tight subsequences next. */
+export function fuzzyScore(query: string, text: string): number {
+  const q = query.toLowerCase().trim();
+  const t = text.toLowerCase();
+  if (!q) return 1;
+  if (t.includes(q)) return 2 + q.length / t.length;
+  let qi = 0;
+  let streak = 0;
+  let score = 0;
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      qi++;
+      streak++;
+      score += streak;
+    } else {
+      streak = 0;
+    }
+  }
+  return qi === q.length ? score / (q.length * q.length + t.length) : 0;
+}

--- a/dashboard/src/pages/TemplatesPage.tsx
+++ b/dashboard/src/pages/TemplatesPage.tsx
@@ -38,6 +38,7 @@ import { TemplateCard } from "@/components/templates/TemplateCard";
 import { TemplateDetail } from "@/components/templates/TemplateDetail";
 import { RunModal } from "@/components/templates/RunModal";
 import { InstallModal } from "@/components/templates/InstallModal";
+import { ProvenModal } from "@/components/templates/ProvenModal";
 import { CommunityCard } from "@/components/templates/CommunityCard";
 import type { CommunityTemplate } from "@/components/templates/CommunityCard";
 import { TOOL_ICON_MAP } from "@/components/integrations/toolIcons";
@@ -56,6 +57,8 @@ interface Template {
   source?: "community";
   author?: string;
   relevance_score?: number | null;
+  /** Installed from a verified .sctpl bundle with replayable proof cassettes */
+  proven?: boolean;
 }
 
 // Fuzzy matching helper: score a template against query words by word overlap
@@ -167,6 +170,9 @@ export default function TemplatesPage() {
   // Install modal state
   const [installPack, setInstallPack] = useState<TemplatePack | null>(null);
   const [installTemplates, setInstallTemplates] = useState<string[]>([]);
+
+  // Proven badge modal - template whose bundle proof is being inspected
+  const [provenTarget, setProvenTarget] = useState<string | null>(null);
 
   // Pack detail - selected templates for selective install
   const [packSelected, setPackSelected] = useState<Record<string, boolean>>({});
@@ -870,6 +876,7 @@ export default function TemplatesPage() {
             setSelectedTag(null);
           }}
           onOpenDetail={openDetail}
+          onProvenClick={setProvenTarget}
           detailName={detailName}
           installedSlugs={installedSlugs}
           communityTemplates={communityTemplates}
@@ -1233,6 +1240,14 @@ export default function TemplatesPage() {
           selectedTemplates={installTemplates}
           onClose={handleInstallClose}
           onComplete={handleInstallComplete}
+        />
+      )}
+
+      {/* Proven badge - bundle proof modal */}
+      {provenTarget && (
+        <ProvenModal
+          templateName={provenTarget}
+          onClose={() => setProvenTarget(null)}
         />
       )}
 
@@ -1853,6 +1868,7 @@ function AllTemplatesView({
   onTagSelect,
   onReset,
   onOpenDetail,
+  onProvenClick,
   detailName,
   installedSlugs,
   communityTemplates,
@@ -1864,6 +1880,7 @@ function AllTemplatesView({
   onTagSelect: (tag: string | null) => void;
   onReset: () => void;
   onOpenDetail: (name: string) => void;
+  onProvenClick: (name: string) => void;
   detailName: string | null;
   installedSlugs: Set<string>;
   communityTemplates: CommunityTemplate[];
@@ -1970,6 +1987,7 @@ function AllTemplatesView({
               template={t}
               isSelected={detailName === t.name}
               onClick={() => onOpenDetail(t.name)}
+              onProvenClick={() => onProvenClick(t.name)}
             />
           ))}
         </div>

--- a/dashboard/src/pages/Workflows.tsx
+++ b/dashboard/src/pages/Workflows.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { GitBranch, LayoutGrid, Network, Plus, Search, Star, Trash2, X, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { api } from "@/api/client";
@@ -35,6 +35,7 @@ interface WorkflowInfo {
 
 export default function Workflows() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [workflows, setWorkflows] = useState<WorkflowInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -82,6 +83,27 @@ export default function Workflows() {
   useEffect(() => {
     void fetchWorkflows();
   }, [fetchWorkflows]);
+
+  // Deep link from the command palette: /workflows?run=<name> opens the run
+  // form for that workflow as soon as the list is loaded.
+  useEffect(() => {
+    const runParam = searchParams.get("run");
+    if (!runParam || workflows.length === 0) return;
+    const wf = workflows.find(
+      (w) =>
+        w.name === runParam ||
+        w.file_name?.replace(/\.ya?ml$/, "") === runParam
+    );
+    if (wf) setRunModal(wf);
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete("run");
+        return next;
+      },
+      { replace: true }
+    );
+  }, [workflows, searchParams, setSearchParams]);
 
   const handleRun = useCallback(
     async (input: Record<string, unknown>, callbackUrl?: string) => {

--- a/src/sandcastle/__main__.py
+++ b/src/sandcastle/__main__.py
@@ -3449,6 +3449,9 @@ def _cmd_template_install(args: argparse.Namespace) -> None:
         for arcname, blob in cassettes.items():
             cassette_name = _sanitize_bundle_stem(Path(arcname).stem) + ".cassette.json"
             (target_dir / f"{stem}.{cassette_name}").write_bytes(blob)
+        # Keep the bundle itself too - the dashboard's "Replay proof locally"
+        # and the verification API re-verify from this exact archive.
+        (target_dir / f"{stem}.sctpl").write_bytes(bundle_path.read_bytes())
 
     print(f"{_color('Installed', _C.GREEN)}: {manifest['name']} v{manifest['version']}"
           f" -> {target_path}")

--- a/src/sandcastle/api/routes.py
+++ b/src/sandcastle/api/routes.py
@@ -1496,6 +1496,28 @@ def _score_template_relevance(
     return overlap / len(query_words)
 
 
+def _template_to_dict(t: Any, relevance_score: float | None) -> dict[str, Any]:
+    """Serialize a TemplateInfo for the templates list endpoints.
+
+    ``proven`` is True when the template was installed from a verified .sctpl
+    bundle - the bundle archive sits next to the workflow YAML and carries the
+    replayable proof-of-execution.
+    """
+    from sandcastle.engine.bundle import bundle_for_template
+
+    return {
+        "name": t.name,
+        "description": t.description,
+        "tags": t.tags,
+        "step_count": t.step_count,
+        "input_schema": t.input_schema,
+        "category": t.category,
+        "source": t.source,
+        "relevance_score": relevance_score,
+        "proven": t.source == "community" and bundle_for_template(t.file_name) is not None,
+    }
+
+
 @router.get("/templates")
 async def list_templates(
     q: str | None = Query(None, description="Search query for templates"),
@@ -1514,21 +1536,7 @@ async def list_templates(
     templates = _list_templates()
 
     if not q or not q.strip():
-        return ApiResponse(
-            data=[
-                {
-                    "name": t.name,
-                    "description": t.description,
-                    "tags": t.tags,
-                    "step_count": t.step_count,
-                    "input_schema": t.input_schema,
-                    "category": t.category,
-                    "source": t.source,
-                    "relevance_score": None,
-                }
-                for t in templates
-            ]
-        )
+        return ApiResponse(data=[_template_to_dict(t, None) for t in templates])
 
     query = q.strip().lower()
 
@@ -1544,19 +1552,7 @@ async def list_templates(
 
     if exact_matches:
         return ApiResponse(
-            data=[
-                {
-                    "name": t.name,
-                    "description": t.description,
-                    "tags": t.tags,
-                    "step_count": t.step_count,
-                    "input_schema": t.input_schema,
-                    "category": t.category,
-                    "source": t.source,
-                    "relevance_score": score,
-                }
-                for t, score in exact_matches
-            ]
+            data=[_template_to_dict(t, score) for t, score in exact_matches]
         )
 
     # Phase 2: fuzzy word overlap matching
@@ -1577,21 +1573,7 @@ async def list_templates(
     # Sort by score descending
     scored.sort(key=lambda x: x[1], reverse=True)
 
-    return ApiResponse(
-        data=[
-            {
-                "name": t.name,
-                "description": t.description,
-                "tags": t.tags,
-                "step_count": t.step_count,
-                "input_schema": t.input_schema,
-                "category": t.category,
-                "source": t.source,
-                "relevance_score": score,
-            }
-            for t, score in scored
-        ]
-    )
+    return ApiResponse(data=[_template_to_dict(t, score) for t, score in scored])
 
 
 @router.get("/templates/{template_name}")
@@ -1612,6 +1594,8 @@ async def get_template(template_name: str) -> ApiResponse:
             ).model_dump(),
         ) from exc
 
+    from sandcastle.engine.bundle import bundle_for_template
+
     return ApiResponse(
         data={
             "name": info.name,
@@ -1623,6 +1607,113 @@ async def get_template(template_name: str) -> ApiResponse:
             "input_schema": info.input_schema,
             "category": info.category,
             "source": info.source,
+            "proven": info.source == "community"
+            and bundle_for_template(info.file_name) is not None,
+        }
+    )
+
+
+def _resolve_template_bundle(template_name: str) -> tuple[str, Any, Path]:
+    """Resolve a template and its installed .sctpl bundle, or raise 404."""
+    from sandcastle.engine.bundle import bundle_for_template
+    from sandcastle.templates import get_template as _get_template
+
+    try:
+        content, info = _get_template(template_name)
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail=ApiResponse(
+                error=ErrorResponse(code="NOT_FOUND", message=str(exc))
+            ).model_dump(),
+        ) from exc
+
+    bundle_path = (
+        bundle_for_template(info.file_name) if info.source == "community" else None
+    )
+    if bundle_path is None:
+        raise HTTPException(
+            status_code=404,
+            detail=ApiResponse(
+                error=ErrorResponse(
+                    code="NOT_FOUND",
+                    message=f"Template '{template_name}' was not installed from a "
+                    "verified .sctpl bundle",
+                )
+            ).model_dump(),
+        )
+    return content, info, bundle_path
+
+
+@router.get("/templates/{template_name}/verification")
+async def get_template_verification(template_name: str) -> ApiResponse:
+    """Verification status for a bundle-installed template.
+
+    Returns the bundle manifest (author, version, checksums) plus checksum
+    validity for every payload file, and whether the installed workflow YAML
+    still byte-matches the bundled one. Templates not installed from a .sctpl
+    bundle return ``{"proven": false}``.
+
+    Public endpoint - no authentication required.
+    """
+    from sandcastle.engine.bundle import BundleError, bundle_for_template, bundle_status
+    from sandcastle.templates import get_template as _get_template
+
+    try:
+        content, info = _get_template(template_name)
+    except FileNotFoundError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail=ApiResponse(
+                error=ErrorResponse(code="NOT_FOUND", message=str(exc))
+            ).model_dump(),
+        ) from exc
+
+    bundle_path = (
+        bundle_for_template(info.file_name) if info.source == "community" else None
+    )
+    if bundle_path is None:
+        return ApiResponse(data={"proven": False})
+
+    try:
+        status = await asyncio.to_thread(bundle_status, bundle_path)
+    except BundleError as exc:
+        return ApiResponse(data={"proven": False, "error": str(exc)})
+
+    installed_sha = hashlib.sha256(content.encode()).hexdigest()
+    status["installed_workflow_matches"] = installed_sha == status["workflow"]["sha256"]
+    return ApiResponse(data={"proven": True, **status})
+
+
+@router.post("/templates/{template_name}/verify")
+async def verify_template_bundle(template_name: str) -> ApiResponse:
+    """Replay a bundle-installed template's proof-of-execution cassettes.
+
+    Runs the same strict replay as ``sandcastle template verify`` - checksums,
+    security scan, then every cassette replayed offline at $0 - and reports
+    PASS/FAIL per cassette. 404 when the template has no installed bundle.
+
+    Public endpoint - no authentication required.
+    """
+    from sandcastle.engine.bundle import verify_bundle
+
+    _content, _info, bundle_path = _resolve_template_bundle(template_name)
+
+    result = await asyncio.to_thread(verify_bundle, bundle_path)
+    return ApiResponse(
+        data={
+            "ok": result.ok,
+            "errors": result.errors,
+            "cassettes": [
+                {
+                    "file": c.file,
+                    "passed": c.passed,
+                    "detail": c.detail,
+                    "replay_hits": c.replay_hits,
+                    "replay_misses": c.replay_misses,
+                }
+                for c in result.cassette_results
+            ],
         }
     )
 

--- a/src/sandcastle/engine/bundle.py
+++ b/src/sandcastle/engine/bundle.py
@@ -369,6 +369,72 @@ def read_bundle(path: str | Path) -> tuple[dict[str, Any], str, dict[str, bytes]
 
 
 # ---------------------------------------------------------------------------
+# Installed-bundle status
+# ---------------------------------------------------------------------------
+
+
+def bundle_for_template(file_name: str) -> Path | None:
+    """The sibling .sctpl bundle for an installed community template, if any.
+
+    ``sandcastle template install`` keeps the original bundle next to the
+    extracted workflow (``<stem>.yaml`` + ``<stem>.sctpl``), so the proof can be
+    replayed at any time. Returns the bundle path or None for plain templates.
+    """
+    from sandcastle.templates import _TEMPLATES_DIR
+
+    candidate = (_TEMPLATES_DIR / "community" / file_name).with_suffix(BUNDLE_SUFFIX)
+    return candidate if candidate.is_file() else None
+
+
+def bundle_status(path: str | Path) -> dict[str, Any]:
+    """Manifest info plus checksum validity for a bundle, without replaying.
+
+    Recomputes the SHA-256 of every payload member and compares it against the
+    manifest. This is the cheap half of verification - the replay proof itself
+    lives in :func:`verify_bundle`.
+
+    Raises:
+        BundleError: When the bundle is malformed or unsafe.
+    """
+    manifest, workflow_yaml, cassettes = read_bundle(path)
+
+    workflow_entry = {
+        "file": manifest["workflow"]["file"],
+        "sha256": manifest["workflow"]["sha256"],
+        "valid": _sha256_bytes(workflow_yaml.encode()) == manifest["workflow"]["sha256"],
+    }
+    cassette_entries = [
+        {
+            "file": entry["file"],
+            "sha256": entry["sha256"],
+            "valid": _sha256_bytes(cassettes[entry["file"]]) == entry["sha256"],
+            "step_count": entry.get("step_count"),
+            "recorded_cost_usd": entry.get("recorded_cost_usd"),
+        }
+        for entry in manifest["cassettes"]
+    ]
+
+    return {
+        "manifest": {
+            key: manifest.get(key)
+            for key in (
+                "name",
+                "version",
+                "description",
+                "author",
+                "license",
+                "sandcastle_version",
+                "created_at",
+            )
+        },
+        "workflow": workflow_entry,
+        "cassettes": cassette_entries,
+        "checksums_valid": workflow_entry["valid"]
+        and all(c["valid"] for c in cassette_entries),
+    }
+
+
+# ---------------------------------------------------------------------------
 # Verify
 # ---------------------------------------------------------------------------
 

--- a/tests/test_template_verification_api.py
+++ b/tests/test_template_verification_api.py
@@ -1,0 +1,250 @@
+"""Tests for the template verification API behind the dashboard's Proven badge.
+
+A template installed from a verified .sctpl bundle keeps the bundle next to the
+workflow YAML. The API surfaces that proof: the templates list flags such
+templates as ``proven``, ``GET /templates/{name}/verification`` returns the
+manifest plus checksum validity, and ``POST /templates/{name}/verify`` replays
+the bundled cassettes strictly offline and reports PASS/FAIL per cassette.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from sandcastle.main import app
+from tests.test_template_bundle import WORKFLOW, _install_args, _make_bundle
+
+client = TestClient(app)
+
+PLAIN_TEMPLATE = """# name: plain-local
+# description: A hand-written template with no bundle proof.
+name: plain-local
+description: A hand-written template with no bundle proof.
+steps:
+  - id: think
+    prompt: "Say hi"
+"""
+
+
+@pytest.fixture
+def templates_dir(tmp_path, monkeypatch) -> Path:
+    """Patch the templates dir to an isolated tmp tree with a community subdir."""
+    root = tmp_path / "templates"
+    (root / "community").mkdir(parents=True)
+    monkeypatch.setattr("sandcastle.templates._TEMPLATES_DIR", root)
+    return root
+
+
+@pytest.fixture
+def installed_bundle(templates_dir, tmp_path, capsys) -> Path:
+    """Install a freshly packed, verified bundle into the community dir."""
+    from sandcastle.__main__ import _cmd_template_install
+
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    bundle = _make_bundle(src_dir)
+    _cmd_template_install(_install_args(str(bundle), templates_dir / "community"))
+    capsys.readouterr()  # swallow the CLI verify report
+    return templates_dir / "community"
+
+
+def _tamper_cassette(bundle_path: Path) -> None:
+    """Flip one byte of the bundled cassette so its manifest checksum breaks."""
+    with zipfile.ZipFile(bundle_path) as zf:
+        members = {i.filename: zf.read(i) for i in zf.infolist() if not i.is_dir()}
+    cassette_name = next(n for n in members if n.startswith("cassettes/"))
+    members[cassette_name] += b" "
+    with zipfile.ZipFile(bundle_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, blob in members.items():
+            zf.writestr(name, blob)
+
+
+# ---------------------------------------------------------------------------
+# install keeps the bundle alongside the workflow
+# ---------------------------------------------------------------------------
+
+
+def test_install_keeps_bundle_next_to_workflow(installed_bundle):
+    assert (installed_bundle / "bundle-test.yaml").exists()
+    assert (installed_bundle / "bundle-test.sctpl").exists()
+
+
+def test_bundle_for_template_resolves_sibling(installed_bundle):
+    from sandcastle.engine.bundle import bundle_for_template
+
+    assert bundle_for_template("bundle-test.yaml") == installed_bundle / "bundle-test.sctpl"
+    assert bundle_for_template("no-such-template.yaml") is None
+
+
+# ---------------------------------------------------------------------------
+# templates list flags proven templates
+# ---------------------------------------------------------------------------
+
+
+def test_list_templates_marks_bundle_installed_as_proven(installed_bundle):
+    (installed_bundle / "plain-local.yaml").write_text(PLAIN_TEMPLATE)
+
+    resp = client.get("/api/templates")
+    assert resp.status_code == 200
+    by_name = {t["name"]: t for t in resp.json()["data"]}
+
+    assert by_name["bundle-test"]["proven"] is True
+    assert by_name["plain-local"]["proven"] is False
+
+
+def test_get_template_includes_proven_flag(installed_bundle):
+    resp = client.get("/api/templates/bundle-test")
+    assert resp.status_code == 200
+    assert resp.json()["data"]["proven"] is True
+
+
+# ---------------------------------------------------------------------------
+# GET /templates/{name}/verification
+# ---------------------------------------------------------------------------
+
+
+def test_verification_returns_manifest_and_valid_checksums(installed_bundle):
+    resp = client.get("/api/templates/bundle-test/verification")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+
+    assert data["proven"] is True
+    assert data["manifest"]["name"] == "bundle-test"
+    assert data["manifest"]["author"] == "tester"
+    assert data["manifest"]["version"] == "1.0.0"
+    assert data["workflow"]["valid"] is True
+    assert len(data["workflow"]["sha256"]) == 64
+    assert len(data["cassettes"]) == 1
+    assert data["cassettes"][0]["valid"] is True
+    assert len(data["cassettes"][0]["sha256"]) == 64
+    assert data["checksums_valid"] is True
+    assert data["installed_workflow_matches"] is True
+
+
+def test_verification_detects_locally_edited_workflow(installed_bundle):
+    installed = installed_bundle / "bundle-test.yaml"
+    installed.write_text(WORKFLOW + "\n# locally edited after install\n")
+
+    resp = client.get("/api/templates/bundle-test/verification")
+    data = resp.json()["data"]
+
+    assert data["proven"] is True
+    assert data["checksums_valid"] is True  # the bundle itself is intact
+    assert data["installed_workflow_matches"] is False
+
+
+def test_verification_detects_tampered_bundle_cassette(installed_bundle):
+    _tamper_cassette(installed_bundle / "bundle-test.sctpl")
+
+    resp = client.get("/api/templates/bundle-test/verification")
+    data = resp.json()["data"]
+
+    assert data["proven"] is True
+    assert data["cassettes"][0]["valid"] is False
+    assert data["checksums_valid"] is False
+
+
+def test_verification_plain_template_is_not_proven(templates_dir):
+    (templates_dir / "community" / "plain-local.yaml").write_text(PLAIN_TEMPLATE)
+
+    resp = client.get("/api/templates/plain-local/verification")
+    assert resp.status_code == 200
+    assert resp.json()["data"] == {"proven": False}
+
+
+def test_verification_unknown_template_404(templates_dir):
+    resp = client.get("/api/templates/no-such-template/verification")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /templates/{name}/verify - the replay proof
+# ---------------------------------------------------------------------------
+
+
+def test_verify_replays_cassettes_and_passes(installed_bundle):
+    resp = client.post("/api/templates/bundle-test/verify")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+
+    assert data["ok"] is True
+    assert data["errors"] == []
+    assert len(data["cassettes"]) == 1
+    proof = data["cassettes"][0]
+    assert proof["passed"] is True
+    assert proof["replay_hits"] == 1
+    assert proof["replay_misses"] == 0
+
+
+def test_verify_fails_on_tampered_bundle(installed_bundle):
+    _tamper_cassette(installed_bundle / "bundle-test.sctpl")
+
+    resp = client.post("/api/templates/bundle-test/verify")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+
+    assert data["ok"] is False
+    assert any("checksum mismatch" in e for e in data["errors"])
+    assert data["cassettes"] == []  # replay must not run after a checksum failure
+
+
+def test_verify_404_for_template_without_bundle(templates_dir):
+    (templates_dir / "community" / "plain-local.yaml").write_text(PLAIN_TEMPLATE)
+
+    resp = client.post("/api/templates/plain-local/verify")
+    assert resp.status_code == 404
+
+
+def test_verify_404_for_unknown_template(templates_dir):
+    resp = client.post("/api/templates/no-such-template/verify")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# bundle_status unit coverage
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_status_reports_manifest_and_checksums(tmp_path):
+    from sandcastle.engine.bundle import bundle_status
+
+    bundle = _make_bundle(tmp_path)
+    status = bundle_status(bundle)
+
+    assert status["manifest"]["name"] == "bundle-test"
+    assert status["manifest"]["license"] == "MIT"
+    assert status["workflow"]["valid"] is True
+    assert status["cassettes"][0]["step_count"] == 1
+    assert status["checksums_valid"] is True
+
+
+def test_bundle_status_flags_invalid_checksum(tmp_path):
+    from sandcastle.engine.bundle import bundle_status
+
+    bundle = _make_bundle(tmp_path)
+    _tamper_cassette(bundle)
+    status = bundle_status(bundle)
+
+    assert status["cassettes"][0]["valid"] is False
+    assert status["checksums_valid"] is False
+
+
+def test_bundle_status_raises_on_garbage(tmp_path):
+    from sandcastle.engine.bundle import BundleError, bundle_status
+
+    garbage = tmp_path / "garbage.sctpl"
+    garbage.write_bytes(b"not a zip at all")
+    with pytest.raises(BundleError):
+        bundle_status(garbage)
+
+
+def test_verify_response_shape_is_json_safe(installed_bundle):
+    """The verify payload round-trips through JSON without loss."""
+    resp = client.post("/api/templates/bundle-test/verify")
+    data = resp.json()["data"]
+    assert json.loads(json.dumps(data)) == data


### PR DESCRIPTION
Two dashboard features, stacked on the template-hub bundle backend (#264).

**⌘K command palette** (enhanced the existing one — no new dependency): fuzzy page search across all 20 routes, jump-to-run, jump-to-workflow + "Run <wf>" deep-link action, theme toggle; Tab focus trap, `aria-modal`, arrow/Esc keyboard handling, debounced API search with graceful API-down path.

**✓ Proven badge**: bundle-installed templates get a bold "✓ Proven" badge; clicking opens a modal with manifest details (author, version, checksums) + a **"Replay proof locally"** button that runs verification and shows live PASS/FAIL per cassette. Non-bundle templates show nothing (no shaming labels). New endpoints: `GET /api/templates/{name}/verification`, `POST /api/templates/{name}/verify`.

Tests: 24 new (13 palette + 11 badge/modal); pytest 17 new on verification API; lint zero new, build green.

**Stacked on #264 (template-hub)** — review/merge that first.