### PR TITLE
feat(mesh): Sandcastle Mesh — capability-routed steps across your own machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 - [Why Sandcastle?](#why-sandcastle)
 - [Start Local. Scale When Ready.](#start-local-scale-when-ready)
 - [⚡ Spark Mode — local AI on NVIDIA DGX Spark](#-spark-mode--local-ai-on-nvidia-dgx-spark)
+- [🕸️ Sandcastle Mesh — one workflow, your whole fleet](#%EF%B8%8F-sandcastle-mesh--one-workflow-your-whole-fleet)
 - [Quickstart](#quickstart)
 - [MCP Integration](#mcp-integration)
 - [Features](#features)
@@ -238,6 +239,68 @@ changes — detection is fail-closed.
 > Spark Mode auto-configures Sandcastle for NVIDIA DGX Spark and local NVIDIA GPU inference. It is
 > **not** an official NVIDIA certification or endorsement. "NVIDIA", "DGX", and "DGX Spark" are
 > trademarks of NVIDIA Corporation, used here only to describe compatibility.
+
+---
+
+## 🕸️ Sandcastle Mesh — one workflow, your whole fleet
+
+Your machines have different superpowers. Sandcastle Mesh turns them into **one orchestration
+mesh**: a DGX Spark runs the GPU steps, a Mac mini runs the browser steps, and any spare box runs
+the code steps — all inside a single workflow.
+
+```
+┌─────────────┐      requires: [gpu]      ┌─────────────┐
+│ Coordinator │ ────────────────────────▶ │  DGX Spark  │  gpu · spark · code
+│  (any box)  │      requires: [browser]  ├─────────────┤
+│   runs the  │ ────────────────────────▶ │  Mac mini   │  browser · code
+│   workflow  │      (no requires)        ├─────────────┤
+│             │ ──── runs locally ──────  │  any server │  docker · code
+└─────────────┘                           └─────────────┘
+```
+
+Joining a machine is one command — it registers itself, auto-detects its capabilities
+(DGX Spark → `gpu`+`spark`, Playwright → `browser`, Docker socket → `docker`, always `code`)
+and heartbeats every 15 seconds:
+
+```bash
+# On the coordinator
+MESH_ENABLED=true MESH_TOKEN=<shared-secret> sandcastle serve
+
+# On each machine you want in the mesh
+sandcastle node join http://coordinator:8080 --token <shared-secret>
+```
+
+Steps declare what they need; the dispatcher does the rest. Local execution is always preferred
+when the local machine qualifies, and steps without `requires` behave exactly as before:
+
+```yaml
+steps:
+  - id: scrape
+    type: browser
+    requires: [browser]        # routed to the Mac mini
+    browser_config:
+      start_url: "https://example.com"
+
+  - id: analyze
+    type: llm
+    requires: [gpu]            # routed to the Spark
+    prompt: "Analyze {steps.scrape.output}"
+
+  - id: summarize
+    prompt: "Summarize {steps.analyze.output}"   # no requires - runs locally
+```
+
+The dashboard's **Fleet** page shows every node, its capability chips, heartbeat age and a live
+status dot. Nodes are declared dead after 3 missed heartbeats, and unsatisfiable `requires` fail
+fast with the full picture: which nodes exist, what they can do, and the exact join command to fix
+it. All mesh traffic is authenticated with a shared `MESH_TOKEN` (constant-time comparison) — a
+node never executes a step for an unauthenticated caller.
+
+| Setting | Default | Meaning |
+|---|---|---|
+| `MESH_ENABLED` | `false` | Master switch for the mesh planes |
+| `MESH_TOKEN` | — | Shared secret for register/heartbeat/execute |
+| `MESH_HEARTBEAT_SECONDS` | `15` | Heartbeat interval (dead after 3 missed) |
 
 ---
 

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -34,6 +34,7 @@ const IntegrationsPage = lazyWithRetry(() => import("@/pages/IntegrationsPage"),
 const EvaluationsPage = lazyWithRetry(() => import("@/pages/EvaluationsPage"), "evaluations");
 const EvolutionPage = lazyWithRetry(() => import("@/pages/EvolutionPage"), "evolution");
 const SystemHealthPage = lazyWithRetry(() => import("@/pages/SystemHealthPage"), "system-health");
+const FleetPage = lazyWithRetry(() => import("@/pages/FleetPage"), "fleet");
 const CompliancePage = lazyWithRetry(() => import("@/pages/CompliancePage"), "compliance");
 const MemoryPage = lazyWithRetry(() => import("@/pages/MemoryPage"), "memory");
 const Onboarding = lazyWithRetry(() => import("@/pages/Onboarding"), "onboarding");
@@ -150,6 +151,7 @@ export default function App() {
               <Route path="/api-keys" element={<LiteGuard><PageBoundary name="api-keys"><ApiKeysPage /></PageBoundary></LiteGuard>} />
               <Route path="/settings" element={<PageBoundary name="settings"><SettingsPage /></PageBoundary>} />
               <Route path="/system-health" element={<PageBoundary name="system-health"><SystemHealthPage /></PageBoundary>} />
+              <Route path="/fleet" element={<PageBoundary name="fleet"><FleetPage /></PageBoundary>} />
               <Route path="/compliance" element={<LiteGuard><PageBoundary name="compliance"><CompliancePage /></PageBoundary></LiteGuard>} />
               <Route path="/memory" element={<LiteGuard><PageBoundary name="memory"><MemoryPage /></PageBoundary></LiteGuard>} />
               <Route path="*" element={<NotFound />} />

--- a/dashboard/src/__tests__/FleetPage.test.tsx
+++ b/dashboard/src/__tests__/FleetPage.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+const mockGet = vi.fn();
+
+vi.mock("@/api/client", () => ({
+  api: {
+    get: (...args: unknown[]) => mockGet(...args),
+  },
+}));
+
+import FleetPage from "@/pages/FleetPage";
+import { formatHeartbeatAge } from "@/lib/utils";
+
+const NODES_RESPONSE = {
+  data: {
+    enabled: true,
+    heartbeat_seconds: 15,
+    local_capabilities: ["code"],
+    nodes: [
+      {
+        id: "n1",
+        name: "dgx-spark",
+        base_url: "http://spark.local:8080",
+        capabilities: ["code", "gpu", "spark"],
+        last_heartbeat: new Date().toISOString(),
+        heartbeat_age_seconds: 4,
+        status: "alive",
+        registered_at: new Date().toISOString(),
+      },
+      {
+        id: "n2",
+        name: "mac-mini",
+        base_url: "http://mac-mini.local:8080",
+        capabilities: ["code", "browser"],
+        last_heartbeat: new Date().toISOString(),
+        heartbeat_age_seconds: 312,
+        status: "dead",
+        registered_at: new Date().toISOString(),
+      },
+    ],
+  },
+  error: null,
+};
+
+describe("FleetPage", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it("renders node cards with name, capabilities and status", async () => {
+    mockGet.mockResolvedValue(NODES_RESPONSE);
+    render(<FleetPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("dgx-spark")).toBeInTheDocument();
+    });
+    expect(mockGet).toHaveBeenCalledWith("/mesh/nodes");
+    expect(screen.getByText("mac-mini")).toBeInTheDocument();
+    expect(screen.getAllByTestId("mesh-node-card")).toHaveLength(2);
+    // Capability chips
+    expect(screen.getByText("gpu")).toBeInTheDocument();
+    expect(screen.getByText("browser")).toBeInTheDocument();
+    // Status labels (one alive, one dead)
+    expect(screen.getByText("Alive")).toBeInTheDocument();
+    expect(screen.getByText("Dead")).toBeInTheDocument();
+    // Heartbeat ages
+    expect(screen.getByText("4s ago")).toBeInTheDocument();
+    expect(screen.getByText("5m ago")).toBeInTheDocument();
+  });
+
+  it("shows the local capability summary bar", async () => {
+    mockGet.mockResolvedValue(NODES_RESPONSE);
+    render(<FleetPage />);
+    await waitFor(() => {
+      expect(screen.getByText("This machine:")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/heartbeat every 15s/)).toBeInTheDocument();
+  });
+
+  it("shows empty state with the join command when no nodes", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        enabled: false,
+        heartbeat_seconds: 15,
+        local_capabilities: ["code"],
+        nodes: [],
+      },
+      error: null,
+    });
+    render(<FleetPage />);
+    await waitFor(() => {
+      expect(screen.getByText("No mesh nodes yet")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/sandcastle node join/)).toBeInTheDocument();
+    expect(screen.queryByTestId("mesh-node-card")).toBeNull();
+  });
+
+  it("shows an error state when the API fails", async () => {
+    mockGet.mockResolvedValue({
+      data: null,
+      error: { code: "FORBIDDEN", message: "Admin access required" },
+    });
+    render(<FleetPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Admin access required")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("formatHeartbeatAge", () => {
+  it("formats seconds, minutes, hours, days and never", () => {
+    expect(formatHeartbeatAge(null)).toBe("never");
+    expect(formatHeartbeatAge(12)).toBe("12s ago");
+    expect(formatHeartbeatAge(90)).toBe("1m ago");
+    expect(formatHeartbeatAge(7200)).toBe("2h ago");
+    expect(formatHeartbeatAge(200_000)).toBe("2d ago");
+  });
+});

--- a/dashboard/src/api/mock.ts
+++ b/dashboard/src/api/mock.ts
@@ -6513,6 +6513,47 @@ const routes: MockRoute[] = [
     handler: () => MOCK_STATS,
   },
   {
+    match: /^\/mesh\/nodes$/,
+    method: "GET",
+    handler: () => ({
+      enabled: true,
+      heartbeat_seconds: 15,
+      local_capabilities: ["code"],
+      nodes: [
+        {
+          id: "mesh-node-spark",
+          name: "dgx-spark",
+          base_url: "http://spark.local:8080",
+          capabilities: ["code", "gpu", "spark", "docker"],
+          last_heartbeat: new Date(Date.now() - 4_000).toISOString(),
+          heartbeat_age_seconds: 4,
+          status: "alive",
+          registered_at: new Date(Date.now() - 86_400_000).toISOString(),
+        },
+        {
+          id: "mesh-node-mac",
+          name: "mac-mini",
+          base_url: "http://mac-mini.local:8080",
+          capabilities: ["code", "browser"],
+          last_heartbeat: new Date(Date.now() - 11_000).toISOString(),
+          heartbeat_age_seconds: 11,
+          status: "alive",
+          registered_at: new Date(Date.now() - 43_200_000).toISOString(),
+        },
+        {
+          id: "mesh-node-server",
+          name: "hetzner-1",
+          base_url: "http://10.0.0.7:8080",
+          capabilities: ["code", "docker"],
+          last_heartbeat: new Date(Date.now() - 312_000).toISOString(),
+          heartbeat_age_seconds: 312,
+          status: "dead",
+          registered_at: new Date(Date.now() - 172_800_000).toISOString(),
+        },
+      ],
+    }),
+  },
+  {
     match: /^\/stats\/forecast$/,
     method: "GET",
     handler: () => {

--- a/dashboard/src/components/layout/Sidebar.tsx
+++ b/dashboard/src/components/layout/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
   Key,
   Layers,
   LayoutDashboard,
+  Network,
   Plug,
   PlayCircle,
   Settings,
@@ -92,6 +93,7 @@ const navSections: NavSection[] = [
     label: "SYSTEM",
     items: [
       { to: "/system-health", icon: HeartPulse, label: "System Health" },
+      { to: "/fleet", icon: Network, label: "Fleet" },
       { to: "/api-keys", icon: Key, label: "API Keys" },
       { to: "/settings", icon: Settings, label: "Settings" },
     ],

--- a/dashboard/src/lib/utils.ts
+++ b/dashboard/src/lib/utils.ts
@@ -115,3 +115,17 @@ export function formatRelativeTime(date: string | Date): string {
   if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`;
   return `${Math.floor(diffSec / 86400)}d ago`;
 }
+
+/**
+ * Format a mesh node heartbeat age (seconds) as a compact "Ns/Nm/Nh/Nd ago"
+ * string. Null/undefined means the node has never heartbeated.
+ */
+export function formatHeartbeatAge(seconds: number | null): string {
+  if (seconds === null || seconds === undefined) return "never";
+  if (seconds < 60) return `${Math.round(seconds)}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}

--- a/dashboard/src/pages/FleetPage.tsx
+++ b/dashboard/src/pages/FleetPage.tsx
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useState } from "react";
+import { Cpu, Network, RefreshCw, Server } from "lucide-react";
+import { api } from "@/api/client";
+import { EmptyState } from "@/components/shared/EmptyState";
+import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
+import { ErrorState } from "@/components/shared/ErrorState";
+import { cn, formatHeartbeatAge } from "@/lib/utils";
+
+// -- Types --------------------------------------------------------------
+
+export interface MeshNode {
+  id: string;
+  name: string;
+  base_url: string;
+  capabilities: string[];
+  last_heartbeat: string | null;
+  heartbeat_age_seconds: number | null;
+  status: "alive" | "dead";
+  registered_at: string | null;
+}
+
+interface MeshNodesData {
+  enabled: boolean;
+  heartbeat_seconds: number;
+  local_capabilities: string[];
+  nodes: MeshNode[];
+}
+
+// -- Helpers ------------------------------------------------------------
+
+const CAPABILITY_STYLES: Record<string, string> = {
+  gpu: "bg-accent/10 text-accent",
+  spark: "bg-success/10 text-success",
+  browser: "bg-info/10 text-info",
+  docker: "bg-warning/10 text-warning",
+};
+
+function CapabilityChip({ capability }: { capability: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+        CAPABILITY_STYLES[capability] ?? "bg-secondary text-muted"
+      )}
+    >
+      {capability}
+    </span>
+  );
+}
+
+function NodeCard({ node }: { node: MeshNode }) {
+  const alive = node.status === "alive";
+  return (
+    <div
+      data-testid="mesh-node-card"
+      className="rounded-xl border border-border bg-card p-5 shadow-sm"
+    >
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Server className="h-4 w-4 text-muted" />
+          <span className="font-semibold text-foreground">{node.name}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span
+            data-testid="mesh-status-dot"
+            className={cn(
+              "h-2.5 w-2.5 rounded-full",
+              alive ? "bg-success" : "bg-error animate-pulse"
+            )}
+          />
+          <span className={cn("text-xs font-medium", alive ? "text-success" : "text-error")}>
+            {alive ? "Alive" : "Dead"}
+          </span>
+        </div>
+      </div>
+      <p className="mb-3 truncate font-mono text-xs text-muted">{node.base_url}</p>
+      <div className="mb-3 flex flex-wrap gap-1.5">
+        {node.capabilities.length > 0 ? (
+          node.capabilities.map((cap) => <CapabilityChip key={cap} capability={cap} />)
+        ) : (
+          <span className="text-xs text-muted">no capabilities</span>
+        )}
+      </div>
+      <p className="text-xs text-muted">
+        Heartbeat: <span className="text-foreground">{formatHeartbeatAge(node.heartbeat_age_seconds)}</span>
+      </p>
+    </div>
+  );
+}
+
+// -- Page ---------------------------------------------------------------
+
+export default function FleetPage() {
+  const [data, setData] = useState<MeshNodesData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const fetchNodes = useCallback(async (isRefresh = false) => {
+    if (isRefresh) setRefreshing(true);
+    setError(null);
+    try {
+      const res = await api.get<MeshNodesData>("/mesh/nodes");
+      if (res.error) {
+        setError(res.error.message);
+      } else {
+        setData(res.data);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load mesh nodes");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchNodes();
+    const interval = setInterval(() => fetchNodes(true), 15_000);
+    return () => clearInterval(interval);
+  }, [fetchNodes]);
+
+  if (loading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (error) {
+    return <ErrorState message={error} onRetry={() => fetchNodes(true)} />;
+  }
+
+  const nodes = data?.nodes ?? [];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-bold text-foreground">
+            <Network className="h-6 w-6 text-accent" />
+            Fleet
+          </h1>
+          <p className="mt-1 text-sm text-muted">
+            Sandcastle Mesh nodes - steps with <code className="rounded bg-secondary px-1">requires</code> are
+            routed to the machine with the right capabilities.
+          </p>
+        </div>
+        <button
+          onClick={() => fetchNodes(true)}
+          disabled={refreshing}
+          className={cn(
+            "flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2",
+            "text-sm font-medium text-foreground hover:bg-secondary transition-colors",
+            refreshing && "opacity-60"
+          )}
+        >
+          <RefreshCw className={cn("h-4 w-4", refreshing && "animate-spin")} />
+          Refresh
+        </button>
+      </div>
+
+      {data && (
+        <div className="flex flex-wrap items-center gap-3 rounded-lg border border-border bg-card px-4 py-3 text-sm">
+          <Cpu className="h-4 w-4 text-muted" />
+          <span className="text-muted">This machine:</span>
+          <div className="flex flex-wrap gap-1.5">
+            {data.local_capabilities.map((cap) => (
+              <CapabilityChip key={cap} capability={cap} />
+            ))}
+          </div>
+          <span className="ml-auto text-xs text-muted">
+            Mesh {data.enabled ? "enabled" : "disabled"} · heartbeat every {data.heartbeat_seconds}s
+          </span>
+        </div>
+      )}
+
+      {nodes.length === 0 ? (
+        <EmptyState
+          icon={Network}
+          title="No mesh nodes yet"
+          description={
+            "Join a machine to the mesh and its capabilities (gpu, browser, docker) become " +
+            "available to every workflow: sandcastle node join <coordinator-url> --token <mesh-token>"
+          }
+        />
+      ) : (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {nodes.map((node) => (
+            <NodeCard key={node.id} node={node} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/sandcastle/__main__.py
+++ b/src/sandcastle/__main__.py
@@ -950,6 +950,148 @@ def _cmd_serve(args: argparse.Namespace) -> None:
     )
 
 
+async def _node_join_loop(
+    coordinator: str,
+    token: str,
+    name: str,
+    base_url: str,
+    capabilities: list[str],
+    heartbeat_seconds: int,
+) -> None:
+    """Register with the coordinator and heartbeat forever.
+
+    Re-registers automatically when the coordinator forgets us (404 on
+    heartbeat, e.g. after a coordinator DB reset).
+    """
+    import asyncio
+
+    import httpx
+
+    headers = {"X-Mesh-Token": token}
+    register_body = {"name": name, "base_url": base_url, "capabilities": capabilities}
+
+    async with httpx.AsyncClient(timeout=15) as client:
+
+        async def _register() -> str | None:
+            try:
+                resp = await client.post(
+                    f"{coordinator}/api/mesh/register", json=register_body, headers=headers
+                )
+            except httpx.HTTPError as exc:
+                print(f"  {_color('Coordinator unreachable: ' + str(exc), _C.YELLOW)}")
+                return None
+            if resp.status_code != 200:
+                print(
+                    f"  {_color('Registration rejected: HTTP ' + str(resp.status_code), _C.RED)}"
+                    f" {resp.text[:200]}"
+                )
+                return None
+            node = resp.json().get("data") or {}
+            print(
+                f"  {_color('Joined mesh', _C.GREEN)} as "
+                f"{_color(name, _C.BOLD)} ({base_url}) "
+                f"caps={_color(','.join(capabilities), _C.CYAN)} id={node.get('id')}"
+            )
+            return node.get("id")
+
+        node_id = None
+        while node_id is None:
+            node_id = await _register()
+            if node_id is None:
+                await asyncio.sleep(heartbeat_seconds)
+
+        while True:
+            await asyncio.sleep(heartbeat_seconds)
+            try:
+                resp = await client.post(
+                    f"{coordinator}/api/mesh/heartbeat",
+                    json={"node_id": node_id},
+                    headers=headers,
+                )
+            except httpx.HTTPError as exc:
+                print(f"  {_color('Heartbeat failed: ' + str(exc), _C.YELLOW)}")
+                continue
+            if resp.status_code == 404:
+                print(f"  {_color('Coordinator forgot us - re-registering', _C.YELLOW)}")
+                node_id = await _register() or node_id
+            elif resp.status_code != 200:
+                print(
+                    f"  {_color('Heartbeat rejected: HTTP ' + str(resp.status_code), _C.YELLOW)}"
+                )
+
+
+def _cmd_node(args: argparse.Namespace) -> None:
+    """Sandcastle Mesh node commands (currently: join)."""
+    if getattr(args, "node_action", None) != "join":
+        print("Usage: sandcastle node join <coordinator-url> --token <t>", file=sys.stderr)
+        sys.exit(1)
+
+    import asyncio
+    import socket
+
+    coordinator = args.coordinator.rstrip("/")
+    token = args.token or os.getenv("MESH_TOKEN", "")
+    if not token:
+        print(
+            f"  {_color('A mesh token is required: --token <t> or MESH_TOKEN env.', _C.RED)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Enable the mesh plane on this node's own API server BEFORE the app
+    # starts, so /api/mesh/execute-step accepts the coordinator's token.
+    os.environ["MESH_ENABLED"] = "true"
+    os.environ["MESH_TOKEN"] = token
+    from sandcastle.config import settings
+
+    settings.mesh_enabled = True
+    settings.mesh_token = token
+
+    if args.capabilities:
+        capabilities = [
+            c.strip().lower() for c in args.capabilities.split(",") if c.strip()
+        ]
+    else:
+        from sandcastle.engine.mesh import detect_local_capabilities
+
+        capabilities = detect_local_capabilities()
+
+    hostname = socket.gethostname()
+    name = args.name or hostname
+    base_url = (args.base_url or f"http://{hostname}:{args.port}").rstrip("/")
+    heartbeat_seconds = args.heartbeat or settings.mesh_heartbeat_seconds
+
+    _print_banner()
+    print(f"  {_color('Sandcastle Mesh node', _C.BOLD)}")
+    print(f"  Coordinator ........ {coordinator}")
+    print(f"  Node ............... {name} ({base_url})")
+    print(f"  Capabilities ....... {_color(','.join(capabilities), _C.CYAN)}")
+    print(f"  Heartbeat .......... every {heartbeat_seconds}s\n")
+
+    if not args.no_serve:
+        # Serve this node's own API (the /api/mesh/execute-step surface)
+        # in a background thread; the heartbeat loop owns the foreground.
+        import threading
+
+        import uvicorn
+
+        config = uvicorn.Config(
+            "sandcastle.main:app", host=args.host, port=args.port, log_level="warning"
+        )
+        server = uvicorn.Server(config)
+        threading.Thread(target=server.run, daemon=True, name="mesh-node-api").start()
+        print(f"  {_color('Node API serving on port ' + str(args.port), _C.GREEN)}")
+
+    try:
+        asyncio.run(
+            _node_join_loop(
+                coordinator, token, name, base_url, capabilities, heartbeat_seconds
+            )
+        )
+    except KeyboardInterrupt:
+        print(f"\n  {_color('Node left the mesh.', _C.DIM)}")
+
+
 def _run_local(
     workflow: str,
     input_data: dict[str, Any],
@@ -4582,6 +4724,40 @@ def _build_parser() -> argparse.ArgumentParser:
         "--reload", action="store_true", default=False, help="Enable auto-reload for development"
     )
 
+    # --- node (Sandcastle Mesh) ---
+    p_node = subparsers.add_parser("node", help="Sandcastle Mesh node commands")
+    node_sub = p_node.add_subparsers(dest="node_action")
+    p_node_join = node_sub.add_parser(
+        "join", help="Join a Sandcastle Mesh as a worker node"
+    )
+    p_node_join.add_argument(
+        "coordinator", help="Coordinator base URL, e.g. http://spark.local:8080"
+    )
+    p_node_join.add_argument(
+        "--token", default="", help="Shared mesh token (or MESH_TOKEN env var)"
+    )
+    p_node_join.add_argument(
+        "--capabilities", default="",
+        help="Comma-separated capability override (default: auto-detect)",
+    )
+    p_node_join.add_argument("--name", default="", help="Node name (default: hostname)")
+    p_node_join.add_argument(
+        "--base-url", default="",
+        help="URL the coordinator uses to reach this node (default: http://<hostname>:<port>)",
+    )
+    p_node_join.add_argument("--host", default="0.0.0.0", help="Bind host for the node API")
+    p_node_join.add_argument(
+        "--port", type=int, default=8080, help="Bind port for the node API (default: 8080)"
+    )
+    p_node_join.add_argument(
+        "--heartbeat", type=int, default=0,
+        help="Heartbeat interval in seconds (default: MESH_HEARTBEAT_SECONDS)",
+    )
+    p_node_join.add_argument(
+        "--no-serve", action="store_true", default=False,
+        help="Do not start the node API server (one is already running)",
+    )
+
     # --- run ---
     p_run = subparsers.add_parser("run", help="Run a workflow")
     p_run.add_argument("workflow", help="Workflow name or path to .yaml file")
@@ -5039,6 +5215,11 @@ def main() -> None:
         else:
             print("Usage: sandcastle db migrate", file=sys.stderr)
             sys.exit(1)
+        return
+
+    # --- node (Sandcastle Mesh) ---
+    if args.command == "node":
+        _cmd_node(args)
         return
 
     # --- schedule ---

--- a/src/sandcastle/api/auth.py
+++ b/src/sandcastle/api/auth.py
@@ -34,6 +34,15 @@ PUBLIC_PREFIXES = ("/api/templates", "/api/r/")
 # Path suffixes that don't require authentication (e.g. workflow API spec)
 PUBLIC_SUFFIXES = ("/spec",)
 
+# Mesh control/execution plane: these endpoints enforce their own shared-secret
+# auth (X-Mesh-Token, constant-time, fail-closed when mesh is disabled or the
+# token is unset - see api/mesh.py require_mesh_token). They are exempt from
+# API-key auth so nodes can join without an API key. GET /api/mesh/nodes is
+# NOT listed: operator reads stay behind the regular API-key auth + admin gate.
+MESH_TOKEN_PATHS = frozenset(
+    {"/api/mesh/register", "/api/mesh/heartbeat", "/api/mesh/execute-step"}
+)
+
 # Pepper for HMAC key hashing - falls back to a stable default for dev/local mode.
 # In production, set API_KEY_PEPPER as an environment variable.
 _API_KEY_PEPPER = os.getenv("API_KEY_PEPPER", "sandcastle-default-pepper-change-in-production")
@@ -105,6 +114,11 @@ async def auth_middleware(request: Request, call_next):
 
     # Skip auth for public API paths
     if request.url.path in PUBLIC_PATHS:
+        request.state._auth_checked = True
+        return await call_next(request)
+
+    # Mesh-plane endpoints authenticate themselves with the mesh token
+    if request.url.path in MESH_TOKEN_PATHS:
         request.state._auth_checked = True
         return await call_next(request)
 

--- a/src/sandcastle/api/mesh.py
+++ b/src/sandcastle/api/mesh.py
@@ -1,0 +1,135 @@
+"""Sandcastle Mesh API: node registry, heartbeats and routed step execution.
+
+Mounted at ``/api/mesh``. Three planes:
+
+* ``POST /register`` / ``POST /heartbeat`` - node -> coordinator control
+  plane, authenticated with the shared ``mesh_token`` (constant-time).
+* ``POST /execute-step`` - coordinator -> node execution plane, same
+  token. A node NEVER executes a step for an unauthenticated caller and
+  everything 403s while ``mesh_enabled`` is off.
+* ``GET /nodes`` - operator read, admin-gated via the regular API-key
+  auth (it does not accept the mesh token).
+"""
+
+from __future__ import annotations
+
+import hmac
+import logging
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from sandcastle.api.schemas import ApiResponse, ErrorResponse
+from sandcastle.config import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/mesh", tags=["mesh"])
+
+class MeshRegisterRequest(BaseModel):
+    """Node self-registration payload."""
+
+    name: str = Field(..., min_length=1, max_length=255)
+    base_url: str = Field(..., min_length=1, max_length=2048)
+    capabilities: list[str] = Field(default_factory=list)
+
+
+class MeshHeartbeatRequest(BaseModel):
+    """Node heartbeat payload."""
+
+    node_id: str = Field(..., min_length=1, max_length=64)
+
+
+def _error(status_code: int, code: str, message: str) -> HTTPException:
+    return HTTPException(
+        status_code=status_code,
+        detail=ApiResponse(
+            error=ErrorResponse(code=code, message=message)
+        ).model_dump(),
+    )
+
+
+def require_mesh_token(request: Request) -> None:
+    """Authenticate a mesh-plane request with the shared mesh token.
+
+    Fails closed: mesh disabled -> 403; no token configured -> 403 (we
+    never fall back to "open"); missing/wrong token -> 401. Comparison is
+    constant-time.
+    """
+    if not settings.mesh_enabled:
+        raise _error(403, "MESH_DISABLED", "Sandcastle Mesh is disabled (set MESH_ENABLED=true)")
+    if not settings.mesh_token:
+        raise _error(
+            403, "MESH_TOKEN_UNSET",
+            "MESH_TOKEN is not configured; refusing all mesh requests",
+        )
+    provided = request.headers.get("X-Mesh-Token", "")
+    if not provided or not hmac.compare_digest(provided, settings.mesh_token):
+        raise _error(401, "UNAUTHORIZED", "Invalid mesh token")
+
+
+def _require_admin(request: Request) -> None:
+    """Admin gate for operator reads (lazy import avoids a routes.py cycle)."""
+    from sandcastle.api.auth import is_admin
+
+    if not is_admin(request):
+        raise _error(403, "FORBIDDEN", "Admin access required")
+
+
+@router.get("/nodes")
+async def get_nodes(request: Request) -> ApiResponse:
+    """List registered mesh nodes with live health (admin-gated)."""
+    _require_admin(request)
+    from sandcastle.engine.mesh import get_local_capabilities, list_nodes
+
+    nodes = await list_nodes()
+    return ApiResponse(
+        data={
+            "enabled": settings.mesh_enabled,
+            "heartbeat_seconds": settings.mesh_heartbeat_seconds,
+            "local_capabilities": get_local_capabilities(),
+            "nodes": nodes,
+        }
+    )
+
+
+@router.post("/register")
+async def register(request: Request, body: MeshRegisterRequest) -> ApiResponse:
+    """Register (or refresh) a mesh node. Token-authed."""
+    require_mesh_token(request)
+    from sandcastle.engine.mesh import register_node
+
+    base_url = body.base_url.strip()
+    if not base_url.startswith(("http://", "https://")):
+        raise _error(422, "VALIDATION_ERROR", "base_url must start with http:// or https://")
+    node = await register_node(body.name.strip(), base_url, body.capabilities)
+    return ApiResponse(data=node)
+
+
+@router.post("/heartbeat")
+async def heartbeat(request: Request, body: MeshHeartbeatRequest) -> ApiResponse:
+    """Record a node heartbeat. Token-authed."""
+    require_mesh_token(request)
+    from sandcastle.engine.mesh import heartbeat_node
+
+    node = await heartbeat_node(body.node_id)
+    if node is None:
+        raise _error(404, "NOT_FOUND", "Unknown mesh node; re-register with /api/mesh/register")
+    return ApiResponse(data=node)
+
+
+@router.post("/execute-step")
+async def execute_step(request: Request, body: dict[str, Any]) -> ApiResponse:
+    """Execute one routed step on this node. Token-authed, never anonymous."""
+    require_mesh_token(request)
+    from sandcastle.engine.mesh import execute_step_payload
+
+    if not isinstance(body.get("step"), dict) or not body["step"].get("id"):
+        raise _error(422, "VALIDATION_ERROR", "Payload must include a step object with an id")
+    try:
+        result = await execute_step_payload(body)
+    except Exception as exc:  # noqa: BLE001 - surface as a failed step, not a 500
+        logger.exception("Mesh step execution crashed")
+        result = {"status": "failed", "error": f"{type(exc).__name__}: {exc}"}
+    return ApiResponse(data=result)

--- a/src/sandcastle/config.py
+++ b/src/sandcastle/config.py
@@ -208,6 +208,13 @@ class Settings(BaseSettings):
     update_blackout_end: str = ""  # e.g. "06:00"
     update_approval_required: bool = False  # enterprise: admin must approve
 
+    # Sandcastle Mesh: multiple machines forming one orchestration mesh.
+    # The coordinator routes steps with `requires: [...]` to nodes whose
+    # capability manifest satisfies ALL required capabilities.
+    mesh_enabled: bool = False
+    mesh_token: str = ""  # shared secret for node registration/heartbeat/execution
+    mesh_heartbeat_seconds: int = 15  # node heartbeat interval; dead after 3 missed beats
+
     # Logging
     log_level: str = "info"
 
@@ -254,6 +261,17 @@ class Settings(BaseSettings):
                 ", ".join(sorted(_VALID_MEMORY_BACKENDS)),
             )
             return "local"
+        return v
+
+    @field_validator("mesh_heartbeat_seconds", mode="after")
+    @classmethod
+    def _validate_mesh_heartbeat(cls, v: int) -> int:
+        """Ensure mesh_heartbeat_seconds is at least 1."""
+        if v < 1:
+            _logger.warning(
+                "MESH_HEARTBEAT_SECONDS=%d is invalid (must be >= 1), using 15", v
+            )
+            return 15
         return v
 
     @field_validator("log_level", mode="after")
@@ -542,6 +560,7 @@ class Settings(BaseSettings):
         "tool_postgresql_url",
         "browserbase_api_key",
         "nim_api_key",
+        "mesh_token",
     })
 
     def safe_dump(self) -> dict:

--- a/src/sandcastle/engine/dag.py
+++ b/src/sandcastle/engine/dag.py
@@ -589,6 +589,10 @@ class StepDefinition:
     context_max_tokens: int = 2000  # Max tokens of context to inject
     # Token optimization: truncate step output before passing to dependents
     output_max_tokens: int = 0  # 0 = no limit, >0 = truncate output before passing to dependents
+    # Sandcastle Mesh: capabilities this step requires (e.g. ["gpu", "browser"]).
+    # Empty = run locally as always. Non-empty = the dispatcher picks a live mesh
+    # node whose capability manifest satisfies ALL entries (local node preferred).
+    requires: list[str] = field(default_factory=list)
     # Self-describing metadata
     responsibility: str = ""  # WHAT this step does in one sentence
     source_hint: str = ""  # WHY this step exists (business reason, ticket, who requested)
@@ -989,6 +993,24 @@ def _parse_memory_config(data) -> MemoryConfig | None:
     )
 
 
+def _parse_requires(data: object) -> list[str]:
+    """Coerce a step's ``requires`` field to a normalized list of capability strings.
+
+    Accepts a YAML list (``requires: [gpu, browser]``) or a single scalar
+    (``requires: gpu``). Entries are lowercased and stripped; empty entries are
+    dropped. Backward compatible: missing/None yields [] (= run locally).
+    """
+    if data is None:
+        return []
+    items = data if isinstance(data, list) else [data]
+    out: list[str] = []
+    for item in items:
+        cap = str(item).strip().lower()
+        if cap and cap not in out:
+            out.append(cap)
+    return out
+
+
 def _parse_llm_config(data: dict | None) -> LlmConfig | None:
     """Parse LLM step configuration from YAML data."""
     if data is None:
@@ -1355,6 +1377,8 @@ def _parse_step(data: dict, defaults: dict) -> StepDefinition:
         context_max_tokens=data.get("context_max_tokens", 2000),
         # Token optimization
         output_max_tokens=data.get("output_max_tokens", 0),
+        # Sandcastle Mesh capability requirements (coerce to list[str])
+        requires=_parse_requires(data.get("requires")),
         # Self-describing metadata
         responsibility=data.get("responsibility", ""),
         source_hint=data.get("source_hint", ""),

--- a/src/sandcastle/engine/executor.py
+++ b/src/sandcastle/engine/executor.py
@@ -7613,6 +7613,32 @@ async def _prepare_and_run_step(
                 async with context._lock:
                     context.step_outputs[step_id] = None
 
+    # --- Sandcastle Mesh: capability-based routing (requires: [gpu, ...]) ---
+    # Steps without `requires` take the exact same local path as always.
+    if getattr(step, "requires", None):
+        from sandcastle.engine.mesh import (
+            MeshRoutingError,
+            execute_step_remote,
+            resolve_route,
+        )
+
+        try:
+            _mesh_target = await resolve_route(step)
+        except MeshRoutingError as mesh_exc:
+            await _handle_step_result(
+                StepResult(step_id=step.id, status="failed", error=str(mesh_exc))
+            )
+            return
+        if _mesh_target is not None:
+            logger.info(
+                "Mesh: executing step '%s' on node '%s' (%s)",
+                step.id, _mesh_target.get("name"), _mesh_target.get("base_url"),
+            )
+            result = await execute_step_remote(_mesh_target, step, context)
+            await _handle_step_result(result, model=step.model)
+            return
+        # _mesh_target is None: local machine satisfies `requires` - fall through.
+
     # --- Helper to dispatch hybrid step types ---
     _HYBRID_TYPES = {
         "llm", "http", "code", "condition", "classify", "loop",

--- a/src/sandcastle/engine/mesh.py
+++ b/src/sandcastle/engine/mesh.py
@@ -1,0 +1,505 @@
+"""Sandcastle Mesh: capability-based step routing across multiple machines.
+
+Multiple machines (a DGX Spark, a Mac mini, a server, ...) form one
+orchestration mesh. Each node registers a static capability manifest
+("gpu", "spark", "browser", "docker", "code") with the coordinator and
+heartbeats every ``mesh_heartbeat_seconds``. Steps that declare
+``requires: [gpu, browser]`` in the workflow YAML are routed at dispatch
+time to a live node that satisfies ALL required capabilities; the local
+machine is preferred whenever it qualifies. Steps without ``requires``
+run locally exactly as before.
+
+Execution surface decision
+--------------------------
+Routed steps run on the node via ``POST /api/mesh/execute-step``, served
+by the node's regular Sandcastle FastAPI app. The handler wraps the step
+in a one-step :class:`WorkflowDefinition` and feeds it to the existing
+:func:`sandcastle.engine.executor.execute_workflow` with
+``initial_context`` (upstream step outputs) + ``skip_steps`` (upstream
+ids). That reuses the ENTIRE existing executor - hybrid type dispatch,
+retries, sandbox creation, policies, template resolution - with zero
+duplicated execution logic. The alternative (the pull-based claim/
+complete worker protocol from ``engine/self_hosted_worker.py``) targets
+Anthropic's hosted work queue at api.anthropic.com; reusing it here
+would have required building a brand-new server-side work queue with
+claim/complete/reclaim endpoints on the coordinator - net-new code, not
+reuse - so the push endpoint won.
+
+Security: every mesh endpoint is authenticated with the shared
+``mesh_token`` (constant-time comparison); a node never executes steps
+for unauthenticated callers, and everything is off unless
+``mesh_enabled`` is set on both sides.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+from sandcastle.config import settings
+from sandcastle.engine.dag import (
+    BrowserConfig,
+    CodeConfig,
+    ExecutionPlan,
+    HttpConfig,
+    LlmConfig,
+    NotifyConfig,
+    ParseConfig,
+    ReportConfig,
+    RetryConfig,
+    StepDefinition,
+    ToolConfig,
+    TransformConfig,
+    WorkflowDefinition,
+)
+
+logger = logging.getLogger(__name__)
+
+# A node is declared dead after this many missed heartbeats.
+DEAD_AFTER_MISSED_BEATS = 3
+
+# Step types that are safe to route to a remote node. Control-flow types
+# (condition/classify/loop/race/gate), approval gates and sub-workflow
+# spawns mutate run-local scheduler state and must stay on the coordinator.
+ROUTABLE_STEP_TYPES = frozenset(
+    {
+        "standard", "llm", "http", "code", "transform", "parse",
+        "browser", "tool", "notify", "report",
+    }
+)
+
+# Nested config dataclasses we can round-trip through the wire payload.
+# Keys are StepDefinition field names, values are the dataclass to rebuild.
+_PAYLOAD_CONFIG_TYPES: dict[str, type] = {
+    "retry": RetryConfig,
+    "llm_config": LlmConfig,
+    "http_config": HttpConfig,
+    "code_config": CodeConfig,
+    "tool_config": ToolConfig,
+    "transform_config": TransformConfig,
+    "notify_config": NotifyConfig,
+    "browser_config": BrowserConfig,
+    "parse_config": ParseConfig,
+    "report_config": ReportConfig,
+}
+
+# Scalar/JSON StepDefinition fields copied verbatim into the wire payload.
+_PAYLOAD_SCALAR_FIELDS = (
+    "id", "prompt", "depends_on", "model", "max_turns", "timeout",
+    "parallel_over", "output_schema", "type", "tools",
+    "context_query", "context_source", "context_max_tokens",
+    "output_max_tokens",
+)
+
+
+class MeshError(Exception):
+    """Base class for mesh errors."""
+
+
+class MeshRoutingError(MeshError):
+    """No mesh node satisfies a step's `requires` capabilities."""
+
+
+class MeshExecutionError(MeshError):
+    """A routed step failed to execute on the remote node."""
+
+
+# ---------------------------------------------------------------------------
+# Capability detection
+# ---------------------------------------------------------------------------
+
+
+def _docker_socket_available() -> bool:
+    """True when a local Docker socket is present."""
+    from pathlib import Path
+
+    return Path("/var/run/docker.sock").exists() or Path(
+        str(Path.home() / ".docker" / "run" / "docker.sock")
+    ).exists()
+
+
+def _playwright_importable() -> bool:
+    """True when playwright can be imported (browser steps can run here)."""
+    import importlib.util
+
+    try:
+        return importlib.util.find_spec("playwright") is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def detect_local_capabilities() -> list[str]:
+    """Auto-detect this machine's capability manifest.
+
+    Every node can run plain code steps ("code"). On a detected DGX Spark
+    the node also reports "gpu" + "spark"; playwright => "browser";
+    a reachable Docker socket => "docker".
+    """
+    caps = ["code"]
+    try:
+        from sandcastle.engine.spark import get_spark_info
+
+        if get_spark_info().is_spark:
+            caps += ["gpu", "spark"]
+    except Exception:  # noqa: BLE001 - detection must never break startup
+        pass
+    if _playwright_importable():
+        caps.append("browser")
+    if _docker_socket_available():
+        caps.append("docker")
+    return caps
+
+
+# ---------------------------------------------------------------------------
+# Node registry (DB-backed, matches codebase persistence style)
+# ---------------------------------------------------------------------------
+
+
+def _dead_after_seconds() -> float:
+    return float(settings.mesh_heartbeat_seconds * DEAD_AFTER_MISSED_BEATS)
+
+
+def node_is_alive(last_heartbeat: datetime | None, now: datetime | None = None) -> bool:
+    """A node is alive when its last heartbeat is younger than 3 intervals."""
+    if last_heartbeat is None:
+        return False
+    if last_heartbeat.tzinfo is None:
+        last_heartbeat = last_heartbeat.replace(tzinfo=timezone.utc)
+    now = now or datetime.now(timezone.utc)
+    return (now - last_heartbeat).total_seconds() <= _dead_after_seconds()
+
+
+def _node_to_dict(node: Any, now: datetime | None = None) -> dict[str, Any]:
+    """Serialize a MeshNode row with live-computed status + heartbeat age."""
+    now = now or datetime.now(timezone.utc)
+    last = node.last_heartbeat
+    if last is not None and last.tzinfo is None:
+        last = last.replace(tzinfo=timezone.utc)
+    alive = node_is_alive(last, now)
+    return {
+        "id": str(node.id),
+        "name": node.name,
+        "base_url": node.base_url,
+        "capabilities": list(node.capabilities or []),
+        "last_heartbeat": last.isoformat() if last else None,
+        "heartbeat_age_seconds": (
+            round((now - last).total_seconds(), 1) if last else None
+        ),
+        "status": "alive" if alive else "dead",
+        "registered_at": (
+            node.registered_at.isoformat() if node.registered_at else None
+        ),
+    }
+
+
+async def register_node(
+    name: str, base_url: str, capabilities: list[str]
+) -> dict[str, Any]:
+    """Register (or re-register) a mesh node. Upserts on base_url."""
+    from sqlalchemy import select
+
+    from sandcastle.models.db import MeshNode, async_session
+
+    base_url = base_url.rstrip("/")
+    caps = sorted({str(c).strip().lower() for c in capabilities if str(c).strip()})
+    now = datetime.now(timezone.utc)
+    async with async_session() as session:
+        existing = await session.scalar(
+            select(MeshNode).where(MeshNode.base_url == base_url)
+        )
+        if existing:
+            existing.name = name
+            existing.capabilities = caps
+            existing.last_heartbeat = now
+            existing.status = "alive"
+            await session.commit()
+            await session.refresh(existing)
+            logger.info("Mesh node re-registered: %s (%s) caps=%s", name, base_url, caps)
+            return _node_to_dict(existing, now)
+        node = MeshNode(
+            name=name,
+            base_url=base_url,
+            capabilities=caps,
+            last_heartbeat=now,
+            status="alive",
+        )
+        session.add(node)
+        await session.commit()
+        await session.refresh(node)
+        logger.info("Mesh node registered: %s (%s) caps=%s", name, base_url, caps)
+        return _node_to_dict(node, now)
+
+
+async def heartbeat_node(node_id: str) -> dict[str, Any] | None:
+    """Record a heartbeat. Returns the node dict, or None if unknown."""
+    import uuid as _uuid
+
+    from sandcastle.models.db import MeshNode, async_session
+
+    try:
+        nid = _uuid.UUID(node_id)
+    except (ValueError, TypeError):
+        return None
+    now = datetime.now(timezone.utc)
+    async with async_session() as session:
+        node = await session.get(MeshNode, nid)
+        if node is None:
+            return None
+        node.last_heartbeat = now
+        node.status = "alive"
+        await session.commit()
+        await session.refresh(node)
+        return _node_to_dict(node, now)
+
+
+async def list_nodes() -> list[dict[str, Any]]:
+    """List all registered nodes with live-computed health."""
+    from sqlalchemy import select
+
+    from sandcastle.models.db import MeshNode, async_session
+
+    now = datetime.now(timezone.utc)
+    async with async_session() as session:
+        result = await session.execute(
+            select(MeshNode).order_by(MeshNode.registered_at)
+        )
+        return [_node_to_dict(n, now) for n in result.scalars().all()]
+
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+
+# Cached local manifest (capability probes are cheap but not free).
+_LOCAL_CAPS: list[str] | None = None
+
+
+def get_local_capabilities() -> list[str]:
+    """Cached :func:`detect_local_capabilities` for the process lifetime."""
+    global _LOCAL_CAPS
+    if _LOCAL_CAPS is None:
+        _LOCAL_CAPS = detect_local_capabilities()
+    return _LOCAL_CAPS
+
+
+def _satisfies(capabilities: list[str], requires: list[str]) -> bool:
+    return set(requires).issubset(set(capabilities))
+
+
+async def resolve_route(step: StepDefinition) -> dict[str, Any] | None:
+    """Decide where a step with ``requires`` runs.
+
+    Returns None to run locally (local manifest satisfies all required
+    capabilities - local is always preferred), or the chosen node dict.
+    Raises :class:`MeshRoutingError` with the full picture (known nodes +
+    capabilities) when nothing qualifies.
+    """
+    requires = [c.strip().lower() for c in step.requires if c.strip()]
+    if not requires:
+        return None
+
+    if step.type not in ROUTABLE_STEP_TYPES:
+        raise MeshRoutingError(
+            f"Step '{step.id}' (type={step.type}) declares requires={requires} "
+            f"but this step type cannot be routed to a mesh node. Routable "
+            f"types: {sorted(ROUTABLE_STEP_TYPES)}."
+        )
+
+    # Prefer local whenever the local manifest qualifies.
+    local_caps = get_local_capabilities()
+    if _satisfies(local_caps, requires):
+        logger.info(
+            "Mesh: step '%s' requires=%s satisfied locally (caps=%s)",
+            step.id, requires, local_caps,
+        )
+        return None
+
+    nodes = await list_nodes() if settings.mesh_enabled else []
+    candidates = [
+        n for n in nodes
+        if n["status"] == "alive" and _satisfies(n["capabilities"], requires)
+    ]
+    if candidates:
+        chosen = candidates[0]
+        logger.info(
+            "Mesh: step '%s' requires=%s routed to node '%s' (%s)",
+            step.id, requires, chosen["name"], chosen["base_url"],
+        )
+        return chosen
+
+    known = ", ".join(
+        f"{n['name']}[{n['status']}: {', '.join(n['capabilities']) or '-'}]"
+        for n in nodes
+    ) or "none"
+    mesh_state = "" if settings.mesh_enabled else " (mesh is disabled: set MESH_ENABLED=true)"
+    raise MeshRoutingError(
+        f"Step '{step.id}' requires capabilities {requires} but no live mesh "
+        f"node satisfies them{mesh_state}. Local capabilities: {local_caps}. "
+        f"Known nodes: {known}. Join a capable node with: "
+        f"sandcastle node join <coordinator-url> --token <mesh-token>"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wire format: StepDefinition <-> JSON payload
+# ---------------------------------------------------------------------------
+
+
+def step_to_payload(step: StepDefinition) -> dict[str, Any]:
+    """Serialize a routable step for the /api/mesh/execute-step wire.
+
+    ``requires`` is intentionally dropped so the receiving node never
+    re-routes (no forwarding loops).
+    """
+    payload: dict[str, Any] = {}
+    for name in _PAYLOAD_SCALAR_FIELDS:
+        payload[name] = getattr(step, name)
+    for name in _PAYLOAD_CONFIG_TYPES:
+        value = getattr(step, name)
+        payload[name] = dataclasses.asdict(value) if value is not None else None
+    return payload
+
+
+def _rebuild_config(cls: type, data: dict[str, Any] | None) -> Any:
+    """Rebuild a config dataclass from a dict, ignoring unknown keys."""
+    if data is None:
+        return None
+    field_names = {f.name for f in dataclasses.fields(cls)}
+    return cls(**{k: v for k, v in data.items() if k in field_names})
+
+
+def step_from_payload(payload: dict[str, Any]) -> StepDefinition:
+    """Reconstruct a StepDefinition from its wire payload."""
+    kwargs: dict[str, Any] = {
+        name: payload[name] for name in _PAYLOAD_SCALAR_FIELDS if name in payload
+    }
+    for name, cls in _PAYLOAD_CONFIG_TYPES.items():
+        kwargs[name] = _rebuild_config(cls, payload.get(name))
+    kwargs["depends_on"] = [str(d) for d in (kwargs.get("depends_on") or [])]
+    return StepDefinition(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Remote execution (coordinator side)
+# ---------------------------------------------------------------------------
+
+# Test seam: tests monkeypatch this to an httpx.ASGITransport pointed at an
+# in-process "node" app, so the full route->execute->result loop runs without
+# real networking.
+_TRANSPORT: httpx.AsyncBaseTransport | None = None
+
+
+async def execute_step_remote(node: dict[str, Any], step: Any, context: Any) -> Any:
+    """Execute a step on a remote mesh node and return a StepResult."""
+    from sandcastle.engine.executor import StepResult
+
+    body = {
+        "run_id": context.run_id,
+        "workflow_name": context.workflow_name,
+        "node_name": node.get("name", ""),
+        "step": step_to_payload(step),
+        "input": context.input,
+        "step_outputs": dict(context.step_outputs),
+        "default_tools": list(context.default_tools or []),
+    }
+    url = f"{node['base_url'].rstrip('/')}/api/mesh/execute-step"
+    # Generous network budget on top of the step's own timeout + retries.
+    max_attempts = step.retry.max_attempts if step.retry else 1
+    http_timeout = (step.timeout + 60) * max(1, max_attempts)
+    try:
+        async with httpx.AsyncClient(transport=_TRANSPORT, timeout=http_timeout) as client:
+            resp = await client.post(
+                url, json=body, headers={"X-Mesh-Token": settings.mesh_token}
+            )
+    except httpx.HTTPError as exc:
+        return StepResult(
+            step_id=step.id,
+            status="failed",
+            error=(
+                f"Mesh node '{node.get('name')}' unreachable at {url}: "
+                f"{type(exc).__name__}: {exc}"
+            ),
+        )
+    if resp.status_code != 200:
+        return StepResult(
+            step_id=step.id,
+            status="failed",
+            error=(
+                f"Mesh node '{node.get('name')}' rejected step '{step.id}': "
+                f"HTTP {resp.status_code} {resp.text[:500]}"
+            ),
+        )
+    data = resp.json().get("data") or {}
+    return StepResult(
+        step_id=step.id,
+        output=data.get("output"),
+        cost_usd=float(data.get("cost_usd") or 0.0),
+        duration_seconds=float(data.get("duration_seconds") or 0.0),
+        status=data.get("status", "failed"),
+        error=data.get("error"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Node-side execution of a routed step
+# ---------------------------------------------------------------------------
+
+
+async def execute_step_payload(body: dict[str, Any]) -> dict[str, Any]:
+    """Run one routed step on this node and return a result dict.
+
+    Wraps the step in a one-step WorkflowDefinition and reuses the full
+    existing executor: upstream outputs arrive via ``initial_context`` and
+    the upstream step ids are passed as ``skip_steps`` so template
+    references like ``{steps.x.output}`` resolve exactly as they would
+    have on the coordinator.
+    """
+    import uuid as _uuid
+
+    from sandcastle.engine.executor import execute_workflow
+
+    step = step_from_payload(body.get("step") or {})
+    if step.type not in ROUTABLE_STEP_TYPES:
+        return {
+            "status": "failed",
+            "error": f"Step type '{step.type}' is not executable via the mesh",
+        }
+
+    workflow = WorkflowDefinition(
+        name=f"mesh:{body.get('workflow_name', 'remote')}",
+        description="Sandcastle Mesh routed step",
+        default_model=step.model,
+        default_max_turns=step.max_turns,
+        default_timeout=step.timeout,
+        steps=[step],
+        default_tools=list(body.get("default_tools") or []),
+    )
+    plan = ExecutionPlan(stages=[[step.id]])
+    step_outputs = dict(body.get("step_outputs") or {})
+
+    result = await execute_workflow(
+        workflow=workflow,
+        plan=plan,
+        input_data=dict(body.get("input") or {}),
+        run_id=str(_uuid.uuid4()),  # node-local run id (RunStep bookkeeping)
+        initial_context={"step_outputs": step_outputs, "costs": []},
+        skip_steps=set(step.depends_on),
+    )
+
+    output = result.outputs.get(step.id)
+    failed = result.status != "completed"
+    return {
+        "status": "failed" if failed else "completed",
+        "output": output,
+        "cost_usd": result.total_cost_usd,
+        "duration_seconds": (
+            (result.completed_at - result.started_at).total_seconds()
+            if result.completed_at and result.started_at
+            else 0.0
+        ),
+        "error": result.error,
+    }

--- a/src/sandcastle/main.py
+++ b/src/sandcastle/main.py
@@ -20,6 +20,7 @@ from sandcastle.api.agent_webhooks import router as agent_webhooks_router
 from sandcastle.api.agui import agui_router
 from sandcastle.api.auth import auth_middleware
 from sandcastle.api.environments_admin import router as environments_admin_router
+from sandcastle.api.mesh import router as mesh_router
 from sandcastle.api.routes import router
 from sandcastle.api.security_headers import security_headers_middleware
 from sandcastle.config import Settings, settings
@@ -483,6 +484,9 @@ app.include_router(agui_router, prefix="/api/agui")
 # Anthropic Managed Agents webhook receiver (root level - /agent-webhooks/anthropic)
 app.include_router(agent_webhooks_router)
 app.include_router(environments_admin_router)
+
+# Sandcastle Mesh: node registry + routed step execution (/api/mesh/*)
+app.include_router(mesh_router)
 
 # ---------------------------------------------------------------------------
 # Dashboard static files (served from the same port)

--- a/src/sandcastle/models/db.py
+++ b/src/sandcastle/models/db.py
@@ -863,6 +863,36 @@ class EvolutionIteration(Base):
     evolution: Mapped[WorkflowEvolution] = relationship(back_populates="iterations")
 
 
+class MeshNode(Base):
+    """A registered Sandcastle Mesh node (remote machine that executes routed steps).
+
+    Nodes self-register via ``POST /api/mesh/register`` and stay alive by
+    heartbeating every ``mesh_heartbeat_seconds``. A node is considered dead
+    after 3 missed heartbeats (computed at read time, not stored).
+    """
+
+    __tablename__ = "mesh_nodes"
+    __table_args__ = (
+        Index("ix_mesh_nodes_name", "name"),
+        UniqueConstraint("base_url", name="uq_mesh_nodes_base_url"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    base_url: Mapped[str] = mapped_column(String(2048), nullable=False)
+    # Capability manifest, e.g. ["gpu", "spark", "browser", "docker", "code"]
+    capabilities: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    last_heartbeat: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # "alive" | "dead" - persisted snapshot; liveness is recomputed from
+    # last_heartbeat on every read so a stale snapshot never lies.
+    status: Mapped[str] = mapped_column(String(50), default="alive")
+    registered_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+
 # Database engine and session factory
 
 def _build_engine_url() -> str:

--- a/tests/test_executor_deep.py
+++ b/tests/test_executor_deep.py
@@ -1085,13 +1085,13 @@ class TestFieldPreservation:
         assert result.autopilot is None
 
     def test_dataclasses_replace_count(self):
-        """Sanity check: StepDefinition has 50 fields (added tool_config for tool steps)."""
+        """Sanity check: StepDefinition has 51 fields (added requires for mesh routing)."""
         import dataclasses as dc
         fields = dc.fields(StepDefinition)
         # If someone adds a field, this test reminds them to check
         # all places that construct StepDefinitions
-        assert len(fields) == 50, (
-            f"StepDefinition has {len(fields)} fields (expected 50). "
+        assert len(fields) == 51, (
+            f"StepDefinition has {len(fields)} fields (expected 51). "
             "If you added a new field, verify all dataclasses.replace() "
             "callers handle it correctly."
         )

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,0 +1,501 @@
+"""Sandcastle Mesh tests: registration, heartbeat/death, routing, auth, E2E.
+
+The "E2E" tests run two in-process nodes by pointing the coordinator's
+HTTP client at an ``httpx.ASGITransport`` wrapped around the same FastAPI
+app - the full route -> POST /api/mesh/execute-step -> executor loop runs
+with no real networking.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from sandcastle.config import settings
+from sandcastle.engine import mesh
+from sandcastle.engine.dag import StepDefinition, TransformConfig, parse_yaml_string
+from sandcastle.engine.executor import RunContext
+from sandcastle.main import app
+
+client = TestClient(app)
+
+MESH_TOKEN = "test-mesh-token-123"
+
+
+@pytest.fixture
+def mesh_on(monkeypatch):
+    """Enable the mesh with a known token for the duration of a test."""
+    monkeypatch.setattr(settings, "mesh_enabled", True)
+    monkeypatch.setattr(settings, "mesh_token", MESH_TOKEN)
+    monkeypatch.setattr(settings, "mesh_heartbeat_seconds", 15)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _clean_mesh_nodes():
+    """Each test starts with an empty node registry and no cached caps."""
+    import asyncio
+
+    async def _wipe():
+        from sqlalchemy import delete
+
+        from sandcastle.models.db import MeshNode, async_session
+
+        async with async_session() as session:
+            await session.execute(delete(MeshNode))
+            await session.commit()
+
+    asyncio.new_event_loop().run_until_complete(_wipe())
+    mesh._LOCAL_CAPS = None
+    yield
+    mesh._LOCAL_CAPS = None
+
+
+def _headers(token: str = MESH_TOKEN) -> dict:
+    return {"X-Mesh-Token": token}
+
+
+# ---------------------------------------------------------------------------
+# Capability detection
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilities:
+    def test_code_always_present(self):
+        assert "code" in mesh.detect_local_capabilities()
+
+    def test_spark_adds_gpu_and_spark(self, monkeypatch):
+        from sandcastle.engine.spark import SparkInfo
+
+        monkeypatch.setattr(
+            "sandcastle.engine.spark.get_spark_info",
+            lambda: SparkInfo(is_spark=True, gpu_name="GB10"),
+        )
+        caps = mesh.detect_local_capabilities()
+        assert "gpu" in caps and "spark" in caps
+
+    def test_browser_when_playwright_importable(self, monkeypatch):
+        monkeypatch.setattr(mesh, "_playwright_importable", lambda: True)
+        assert "browser" in mesh.detect_local_capabilities()
+
+    def test_docker_when_socket_present(self, monkeypatch):
+        monkeypatch.setattr(mesh, "_docker_socket_available", lambda: True)
+        assert "docker" in mesh.detect_local_capabilities()
+
+
+# ---------------------------------------------------------------------------
+# Liveness
+# ---------------------------------------------------------------------------
+
+
+class TestLiveness:
+    def test_alive_within_three_beats(self, mesh_on):
+        now = datetime.now(timezone.utc)
+        assert mesh.node_is_alive(now - timedelta(seconds=44), now) is True
+
+    def test_dead_after_three_missed_beats(self, mesh_on):
+        now = datetime.now(timezone.utc)
+        assert mesh.node_is_alive(now - timedelta(seconds=46), now) is False
+
+    def test_never_heartbeated_is_dead(self):
+        assert mesh.node_is_alive(None) is False
+
+    def test_naive_datetime_treated_as_utc(self, mesh_on):
+        now = datetime.now(timezone.utc)
+        naive = (now - timedelta(seconds=5)).replace(tzinfo=None)
+        assert mesh.node_is_alive(naive, now) is True
+
+
+# ---------------------------------------------------------------------------
+# Registration + heartbeat API
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrationApi:
+    def test_register_and_list(self, mesh_on):
+        resp = client.post(
+            "/api/mesh/register",
+            json={
+                "name": "spark-1",
+                "base_url": "http://spark.local:8080",
+                "capabilities": ["GPU", "spark", "code"],
+            },
+            headers=_headers(),
+        )
+        assert resp.status_code == 200
+        node = resp.json()["data"]
+        assert node["name"] == "spark-1"
+        assert node["status"] == "alive"
+        assert sorted(node["capabilities"]) == ["code", "gpu", "spark"]  # lowercased
+
+        listing = client.get("/api/mesh/nodes")
+        assert listing.status_code == 200
+        data = listing.json()["data"]
+        assert data["enabled"] is True
+        assert len(data["nodes"]) == 1
+        assert data["nodes"][0]["id"] == node["id"]
+
+    def test_register_upserts_on_base_url(self, mesh_on):
+        body = {"name": "n1", "base_url": "http://node:8080", "capabilities": ["code"]}
+        first = client.post("/api/mesh/register", json=body, headers=_headers())
+        body2 = {"name": "n1-renamed", "base_url": "http://node:8080", "capabilities": ["browser"]}
+        second = client.post("/api/mesh/register", json=body2, headers=_headers())
+        assert first.json()["data"]["id"] == second.json()["data"]["id"]
+        assert second.json()["data"]["capabilities"] == ["browser"]
+
+    def test_register_rejects_non_http_url(self, mesh_on):
+        resp = client.post(
+            "/api/mesh/register",
+            json={"name": "x", "base_url": "ftp://nope", "capabilities": []},
+            headers=_headers(),
+        )
+        assert resp.status_code == 422
+
+    def test_heartbeat_known_node(self, mesh_on):
+        node = client.post(
+            "/api/mesh/register",
+            json={"name": "n", "base_url": "http://n:1", "capabilities": ["code"]},
+            headers=_headers(),
+        ).json()["data"]
+        resp = client.post(
+            "/api/mesh/heartbeat", json={"node_id": node["id"]}, headers=_headers()
+        )
+        assert resp.status_code == 200
+        assert resp.json()["data"]["status"] == "alive"
+
+    def test_heartbeat_unknown_node_404(self, mesh_on):
+        resp = client.post(
+            "/api/mesh/heartbeat",
+            json={"node_id": "00000000-0000-0000-0000-000000000000"},
+            headers=_headers(),
+        )
+        assert resp.status_code == 404
+
+    async def test_node_goes_dead_without_heartbeats(self, mesh_on):
+        from sqlalchemy import update
+
+        from sandcastle.models.db import MeshNode, async_session
+
+        node = await mesh.register_node("dying", "http://dying:1", ["code"])
+        async with async_session() as session:
+            await session.execute(
+                update(MeshNode).values(
+                    last_heartbeat=datetime.now(timezone.utc) - timedelta(seconds=100)
+                )
+            )
+            await session.commit()
+        nodes = await mesh.list_nodes()
+        assert nodes[0]["id"] == node["id"]
+        assert nodes[0]["status"] == "dead"
+
+
+# ---------------------------------------------------------------------------
+# Token auth (security: never execute for unauthenticated callers)
+# ---------------------------------------------------------------------------
+
+
+class TestMeshAuth:
+    REGISTER_BODY = {"name": "x", "base_url": "http://x:1", "capabilities": []}
+
+    def test_mesh_disabled_403(self, monkeypatch):
+        monkeypatch.setattr(settings, "mesh_enabled", False)
+        monkeypatch.setattr(settings, "mesh_token", MESH_TOKEN)
+        resp = client.post("/api/mesh/register", json=self.REGISTER_BODY, headers=_headers())
+        assert resp.status_code == 403
+
+    def test_no_token_configured_403(self, monkeypatch):
+        monkeypatch.setattr(settings, "mesh_enabled", True)
+        monkeypatch.setattr(settings, "mesh_token", "")
+        resp = client.post("/api/mesh/register", json=self.REGISTER_BODY, headers=_headers(""))
+        assert resp.status_code == 403
+
+    def test_wrong_token_401(self, mesh_on):
+        resp = client.post(
+            "/api/mesh/register", json=self.REGISTER_BODY, headers=_headers("wrong")
+        )
+        assert resp.status_code == 401
+
+    def test_missing_token_401(self, mesh_on):
+        resp = client.post("/api/mesh/register", json=self.REGISTER_BODY)
+        assert resp.status_code == 401
+
+    def test_execute_step_requires_token(self, mesh_on):
+        resp = client.post(
+            "/api/mesh/execute-step",
+            json={"step": {"id": "s", "type": "transform"}},
+            headers=_headers("nope"),
+        )
+        assert resp.status_code == 401
+
+    def test_nodes_read_requires_api_key_when_auth_enabled(self, mesh_on, monkeypatch):
+        monkeypatch.setattr(settings, "auth_required", True)
+        resp = client.get("/api/mesh/nodes")
+        assert resp.status_code == 401  # admin reads stay behind regular auth
+
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+
+
+def _fake_nodes(*nodes: dict) -> list[dict]:
+    base = {
+        "id": "id",
+        "base_url": "http://node:1",
+        "capabilities": [],
+        "status": "alive",
+        "heartbeat_age_seconds": 1.0,
+        "last_heartbeat": None,
+        "registered_at": None,
+    }
+    return [{**base, **n} for n in nodes]
+
+
+class TestRouting:
+    async def test_no_requires_runs_local(self):
+        step = StepDefinition(id="s", prompt="x")
+        assert step.requires == []
+        assert await mesh.resolve_route(step) is None
+
+    async def test_local_preferred_when_it_qualifies(self, mesh_on, monkeypatch):
+        monkeypatch.setattr(mesh, "get_local_capabilities", lambda: ["code", "gpu"])
+        step = StepDefinition(id="s", prompt="x", requires=["gpu"])
+        assert await mesh.resolve_route(step) is None
+
+    async def test_picks_node_satisfying_all_capabilities(self, mesh_on, monkeypatch):
+        monkeypatch.setattr(mesh, "get_local_capabilities", lambda: ["code"])
+
+        async def fake_list():
+            return _fake_nodes(
+                {"id": "a", "name": "gpu-only", "capabilities": ["gpu"]},
+                {"id": "b", "name": "gpu-browser", "capabilities": ["gpu", "browser"]},
+            )
+
+        monkeypatch.setattr(mesh, "list_nodes", fake_list)
+        step = StepDefinition(id="s", prompt="x", requires=["gpu", "browser"])
+        chosen = await mesh.resolve_route(step)
+        assert chosen is not None and chosen["name"] == "gpu-browser"
+
+    async def test_dead_nodes_skipped(self, mesh_on, monkeypatch):
+        monkeypatch.setattr(mesh, "get_local_capabilities", lambda: ["code"])
+
+        async def fake_list():
+            return _fake_nodes(
+                {"id": "a", "name": "dead-gpu", "capabilities": ["gpu"], "status": "dead"},
+            )
+
+        monkeypatch.setattr(mesh, "list_nodes", fake_list)
+        step = StepDefinition(id="s", prompt="x", requires=["gpu"])
+        with pytest.raises(mesh.MeshRoutingError) as exc:
+            await mesh.resolve_route(step)
+        # Error lists known nodes + their capabilities + the join command
+        msg = str(exc.value)
+        assert "dead-gpu" in msg and "gpu" in msg and "sandcastle node join" in msg
+
+    async def test_unsatisfied_requires_clear_error(self, mesh_on, monkeypatch):
+        monkeypatch.setattr(mesh, "get_local_capabilities", lambda: ["code"])
+
+        async def fake_list():
+            return []
+
+        monkeypatch.setattr(mesh, "list_nodes", fake_list)
+        step = StepDefinition(id="train", prompt="x", requires=["gpu"])
+        with pytest.raises(mesh.MeshRoutingError) as exc:
+            await mesh.resolve_route(step)
+        msg = str(exc.value)
+        assert "train" in msg and "['gpu']" in msg and "none" in msg
+
+    async def test_mesh_disabled_but_requires_set(self, monkeypatch):
+        monkeypatch.setattr(settings, "mesh_enabled", False)
+        monkeypatch.setattr(mesh, "get_local_capabilities", lambda: ["code"])
+        step = StepDefinition(id="s", prompt="x", requires=["gpu"])
+        with pytest.raises(mesh.MeshRoutingError, match="mesh is disabled"):
+            await mesh.resolve_route(step)
+
+    async def test_control_flow_types_not_routable(self, mesh_on, monkeypatch):
+        monkeypatch.setattr(mesh, "get_local_capabilities", lambda: ["code"])
+        step = StepDefinition(id="s", prompt="x", type="approval", requires=["gpu"])
+        with pytest.raises(mesh.MeshRoutingError, match="cannot be routed"):
+            await mesh.resolve_route(step)
+
+
+# ---------------------------------------------------------------------------
+# YAML schema (backward compatible)
+# ---------------------------------------------------------------------------
+
+
+class TestRequiresYaml:
+    def test_requires_parsed(self):
+        wf = parse_yaml_string(
+            """
+name: mesh-test
+steps:
+  - id: train
+    prompt: "train it"
+    requires: [GPU, spark]
+  - id: plain
+    prompt: "no requires"
+"""
+        )
+        assert wf.get_step("train").requires == ["gpu", "spark"]
+        assert wf.get_step("plain").requires == []
+
+    def test_requires_scalar_coerced(self):
+        wf = parse_yaml_string(
+            """
+name: mesh-test
+steps:
+  - id: s
+    prompt: "x"
+    requires: gpu
+"""
+        )
+        assert wf.get_step("s").requires == ["gpu"]
+
+
+# ---------------------------------------------------------------------------
+# Wire payload roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestPayloadRoundtrip:
+    def test_transform_step_roundtrip(self):
+        step = StepDefinition(
+            id="t",
+            type="transform",
+            transform_config=TransformConfig(template="Hello {input.name}"),
+            requires=["browser"],
+            depends_on=["earlier"],
+        )
+        rebuilt = mesh.step_from_payload(mesh.step_to_payload(step))
+        assert rebuilt.id == "t"
+        assert rebuilt.type == "transform"
+        assert rebuilt.transform_config.template == "Hello {input.name}"
+        assert rebuilt.depends_on == ["earlier"]
+        # requires is dropped on the wire so a node never re-routes
+        assert rebuilt.requires == []
+
+    def test_unknown_config_keys_ignored(self):
+        payload = mesh.step_to_payload(StepDefinition(id="s", prompt="x"))
+        payload["transform_config"] = {"template": "x", "future_field": True}
+        rebuilt = mesh.step_from_payload(payload)
+        assert rebuilt.transform_config.template == "x"
+
+
+# ---------------------------------------------------------------------------
+# E2E-ish: in-process nodes via ASGITransport (no real network)
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEnd:
+    @pytest.fixture
+    def asgi_mesh(self, mesh_on, monkeypatch):
+        """Route coordinator HTTP calls into the in-process app."""
+        monkeypatch.setattr(mesh, "_TRANSPORT", httpx.ASGITransport(app=app))
+        yield
+
+    async def test_routed_step_executes_on_remote_node(self, asgi_mesh, monkeypatch):
+        # Two registered "machines": a GPU box and a browser box.
+        await mesh.register_node("spark", "http://spark-node", ["code", "gpu", "spark"])
+        await mesh.register_node("mac", "http://mac-node", ["code", "browser"])
+        monkeypatch.setattr(mesh, "get_local_capabilities", lambda: ["code"])
+
+        step = StepDefinition(
+            id="scrape",
+            type="transform",
+            transform_config=TransformConfig(template="Hello {input.name}"),
+            requires=["browser"],
+        )
+        target = await mesh.resolve_route(step)
+        assert target is not None and target["name"] == "mac"
+
+        context = RunContext(run_id="run-1", input={"name": "Mesh"}, workflow_name="wf")
+        result = await mesh.execute_step_remote(target, step, context)
+        assert result.status == "completed", result.error
+        assert result.output == "Hello Mesh"
+
+    async def test_remote_node_sees_upstream_outputs(self, asgi_mesh, monkeypatch):
+        await mesh.register_node("mac", "http://mac-node", ["browser"])
+        monkeypatch.setattr(mesh, "get_local_capabilities", lambda: ["code"])
+
+        step = StepDefinition(
+            id="second",
+            type="transform",
+            transform_config=TransformConfig(template="got: {steps.first.output}"),
+            depends_on=["first"],
+            requires=["browser"],
+        )
+        target = await mesh.resolve_route(step)
+        context = RunContext(
+            run_id="run-2",
+            input={},
+            workflow_name="wf",
+            step_outputs={"first": "upstream-value"},
+        )
+        result = await mesh.execute_step_remote(target, step, context)
+        assert result.status == "completed", result.error
+        assert result.output == "got: upstream-value"
+
+    async def test_unreachable_node_fails_step_cleanly(self, mesh_on, monkeypatch):
+        # No ASGI transport and a non-routable host: httpx raises -> failed StepResult
+        monkeypatch.setattr(
+            mesh, "_TRANSPORT",
+            httpx.MockTransport(lambda request: (_ for _ in ()).throw(
+                httpx.ConnectError("boom")
+            )),
+        )
+        node = {"name": "ghost", "base_url": "http://ghost:9"}
+        step = StepDefinition(id="s", prompt="x", type="transform",
+                              transform_config=TransformConfig(template="t"))
+        context = RunContext(run_id="r", input={}, workflow_name="wf")
+        result = await mesh.execute_step_remote(node, step, context)
+        assert result.status == "failed"
+        assert "unreachable" in result.error
+
+    def test_execute_step_endpoint_rejects_non_routable_type(self, mesh_on):
+        resp = client.post(
+            "/api/mesh/execute-step",
+            json={"step": {"id": "a", "type": "approval"}},
+            headers=_headers(),
+        )
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert data["status"] == "failed"
+        assert "not executable" in data["error"]
+
+    def test_execute_step_endpoint_validates_payload(self, mesh_on):
+        resp = client.post("/api/mesh/execute-step", json={}, headers=_headers())
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Backward compat: workflows without `requires` use the unchanged local path
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompat:
+    async def test_workflow_without_requires_never_touches_mesh(self, monkeypatch):
+        from sandcastle.engine.dag import build_plan
+        from sandcastle.engine.executor import execute_workflow
+
+        def _boom(*a, **k):
+            raise AssertionError("mesh routing must not run for requires-less steps")
+
+        monkeypatch.setattr(mesh, "resolve_route", _boom)
+
+        wf = parse_yaml_string(
+            """
+name: compat
+steps:
+  - id: t
+    type: transform
+    transform_config:
+      template: "plain {input.x}"
+"""
+        )
+        result = await execute_workflow(wf, build_plan(wf), {"x": "ok"})
+        assert result.status == "completed"
+        assert result.outputs["t"] == "plain ok"


### PR DESCRIPTION
Your own private agent cloud: multiple boxes (DGX Spark, Mac mini, server) form one mesh; steps route to the machine that can run them — GPU steps to the Spark, browser steps to the Mac, code steps anywhere.

- **`engine/mesh.py` + `MeshNode` table**: node registry with capability manifests, heartbeats (15s, dead after 3 missed), auto-detected capabilities on join (Spark detection → `gpu`+`spark`, Playwright → `browser`, Docker socket → `docker`)
- **`requires:` on steps** (backward-compatible DAG schema addition): empty → local as today; otherwise the dispatcher picks a live node satisfying ALL capabilities (local preferred when it qualifies); no match → clear error listing known nodes + the join command
- **Execution surface**: `POST /api/mesh/execute-step` — the node wraps the routed step in a one-step workflow and runs it through its own full executor (retries, sandboxing, policies all reused; zero duplicated execution logic). Token-authed (`X-Mesh-Token`, constant-time compare, fail-closed when mesh disabled)
- **CLI**: `sandcastle node join <coordinator> --token <t>` — registers, heartbeats, serves, re-registers on coordinator restart
- **Dashboard**: Fleet page — node cards with capability chips, heartbeat age, status; demo fleet in mock mode

Config: `MESH_ENABLED` (default off), `MESH_TOKEN` (sensitive), `MESH_HEARTBEAT_SECONDS`.

Tests: 37 new pytest (registration/heartbeat/death, routing, auth fail-closed, backward compat) in a 466-test green subset; 5 vitest; lint zero new; build green; ruff clean.

Stacked on #255 (gui-experiment).