### PR TITLE
feat(dashboard): Mission Control — live run theater at /runs/:id/live

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -17,6 +17,7 @@ const Overview = lazyWithRetry(() => import("@/pages/Overview"), "overview");
 const Runs = lazyWithRetry(() => import("@/pages/Runs"), "runs");
 const RunComparePage = lazyWithRetry(() => import("@/pages/RunComparePage"), "run-compare");
 const RunDetailPage = lazyWithRetry(() => import("@/pages/RunDetailPage"), "run-detail");
+const MissionControlPage = lazyWithRetry(() => import("@/pages/MissionControlPage"), "mission-control");
 const Workflows = lazyWithRetry(() => import("@/pages/Workflows"), "workflows");
 const WorkflowBuilderPage = lazyWithRetry(() => import("@/pages/WorkflowBuilderPage"), "workflow-builder");
 const WorkflowDetailPage = lazyWithRetry(() => import("@/pages/WorkflowDetailPage"), "workflow-detail");
@@ -127,6 +128,9 @@ export default function App() {
           <Routes>
             {/* Onboarding lives outside Layout (full-screen, no sidebar) */}
             <Route path="/onboarding" element={<PageBoundary name="onboarding"><Onboarding /></PageBoundary>} />
+
+            {/* Mission Control lives outside Layout (full-bleed live run theater) */}
+            <Route path="/runs/:id/live" element={<PageBoundary name="mission-control"><MissionControlPage /></PageBoundary>} />
 
             <Route element={<Layout />}>
               <Route path="/" element={<PageBoundary name="overview"><Overview /></PageBoundary>} />

--- a/dashboard/src/__tests__/MissionControlComponents.test.tsx
+++ b/dashboard/src/__tests__/MissionControlComponents.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TelemetryRail, Odometer } from "@/components/runs/mission/TelemetryRail";
+import { ThoughtStream } from "@/components/runs/mission/ThoughtStream";
+import { formatClock, type FeedEntry, type Telemetry } from "@/lib/missionControl";
+
+const telemetry: Telemetry = {
+  costUsd: 0.0421,
+  tokensEst: 1234,
+  stepsTotal: 7,
+  stepsDone: 3,
+  stepsFailed: 0,
+  stepsRunning: 1,
+  models: ["mistral/large", "claude/sonnet"],
+  activeStepId: "analyze",
+};
+
+describe("TelemetryRail", () => {
+  it("renders cost, tokens, elapsed, step counter and models", () => {
+    render(
+      <TelemetryRail telemetry={telemetry} throughput={42} elapsedSeconds={83} isLive />
+    );
+    expect(screen.getByText("$0.0421")).toBeInTheDocument();
+    expect(screen.getByText("1,234")).toBeInTheDocument();
+    expect(screen.getByText("42 tok/s")).toBeInTheDocument();
+    expect(screen.getByText("01:23")).toBeInTheDocument();
+    expect(screen.getByText("3/7")).toBeInTheDocument();
+    expect(screen.getByText("mistral/large")).toBeInTheDocument();
+    expect(screen.getByText("claude/sonnet")).toBeInTheDocument();
+  });
+
+  it("shows $0.00 proudly with a free badge for local runs", () => {
+    render(
+      <TelemetryRail
+        telemetry={{ ...telemetry, costUsd: 0 }}
+        throughput={0}
+        elapsedSeconds={5}
+        isLive
+      />
+    );
+    expect(screen.getByText("$0.00")).toBeInTheDocument();
+    expect(screen.getByText("Free")).toBeInTheDocument();
+    expect(screen.getByText("No API spend on this run.")).toBeInTheDocument();
+  });
+
+  it("flags failed steps in the progress card", () => {
+    render(
+      <TelemetryRail
+        telemetry={{ ...telemetry, stepsFailed: 2 }}
+        throughput={0}
+        elapsedSeconds={5}
+        isLive={false}
+      />
+    );
+    expect(screen.getByText("2 steps failed")).toBeInTheDocument();
+  });
+});
+
+describe("Odometer", () => {
+  it("renders the target value immediately on mount (no fake count-up)", () => {
+    render(<Odometer value={12.5} decimals={2} prefix="$" />);
+    expect(screen.getByText("$12.50")).toBeInTheDocument();
+  });
+});
+
+describe("formatClock", () => {
+  it("formats mm:ss and hh:mm:ss", () => {
+    expect(formatClock(0)).toBe("00:00");
+    expect(formatClock(83)).toBe("01:23");
+    expect(formatClock(3723)).toBe("01:02:03");
+    expect(formatClock(-5)).toBe("00:00");
+  });
+});
+
+describe("ThoughtStream", () => {
+  const entries: FeedEntry[] = [
+    { id: "1", ts: new Date(), kind: "run", title: "Run started" },
+    { id: "2", ts: new Date(), kind: "step-start", stepId: "research", title: "research started" },
+    {
+      id: "3",
+      ts: new Date(),
+      kind: "output",
+      stepId: "research",
+      title: "research output",
+      detail: "Found 3 sources.",
+    },
+    { id: "4", ts: new Date(), kind: "step-fail", stepId: "report", title: "report failed", detail: "timeout" },
+  ];
+
+  it("renders feed entries with details", () => {
+    render(<ThoughtStream entries={entries} isLive />);
+    expect(screen.getByText("Run started")).toBeInTheDocument();
+    expect(screen.getByText("research started")).toBeInTheDocument();
+    expect(screen.getByText("Found 3 sources.")).toBeInTheDocument();
+    expect(screen.getByText("report failed")).toBeInTheDocument();
+    expect(screen.getByText("timeout")).toBeInTheDocument();
+    expect(screen.getByText("streaming")).toBeInTheDocument();
+  });
+
+  it("shows a waiting message when there are no events", () => {
+    render(<ThoughtStream entries={[]} isLive={false} />);
+    expect(screen.getByText("Waiting for events…")).toBeInTheDocument();
+    expect(screen.queryByText("streaming")).not.toBeInTheDocument();
+  });
+});

--- a/dashboard/src/__tests__/missionControl.test.ts
+++ b/dashboard/src/__tests__/missionControl.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect } from "vitest";
+import {
+  aggregateTelemetry,
+  applyMissionEvent,
+  buildThoughtFeed,
+  computeThroughput,
+  estimateTokens,
+  initialMissionState,
+  isTerminalRunStatus,
+  mergeLiveSteps,
+  outputPreview,
+  reduceMissionEvents,
+  synthesizeEventsFromSteps,
+  type MissionEvent,
+  type MissionStep,
+} from "@/lib/missionControl";
+
+/* ── Fixtures ── */
+
+const ts = (offsetSec: number) => new Date(Date.UTC(2026, 5, 9, 12, 0, offsetSec));
+
+const baseSteps: MissionStep[] = [
+  {
+    step_id: "research",
+    parallel_index: null,
+    status: "pending",
+    cost_usd: 0,
+    duration_seconds: 0,
+    model: "mistral/large",
+    output: null,
+  },
+  {
+    step_id: "analyze",
+    parallel_index: null,
+    status: "pending",
+    cost_usd: 0,
+    duration_seconds: 0,
+    model: "claude/sonnet",
+    output: null,
+  },
+  {
+    step_id: "report",
+    parallel_index: null,
+    status: "pending",
+    cost_usd: 0,
+    duration_seconds: 0,
+    output: null,
+  },
+];
+
+/** Canonical happy-path event log mirroring GET /runs/{id}/stream. */
+const happyPathEvents: MissionEvent[] = [
+  { event: "status", data: { run_id: "r1", status: "queued", total_cost_usd: 0 }, timestamp: ts(0) },
+  { event: "status", data: { run_id: "r1", status: "running", total_cost_usd: 0 }, timestamp: ts(1) },
+  { event: "step", data: { step_id: "research", parallel_index: null, status: "running", cost_usd: 0, duration_seconds: 0 }, timestamp: ts(2) },
+  { event: "step", data: { step_id: "research", parallel_index: null, status: "completed", cost_usd: 0.0123, duration_seconds: 4.2 }, timestamp: ts(6) },
+  { event: "status", data: { run_id: "r1", status: "running", total_cost_usd: 0.0123 }, timestamp: ts(6) },
+  { event: "step", data: { step_id: "analyze", parallel_index: null, status: "running", cost_usd: 0, duration_seconds: 0 }, timestamp: ts(7) },
+];
+
+const terminalEvents: MissionEvent[] = [
+  ...happyPathEvents,
+  { event: "step", data: { step_id: "analyze", parallel_index: null, status: "completed", cost_usd: 0.02, duration_seconds: 3.0 }, timestamp: ts(10) },
+  { event: "step", data: { step_id: "report", parallel_index: null, status: "running", cost_usd: 0, duration_seconds: 0 }, timestamp: ts(11) },
+  { event: "step", data: { step_id: "report", parallel_index: null, status: "failed", cost_usd: 0, duration_seconds: 1.1 }, timestamp: ts(12) },
+  { event: "result", data: { run_id: "r1", status: "failed", outputs: null, total_cost_usd: 0.0323, error: "report: sandbox timeout" }, timestamp: ts(12) },
+];
+
+/* ── State machine ── */
+
+describe("mission control state machine", () => {
+  it("starts from the run snapshot", () => {
+    const state = initialMissionState({ status: "queued", total_cost_usd: 0 });
+    expect(state.runStatus).toBe("queued");
+    expect(state.finished).toBe(false);
+    expect(state.totalCostUsd).toBe(0);
+  });
+
+  it("marks terminal statuses as finished from the snapshot", () => {
+    expect(initialMissionState({ status: "completed" }).finished).toBe(true);
+    expect(initialMissionState({ status: "failed" }).finished).toBe(true);
+    expect(initialMissionState({ status: "running" }).finished).toBe(false);
+  });
+
+  it("tracks run status, step overrides and cost through the happy path", () => {
+    const state = reduceMissionEvents(initialMissionState({ status: "queued" }), happyPathEvents);
+    expect(state.runStatus).toBe("running");
+    expect(state.finished).toBe(false);
+    expect(state.steps.research.status).toBe("completed");
+    expect(state.steps.research.costUsd).toBeCloseTo(0.0123);
+    expect(state.steps.analyze.status).toBe("running");
+    expect(state.totalCostUsd).toBeCloseTo(0.0123);
+  });
+
+  it("finishes on the result event and surfaces the error", () => {
+    const state = reduceMissionEvents(initialMissionState({ status: "queued" }), terminalEvents);
+    expect(state.finished).toBe(true);
+    expect(state.runStatus).toBe("failed");
+    expect(state.steps.report.status).toBe("failed");
+    expect(state.totalCostUsd).toBeCloseTo(0.0323);
+    expect(state.error).toBe("report: sandbox timeout");
+  });
+
+  it("cost never goes backwards even if events arrive stale", () => {
+    let state = reduceMissionEvents(initialMissionState({ status: "running" }), happyPathEvents);
+    state = applyMissionEvent(state, {
+      event: "status",
+      data: { status: "running", total_cost_usd: 0.001 },
+      timestamp: ts(8),
+    });
+    expect(state.totalCostUsd).toBeCloseTo(0.0123);
+  });
+
+  it("ignores unknown and malformed events", () => {
+    const initial = initialMissionState({ status: "running" });
+    const state = reduceMissionEvents(initial, [
+      { event: "keepalive", data: {}, timestamp: ts(0) },
+      { event: "step", data: { status: "running" }, timestamp: ts(1) }, // no step_id
+    ]);
+    expect(state).toEqual(initial);
+  });
+
+  it("merges live overrides onto REST steps", () => {
+    const state = reduceMissionEvents(initialMissionState({ status: "running" }), happyPathEvents);
+    const merged = mergeLiveSteps(baseSteps, state);
+    expect(merged.find((s) => s.step_id === "research")?.status).toBe("completed");
+    expect(merged.find((s) => s.step_id === "research")?.cost_usd).toBeCloseTo(0.0123);
+    expect(merged.find((s) => s.step_id === "analyze")?.status).toBe("running");
+    expect(merged.find((s) => s.step_id === "report")?.status).toBe("pending");
+  });
+
+  it("knows which run statuses are terminal", () => {
+    for (const s of ["completed", "failed", "partial", "cancelled", "budget_exceeded", "awaiting_approval"]) {
+      expect(isTerminalRunStatus(s)).toBe(true);
+    }
+    expect(isTerminalRunStatus("running")).toBe(false);
+    expect(isTerminalRunStatus("queued")).toBe(false);
+  });
+});
+
+/* ── Telemetry aggregation ── */
+
+describe("telemetry aggregation", () => {
+  it("estimates tokens from string and structured outputs", () => {
+    expect(estimateTokens(null)).toBe(0);
+    expect(estimateTokens("a".repeat(400))).toBe(100);
+    expect(estimateTokens({ text: "abcd" })).toBe(Math.round('{"text":"abcd"}'.length / 4));
+  });
+
+  it("aggregates steps, models, tokens and the active step", () => {
+    const state = reduceMissionEvents(initialMissionState({ status: "running" }), happyPathEvents);
+    const steps = mergeLiveSteps(
+      baseSteps.map((s) =>
+        s.step_id === "research" ? { ...s, output: "x".repeat(800) } : s
+      ),
+      state
+    );
+    const t = aggregateTelemetry(steps, state);
+    expect(t.stepsTotal).toBe(3);
+    expect(t.stepsDone).toBe(1);
+    expect(t.stepsRunning).toBe(1);
+    expect(t.stepsFailed).toBe(0);
+    expect(t.tokensEst).toBe(200);
+    expect(t.costUsd).toBeCloseTo(0.0123);
+    expect(t.models).toEqual(["mistral/large", "claude/sonnet"]);
+    expect(t.activeStepId).toBe("analyze");
+  });
+
+  it("falls back to the last finished step when nothing is running", () => {
+    const state = reduceMissionEvents(initialMissionState({ status: "queued" }), terminalEvents);
+    const steps = mergeLiveSteps(baseSteps, state);
+    const t = aggregateTelemetry(steps, state);
+    expect(t.stepsDone).toBe(2);
+    expect(t.stepsFailed).toBe(1);
+    expect(t.stepsRunning).toBe(0);
+    expect(t.activeStepId).toBe("report");
+  });
+
+  it("computes token throughput over a sliding window", () => {
+    const t0 = 1_000_000;
+    const samples = [
+      { t: t0, tokens: 0 },
+      { t: t0 + 5_000, tokens: 250 },
+      { t: t0 + 10_000, tokens: 500 },
+    ];
+    expect(computeThroughput(samples)).toBeCloseTo(50);
+    // Not enough signal
+    expect(computeThroughput([])).toBe(0);
+    expect(computeThroughput([{ t: t0, tokens: 100 }])).toBe(0);
+    // Token count flat => zero rate
+    expect(
+      computeThroughput([
+        { t: t0, tokens: 100 },
+        { t: t0 + 1000, tokens: 100 },
+      ])
+    ).toBe(0);
+  });
+});
+
+/* ── Thought stream feed ── */
+
+describe("thought stream feed", () => {
+  it("builds readable entries from the event log", () => {
+    const steps = baseSteps.map((s) =>
+      s.step_id === "research" ? { ...s, output: "Found 3 sources about sandcastles." } : s
+    );
+    const feed = buildThoughtFeed(terminalEvents, steps);
+
+    const titles = feed.map((e) => e.title);
+    expect(titles).toContain("Run started");
+    expect(titles).toContain("research started");
+    expect(titles.some((t) => t.startsWith("research completed"))).toBe(true);
+    expect(titles).toContain("report failed");
+    expect(titles).toContain("Run failed");
+
+    // Output preview is attached after the completion entry
+    const outputEntry = feed.find((e) => e.kind === "output");
+    expect(outputEntry?.stepId).toBe("research");
+    expect(outputEntry?.detail).toContain("Found 3 sources");
+
+    // Terminal failure carries the error detail
+    const errorEntry = feed.find((e) => e.title === "Run failed");
+    expect(errorEntry?.detail).toBe("report: sandbox timeout");
+  });
+
+  it("includes duration and cost metadata on completed steps", () => {
+    const feed = buildThoughtFeed(terminalEvents, baseSteps);
+    const research = feed.find((e) => e.kind === "step-done" && e.stepId === "research");
+    expect(research?.title).toContain("4.2s");
+    expect(research?.title).toContain("$0.0123");
+  });
+
+  it("truncates long output previews", () => {
+    expect(outputPreview("x".repeat(1000))?.length).toBeLessThanOrEqual(401);
+    expect(outputPreview(null)).toBeUndefined();
+    expect(outputPreview("   ")).toBeUndefined();
+  });
+
+  it("synthesizes an honest archive feed for finished runs", () => {
+    const finishedSteps: MissionStep[] = [
+      { ...baseSteps[0], status: "completed", cost_usd: 0.01, duration_seconds: 2, started_at: "2026-06-09T12:00:00", output: "result A" },
+      { ...baseSteps[1], status: "completed", cost_usd: 0.02, duration_seconds: 3, started_at: "2026-06-09T12:00:05" },
+    ];
+    const events = synthesizeEventsFromSteps(finishedSteps, {
+      status: "completed",
+      total_cost_usd: 0.03,
+      completed_at: "2026-06-09T12:00:10",
+    });
+    // Steps in start order, then the terminal result
+    expect(events.map((e) => e.event)).toEqual(["step", "step", "result"]);
+    expect(events[0].data.step_id).toBe("research");
+
+    const state = reduceMissionEvents(initialMissionState({ status: "completed" }), events);
+    expect(state.finished).toBe(true);
+    expect(state.totalCostUsd).toBeCloseTo(0.03);
+
+    const feed = buildThoughtFeed(events, finishedSteps);
+    expect(feed.find((e) => e.kind === "output")?.detail).toBe("result A");
+    expect(feed[feed.length - 1].title).toBe("Run completed");
+  });
+});

--- a/dashboard/src/components/runs/mission/MissionDag.tsx
+++ b/dashboard/src/components/runs/mission/MissionDag.tsx
@@ -1,0 +1,227 @@
+import { useEffect, useMemo } from "react";
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  Background,
+  useReactFlow,
+  type Node,
+  type Edge,
+  type NodeTypes,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import { StepNode } from "@/components/workflows/StepNode";
+import type { MissionStep } from "@/lib/missionControl";
+
+interface MissionDagProps {
+  steps: MissionStep[];
+  activeStepId: string | null;
+  follow: boolean;
+}
+
+const nodeTypes: NodeTypes = {
+  step: StepNode,
+};
+
+const DONE = new Set(["completed", "skipped"]);
+
+/** Collapse parallel fan-out rows into one node per step_id. */
+function collapseSteps(steps: MissionStep[]): MissionStep[] {
+  const byId = new Map<string, MissionStep>();
+  for (const step of steps) {
+    const existing = byId.get(step.step_id);
+    if (!existing) {
+      byId.set(step.step_id, { ...step });
+      continue;
+    }
+    // Aggregate: failed > running > queued > pending; completed only when all done
+    const merged = { ...existing };
+    merged.cost_usd = (existing.cost_usd ?? 0) + (step.cost_usd ?? 0);
+    if (step.status === "failed" || existing.status === "failed") {
+      merged.status = "failed";
+    } else if (step.status === "running" || existing.status === "running") {
+      merged.status = "running";
+    } else if (!DONE.has(step.status) || !DONE.has(existing.status)) {
+      merged.status = DONE.has(step.status) ? existing.status : step.status;
+    }
+    byId.set(step.step_id, merged);
+  }
+  return [...byId.values()];
+}
+
+function nodeOpacity(status: string): number {
+  if (status === "pending") return 0.45;
+  if (status === "queued") return 0.7;
+  return 1;
+}
+
+function edgeStyle(sourceStatus: string, targetStatus: string): Partial<Edge> {
+  const sourceDone = DONE.has(sourceStatus);
+  // Data is flowing: upstream finished, downstream consuming it
+  if (sourceDone && targetStatus === "running") {
+    return {
+      animated: true,
+      style: { stroke: "var(--color-success)", strokeWidth: 2 },
+    };
+  }
+  if (sourceStatus === "failed") {
+    return {
+      animated: false,
+      style: { stroke: "var(--color-error)", strokeWidth: 2, opacity: 0.9 },
+    };
+  }
+  if (sourceDone) {
+    return {
+      animated: false,
+      style: { stroke: "var(--color-success)", strokeWidth: 2, opacity: 0.75 },
+    };
+  }
+  if (sourceStatus === "running") {
+    return {
+      animated: true,
+      style: { stroke: "var(--color-accent)", strokeWidth: 2, opacity: 0.9 },
+    };
+  }
+  return {
+    animated: false,
+    style: { stroke: "var(--color-border)", strokeWidth: 1.5, opacity: 0.7 },
+  };
+}
+
+function MissionDagInner({ steps, activeStepId, follow }: MissionDagProps) {
+  const reactFlow = useReactFlow();
+  const collapsed = useMemo(() => collapseSteps(steps), [steps]);
+
+  const { nodes, edges } = useMemo(() => {
+    // Layered layout via topological depth (same approach as DagGraph)
+    const depMap = new Map<string, string[]>();
+    const statusMap = new Map<string, string>();
+    collapsed.forEach((s) => {
+      depMap.set(s.step_id, s.depends_on || []);
+      statusMap.set(s.step_id, s.status);
+    });
+
+    const layers = new Map<string, number>();
+    const visited = new Set<string>();
+
+    function getLayer(id: string): number {
+      if (layers.has(id)) return layers.get(id)!;
+      if (visited.has(id)) return 0; // cycle guard
+      visited.add(id);
+
+      const deps = (depMap.get(id) || []).filter((d) => depMap.has(d));
+      if (deps.length === 0) {
+        layers.set(id, 0);
+        return 0;
+      }
+      const maxDep = Math.max(...deps.map(getLayer));
+      const layer = maxDep + 1;
+      layers.set(id, layer);
+      return layer;
+    }
+
+    collapsed.forEach((s) => getLayer(s.step_id));
+
+    const layerGroups: Map<number, string[]> = new Map();
+    collapsed.forEach((s) => {
+      const layer = layers.get(s.step_id) || 0;
+      if (!layerGroups.has(layer)) layerGroups.set(layer, []);
+      layerGroups.get(layer)!.push(s.step_id);
+    });
+
+    const xSpacing = 220;
+    const ySpacing = 140;
+
+    const nodes: Node[] = collapsed.map((s) => {
+      const layer = layers.get(s.step_id) || 0;
+      const group = layerGroups.get(layer) || [s.step_id];
+      const indexInLayer = group.indexOf(s.step_id);
+      const totalInLayer = group.length;
+      const xOffset = (indexInLayer - (totalInLayer - 1) / 2) * xSpacing;
+      const isActive = s.step_id === activeStepId;
+
+      return {
+        id: s.step_id,
+        type: "step",
+        position: { x: 400 + xOffset, y: layer * ySpacing + 60 },
+        className:
+          s.status === "completed"
+            ? "mission-node-flash"
+            : s.status === "failed"
+              ? "mission-node-flash-error"
+              : undefined,
+        style: {
+          opacity: nodeOpacity(s.status),
+          transition: "opacity 300ms ease",
+        },
+        selected: isActive,
+        data: {
+          label: s.step_id,
+          model: s.model ?? undefined,
+          status: s.status,
+        },
+      };
+    });
+
+    const edges: Edge[] = [];
+    collapsed.forEach((s) => {
+      (s.depends_on || []).forEach((dep) => {
+        if (!statusMap.has(dep)) return;
+        edges.push({
+          id: `${dep}-${s.step_id}`,
+          source: dep,
+          target: s.step_id,
+          ...edgeStyle(statusMap.get(dep) ?? "pending", s.status),
+        });
+      });
+    });
+
+    return { nodes, edges };
+  }, [collapsed, activeStepId]);
+
+  // Auto-pan/zoom to the active node while following the run
+  useEffect(() => {
+    if (!follow || !activeStepId) return;
+    // Defer one frame so the node exists in the flow before fitting
+    const raf = requestAnimationFrame(() => {
+      void reactFlow.fitView({
+        nodes: [{ id: activeStepId }],
+        duration: 600,
+        padding: 2.5,
+        maxZoom: 1.1,
+      });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [follow, activeStepId, reactFlow]);
+
+  // Re-frame the whole graph when follow is switched off
+  useEffect(() => {
+    if (follow) return;
+    void reactFlow.fitView({ duration: 600, padding: 0.2 });
+  }, [follow, reactFlow]);
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      nodeTypes={nodeTypes}
+      fitView
+      minZoom={0.2}
+      proOptions={{ hideAttribution: true }}
+      nodesDraggable={false}
+      nodesConnectable={false}
+      elementsSelectable={false}
+      panOnScroll
+      zoomOnScroll
+    >
+      <Background gap={24} size={1.5} color="var(--color-border)" />
+    </ReactFlow>
+  );
+}
+
+export function MissionDag(props: MissionDagProps) {
+  return (
+    <ReactFlowProvider>
+      <MissionDagInner {...props} />
+    </ReactFlowProvider>
+  );
+}

--- a/dashboard/src/components/runs/mission/TelemetryRail.tsx
+++ b/dashboard/src/components/runs/mission/TelemetryRail.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useRef, useState } from "react";
+import { Coins, Cpu, Gauge, Layers, Timer } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { formatClock, type Telemetry } from "@/lib/missionControl";
+
+/* ── Animated odometer ── */
+
+interface OdometerProps {
+  value: number;
+  decimals?: number;
+  prefix?: string;
+  className?: string;
+  durationMs?: number;
+}
+
+/**
+ * Odometer-style number that eases toward its target value.
+ * Renders the final value immediately on first mount (no fake count-up),
+ * then animates on subsequent changes. Tabular numerals prevent layout
+ * shift while ticking.
+ */
+export function Odometer({ value, decimals = 2, prefix = "", className, durationMs = 700 }: OdometerProps) {
+  const [display, setDisplay] = useState(value);
+  const fromRef = useRef(value);
+  const rafRef = useRef<number | null>(null);
+  const mountedRef = useRef(false);
+
+  useEffect(() => {
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      fromRef.current = value;
+      setDisplay(value);
+      return;
+    }
+    const from = fromRef.current;
+    if (from === value) return;
+    const start = performance.now();
+
+    const tick = (now: number) => {
+      const t = Math.min((now - start) / durationMs, 1);
+      // ease-out cubic
+      const eased = 1 - Math.pow(1 - t, 3);
+      const current = from + (value - from) * eased;
+      setDisplay(current);
+      if (t < 1) {
+        rafRef.current = requestAnimationFrame(tick);
+      } else {
+        fromRef.current = value;
+        rafRef.current = null;
+      }
+    };
+
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      fromRef.current = value;
+    };
+  }, [value, durationMs]);
+
+  return (
+    <span className={cn("font-data", className)}>
+      {prefix}
+      {display.toLocaleString("en-US", {
+        minimumFractionDigits: decimals,
+        maximumFractionDigits: decimals,
+      })}
+    </span>
+  );
+}
+
+/* ── Rail ── */
+
+interface TelemetryRailProps {
+  telemetry: Telemetry;
+  throughput: number;
+  elapsedSeconds: number;
+  isLive: boolean;
+}
+
+function StatLabel({ icon: Icon, children }: { icon: typeof Coins; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+      <Icon className="h-3 w-3" />
+      {children}
+    </div>
+  );
+}
+
+export function TelemetryRail({ telemetry, throughput, elapsedSeconds, isLive }: TelemetryRailProps) {
+  const { costUsd, tokensEst, stepsTotal, stepsDone, stepsFailed, models } = telemetry;
+  const finishedSteps = stepsDone + stepsFailed;
+  const progressPct = stepsTotal > 0 ? (finishedSteps / stepsTotal) * 100 : 0;
+  const isFree = costUsd === 0;
+
+  return (
+    <div className="shrink-0 space-y-3 border-b border-border p-4">
+      {/* Cost - the hero number */}
+      <div className="rounded-xl border border-border bg-surface p-4">
+        <div className="flex items-center justify-between">
+          <StatLabel icon={Coins}>Run cost</StatLabel>
+          {isFree && (
+            <span className="rounded-full bg-success/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-success">
+              Free
+            </span>
+          )}
+        </div>
+        <div className="mt-1.5">
+          <Odometer
+            value={costUsd}
+            decimals={isFree ? 2 : 4}
+            prefix="$"
+            className={cn(
+              "text-3xl font-semibold tracking-tight",
+              isFree ? "text-success" : "text-accent"
+            )}
+          />
+        </div>
+        {isFree && (
+          <p className="mt-1 text-[11px] text-muted">No API spend on this run.</p>
+        )}
+      </div>
+
+      {/* Secondary stats grid */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="rounded-xl border border-border bg-surface p-3">
+          <StatLabel icon={Gauge}>Tokens</StatLabel>
+          <div className="mt-1">
+            <Odometer value={tokensEst} decimals={0} className="text-lg font-semibold text-foreground" />
+            <span className="ml-1 text-[10px] text-muted-foreground">est.</span>
+          </div>
+          <p className="font-data mt-0.5 text-[11px] text-muted">
+            {isLive && throughput > 0 ? `${Math.round(throughput)} tok/s` : "—"}
+          </p>
+        </div>
+
+        <div className="rounded-xl border border-border bg-surface p-3">
+          <StatLabel icon={Timer}>Elapsed</StatLabel>
+          <div className="font-data mt-1 text-lg font-semibold text-foreground">
+            {formatClock(elapsedSeconds)}
+          </div>
+          <p className="mt-0.5 text-[11px] text-muted">{isLive ? "live" : "final"}</p>
+        </div>
+      </div>
+
+      {/* Step progress */}
+      <div className="rounded-xl border border-border bg-surface p-3">
+        <div className="flex items-center justify-between">
+          <StatLabel icon={Layers}>Steps</StatLabel>
+          <span className="font-data text-sm font-semibold text-foreground">
+            {finishedSteps}/{stepsTotal}
+          </span>
+        </div>
+        <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-border/60">
+          <div
+            className={cn(
+              "h-full rounded-full transition-[width] duration-500 ease-out",
+              stepsFailed > 0 ? "bg-error" : "bg-success"
+            )}
+            style={{ width: `${progressPct}%` }}
+          />
+        </div>
+        {stepsFailed > 0 && (
+          <p className="mt-1.5 text-[11px] text-error">
+            {stepsFailed} step{stepsFailed > 1 ? "s" : ""} failed
+          </p>
+        )}
+      </div>
+
+      {/* Models in use */}
+      <div className="rounded-xl border border-border bg-surface p-3">
+        <StatLabel icon={Cpu}>Models</StatLabel>
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {models.length === 0 ? (
+            <span className="text-[11px] text-muted">—</span>
+          ) : (
+            models.map((model) => (
+              <span
+                key={model}
+                className="rounded-md bg-accent/10 px-2 py-0.5 font-mono text-[10px] font-medium text-accent"
+              >
+                {model}
+              </span>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/runs/mission/ThoughtStream.tsx
+++ b/dashboard/src/components/runs/mission/ThoughtStream.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useRef, useState } from "react";
+import { Pause, Terminal } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { FeedEntry, FeedKind } from "@/lib/missionControl";
+
+const KIND_COLORS: Record<FeedKind, string> = {
+  run: "text-accent",
+  "step-start": "text-running",
+  "step-done": "text-success",
+  "step-fail": "text-error",
+  output: "text-muted",
+  error: "text-error",
+};
+
+const KIND_MARKERS: Record<FeedKind, string> = {
+  run: "◆",
+  "step-start": "▸",
+  "step-done": "✓",
+  "step-fail": "✗",
+  output: "·",
+  error: "!",
+};
+
+function formatTime(ts: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(ts.getHours())}:${pad(ts.getMinutes())}:${pad(ts.getSeconds())}`;
+}
+
+interface ThoughtStreamProps {
+  entries: FeedEntry[];
+  isLive: boolean;
+}
+
+/**
+ * Scrolling live feed of step events, monospace, auto-scroll with
+ * pause-on-hover so the operator can read without the log running away.
+ */
+export function ThoughtStream({ entries, isLive }: ThoughtStreamProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [hovered, setHovered] = useState(false);
+
+  // Auto-scroll to the latest entry unless the operator is reading
+  useEffect(() => {
+    if (hovered) return;
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [entries.length, hovered]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-center gap-2 border-b border-border px-4 py-2.5">
+        <Terminal className="h-3.5 w-3.5 text-accent" />
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Thought stream
+        </span>
+        <span className="ml-auto flex items-center gap-1.5">
+          {hovered && isLive ? (
+            <span className="flex items-center gap-1 rounded-full bg-warning/15 px-2 py-0.5 text-[10px] font-medium text-warning">
+              <Pause className="h-2.5 w-2.5" />
+              paused
+            </span>
+          ) : isLive ? (
+            <span className="flex items-center gap-1.5 text-[10px] font-medium text-success">
+              <span className="status-dot-running inline-block h-1.5 w-1.5 rounded-full bg-success" />
+              streaming
+            </span>
+          ) : null}
+        </span>
+      </div>
+
+      <div
+        ref={scrollRef}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        className="min-h-0 flex-1 overflow-y-auto px-4 py-3 font-mono text-xs leading-relaxed"
+      >
+        {entries.length === 0 ? (
+          <p className="text-muted">Waiting for events…</p>
+        ) : (
+          <ol className="space-y-1.5">
+            {entries.map((entry) => (
+              <li key={entry.id} className="mission-feed-line">
+                <div className="flex items-baseline gap-2">
+                  <span className="shrink-0 text-[10px] text-muted-foreground">
+                    {formatTime(entry.ts)}
+                  </span>
+                  <span className={cn("shrink-0", KIND_COLORS[entry.kind])}>
+                    {KIND_MARKERS[entry.kind]}
+                  </span>
+                  <span
+                    className={cn(
+                      "break-words",
+                      entry.kind === "output" ? "text-muted" : "text-foreground"
+                    )}
+                  >
+                    {entry.title}
+                  </span>
+                </div>
+                {entry.detail && (
+                  <pre
+                    className={cn(
+                      "mt-1 ml-[4.5rem] max-h-40 overflow-hidden whitespace-pre-wrap break-words rounded-md border border-border/60 bg-background/60 px-2.5 py-1.5 text-[11px]",
+                      entry.kind === "step-fail" || entry.kind === "error"
+                        ? "text-error/90"
+                        : "text-muted"
+                    )}
+                  >
+                    {entry.detail}
+                  </pre>
+                )}
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/hooks/useRunStream.ts
+++ b/dashboard/src/hooks/useRunStream.ts
@@ -1,0 +1,181 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api } from "@/api/client";
+import { API_BASE_URL } from "@/lib/constants";
+import type { MissionEvent } from "@/lib/missionControl";
+
+export type RunStreamStatus = "idle" | "connecting" | "connected" | "reconnecting" | "done" | "offline";
+
+// Reconnect with exponential backoff - starts at 1s, maxes at 15s
+const BASE_DELAY_MS = 1000;
+const MAX_DELAY_MS = 15000;
+const MAX_ATTEMPTS = 8;
+
+function getBackoffDelay(attempt: number): number {
+  const delay = Math.min(BASE_DELAY_MS * Math.pow(2, attempt), MAX_DELAY_MS);
+  return delay + Math.random() * 400;
+}
+
+/**
+ * Per-run SSE stream (GET /runs/{id}/stream) with automatic reconnection.
+ *
+ * Unlike useSSE this hook reconnects with backoff on connection loss and
+ * stops cleanly once the terminal `result` event arrives. Uses fetch with
+ * auth headers instead of native EventSource so the API key never appears
+ * in URL query parameters.
+ */
+export function useRunStream(runId: string | null, enabled: boolean) {
+  const [events, setEvents] = useState<MissionEvent[]>([]);
+  const [status, setStatus] = useState<RunStreamStatus>("idle");
+  const abortRef = useRef<AbortController | null>(null);
+  const attemptRef = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const unmountedRef = useRef(false);
+  const doneRef = useRef(false);
+  // Read via ref inside connect so the callback identity stays stable.
+  const runIdRef = useRef(runId);
+  // Latest connect function for reconnection timers (avoids a self-reference
+  // inside the useCallback body, which react-hooks forbids).
+  const connectRef = useRef<() => void>(() => {});
+
+  // Same idiom as useEventStream: the reconnect scheduler receives the
+  // connect function instead of closing over it directly.
+  const scheduleReconnect = useCallback((connectFn: () => void) => {
+    if (unmountedRef.current || doneRef.current) return;
+    if (attemptRef.current >= MAX_ATTEMPTS) {
+      setStatus("offline");
+      return;
+    }
+    const delay = getBackoffDelay(attemptRef.current);
+    attemptRef.current += 1;
+    setStatus("reconnecting");
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      connectFn();
+    }, delay);
+  }, []);
+
+  const connect = useCallback(() => {
+    const currentRunId = runIdRef.current;
+    if (!currentRunId || unmountedRef.current || doneRef.current) return;
+    // In mock/demo mode there is no backend to stream from
+    if (api.isMockMode) {
+      setStatus("offline");
+      return;
+    }
+
+    if (abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+
+    setStatus(attemptRef.current > 0 ? "reconnecting" : "connecting");
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    const url = `${API_BASE_URL}/runs/${currentRunId}/stream`;
+
+    (async () => {
+      try {
+        const res = await fetch(url, {
+          headers: api.authHeaders(),
+          signal: controller.signal,
+        });
+
+        if (!res.ok || !res.body) {
+          scheduleReconnect(() => connectRef.current());
+          return;
+        }
+
+        setStatus("connected");
+        attemptRef.current = 0;
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        let currentEvent = "message";
+        let currentData = "";
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() || "";
+
+          for (const line of lines) {
+            if (line.startsWith("event: ")) {
+              currentEvent = line.slice(7).trim();
+            } else if (line.startsWith("data: ")) {
+              currentData += (currentData ? "\n" : "") + line.slice(6);
+            } else if (line.trim() === "" && currentData) {
+              try {
+                const data = JSON.parse(currentData) as Record<string, unknown>;
+                const eventType = currentEvent;
+                if (eventType === "result") doneRef.current = true;
+                setEvents((prev) => {
+                  const updated = [...prev, { event: eventType, data, timestamp: new Date() }];
+                  if (updated.length > 1000) return updated.slice(-1000);
+                  return updated;
+                });
+              } catch {
+                // Ignore parse errors on malformed messages
+              }
+              currentEvent = "message";
+              currentData = "";
+            }
+          }
+        }
+
+        // Stream ended. Terminal `result` => done; otherwise reconnect.
+        if (unmountedRef.current) return;
+        if (doneRef.current) {
+          setStatus("done");
+        } else {
+          scheduleReconnect(() => connectRef.current());
+        }
+      } catch (e: unknown) {
+        if (e instanceof DOMException && e.name === "AbortError") return;
+        scheduleReconnect(() => connectRef.current());
+      }
+    })();
+  }, [scheduleReconnect]);
+
+  useEffect(() => {
+    connectRef.current = connect;
+  }, [connect]);
+
+  // Manual retry after the hook gave up (status === "offline")
+  const retry = useCallback(() => {
+    attemptRef.current = 0;
+    connect();
+  }, [connect]);
+
+  useEffect(() => {
+    unmountedRef.current = false;
+    doneRef.current = false;
+    attemptRef.current = 0;
+    runIdRef.current = runId;
+    setEvents([]);
+
+    if (enabled && runId) {
+      connect();
+    } else {
+      setStatus("idle");
+    }
+
+    return () => {
+      unmountedRef.current = true;
+      if (abortRef.current) {
+        abortRef.current.abort();
+        abortRef.current = null;
+      }
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [runId, enabled, connect]);
+
+  return { events, status, retry };
+}

--- a/dashboard/src/index.css
+++ b/dashboard/src/index.css
@@ -458,6 +458,33 @@ button:active:not(:disabled), [role="button"]:active:not(:disabled), .btn:active
   animation: celebration-checkmark-draw 0.5s ease-out 0.3s both;
 }
 
+/* ──── Mission Control (live run theater) ──── */
+
+/* One-shot green glow when a node lands in the completed state */
+@keyframes mission-flash-success {
+  0%   { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.55); }
+  100% { box-shadow: 0 0 0 14px rgba(34, 197, 94, 0); }
+}
+.mission-node-flash {
+  animation: mission-flash-success 900ms ease-out both;
+  border-radius: var(--radius-lg);
+}
+
+/* One-shot red glow when a node fails */
+@keyframes mission-flash-error {
+  0%   { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.55); }
+  100% { box-shadow: 0 0 0 14px rgba(239, 68, 68, 0); }
+}
+.mission-node-flash-error {
+  animation: mission-flash-error 900ms ease-out both;
+  border-radius: var(--radius-lg);
+}
+
+/* Thought stream lines slide in like a terminal log */
+.mission-feed-line {
+  animation: log-line-enter 200ms ease-out both;
+}
+
 /* Accessibility: disable animations for users who prefer reduced motion */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
@@ -485,7 +512,10 @@ button:active:not(:disabled), [role="button"]:active:not(:disabled), .btn:active
   .celebration-modal-enter,
   .celebration-checkmark-draw,
   .animate-bell-shake,
-  .animate-scale-in {
+  .animate-scale-in,
+  .mission-node-flash,
+  .mission-node-flash-error,
+  .mission-feed-line {
     animation: none !important;
   }
   .btn-shimmer::after {

--- a/dashboard/src/lib/missionControl.ts
+++ b/dashboard/src/lib/missionControl.ts
@@ -1,0 +1,441 @@
+/**
+ * Mission Control - pure state machine and telemetry aggregation for the
+ * live run theater (/runs/:id/live).
+ *
+ * The backend streams SSE events from GET /runs/{run_id}/stream:
+ *   - event: status  data: { run_id, status, total_cost_usd }
+ *   - event: step    data: { step_id, parallel_index, status, cost_usd, duration_seconds }
+ *   - event: result  data: { run_id, status, outputs, total_cost_usd, error }
+ *   - event: error   data: { message }
+ *
+ * Everything in this file is pure so the theater can be developed and
+ * tested against event fixtures without a live backend.
+ */
+
+import { parseUTC } from "@/lib/utils";
+
+/* ── Types ── */
+
+export interface MissionStep {
+  step_id: string;
+  parallel_index: number | null;
+  status: string;
+  cost_usd: number;
+  duration_seconds: number;
+  model?: string | null;
+  output?: unknown;
+  error?: string | null;
+  started_at?: string | null;
+  depends_on?: string[];
+}
+
+export interface MissionEvent {
+  event: string;
+  data: Record<string, unknown>;
+  timestamp: Date;
+}
+
+export interface StepOverride {
+  status: string;
+  costUsd: number;
+  durationSeconds: number;
+}
+
+export interface MissionState {
+  runStatus: string;
+  totalCostUsd: number;
+  /** Live per-step overrides keyed by step_id (latest event wins). */
+  steps: Record<string, StepOverride>;
+  /** True once a terminal `result` event (or terminal status) was seen. */
+  finished: boolean;
+  error: string | null;
+}
+
+export interface Telemetry {
+  costUsd: number;
+  tokensEst: number;
+  stepsTotal: number;
+  stepsDone: number;
+  stepsFailed: number;
+  stepsRunning: number;
+  models: string[];
+  activeStepId: string | null;
+}
+
+export type FeedKind = "run" | "step-start" | "step-done" | "step-fail" | "output" | "error";
+
+export interface FeedEntry {
+  id: string;
+  ts: Date;
+  kind: FeedKind;
+  stepId?: string;
+  title: string;
+  detail?: string;
+}
+
+/* ── Run status helpers ── */
+
+export const TERMINAL_RUN_STATUSES = new Set([
+  "completed",
+  "failed",
+  "partial",
+  "cancelled",
+  "budget_exceeded",
+  "awaiting_approval",
+]);
+
+export function isTerminalRunStatus(status: string): boolean {
+  return TERMINAL_RUN_STATUSES.has(status);
+}
+
+const DONE_STEP_STATUSES = new Set(["completed", "skipped"]);
+
+/* ── State machine ── */
+
+export function initialMissionState(run?: {
+  status?: string;
+  total_cost_usd?: number;
+}): MissionState {
+  const status = run?.status ?? "queued";
+  return {
+    runStatus: status,
+    totalCostUsd: run?.total_cost_usd ?? 0,
+    steps: {},
+    finished: isTerminalRunStatus(status),
+    error: null,
+  };
+}
+
+/** Apply a single SSE event to the mission state. Returns a new state. */
+export function applyMissionEvent(state: MissionState, event: MissionEvent): MissionState {
+  switch (event.event) {
+    case "status": {
+      const status = typeof event.data.status === "string" ? event.data.status : state.runStatus;
+      const cost =
+        typeof event.data.total_cost_usd === "number"
+          ? event.data.total_cost_usd
+          : state.totalCostUsd;
+      return {
+        ...state,
+        runStatus: status,
+        totalCostUsd: Math.max(state.totalCostUsd, cost),
+        finished: state.finished || isTerminalRunStatus(status),
+      };
+    }
+    case "step": {
+      const stepId = typeof event.data.step_id === "string" ? event.data.step_id : null;
+      if (!stepId) return state;
+      const status = typeof event.data.status === "string" ? event.data.status : "running";
+      const costUsd = typeof event.data.cost_usd === "number" ? event.data.cost_usd : 0;
+      const durationSeconds =
+        typeof event.data.duration_seconds === "number" ? event.data.duration_seconds : 0;
+      return {
+        ...state,
+        steps: {
+          ...state.steps,
+          [stepId]: { status, costUsd, durationSeconds },
+        },
+      };
+    }
+    case "result": {
+      const status = typeof event.data.status === "string" ? event.data.status : state.runStatus;
+      const cost =
+        typeof event.data.total_cost_usd === "number"
+          ? event.data.total_cost_usd
+          : state.totalCostUsd;
+      const error = typeof event.data.error === "string" ? event.data.error : null;
+      return {
+        ...state,
+        runStatus: status,
+        totalCostUsd: Math.max(state.totalCostUsd, cost),
+        finished: true,
+        error,
+      };
+    }
+    case "error": {
+      const message = typeof event.data.message === "string" ? event.data.message : "Stream error";
+      return { ...state, error: message };
+    }
+    default:
+      return state;
+  }
+}
+
+/** Fold a list of events over an initial state (fixture-driven testing). */
+export function reduceMissionEvents(state: MissionState, events: MissionEvent[]): MissionState {
+  return events.reduce(applyMissionEvent, state);
+}
+
+/**
+ * Merge live SSE overrides into the steps fetched from the REST API.
+ * SSE events win on status; REST data wins on output/model/error detail.
+ */
+export function mergeLiveSteps(baseSteps: MissionStep[], state: MissionState): MissionStep[] {
+  return baseSteps.map((step) => {
+    const override = state.steps[step.step_id];
+    if (!override) return step;
+    return {
+      ...step,
+      status: override.status,
+      cost_usd: Math.max(step.cost_usd ?? 0, override.costUsd),
+      duration_seconds: Math.max(step.duration_seconds ?? 0, override.durationSeconds),
+    };
+  });
+}
+
+/* ── Telemetry aggregation ── */
+
+/** Rough token estimate from an arbitrary step output (~4 chars per token). */
+export function estimateTokens(output: unknown): number {
+  if (output == null) return 0;
+  let chars = 0;
+  if (typeof output === "string") {
+    chars = output.length;
+  } else {
+    try {
+      chars = JSON.stringify(output)?.length ?? 0;
+    } catch {
+      chars = 0;
+    }
+  }
+  return Math.round(chars / 4);
+}
+
+export function aggregateTelemetry(steps: MissionStep[], state: MissionState): Telemetry {
+  let tokensEst = 0;
+  let stepsDone = 0;
+  let stepsFailed = 0;
+  let stepsRunning = 0;
+  const models = new Set<string>();
+  let activeStepId: string | null = null;
+  let lastDoneStepId: string | null = null;
+
+  for (const step of steps) {
+    if (step.model) models.add(step.model);
+    tokensEst += estimateTokens(step.output);
+    if (DONE_STEP_STATUSES.has(step.status)) {
+      stepsDone += 1;
+      lastDoneStepId = step.step_id;
+    } else if (step.status === "failed") {
+      stepsFailed += 1;
+      lastDoneStepId = step.step_id;
+    } else if (step.status === "running") {
+      stepsRunning += 1;
+      if (!activeStepId) activeStepId = step.step_id;
+    }
+  }
+
+  return {
+    costUsd: state.totalCostUsd,
+    tokensEst,
+    stepsTotal: steps.length,
+    stepsDone,
+    stepsFailed,
+    stepsRunning,
+    models: [...models],
+    activeStepId: activeStepId ?? lastDoneStepId,
+  };
+}
+
+/**
+ * Token throughput over a sliding window from (time, cumulative tokens)
+ * samples. Returns tokens/second, 0 when there is not enough signal.
+ */
+export function computeThroughput(
+  samples: { t: number; tokens: number }[],
+  windowMs = 30_000
+): number {
+  if (samples.length < 2) return 0;
+  const latest = samples[samples.length - 1];
+  const cutoff = latest.t - windowMs;
+  // Oldest sample still inside the window (samples are time-ordered)
+  let oldest = samples[0];
+  for (const s of samples) {
+    if (s.t >= cutoff) {
+      oldest = s;
+      break;
+    }
+  }
+  const dt = (latest.t - oldest.t) / 1000;
+  if (dt <= 0) return 0;
+  const delta = latest.tokens - oldest.tokens;
+  return delta > 0 ? delta / dt : 0;
+}
+
+/** Control-room clock format: mm:ss, or hh:mm:ss past the hour. */
+export function formatClock(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return "00:00";
+  const s = Math.floor(seconds);
+  const hh = Math.floor(s / 3600);
+  const mm = Math.floor((s % 3600) / 60);
+  const ss = s % 60;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return hh > 0 ? `${pad(hh)}:${pad(mm)}:${pad(ss)}` : `${pad(mm)}:${pad(ss)}`;
+}
+
+/* ── Thought stream feed ── */
+
+const RUN_STATUS_TITLES: Record<string, string> = {
+  queued: "Run queued — waiting for a runner",
+  running: "Run started",
+  completed: "Run completed",
+  failed: "Run failed",
+  partial: "Run finished partially",
+  cancelled: "Run cancelled",
+  budget_exceeded: "Run stopped — budget exceeded",
+  awaiting_approval: "Run paused — awaiting approval",
+};
+
+export function outputPreview(output: unknown, maxChars = 400): string | undefined {
+  if (output == null) return undefined;
+  let text: string;
+  if (typeof output === "string") {
+    text = output;
+  } else {
+    try {
+      text = JSON.stringify(output, null, 2) ?? "";
+    } catch {
+      return undefined;
+    }
+  }
+  text = text.trim();
+  if (!text) return undefined;
+  return text.length > maxChars ? `${text.slice(0, maxChars)}…` : text;
+}
+
+/**
+ * Synthesize an event log for a finished run that has no live SSE events
+ * (the operator opened Mission Control after the fact). Renders the final
+ * state honestly - no fake replay, just the recorded step results in order.
+ */
+export function synthesizeEventsFromSteps(
+  steps: MissionStep[],
+  run: { status: string; total_cost_usd?: number; error?: string | null; completed_at?: string | null }
+): MissionEvent[] {
+  const ordered = [...steps].sort((a, b) => {
+    const ta = a.started_at ? parseUTC(a.started_at).getTime() : 0;
+    const tb = b.started_at ? parseUTC(b.started_at).getTime() : 0;
+    return ta - tb;
+  });
+
+  const events: MissionEvent[] = [];
+  for (const step of ordered) {
+    const ts = step.started_at ? parseUTC(step.started_at) : new Date(0);
+    events.push({
+      event: "step",
+      data: {
+        step_id: step.step_id,
+        parallel_index: step.parallel_index,
+        status: step.status,
+        cost_usd: step.cost_usd,
+        duration_seconds: step.duration_seconds,
+      },
+      timestamp: ts,
+    });
+  }
+  events.push({
+    event: "result",
+    data: {
+      status: run.status,
+      total_cost_usd: run.total_cost_usd ?? 0,
+      error: run.error ?? null,
+    },
+    timestamp: run.completed_at ? parseUTC(run.completed_at) : new Date(0),
+  });
+  return events;
+}
+
+/**
+ * Build the thought-stream feed from the SSE event log, enriching completed
+ * step entries with output previews from the REST snapshot.
+ */
+export function buildThoughtFeed(events: MissionEvent[], steps: MissionStep[]): FeedEntry[] {
+  const stepsById = new Map(steps.map((s) => [s.step_id, s]));
+  const entries: FeedEntry[] = [];
+
+  events.forEach((event, i) => {
+    const id = `evt-${i}`;
+    switch (event.event) {
+      case "status": {
+        const status = typeof event.data.status === "string" ? event.data.status : "unknown";
+        entries.push({
+          id,
+          ts: event.timestamp,
+          kind: "run",
+          title: RUN_STATUS_TITLES[status] ?? `Run status: ${status}`,
+        });
+        break;
+      }
+      case "step": {
+        const stepId = typeof event.data.step_id === "string" ? event.data.step_id : "step";
+        const status = typeof event.data.status === "string" ? event.data.status : "running";
+        const step = stepsById.get(stepId);
+        if (status === "running" || status === "queued") {
+          entries.push({
+            id,
+            ts: event.timestamp,
+            kind: "step-start",
+            stepId,
+            title: `${stepId} ${status === "queued" ? "queued" : "started"}`,
+            detail: step?.model ? `model: ${step.model}` : undefined,
+          });
+        } else if (status === "failed") {
+          entries.push({
+            id,
+            ts: event.timestamp,
+            kind: "step-fail",
+            stepId,
+            title: `${stepId} failed`,
+            detail: step?.error ?? undefined,
+          });
+        } else {
+          const duration =
+            typeof event.data.duration_seconds === "number" ? event.data.duration_seconds : 0;
+          const cost = typeof event.data.cost_usd === "number" ? event.data.cost_usd : 0;
+          const meta: string[] = [];
+          if (duration > 0) meta.push(`${duration.toFixed(1)}s`);
+          if (cost > 0) meta.push(`$${cost.toFixed(4)}`);
+          entries.push({
+            id,
+            ts: event.timestamp,
+            kind: "step-done",
+            stepId,
+            title: `${stepId} ${status}${meta.length ? ` (${meta.join(" · ")})` : ""}`,
+          });
+          const preview = outputPreview(step?.output);
+          if (preview) {
+            entries.push({
+              id: `${id}-out`,
+              ts: event.timestamp,
+              kind: "output",
+              stepId,
+              title: `${stepId} output`,
+              detail: preview,
+            });
+          }
+        }
+        break;
+      }
+      case "result": {
+        const status = typeof event.data.status === "string" ? event.data.status : "completed";
+        const error = typeof event.data.error === "string" ? event.data.error : undefined;
+        entries.push({
+          id,
+          ts: event.timestamp,
+          kind: status === "failed" ? "error" : "run",
+          title: RUN_STATUS_TITLES[status] ?? `Run finished: ${status}`,
+          detail: error,
+        });
+        break;
+      }
+      case "error": {
+        const message =
+          typeof event.data.message === "string" ? event.data.message : "Stream error";
+        entries.push({ id, ts: event.timestamp, kind: "error", title: message });
+        break;
+      }
+    }
+  });
+
+  return entries;
+}

--- a/dashboard/src/pages/MissionControlPage.tsx
+++ b/dashboard/src/pages/MissionControlPage.tsx
@@ -1,0 +1,403 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  ArrowLeft,
+  CheckCircle2,
+  Crosshair,
+  Radar,
+  RefreshCw,
+  XCircle,
+} from "lucide-react";
+import { api } from "@/api/client";
+import { useRunStream } from "@/hooks/useRunStream";
+import { MissionDag } from "@/components/runs/mission/MissionDag";
+import { TelemetryRail } from "@/components/runs/mission/TelemetryRail";
+import { ThoughtStream } from "@/components/runs/mission/ThoughtStream";
+import { RunStatusBadge } from "@/components/runs/RunStatusBadge";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import {
+  aggregateTelemetry,
+  buildThoughtFeed,
+  computeThroughput,
+  formatClock,
+  initialMissionState,
+  isTerminalRunStatus,
+  mergeLiveSteps,
+  reduceMissionEvents,
+  synthesizeEventsFromSteps,
+  type MissionStep,
+} from "@/lib/missionControl";
+import { cn, formatCost, parseUTC } from "@/lib/utils";
+
+interface RunDetail {
+  run_id: string;
+  workflow_name: string;
+  status: string;
+  total_cost_usd: number;
+  started_at: string | null;
+  completed_at: string | null;
+  error: string | null;
+  steps: MissionStep[] | null;
+}
+
+interface WorkflowStepInfo {
+  id: string;
+  depends_on?: string[] | null;
+  model?: string | null;
+}
+
+const POLL_INTERVAL_MS = 4000;
+
+/** Connection indicator for the top bar. */
+function ConnectionPill({
+  streamStatus,
+  isActive,
+  onRetry,
+}: {
+  streamStatus: string;
+  isActive: boolean;
+  onRetry: () => void;
+}) {
+  if (!isActive) {
+    return (
+      <span className="flex items-center gap-1.5 rounded-full border border-border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted">
+        <span className="inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground" />
+        Final
+      </span>
+    );
+  }
+  if (streamStatus === "connected") {
+    return (
+      <span className="flex items-center gap-1.5 rounded-full border border-success/30 bg-success/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider text-success">
+        <span className="status-dot-running inline-block h-1.5 w-1.5 rounded-full bg-success" />
+        Live
+      </span>
+    );
+  }
+  if (streamStatus === "connecting" || streamStatus === "reconnecting") {
+    return (
+      <span className="flex items-center gap-1.5 rounded-full border border-warning/30 bg-warning/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider text-warning">
+        <RefreshCw className="h-2.5 w-2.5 animate-spin" />
+        {streamStatus === "reconnecting" ? "Reconnecting" : "Connecting"}
+      </span>
+    );
+  }
+  return (
+    <button
+      onClick={onRetry}
+      className="flex items-center gap-1.5 rounded-full border border-error/30 bg-error/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider text-error hover:bg-error/20 transition-colors"
+    >
+      <span className="inline-block h-1.5 w-1.5 rounded-full bg-error" />
+      Offline — retry
+    </button>
+  );
+}
+
+export default function MissionControlPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [run, setRun] = useState<RunDetail | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [wfSteps, setWfSteps] = useState<WorkflowStepInfo[] | null>(null);
+  const [follow, setFollow] = useState(true);
+  const [now, setNow] = useState(() => Date.now());
+  const throughputSamplesRef = useRef<{ t: number; tokens: number }[]>([]);
+
+  const fetchRun = useCallback(async () => {
+    if (!id) return;
+    try {
+      const res = await api.get<RunDetail>(`/runs/${id}`);
+      if (res.data) {
+        setRun(res.data);
+        setLoadError(null);
+      } else if (res.error) {
+        setLoadError(res.error.message || "Failed to load run");
+      }
+    } catch {
+      setLoadError("Could not connect to the API server");
+    }
+  }, [id]);
+
+  useEffect(() => {
+    setRun(null);
+    setLoadError(null);
+    void fetchRun();
+  }, [fetchRun]);
+
+  // Workflow definition gives the DAG shape (depends_on per step)
+  const workflowName = run?.workflow_name ?? null;
+  useEffect(() => {
+    if (!workflowName) return;
+    let cancelled = false;
+    (async () => {
+      const res = await api.get<{ steps?: WorkflowStepInfo[] }>(
+        `/workflows/${encodeURIComponent(workflowName)}`
+      );
+      if (cancelled) return;
+      const steps = res.data?.steps;
+      if (Array.isArray(steps) && steps.length > 0) {
+        setWfSteps(steps.filter((s) => s?.id));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [workflowName]);
+
+  // Live SSE stream while the run is active
+  const runIsActive = run != null && !isTerminalRunStatus(run.status);
+  const { events, status: streamStatus, retry } = useRunStream(id ?? null, runIsActive);
+
+  // Fold the event log into the mission state machine
+  const missionState = useMemo(() => {
+    const base = initialMissionState(run ?? undefined);
+    return reduceMissionEvents(base, events);
+  }, [run, events]);
+
+  const isActive = run != null && !missionState.finished && !isTerminalRunStatus(missionState.runStatus);
+
+  // Poll REST while active (outputs, models and durable state catch up here)
+  useEffect(() => {
+    if (!isActive) return;
+    const interval = setInterval(() => void fetchRun(), POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [isActive, fetchRun]);
+
+  // One final fetch when the stream reports the terminal result
+  const finishedRef = useRef(false);
+  useEffect(() => {
+    if (missionState.finished && !finishedRef.current) {
+      finishedRef.current = true;
+      void fetchRun();
+    }
+  }, [missionState.finished, fetchRun]);
+
+  // 1s clock tick while active (elapsed time, throughput decay)
+  useEffect(() => {
+    if (!isActive) return;
+    const t = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, [isActive]);
+
+  // Esc returns to the run detail page
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && id) navigate(`/runs/${id}`);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [id, navigate]);
+
+  // Merge live overrides into REST steps and attach DAG dependencies
+  const liveSteps = useMemo<MissionStep[]>(() => {
+    let base = run?.steps ?? [];
+
+    // A queued run has no step rows yet - show the workflow's DAG as
+    // dim pending nodes so the stage is set before the agent arrives.
+    if (base.length === 0 && wfSteps) {
+      base = wfSteps.map((s) => ({
+        step_id: s.id,
+        parallel_index: null,
+        status: "pending",
+        cost_usd: 0,
+        duration_seconds: 0,
+        model: s.model ?? null,
+        output: null,
+      }));
+    }
+
+    const merged = mergeLiveSteps(base, missionState);
+
+    if (!wfSteps) {
+      // Fallback: linear chain in execution order
+      return merged.map((s, i) => ({
+        ...s,
+        depends_on: i > 0 ? [merged[i - 1].step_id] : [],
+      }));
+    }
+
+    const dependsOn = new Map(wfSteps.map((s) => [s.id, s.depends_on ?? []]));
+    const models = new Map(wfSteps.map((s) => [s.id, s.model ?? null]));
+    return merged.map((s) => ({
+      ...s,
+      model: s.model ?? models.get(s.step_id) ?? null,
+      depends_on: dependsOn.get(s.step_id) ?? [],
+    }));
+  }, [run?.steps, missionState, wfSteps]);
+
+  const telemetry = useMemo(
+    () => aggregateTelemetry(liveSteps, missionState),
+    [liveSteps, missionState]
+  );
+
+  // Token throughput from cumulative-estimate samples
+  const throughput = useMemo(() => {
+    const samples = throughputSamplesRef.current;
+    const last = samples[samples.length - 1];
+    if (!last || last.tokens !== telemetry.tokensEst) {
+      samples.push({ t: Date.now(), tokens: telemetry.tokensEst });
+      if (samples.length > 100) samples.splice(0, samples.length - 100);
+    }
+    return computeThroughput(samples);
+    // `now` keeps the rate decaying between samples while the clock ticks
+  }, [telemetry.tokensEst, now]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const elapsedSeconds = useMemo(() => {
+    if (!run?.started_at) return 0;
+    const start = parseUTC(run.started_at).getTime();
+    if (run.completed_at) return (parseUTC(run.completed_at).getTime() - start) / 1000;
+    if (!isActive) return 0;
+    return Math.max(0, (now - start) / 1000);
+  }, [run?.started_at, run?.completed_at, isActive, now]);
+
+  // Thought stream: live events, or the recorded history for finished runs
+  const feed = useMemo(() => {
+    if (events.length > 0) return buildThoughtFeed(events, liveSteps);
+    if (run && isTerminalRunStatus(run.status)) {
+      return buildThoughtFeed(synthesizeEventsFromSteps(liveSteps, run), liveSteps);
+    }
+    return [];
+  }, [events, liveSteps, run]);
+
+  const displayStatus = missionState.runStatus;
+  const isQueued = displayStatus === "queued" && telemetry.stepsRunning === 0;
+  const finished = run != null && !isActive;
+
+  if (!run) {
+    return (
+      <div className="dark fixed inset-0 z-40 flex flex-col items-center justify-center gap-4 bg-background text-foreground">
+        {loadError ? (
+          <>
+            <p className="text-sm text-muted">{loadError}</p>
+            <button
+              onClick={() => navigate("/runs")}
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-accent hover:text-accent-hover transition-colors"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Back to Runs
+            </button>
+          </>
+        ) : (
+          <LoadingSpinner size="lg" />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="dark fixed inset-0 z-40 flex flex-col bg-background text-foreground">
+      {/* Top bar */}
+      <header className="flex h-12 shrink-0 items-center gap-3 border-b border-border bg-surface/80 px-4 backdrop-blur">
+        <Radar className="h-4 w-4 text-accent" />
+        <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-accent">
+          Mission Control
+        </span>
+        <span className="hidden text-muted sm:inline">/</span>
+        <span className="hidden truncate text-sm font-medium text-foreground sm:inline">
+          {run.workflow_name}
+        </span>
+        <span className="hidden font-mono text-[11px] text-muted md:inline">
+          {run.run_id.slice(0, 8)}
+        </span>
+        <RunStatusBadge status={displayStatus} />
+
+        <div className="ml-auto flex items-center gap-2">
+          <ConnectionPill streamStatus={streamStatus} isActive={isActive} onRetry={retry} />
+          <button
+            onClick={() => setFollow((f) => !f)}
+            title={follow ? "Stop following the active step" : "Follow the active step"}
+            aria-pressed={follow}
+            className={cn(
+              "flex items-center gap-1.5 rounded-lg border px-2.5 py-1 text-[11px] font-medium transition-colors",
+              follow
+                ? "border-accent/40 bg-accent/10 text-accent"
+                : "border-border text-muted hover:text-foreground hover:bg-border/40"
+            )}
+          >
+            <Crosshair className="h-3 w-3" />
+            Follow
+          </button>
+          <button
+            onClick={() => navigate(`/runs/${run.run_id}`)}
+            className="flex items-center gap-1.5 rounded-lg border border-border px-2.5 py-1 text-[11px] font-medium text-muted hover:text-foreground hover:bg-border/40 transition-colors"
+          >
+            <ArrowLeft className="h-3 w-3" />
+            Exit
+            <kbd className="rounded border border-border bg-background px-1 text-[9px] text-muted-foreground">
+              Esc
+            </kbd>
+          </button>
+        </div>
+      </header>
+
+      {/* Run-complete banner */}
+      {finished && (
+        <div
+          className={cn(
+            "flex shrink-0 flex-wrap items-center gap-x-4 gap-y-1 border-b px-4 py-2 text-xs",
+            displayStatus === "completed"
+              ? "border-success/30 bg-success/10 text-success"
+              : displayStatus === "failed"
+                ? "border-error/30 bg-error/10 text-error"
+                : "border-warning/30 bg-warning/10 text-warning"
+          )}
+        >
+          {displayStatus === "completed" ? (
+            <CheckCircle2 className="h-3.5 w-3.5" />
+          ) : (
+            <XCircle className="h-3.5 w-3.5" />
+          )}
+          <span className="font-semibold">
+            {displayStatus === "completed" ? "Run complete" : `Run ${displayStatus.replace(/_/g, " ")}`}
+          </span>
+          <span className="font-data text-foreground/80">
+            {telemetry.stepsDone}/{telemetry.stepsTotal} steps · {formatCost(missionState.totalCostUsd)} ·{" "}
+            {formatClock(elapsedSeconds)}
+          </span>
+          {(missionState.error ?? run.error) && (
+            <span className="min-w-0 truncate font-mono text-error/90">
+              {missionState.error ?? run.error}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Stage */}
+      <div className="flex min-h-0 flex-1">
+        {/* DAG theater */}
+        <div className="relative min-w-0 flex-1">
+          {liveSteps.length > 0 ? (
+            <MissionDag steps={liveSteps} activeStepId={telemetry.activeStepId} follow={follow} />
+          ) : (
+            <div className="bg-grid h-full w-full" />
+          )}
+
+          {/* Queued overlay */}
+          {isQueued && liveSteps.every((s) => s.status !== "running") && (
+            <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+              <div className="ambient-glow flex flex-col items-center gap-3 rounded-2xl border border-queued/30 bg-surface/90 px-8 py-6 shadow-lg backdrop-blur">
+                <span className="relative flex h-10 w-10 items-center justify-center">
+                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-queued/30" />
+                  <Radar className="h-5 w-5 text-queued" />
+                </span>
+                <p className="text-sm font-medium text-foreground">Waiting for a runner…</p>
+                <p className="text-xs text-muted">The agent will appear here the moment it starts.</p>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Right rail: telemetry + thought stream */}
+        <aside className="flex w-[360px] shrink-0 flex-col border-l border-border bg-surface/40 lg:w-[400px]">
+          <TelemetryRail
+            telemetry={telemetry}
+            throughput={throughput}
+            elapsedSeconds={elapsedSeconds}
+            isLive={isActive}
+          />
+          <ThoughtStream entries={feed} isLive={isActive} />
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/pages/RunDetailPage.tsx
+++ b/dashboard/src/pages/RunDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { XCircle, GitCompareArrows, Trash2, Download, Copy, FileDown, ChevronDown, ArrowLeft, Sparkles, AlertTriangle, AlertOctagon, Shield, ChevronRight, Share2, ExternalLink } from "lucide-react";
+import { XCircle, GitCompareArrows, Trash2, Download, Copy, FileDown, ChevronDown, ArrowLeft, Sparkles, AlertTriangle, AlertOctagon, Shield, ChevronRight, Share2, ExternalLink, Radar } from "lucide-react";
 import { useNotifications } from "@/hooks/useNotifications";
 import { useRuns } from "@/hooks/useRuns";
 import { useEventStreamContext } from "@/hooks/useEventStreamContext";
@@ -546,6 +546,21 @@ export default function RunDetailPage() {
                 <GitCompareArrows className="h-4 w-4" />
                 <span className="hidden sm:inline">Compare with Parent</span>
                 <span className="sm:hidden">Compare</span>
+              </button>
+            )}
+            {isRunning && (
+              <button
+                onClick={() => navigate(`/runs/${run.run_id}/live`)}
+                title="Open Mission Control - watch this run live"
+                className={cn(
+                  "flex items-center gap-1.5 rounded-lg px-3 py-1.5",
+                  "bg-accent text-accent-foreground text-xs sm:text-sm font-medium",
+                  "hover:bg-accent-hover transition-colors btn-shimmer"
+                )}
+              >
+                <Radar className="h-4 w-4" />
+                <span className="hidden sm:inline">Mission Control</span>
+                <span className="sm:hidden">Live</span>
               </button>
             )}
             {isRunning && (

--- a/dashboard/src/pages/TemplatesPage.tsx
+++ b/dashboard/src/pages/TemplatesPage.tsx
@@ -501,9 +501,18 @@ export default function TemplatesPage() {
     if (res.error) {
       toast.error(`Run failed: ${res.error.message}`);
     } else if (res.data) {
-      toast.success("Workflow run queued");
       const runId = (res.data as Record<string, unknown>).run_id as string;
-      if (runId) navigate(`/runs/${runId}`);
+      if (runId) {
+        toast.success("Workflow run queued", {
+          action: {
+            label: "Mission Control",
+            onClick: () => navigate(`/runs/${runId}/live`),
+          },
+        });
+        navigate(`/runs/${runId}`);
+      } else {
+        toast.success("Workflow run queued");
+      }
     }
   }, [detail, fieldValues, runInput, navigate]);
 

--- a/dashboard/src/pages/WorkflowBuilderPage.tsx
+++ b/dashboard/src/pages/WorkflowBuilderPage.tsx
@@ -107,7 +107,14 @@ export default function WorkflowBuilderPage() {
         return;
       }
       if (res.data?.run_id) {
-        navigate(`/runs/${res.data.run_id}`);
+        const runId = res.data.run_id;
+        toast.success("Run started", {
+          action: {
+            label: "Mission Control",
+            onClick: () => navigate(`/runs/${runId}/live`),
+          },
+        });
+        navigate(`/runs/${runId}`);
       }
     },
     [navigate]

--- a/dashboard/src/pages/Workflows.tsx
+++ b/dashboard/src/pages/Workflows.tsx
@@ -86,7 +86,7 @@ export default function Workflows() {
   const handleRun = useCallback(
     async (input: Record<string, unknown>, callbackUrl?: string) => {
       if (!runModal) return;
-      const res = await api.post("/workflows/run", {
+      const res = await api.post<{ run_id: string }>("/workflows/run", {
         workflow_name: runModal.file_name.replace(".yaml", ""),
         input,
         callback_url: callbackUrl,
@@ -95,6 +95,15 @@ export default function Workflows() {
       if (res.error) {
         toast.error(`Run failed: ${res.error.message}`);
         return;
+      }
+      const runId = res.data?.run_id;
+      if (runId) {
+        toast.success("Run started", {
+          action: {
+            label: "Mission Control",
+            onClick: () => navigate(`/runs/${runId}/live`),
+          },
+        });
       }
       navigate("/runs");
     },


### PR DESCRIPTION
A full-screen, demo-grade live view of a running agent: "watch your agent think." Frontend-only (reuses the existing SSE `/api/runs/{id}/stream`).

- **Route** `/runs/:id/live` + a "Mission Control" button on RunDetailPage for running/queued runs; toast action when a run is started from the UI
- **Live DAG stage** (reuses StepNode): nodes light up by state (dim queued, pulsing running, green/red flash on finish), animated edges, follow-mode auto-pan/zoom to the active node
- **Telemetry rail**: rAF-eased odometer cost counter (proud "Free / No API spend" for \$0 local runs), token throughput, elapsed clock, step counter, model chips
- **Thought stream**: monospace live feed, auto-scroll with pause-on-hover
- States: queued (waiting), running (live), finished (final state + summary, no fake replay); SSE reconnect with backoff

Honest note: the SSE `step` event carries no token deltas/output chunks, so tokens show as an "est." and the thought stream shows start/finish + output previews (documented fallback; a backward-compatible event extension would enable true streaming later).

Tests: 23 new, event-fixture-driven; lint/build green.

Stacked on #255 (gui-experiment). Will need a light rebase if the visual PRs (#256+) land first.