### PR TITLE
feat(healer): self-healing workflows — dead-letter items that fix themselves

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 - [Managed Agents](#managed-agents)
 - [Human Approval Gates](#human-approval-gates)
 - [Self-Optimizing Workflows (AutoPilot)](#self-optimizing-workflows-autopilot)
+- [Self-Healing Workflows](#self-healing-workflows)
 - [Hierarchical Workflows (Workflow-as-Step)](#hierarchical-workflows-workflow-as-step)
 - [Policy Engine](#policy-engine)
 - [Privacy Router (PII Redaction)](#privacy-router-pii-redaction)
@@ -1039,6 +1040,33 @@ steps:
         method: llm_judge
         criteria: "Rate completeness, accuracy, and depth 1-10"
 ```
+
+---
+
+## Self-Healing Workflows
+
+When a step lands in the dead letter queue, Sandcastle can fix the workflow itself. The healer scans unresolved failures, gathers the workflow YAML, the failing step, the error, and the last successful run, then asks the advisor LLM for a minimal patch with a diagnosis and a confidence score. Every patch is validated through the DAG parser and filed as a new draft workflow version behind an approval request - a human reviews the diagnosis and diff, approves, and the patched version ships on the next pass.
+
+Once a healed workflow completes its next run, the originating dead-letter item is resolved automatically (`resolved_by="healer"`). If the patch regresses, the item stays open and the healer tries again, up to `healer_max_attempts` times.
+
+```bash
+# Opt in (nightly pass at 03:30 UTC)
+HEALER_ENABLED=true
+
+# Fully autonomous mode: publish high-confidence patches directly
+HEALER_AUTO_APPLY=true
+HEALER_CONFIDENCE_THRESHOLD=0.8
+```
+
+```bash
+# Trigger a pass on demand
+curl -X POST http://localhost:8000/api/healer/run
+
+# Review recent heal attempts (diagnosis, status, workflow, version)
+curl http://localhost:8000/api/healer/activity
+```
+
+Human-in-the-loop by default: with `healer_auto_apply=false`, every patch waits for explicit approval before it goes live.
 
 ---
 
@@ -2228,6 +2256,13 @@ MEMORY_BACKEND=local           # "local" (SQLite + embeddings) or "cloud"
 MEMORY_MAX_AGE_DAYS=90         # TTL for memory decay (0 = keep forever)
 MEMORY_ADMIT_THRESHOLD=0.3     # Minimum quality score for admission
 MEMORY_GRAPH_ENABLED=false     # Enable Neo4j graph backend
+
+# Self-Healing Workflows
+HEALER_ENABLED=false           # Nightly healer pass (opt-in)
+HEALER_AUTO_APPLY=false        # Publish high-confidence patches without approval
+HEALER_CONFIDENCE_THRESHOLD=0.8
+HEALER_MAX_ATTEMPTS=2          # Max heal attempts per dead-letter item
+HEALER_LOOKBACK_HOURS=168      # Scan window for unresolved failures
 
 # License
 LICENSE_KEY=                   # sc_lic_... (community tier if empty)

--- a/src/sandcastle/api/routes.py
+++ b/src/sandcastle/api/routes.py
@@ -65,6 +65,8 @@ from sandcastle.api.schemas import (
     ForkRequest,
     GenerateChatRequest,
     GenerateWorkflowResponse,
+    HealAttemptResponse,
+    HealerRunSummaryResponse,
     HealthResponse,
     HubRateRequest,
     HubSubmissionResponse,
@@ -147,6 +149,7 @@ from sandcastle.models.db import (
     ExperimentStatus,
     GoldenCase,
     GoldenDataset,
+    HealAttempt,
     HubSubmission,
     PolicyViolation,
     RoutingDecision,
@@ -7438,6 +7441,75 @@ async def resolve_dead_letter(
             resolved_at=item.resolved_at,
             resolved_by=item.resolved_by,
         )
+    )
+
+
+# --- Self-Healing Workflows ---
+
+
+@router.post("/healer/run")
+async def trigger_healer_run(
+    request: Request,
+    lookback_hours: int | None = Query(
+        None, ge=1, le=8760, description="Override the configured lookback window"
+    ),
+) -> ApiResponse:
+    """Trigger a self-healing pass on demand. Admin-only when auth is enabled.
+
+    Works regardless of healer_enabled (which only gates the nightly pass) -
+    triggering manually is an explicit operator action.
+    """
+    _require_admin(request)
+    from sandcastle.engine.healer import run_healer_pass
+
+    summary = await run_healer_pass(lookback_hours=lookback_hours)
+    return ApiResponse(data=HealerRunSummaryResponse(**summary))
+
+
+@router.get("/healer/activity")
+async def list_healer_activity(
+    request: Request,
+    workflow_name: str | None = Query(None, description="Filter by workflow"),
+    status: str | None = Query(None, description="Filter by attempt status"),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+) -> ApiResponse:
+    """List recent self-healing attempts (diagnosis, status, workflow, version)."""
+    _require_admin(request)
+    async with async_session() as session:
+        base = select(HealAttempt)
+        count_base = select(func.count(HealAttempt.id))
+        if workflow_name:
+            base = base.where(HealAttempt.workflow_name == workflow_name)
+            count_base = count_base.where(HealAttempt.workflow_name == workflow_name)
+        if status:
+            base = base.where(HealAttempt.status == status)
+            count_base = count_base.where(HealAttempt.status == status)
+        total = await session.scalar(count_base)
+        stmt = base.order_by(HealAttempt.created_at.desc()).offset(offset).limit(limit)
+        attempts = (await session.execute(stmt)).scalars().all()
+
+    data = [
+        HealAttemptResponse(
+            id=str(a.id),
+            dead_letter_id=str(a.dead_letter_id),
+            workflow_name=a.workflow_name,
+            step_id=a.step_id,
+            diagnosis=a.diagnosis,
+            confidence=a.confidence,
+            diff=a.diff,
+            from_version=a.from_version,
+            to_version=a.to_version,
+            status=a.status,
+            approval_id=str(a.approval_id) if a.approval_id else None,
+            applied_at=a.applied_at,
+            created_at=a.created_at,
+        )
+        for a in attempts
+    ]
+    return ApiResponse(
+        data=data,
+        meta=PaginationMeta(total=total or 0, limit=limit, offset=offset),
     )
 
 

--- a/src/sandcastle/api/schemas.py
+++ b/src/sandcastle/api/schemas.py
@@ -718,6 +718,38 @@ class DeadLetterItemResponse(BaseModel):
     resolved_by: str | None = None
 
 
+class HealAttemptResponse(BaseModel):
+    """A self-healing attempt for a dead-letter failure."""
+
+    id: str
+    dead_letter_id: str
+    workflow_name: str
+    step_id: str
+    diagnosis: str = ""
+    confidence: float = 0.0
+    diff: str | None = None
+    from_version: int | None = None
+    to_version: int | None = None
+    status: str
+    approval_id: str | None = None
+    applied_at: datetime | None = None
+    created_at: datetime | None = None
+
+
+class HealerRunSummaryResponse(BaseModel):
+    """Summary of a healer pass."""
+
+    scanned: int = 0
+    proposed: int = 0
+    auto_applied: int = 0
+    rejected: int = 0
+    failed: int = 0
+    skipped: int = 0
+    published_approved: int = 0
+    resolved: int = 0
+    regressed: int = 0
+
+
 class ExperimentResponse(BaseModel):
     """AutoPilot experiment details."""
 

--- a/src/sandcastle/config.py
+++ b/src/sandcastle/config.py
@@ -64,6 +64,16 @@ class Settings(BaseSettings):
     lora_lr: float = 1e-4
     lora_epochs: int = 3
 
+    # Self-Healing Workflows: a nightly pass scans unresolved dead-letter items,
+    # asks the advisor LLM for a minimal patch, files it as a draft workflow version
+    # behind an approval request. healer_auto_apply publishes high-confidence patches
+    # (>= healer_confidence_threshold) directly. Off by default; opt in explicitly.
+    healer_enabled: bool = False
+    healer_auto_apply: bool = False
+    healer_confidence_threshold: float = 0.8
+    healer_max_attempts: int = 2
+    healer_lookback_hours: int = 168  # how far back to scan for unresolved failures
+
     # E2B custom template (pre-built sandbox with SDK installed)
     e2b_template: str = ""  # e.g. "sandcastle-runner"
 

--- a/src/sandcastle/engine/healer.py
+++ b/src/sandcastle/engine/healer.py
@@ -1,0 +1,607 @@
+"""Self-Healing Workflows engine.
+
+Closes the loop on failed runs: scan unresolved dead-letter items, ask the
+advisor LLM for a minimal patched workflow YAML plus a diagnosis and a
+confidence score, validate the patch through the DAG parser, and file it as a
+new draft workflow version behind an ApprovalRequest. With
+``healer_auto_apply=true`` and confidence above the configured threshold the
+patch is published directly and the approval is recorded as auto-approved.
+
+The resolution loop runs at the start of every healer pass: applied patches
+whose workflow has since completed a successful run mark the originating
+DeadLetterItem as resolved (``resolved_by="healer"``); a failed run after the
+patch marks the attempt as regressed so the item can be healed again, up to
+``healer_max_attempts`` times.
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from sqlalchemy import func, select
+
+from sandcastle.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Statuses of attempts that are still in flight (a new heal would be redundant).
+_ACTIVE_STATUSES = ("proposed", "applied", "auto_applied")
+# Statuses that count against healer_max_attempts.
+_COUNTED_STATUSES = ("proposed", "applied", "auto_applied", "rejected", "regressed")
+
+_SYSTEM_PROMPT = (
+    "You are a workflow repair expert for the Sandcastle orchestrator. "
+    "You receive a workflow YAML, the failing step, and the error from the dead "
+    "letter queue. Produce the smallest possible change to the YAML that fixes "
+    "the failure while preserving the workflow's intent and structure. "
+    "Respond with ONLY a JSON object with exactly these keys: "
+    '"diagnosis" (one paragraph explaining the root cause and the fix), '
+    '"confidence" (a number between 0 and 1), '
+    '"patched_yaml" (the complete patched workflow YAML as a string). '
+    "Do not wrap the JSON in markdown fences."
+)
+
+
+async def _call_llm(system: str, user: str) -> str:
+    """Call the advisor LLM (same provider failover stack as generation/evolution)."""
+    from sandcastle.engine.generator import _call_advisor_llm
+
+    return await _call_advisor_llm(system=system, user=user, max_tokens=4096, purpose="evolution")
+
+
+def _parse_llm_response(raw: str) -> tuple[str, float, str]:
+    """Parse the LLM response into (diagnosis, confidence, patched_yaml).
+
+    Tolerates markdown code fences around the JSON object.
+
+    Raises:
+        ValueError: when the response is not valid JSON or misses required keys.
+    """
+    text = raw.strip()
+    if text.startswith("```"):
+        # Strip ```json ... ``` fences
+        lines = text.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip().startswith("```"):
+            lines = lines[:-1]
+        text = "\n".join(lines).strip()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"healer LLM response is not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("healer LLM response is not a JSON object")
+    diagnosis = str(data.get("diagnosis", "")).strip()
+    patched_yaml = data.get("patched_yaml", "")
+    if not diagnosis or not isinstance(patched_yaml, str) or not patched_yaml.strip():
+        raise ValueError("healer LLM response misses 'diagnosis' or 'patched_yaml'")
+    try:
+        confidence = max(0.0, min(1.0, float(data.get("confidence", 0.0))))
+    except (TypeError, ValueError):
+        confidence = 0.0
+    return diagnosis, confidence, patched_yaml
+
+
+def _make_diff(old_yaml: str, new_yaml: str, workflow_name: str) -> str:
+    """Build a unified diff between the current and the patched workflow YAML."""
+    return "".join(
+        difflib.unified_diff(
+            old_yaml.splitlines(keepends=True),
+            new_yaml.splitlines(keepends=True),
+            fromfile=f"{workflow_name}.yaml",
+            tofile=f"{workflow_name}.yaml (healed)",
+        )
+    )
+
+
+def _load_yaml_from_disk(workflow_name: str) -> str | None:
+    """Load workflow YAML from the workflows directory, or None if missing."""
+    workflows_dir = Path(settings.workflows_dir).resolve()
+    safe_name = "".join(c if c.isalnum() or c in "-_" else "_" for c in workflow_name)
+    candidate = (workflows_dir / f"{safe_name}.yaml").resolve()
+    if candidate.is_relative_to(workflows_dir) and candidate.is_file():
+        return candidate.read_text()
+    return None
+
+
+async def _load_current_yaml(workflow_name: str) -> tuple[str, int | None] | None:
+    """Load the current workflow YAML, preferring the registry over disk.
+
+    Returns (yaml_content, version) where version is None for disk-only
+    workflows, or None when the workflow cannot be found at all.
+    """
+    from sandcastle.models.db import WorkflowVersion, WorkflowVersionStatus, async_session
+
+    async with async_session() as session:
+        stmt = (
+            select(WorkflowVersion)
+            .where(
+                WorkflowVersion.workflow_name == workflow_name,
+                WorkflowVersion.status == WorkflowVersionStatus.PRODUCTION,
+            )
+            .order_by(WorkflowVersion.version.desc())
+            .limit(1)
+        )
+        wv = (await session.execute(stmt)).scalar_one_or_none()
+        if wv is None:
+            stmt = (
+                select(WorkflowVersion)
+                .where(WorkflowVersion.workflow_name == workflow_name)
+                .order_by(WorkflowVersion.version.desc())
+                .limit(1)
+            )
+            wv = (await session.execute(stmt)).scalar_one_or_none()
+        if wv is not None:
+            return wv.yaml_content, wv.version
+    yaml_content = _load_yaml_from_disk(workflow_name)
+    if yaml_content is not None:
+        return yaml_content, None
+    return None
+
+
+async def _last_successful_run_summary(workflow_name: str) -> str:
+    """Describe the last successful run of the workflow for LLM context."""
+    from sandcastle.models.db import Run, RunStatus, async_session
+
+    async with async_session() as session:
+        stmt = (
+            select(Run)
+            .where(Run.workflow_name == workflow_name, Run.status == RunStatus.COMPLETED)
+            .order_by(Run.created_at.desc())
+            .limit(1)
+        )
+        run = (await session.execute(stmt)).scalar_one_or_none()
+    if run is None:
+        return "No successful run of this workflow on record."
+    version = f" (workflow version {run.workflow_version})" if run.workflow_version else ""
+    return (
+        f"Last successful run{version} completed at {run.completed_at or run.created_at} "
+        f"with input: {json.dumps(run.input_data, default=str)[:500]}"
+    )
+
+
+def _build_user_prompt(
+    workflow_name: str,
+    workflow_yaml: str,
+    step_id: str,
+    error: str,
+    attempts: int,
+    last_success: str,
+) -> str:
+    """Assemble the user prompt with all failure context."""
+    return (
+        f"Workflow '{workflow_name}' failed at step '{step_id}' after {attempts} attempt(s).\n\n"
+        f"Error:\n{error[:2000]}\n\n"
+        f"{last_success}\n\n"
+        f"Current workflow YAML:\n{workflow_yaml}\n\n"
+        "Produce the minimal patch that fixes this failure."
+    )
+
+
+async def _count_attempts(session, dead_letter_id: uuid.UUID) -> int:
+    """Count heal attempts already made for a dead-letter item."""
+    from sandcastle.models.db import HealAttempt
+
+    return (
+        await session.scalar(
+            select(func.count(HealAttempt.id)).where(
+                HealAttempt.dead_letter_id == dead_letter_id,
+                HealAttempt.status.in_(_COUNTED_STATUSES),
+            )
+        )
+    ) or 0
+
+
+async def _has_active_attempt(session, dead_letter_id: uuid.UUID) -> bool:
+    """Check whether the item already has an in-flight heal attempt."""
+    from sandcastle.models.db import HealAttempt
+
+    result = await session.scalar(
+        select(HealAttempt.id)
+        .where(
+            HealAttempt.dead_letter_id == dead_letter_id,
+            HealAttempt.status.in_(_ACTIVE_STATUSES),
+        )
+        .limit(1)
+    )
+    return result is not None
+
+
+async def _publish_version(workflow_name: str, version: int) -> None:
+    """Publish a workflow version: archive current production, promote, sync disk."""
+    from sandcastle.models.db import WorkflowVersion, WorkflowVersionStatus, async_session
+
+    async with async_session() as session:
+        prod_stmt = select(WorkflowVersion).where(
+            WorkflowVersion.workflow_name == workflow_name,
+            WorkflowVersion.status == WorkflowVersionStatus.PRODUCTION,
+        )
+        for old_prod in (await session.execute(prod_stmt)).scalars().all():
+            old_prod.status = WorkflowVersionStatus.ARCHIVED
+        stmt = select(WorkflowVersion).where(
+            WorkflowVersion.workflow_name == workflow_name,
+            WorkflowVersion.version == version,
+        )
+        wv = (await session.execute(stmt)).scalar_one_or_none()
+        if wv is None:
+            raise ValueError(f"workflow version {workflow_name} v{version} not found")
+        wv.status = WorkflowVersionStatus.PRODUCTION
+        wv.promoted_by = "healer"
+        wv.promoted_at = datetime.now(timezone.utc)
+        yaml_content = wv.yaml_content
+        await session.commit()
+
+    # Keep the disk copy in sync for backward compatibility
+    try:
+        workflows_dir = Path(settings.workflows_dir)
+        workflows_dir.mkdir(parents=True, exist_ok=True)
+        safe_name = "".join(c if c.isalnum() or c in "-_" else "_" for c in workflow_name)
+        (workflows_dir / f"{safe_name}.yaml").write_text(yaml_content)
+    except OSError:
+        logger.warning("Could not write healed workflow %s to disk", workflow_name, exc_info=True)
+
+
+async def _emit_audit(event_type: str, run_id: str | None, payload: dict) -> None:
+    """Append an audit event in its own session; failures never abort healing."""
+    try:
+        from sandcastle.engine.audit import append_audit_event
+        from sandcastle.models.db import async_session
+
+        async with async_session() as session:
+            await append_audit_event(
+                session=session,
+                event_type=event_type,
+                run_id=run_id,
+                actor_id="healer",
+                payload=payload,
+            )
+    except Exception as exc:
+        logger.debug("Audit event %s failed: %s", event_type, exc)
+
+
+async def heal_item(item_id: uuid.UUID) -> dict:
+    """Run one heal cycle for a single dead-letter item.
+
+    Returns a result dict with at least a "status" key:
+    proposed | auto_applied | rejected | failed | skipped.
+    """
+    from sandcastle.engine.dag import parse_yaml_string
+    from sandcastle.models.db import (
+        ApprovalRequest,
+        ApprovalStatus,
+        DeadLetterItem,
+        HealAttempt,
+        Run,
+        WorkflowVersion,
+        WorkflowVersionStatus,
+        async_session,
+    )
+
+    async with async_session() as session:
+        item = await session.get(DeadLetterItem, item_id)
+        if item is None or item.resolved_at is not None:
+            return {"status": "skipped", "reason": "item missing or already resolved"}
+        run = await session.get(Run, item.run_id)
+        if run is None:
+            return {"status": "skipped", "reason": "originating run not found"}
+        workflow_name = run.workflow_name
+        if await _has_active_attempt(session, item_id):
+            return {"status": "skipped", "reason": "heal already in flight"}
+        if await _count_attempts(session, item_id) >= settings.healer_max_attempts:
+            return {"status": "skipped", "reason": "max heal attempts reached"}
+        # Capture primitives before the session closes (ORM object detaches)
+        step_id: str = item.step_id
+        error_text: str = item.error or "(no error recorded)"
+        prior_attempts: int = item.attempts
+        run_id = item.run_id
+
+    loaded = await _load_current_yaml(workflow_name)
+    if loaded is None:
+        return {"status": "skipped", "reason": f"workflow '{workflow_name}' not found"}
+    current_yaml, current_version = loaded
+    last_success = await _last_successful_run_summary(workflow_name)
+
+    user_prompt = _build_user_prompt(
+        workflow_name=workflow_name,
+        workflow_yaml=current_yaml,
+        step_id=step_id,
+        error=error_text,
+        attempts=prior_attempts,
+        last_success=last_success,
+    )
+
+    try:
+        raw = await _call_llm(_SYSTEM_PROMPT, user_prompt)
+        diagnosis, confidence, patched_yaml = _parse_llm_response(raw)
+    except Exception as exc:
+        logger.warning("Healer LLM call failed for %s/%s: %s", workflow_name, step_id, exc)
+        async with async_session() as session:
+            session.add(
+                HealAttempt(
+                    dead_letter_id=item_id,
+                    workflow_name=workflow_name,
+                    step_id=step_id,
+                    diagnosis=f"LLM call failed: {exc}",
+                    status="failed",
+                )
+            )
+            await session.commit()
+        return {"status": "failed", "reason": str(exc)}
+
+    # Validate the patch through the existing DAG parser
+    try:
+        patched_workflow = parse_yaml_string(patched_yaml)
+    except Exception as exc:
+        logger.info("Healer patch for %s rejected (unparseable): %s", workflow_name, exc)
+        async with async_session() as session:
+            session.add(
+                HealAttempt(
+                    dead_letter_id=item_id,
+                    workflow_name=workflow_name,
+                    step_id=step_id,
+                    diagnosis=diagnosis,
+                    confidence=confidence,
+                    status="rejected",
+                )
+            )
+            await session.commit()
+        return {"status": "rejected", "reason": f"patch does not parse: {exc}"}
+
+    diff = _make_diff(current_yaml, patched_yaml, workflow_name)
+    auto_apply = settings.healer_auto_apply and confidence >= settings.healer_confidence_threshold
+    now = datetime.now(timezone.utc)
+
+    import hashlib
+
+    async with async_session() as session:
+        next_version = (
+            await session.scalar(
+                select(func.max(WorkflowVersion.version)).where(
+                    WorkflowVersion.workflow_name == workflow_name
+                )
+            )
+            or 0
+        ) + 1
+        wv = WorkflowVersion(
+            workflow_name=workflow_name,
+            version=next_version,
+            status=WorkflowVersionStatus.DRAFT,
+            yaml_content=patched_yaml,
+            description=f"Healer patch for step '{step_id}': {diagnosis[:400]}",
+            steps_count=len(patched_workflow.steps),
+            checksum=hashlib.sha256(patched_yaml.encode()).hexdigest(),
+            created_by="healer",
+        )
+        session.add(wv)
+
+        approval = ApprovalRequest(
+            run_id=run_id,
+            step_id=step_id,
+            status=ApprovalStatus.APPROVED if auto_apply else ApprovalStatus.PENDING,
+            message=(
+                f"[Self-Healing] Patch proposed for workflow '{workflow_name}' "
+                f"(v{current_version or '?'} -> v{next_version}).\n\n"
+                f"Diagnosis: {diagnosis}\n\nConfidence: {confidence:.2f}\n\nDiff:\n{diff}"
+            ),
+            request_data={
+                "type": "healer",
+                "workflow_name": workflow_name,
+                "from_version": current_version,
+                "to_version": next_version,
+                "confidence": confidence,
+                "dead_letter_id": str(item_id),
+            },
+            reviewer_id="healer" if auto_apply else None,
+            reviewer_comment=(
+                f"Auto-approved: confidence {confidence:.2f} >= "
+                f"threshold {settings.healer_confidence_threshold:.2f}"
+                if auto_apply
+                else None
+            ),
+            resolved_at=now if auto_apply else None,
+        )
+        session.add(approval)
+        await session.flush()
+
+        attempt = HealAttempt(
+            dead_letter_id=item_id,
+            workflow_name=workflow_name,
+            step_id=step_id,
+            diagnosis=diagnosis,
+            confidence=confidence,
+            diff=diff,
+            from_version=current_version,
+            to_version=next_version,
+            status="auto_applied" if auto_apply else "proposed",
+            approval_id=approval.id,
+            applied_at=now if auto_apply else None,
+        )
+        session.add(attempt)
+        await session.commit()
+        attempt_id = attempt.id
+
+    if auto_apply:
+        await _publish_version(workflow_name, next_version)
+
+    await _emit_audit(
+        "healer.patch_auto_applied" if auto_apply else "healer.patch_proposed",
+        run_id=str(run_id),
+        payload={
+            "workflow_name": workflow_name,
+            "step_id": step_id,
+            "to_version": next_version,
+            "confidence": confidence,
+            "heal_attempt_id": str(attempt_id),
+        },
+    )
+    return {
+        "status": "auto_applied" if auto_apply else "proposed",
+        "workflow_name": workflow_name,
+        "to_version": next_version,
+        "confidence": confidence,
+        "heal_attempt_id": str(attempt_id),
+    }
+
+
+async def apply_approved_heals() -> int:
+    """Publish patches whose approval request has been approved by a human.
+
+    Returns the number of patches published.
+    """
+    from sandcastle.models.db import ApprovalRequest, ApprovalStatus, HealAttempt, async_session
+
+    applied = 0
+    async with async_session() as session:
+        stmt = (
+            select(HealAttempt, ApprovalRequest)
+            .join(ApprovalRequest, HealAttempt.approval_id == ApprovalRequest.id)
+            .where(
+                HealAttempt.status == "proposed",
+                ApprovalRequest.status == ApprovalStatus.APPROVED,
+            )
+        )
+        rows = (await session.execute(stmt)).all()
+    for attempt, _approval in rows:
+        try:
+            await _publish_version(attempt.workflow_name, attempt.to_version)
+        except Exception as exc:
+            logger.warning("Could not publish heal %s: %s", attempt.id, exc)
+            continue
+        async with async_session() as session:
+            db_attempt = await session.get(HealAttempt, attempt.id)
+            if db_attempt is not None:
+                db_attempt.status = "applied"
+                db_attempt.applied_at = datetime.now(timezone.utc)
+                await session.commit()
+        applied += 1
+        await _emit_audit(
+            "healer.patch_applied",
+            run_id=None,
+            payload={
+                "workflow_name": attempt.workflow_name,
+                "to_version": attempt.to_version,
+                "heal_attempt_id": str(attempt.id),
+            },
+        )
+    return applied
+
+
+async def check_heal_resolutions() -> dict:
+    """Resolve or regress applied heals based on the workflow's runs since the patch.
+
+    A successful run after the patch marks the originating DeadLetterItem
+    resolved with resolved_by="healer" and the attempt as "succeeded". A failed
+    run marks the attempt as "regressed" so the item stays open for another
+    heal (bounded by healer_max_attempts).
+    """
+    from sandcastle.models.db import (
+        DeadLetterItem,
+        HealAttempt,
+        Run,
+        RunStatus,
+        async_session,
+    )
+
+    resolved = 0
+    regressed = 0
+    async with async_session() as session:
+        stmt = select(HealAttempt).where(
+            HealAttempt.status.in_(("applied", "auto_applied")),
+            HealAttempt.applied_at.is_not(None),
+        )
+        attempts = (await session.execute(stmt)).scalars().all()
+
+        for attempt in attempts:
+            run_stmt = (
+                select(Run)
+                .where(
+                    Run.workflow_name == attempt.workflow_name,
+                    Run.created_at > attempt.applied_at,
+                    Run.status.in_((RunStatus.COMPLETED, RunStatus.FAILED)),
+                )
+                .order_by(Run.created_at.desc())
+                .limit(1)
+            )
+            latest = (await session.execute(run_stmt)).scalar_one_or_none()
+            if latest is None:
+                continue  # no run since the patch yet
+            if latest.status == RunStatus.COMPLETED:
+                attempt.status = "succeeded"
+                item = await session.get(DeadLetterItem, attempt.dead_letter_id)
+                if item is not None and item.resolved_at is None:
+                    item.resolved_at = datetime.now(timezone.utc)
+                    item.resolved_by = "healer"
+                resolved += 1
+            else:
+                attempt.status = "regressed"
+                regressed += 1
+        await session.commit()
+
+    if resolved or regressed:
+        await _emit_audit(
+            "healer.resolutions_checked",
+            run_id=None,
+            payload={"resolved": resolved, "regressed": regressed},
+        )
+    return {"resolved": resolved, "regressed": regressed}
+
+
+async def run_healer_pass(lookback_hours: int | None = None) -> dict:
+    """Run a full healer pass: resolutions, approved publishes, then new heals.
+
+    Args:
+        lookback_hours: how far back to scan for unresolved dead-letter items;
+            defaults to settings.healer_lookback_hours.
+
+    Returns:
+        Summary dict with scanned/proposed/auto_applied/rejected/failed/skipped
+        counts plus the resolution-loop results.
+    """
+    from sandcastle.models.db import DeadLetterItem, async_session
+
+    lookback = lookback_hours if lookback_hours is not None else settings.healer_lookback_hours
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=lookback)
+
+    resolutions = await check_heal_resolutions()
+    published = await apply_approved_heals()
+
+    async with async_session() as session:
+        stmt = (
+            select(DeadLetterItem.id)
+            .where(
+                DeadLetterItem.resolved_at.is_(None),
+                DeadLetterItem.created_at >= cutoff,
+            )
+            .order_by(DeadLetterItem.created_at.asc())
+        )
+        item_ids = [row[0] for row in (await session.execute(stmt)).all()]
+
+    summary = {
+        "scanned": len(item_ids),
+        "proposed": 0,
+        "auto_applied": 0,
+        "rejected": 0,
+        "failed": 0,
+        "skipped": 0,
+        "published_approved": published,
+        "resolved": resolutions["resolved"],
+        "regressed": resolutions["regressed"],
+    }
+    for item_id in item_ids:
+        try:
+            result = await heal_item(item_id)
+        except Exception as exc:
+            logger.error("Healer crashed on item %s: %s", item_id, exc, exc_info=True)
+            summary["failed"] += 1
+            continue
+        status = result.get("status", "failed")
+        summary[status] = summary.get(status, 0) + 1
+
+    logger.info("Healer pass complete: %s", summary)
+    return summary

--- a/src/sandcastle/models/db.py
+++ b/src/sandcastle/models/db.py
@@ -863,6 +863,48 @@ class EvolutionIteration(Base):
     evolution: Mapped[WorkflowEvolution] = relationship(back_populates="iterations")
 
 
+class HealAttempt(Base):
+    """A self-healing attempt for a dead-letter failure.
+
+    Records the LLM diagnosis, the proposed patched workflow version, and the
+    lifecycle of the patch: proposed -> applied/auto_applied -> succeeded/regressed
+    (or rejected when the patch did not parse).
+    """
+
+    __tablename__ = "heal_attempts"
+    __table_args__ = (
+        Index("ix_heal_attempts_dead_letter_id", "dead_letter_id"),
+        Index("ix_heal_attempts_workflow_name", "workflow_name"),
+        Index("ix_heal_attempts_status", "status"),
+        CheckConstraint(
+            "confidence >= 0 AND confidence <= 1", name="ck_heal_attempts_confidence_range"
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    dead_letter_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid, ForeignKey("dead_letter_queue.id", ondelete="CASCADE"), nullable=False
+    )
+    workflow_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    step_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    diagnosis: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    confidence: Mapped[float] = mapped_column(Float, default=0.0)
+    diff: Mapped[str | None] = mapped_column(Text, nullable=True)
+    from_version: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    to_version: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    status: Mapped[str] = mapped_column(String(50), nullable=False, default="proposed")
+    # proposed, applied, auto_applied, rejected, failed, succeeded, regressed
+    approval_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid, ForeignKey("approval_requests.id", ondelete="SET NULL"), nullable=True
+    )
+    applied_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    dead_letter_item: Mapped[DeadLetterItem] = relationship(foreign_keys=[dead_letter_id])
+
+
 # Database engine and session factory
 
 def _build_engine_url() -> str:

--- a/src/sandcastle/queue/scheduler.py
+++ b/src/sandcastle/queue/scheduler.py
@@ -51,6 +51,14 @@ async def start_scheduler() -> None:
             replace_existing=True,
             misfire_grace_time=30,
         )
+        # Register nightly self-healing pass (no-op unless healer_enabled)
+        scheduler.add_job(
+            _run_healer_nightly,
+            trigger=CronTrigger(hour=3, minute=30, timezone=timezone.utc),
+            id="healer_nightly_pass",
+            replace_existing=True,
+            misfire_grace_time=3600,
+        )
         logger.info("Scheduler started")
 
 
@@ -243,6 +251,19 @@ async def _run_scheduled_workflow(
                     logger.info(f"Marked stuck run {run_id} as FAILED")
         except Exception as cleanup_err:
             logger.error(f"Failed to mark run {run_id} as FAILED: {cleanup_err}")
+
+
+async def _run_healer_nightly() -> None:
+    """Run the nightly self-healing pass when the healer is enabled."""
+    if not settings.healer_enabled:
+        return
+    try:
+        from sandcastle.engine.healer import run_healer_pass
+
+        summary = await run_healer_pass()
+        logger.info(f"Nightly healer pass: {summary}")
+    except Exception as e:
+        logger.error(f"Nightly healer pass failed: {e}", exc_info=True)
 
 
 async def _check_approval_timeouts() -> None:

--- a/tests/test_healer.py
+++ b/tests/test_healer.py
@@ -1,0 +1,573 @@
+"""Tests for the Self-Healing Workflows engine and API."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from sandcastle.config import settings
+from sandcastle.engine.healer import (
+    _make_diff,
+    _parse_llm_response,
+    check_heal_resolutions,
+    heal_item,
+    run_healer_pass,
+)
+
+BROKEN_YAML = """
+name: {name}
+description: Workflow that fails at summarize
+steps:
+  - id: fetch
+    prompt: "Fetch the document at {{input.url}}"
+  - id: summarize
+    prompt: "Summarize {{steps.fetch.output}}"
+    depends_on: [fetch]
+"""
+
+PATCHED_YAML = """
+name: {name}
+description: Workflow that fails at summarize
+steps:
+  - id: fetch
+    prompt: "Fetch the document at {{input.url}} and return plain text"
+  - id: summarize
+    prompt: "Summarize the following text: {{steps.fetch.output}}"
+    depends_on: [fetch]
+"""
+
+
+def _llm_response(patched_yaml: str, confidence: float = 0.9) -> str:
+    return json.dumps(
+        {
+            "diagnosis": "The summarize step received empty output; clarified the fetch prompt.",
+            "confidence": confidence,
+            "patched_yaml": patched_yaml,
+        }
+    )
+
+
+async def _make_failure(workflow_name: str, with_version: bool = True):
+    """Create a failed run + unresolved dead-letter item (+ v1 production version)."""
+    from sandcastle.models.db import (
+        DeadLetterItem,
+        Run,
+        RunStatus,
+        WorkflowVersion,
+        WorkflowVersionStatus,
+        async_session,
+    )
+
+    run_id = uuid.uuid4()
+    async with async_session() as session:
+        session.add(
+            Run(
+                id=run_id,
+                workflow_name=workflow_name,
+                status=RunStatus.FAILED,
+                error="step summarize failed",
+            )
+        )
+        await session.commit()
+
+    async with async_session() as session:
+        if with_version:
+            session.add(
+                WorkflowVersion(
+                    workflow_name=workflow_name,
+                    version=1,
+                    status=WorkflowVersionStatus.PRODUCTION,
+                    yaml_content=BROKEN_YAML.format(name=workflow_name),
+                    description="initial",
+                    steps_count=2,
+                    checksum="x" * 64,
+                )
+            )
+        item = DeadLetterItem(
+            run_id=run_id,
+            step_id="summarize",
+            error="LLM returned empty output after 3 attempts",
+            attempts=3,
+        )
+        session.add(item)
+        await session.commit()
+        return run_id, item.id
+
+
+# --- LLM response parsing ---
+
+
+class TestParseLlmResponse:
+    def test_parses_plain_json(self):
+        diagnosis, confidence, patched = _parse_llm_response(_llm_response("name: x", 0.7))
+        assert "summarize step" in diagnosis
+        assert confidence == 0.7
+        assert patched == "name: x"
+
+    def test_strips_markdown_fences(self):
+        raw = "```json\n" + _llm_response("name: x") + "\n```"
+        _, confidence, patched = _parse_llm_response(raw)
+        assert confidence == 0.9
+        assert patched == "name: x"
+
+    def test_clamps_confidence(self):
+        _, confidence, _ = _parse_llm_response(_llm_response("name: x", 7.5))
+        assert confidence == 1.0
+
+    def test_rejects_non_json(self):
+        with pytest.raises(ValueError):
+            _parse_llm_response("here is the patch: ...")
+
+    def test_rejects_missing_keys(self):
+        with pytest.raises(ValueError):
+            _parse_llm_response(json.dumps({"diagnosis": "x"}))
+
+
+def test_make_diff_contains_change():
+    diff = _make_diff("a: 1\nb: 2\n", "a: 1\nb: 3\n", "wf")
+    assert "-b: 2" in diff
+    assert "+b: 3" in diff
+
+
+# --- heal_item: propose / auto-apply / reject / limits ---
+
+
+class TestHealItem:
+    @pytest.mark.asyncio
+    async def test_patch_proposed_and_approval_created(self, monkeypatch, tmp_path):
+        from sandcastle.models.db import (
+            ApprovalRequest,
+            ApprovalStatus,
+            HealAttempt,
+            WorkflowVersion,
+            WorkflowVersionStatus,
+            async_session,
+        )
+
+        monkeypatch.setattr(settings, "workflows_dir", str(tmp_path))
+        name = f"heal-propose-{uuid.uuid4().hex[:8]}"
+        run_id, item_id = await _make_failure(name)
+
+        with patch(
+            "sandcastle.engine.healer._call_llm",
+            new=AsyncMock(return_value=_llm_response(PATCHED_YAML.format(name=name))),
+        ):
+            result = await heal_item(item_id)
+
+        assert result["status"] == "proposed"
+        assert result["to_version"] == 2
+
+        from sqlalchemy import select
+
+        async with async_session() as session:
+            attempt = (
+                await session.execute(
+                    select(HealAttempt).where(HealAttempt.dead_letter_id == item_id)
+                )
+            ).scalar_one()
+            assert attempt.status == "proposed"
+            assert attempt.from_version == 1
+            assert attempt.to_version == 2
+            assert attempt.confidence == 0.9
+            assert "summarize step" in attempt.diagnosis
+            assert attempt.diff and "+" in attempt.diff
+
+            wv = (
+                await session.execute(
+                    select(WorkflowVersion).where(
+                        WorkflowVersion.workflow_name == name, WorkflowVersion.version == 2
+                    )
+                )
+            ).scalar_one()
+            assert wv.status == WorkflowVersionStatus.DRAFT
+            assert wv.created_by == "healer"
+
+            approval = await session.get(ApprovalRequest, attempt.approval_id)
+            assert approval.status == ApprovalStatus.PENDING
+            assert approval.request_data["type"] == "healer"
+            assert approval.request_data["to_version"] == 2
+            assert "Diagnosis" in approval.message
+
+    @pytest.mark.asyncio
+    async def test_auto_apply_publishes_and_auto_approves(self, monkeypatch, tmp_path):
+        from sandcastle.models.db import (
+            ApprovalRequest,
+            ApprovalStatus,
+            HealAttempt,
+            WorkflowVersion,
+            WorkflowVersionStatus,
+            async_session,
+        )
+
+        monkeypatch.setattr(settings, "workflows_dir", str(tmp_path))
+        monkeypatch.setattr(settings, "healer_auto_apply", True)
+        name = f"heal-auto-{uuid.uuid4().hex[:8]}"
+        run_id, item_id = await _make_failure(name)
+
+        with patch(
+            "sandcastle.engine.healer._call_llm",
+            new=AsyncMock(return_value=_llm_response(PATCHED_YAML.format(name=name), 0.95)),
+        ):
+            result = await heal_item(item_id)
+
+        assert result["status"] == "auto_applied"
+
+        from sqlalchemy import select
+
+        async with async_session() as session:
+            attempt = (
+                await session.execute(
+                    select(HealAttempt).where(HealAttempt.dead_letter_id == item_id)
+                )
+            ).scalar_one()
+            assert attempt.status == "auto_applied"
+            assert attempt.applied_at is not None
+
+            v2 = (
+                await session.execute(
+                    select(WorkflowVersion).where(
+                        WorkflowVersion.workflow_name == name, WorkflowVersion.version == 2
+                    )
+                )
+            ).scalar_one()
+            assert v2.status == WorkflowVersionStatus.PRODUCTION
+            assert v2.promoted_by == "healer"
+
+            v1 = (
+                await session.execute(
+                    select(WorkflowVersion).where(
+                        WorkflowVersion.workflow_name == name, WorkflowVersion.version == 1
+                    )
+                )
+            ).scalar_one()
+            assert v1.status == WorkflowVersionStatus.ARCHIVED
+
+            approval = await session.get(ApprovalRequest, attempt.approval_id)
+            assert approval.status == ApprovalStatus.APPROVED
+            assert approval.reviewer_id == "healer"
+
+        # Disk copy synced for backward compat
+        assert (tmp_path / f"{name}.yaml").read_text() == PATCHED_YAML.format(name=name)
+
+    @pytest.mark.asyncio
+    async def test_low_confidence_not_auto_applied(self, monkeypatch, tmp_path):
+        from sandcastle.models.db import HealAttempt, async_session
+
+        monkeypatch.setattr(settings, "workflows_dir", str(tmp_path))
+        monkeypatch.setattr(settings, "healer_auto_apply", True)
+        name = f"heal-lowconf-{uuid.uuid4().hex[:8]}"
+        _, item_id = await _make_failure(name)
+
+        with patch(
+            "sandcastle.engine.healer._call_llm",
+            new=AsyncMock(return_value=_llm_response(PATCHED_YAML.format(name=name), 0.4)),
+        ):
+            result = await heal_item(item_id)
+
+        assert result["status"] == "proposed"
+
+        from sqlalchemy import select
+
+        async with async_session() as session:
+            attempt = (
+                await session.execute(
+                    select(HealAttempt).where(HealAttempt.dead_letter_id == item_id)
+                )
+            ).scalar_one()
+            assert attempt.status == "proposed"
+            assert attempt.applied_at is None
+
+    @pytest.mark.asyncio
+    async def test_unparseable_patch_rejected(self, monkeypatch, tmp_path):
+        from sandcastle.models.db import HealAttempt, WorkflowVersion, async_session
+
+        monkeypatch.setattr(settings, "workflows_dir", str(tmp_path))
+        name = f"heal-reject-{uuid.uuid4().hex[:8]}"
+        _, item_id = await _make_failure(name)
+
+        with patch(
+            "sandcastle.engine.healer._call_llm",
+            new=AsyncMock(return_value=_llm_response("steps: [this is not: a workflow")),
+        ):
+            result = await heal_item(item_id)
+
+        assert result["status"] == "rejected"
+
+        from sqlalchemy import select
+
+        async with async_session() as session:
+            attempt = (
+                await session.execute(
+                    select(HealAttempt).where(HealAttempt.dead_letter_id == item_id)
+                )
+            ).scalar_one()
+            assert attempt.status == "rejected"
+            assert attempt.to_version is None
+            # No draft version was filed
+            max_version = (
+                await session.execute(
+                    select(WorkflowVersion.version)
+                    .where(WorkflowVersion.workflow_name == name)
+                    .order_by(WorkflowVersion.version.desc())
+                    .limit(1)
+                )
+            ).scalar_one()
+            assert max_version == 1
+
+    @pytest.mark.asyncio
+    async def test_max_attempts_respected(self, monkeypatch, tmp_path):
+        from sandcastle.models.db import HealAttempt, async_session
+
+        monkeypatch.setattr(settings, "workflows_dir", str(tmp_path))
+        name = f"heal-max-{uuid.uuid4().hex[:8]}"
+        _, item_id = await _make_failure(name)
+
+        async with async_session() as session:
+            for _ in range(settings.healer_max_attempts):
+                session.add(
+                    HealAttempt(
+                        dead_letter_id=item_id,
+                        workflow_name=name,
+                        step_id="summarize",
+                        diagnosis="previous try",
+                        status="regressed",
+                    )
+                )
+            await session.commit()
+
+        llm = AsyncMock(return_value=_llm_response(PATCHED_YAML.format(name=name)))
+        with patch("sandcastle.engine.healer._call_llm", new=llm):
+            result = await heal_item(item_id)
+
+        assert result["status"] == "skipped"
+        assert "max heal attempts" in result["reason"]
+        llm.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_in_flight_attempt_not_duplicated(self, monkeypatch, tmp_path):
+        from sandcastle.models.db import HealAttempt, async_session
+
+        monkeypatch.setattr(settings, "workflows_dir", str(tmp_path))
+        name = f"heal-dup-{uuid.uuid4().hex[:8]}"
+        _, item_id = await _make_failure(name)
+
+        async with async_session() as session:
+            session.add(
+                HealAttempt(
+                    dead_letter_id=item_id,
+                    workflow_name=name,
+                    step_id="summarize",
+                    diagnosis="pending review",
+                    status="proposed",
+                )
+            )
+            await session.commit()
+
+        llm = AsyncMock(return_value=_llm_response(PATCHED_YAML.format(name=name)))
+        with patch("sandcastle.engine.healer._call_llm", new=llm):
+            result = await heal_item(item_id)
+
+        assert result["status"] == "skipped"
+        llm.assert_not_awaited()
+
+
+# --- Resolution loop ---
+
+
+class TestResolutionLoop:
+    @pytest.mark.asyncio
+    async def test_success_marks_item_resolved_by_healer(self):
+        from sandcastle.models.db import (
+            DeadLetterItem,
+            HealAttempt,
+            Run,
+            RunStatus,
+            async_session,
+        )
+
+        name = f"heal-resolve-{uuid.uuid4().hex[:8]}"
+        _, item_id = await _make_failure(name, with_version=False)
+        applied_at = datetime.now(timezone.utc) - timedelta(hours=2)
+
+        async with async_session() as session:
+            attempt = HealAttempt(
+                dead_letter_id=item_id,
+                workflow_name=name,
+                step_id="summarize",
+                diagnosis="fixed prompt",
+                status="auto_applied",
+                to_version=2,
+                applied_at=applied_at,
+            )
+            session.add(attempt)
+            # A successful run after the patch was applied
+            session.add(Run(workflow_name=name, status=RunStatus.COMPLETED))
+            await session.commit()
+            attempt_id = attempt.id
+
+        summary = await check_heal_resolutions()
+        assert summary["resolved"] >= 1
+
+        async with async_session() as session:
+            item = await session.get(DeadLetterItem, item_id)
+            assert item.resolved_at is not None
+            assert item.resolved_by == "healer"
+            attempt = await session.get(HealAttempt, attempt_id)
+            assert attempt.status == "succeeded"
+
+    @pytest.mark.asyncio
+    async def test_failure_marks_attempt_regressed(self):
+        from sandcastle.models.db import (
+            DeadLetterItem,
+            HealAttempt,
+            Run,
+            RunStatus,
+            async_session,
+        )
+
+        name = f"heal-regress-{uuid.uuid4().hex[:8]}"
+        _, item_id = await _make_failure(name, with_version=False)
+        applied_at = datetime.now(timezone.utc) - timedelta(hours=2)
+
+        async with async_session() as session:
+            attempt = HealAttempt(
+                dead_letter_id=item_id,
+                workflow_name=name,
+                step_id="summarize",
+                diagnosis="fixed prompt",
+                status="applied",
+                to_version=2,
+                applied_at=applied_at,
+            )
+            session.add(attempt)
+            session.add(Run(workflow_name=name, status=RunStatus.FAILED))
+            await session.commit()
+            attempt_id = attempt.id
+
+        summary = await check_heal_resolutions()
+        assert summary["regressed"] >= 1
+
+        async with async_session() as session:
+            item = await session.get(DeadLetterItem, item_id)
+            assert item.resolved_at is None  # stays open for another heal
+            attempt = await session.get(HealAttempt, attempt_id)
+            assert attempt.status == "regressed"
+
+
+# --- Full pass ---
+
+
+class TestHealerPass:
+    @pytest.mark.asyncio
+    async def test_pass_heals_unresolved_items(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(settings, "workflows_dir", str(tmp_path))
+        name = f"heal-pass-{uuid.uuid4().hex[:8]}"
+        _, item_id = await _make_failure(name)
+
+        with patch(
+            "sandcastle.engine.healer._call_llm",
+            new=AsyncMock(return_value=_llm_response(PATCHED_YAML.format(name=name))),
+        ):
+            summary = await run_healer_pass(lookback_hours=1)
+
+        assert summary["scanned"] >= 1
+        assert summary["proposed"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_pass_lookback_excludes_old_items(self, monkeypatch, tmp_path):
+        from sandcastle.models.db import DeadLetterItem, async_session
+
+        monkeypatch.setattr(settings, "workflows_dir", str(tmp_path))
+        name = f"heal-old-{uuid.uuid4().hex[:8]}"
+        _, item_id = await _make_failure(name)
+        async with async_session() as session:
+            item = await session.get(DeadLetterItem, item_id)
+            item.created_at = datetime.now(timezone.utc) - timedelta(days=30)
+            await session.commit()
+
+        llm = AsyncMock(return_value=_llm_response(PATCHED_YAML.format(name=name)))
+        with patch("sandcastle.engine.healer._call_llm", new=llm):
+            await run_healer_pass(lookback_hours=24)
+
+        # The 30-day-old item is outside the 24h lookback - no attempt filed for it
+        from sqlalchemy import select
+
+        async with async_session() as session:
+            from sandcastle.models.db import HealAttempt
+
+            attempts = (
+                await session.execute(
+                    select(HealAttempt).where(HealAttempt.dead_letter_id == item_id)
+                )
+            ).scalars().all()
+        assert attempts == []
+
+
+# --- API endpoints ---
+
+
+class TestHealerApi:
+    def _client(self):
+        from fastapi.testclient import TestClient
+
+        from sandcastle.main import app
+
+        return TestClient(app)
+
+    def test_trigger_healer_run(self):
+        summary = {
+            "scanned": 3,
+            "proposed": 1,
+            "auto_applied": 1,
+            "rejected": 0,
+            "failed": 0,
+            "skipped": 1,
+            "published_approved": 0,
+            "resolved": 1,
+            "regressed": 0,
+        }
+        with patch(
+            "sandcastle.engine.healer.run_healer_pass", new=AsyncMock(return_value=summary)
+        ):
+            resp = self._client().post("/api/healer/run")
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["scanned"] == 3
+        assert data["auto_applied"] == 1
+        assert data["resolved"] == 1
+
+    @pytest.mark.asyncio
+    async def test_healer_activity_lists_attempts(self, tmp_path, monkeypatch):
+        from sandcastle.models.db import HealAttempt, async_session
+
+        monkeypatch.setattr(settings, "workflows_dir", str(tmp_path))
+        name = f"heal-activity-{uuid.uuid4().hex[:8]}"
+        _, item_id = await _make_failure(name, with_version=False)
+        async with async_session() as session:
+            session.add(
+                HealAttempt(
+                    dead_letter_id=item_id,
+                    workflow_name=name,
+                    step_id="summarize",
+                    diagnosis="prompt was ambiguous",
+                    confidence=0.85,
+                    from_version=1,
+                    to_version=2,
+                    status="proposed",
+                )
+            )
+            await session.commit()
+
+        resp = self._client().get(f"/api/healer/activity?workflow_name={name}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["meta"]["total"] == 1
+        entry = body["data"][0]
+        assert entry["workflow_name"] == name
+        assert entry["diagnosis"] == "prompt was ambiguous"
+        assert entry["status"] == "proposed"
+        assert entry["to_version"] == 2


### PR DESCRIPTION
Closes the loop on the dead-letter queue: failed run → LLM diagnosis → patched workflow version → approval gate → redeploy → regression tracking.

- **`engine/healer.py`**: scans unresolved `DeadLetterItem`s (configurable lookback), gathers context (workflow YAML, failing step, error, last successful run), asks the advisor LLM for a minimal patch + diagnosis + confidence; patch validated through the DAG parser, filed as a draft `WorkflowVersion` + `ApprovalRequest` with a unified diff
- **Auto-apply** (`healer_auto_apply`, default off) publishes high-confidence patches directly; otherwise human approves
- **Resolution tracking**: next successful run → DLQ item `resolved_by="healer"`; a failed run → attempt marked `regressed`, capped by `healer_max_attempts` (2) so it never loops forever
- **Nightly pass** (03:30 UTC, gated by `healer_enabled`, default off) + `POST /api/healer/run` and `GET /api/healer/activity` admin endpoints
- New `HealAttempt` table records diagnosis, confidence, diff, status, approval linkage

Tests: 18 new (propose / auto-apply / reject / limits / resolution / API), 402-test subset green; ruff clean. Human-in-the-loop by default.

Stacked on #255 (gui-experiment).