### PR TITLE
fix(security): 0.40.2 audit sweep - harden steps, sandbox, MCP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,12 @@
 #   Set DATABASE_URL and REDIS_URL to use PostgreSQL + Redis + S3.
 
 # --- Required ---
-SANDSTORM_URL=http://localhost:8000
+# Base URL the CLI targets. `sandcastle serve` listens on port 8080 by default.
+SANDCASTLE_URL=http://localhost:8080
 ANTHROPIC_API_KEY=sk-ant-...
+
+# --- Sandbox backend credentials ---
+# Required only for the E2B sandbox backend (SANDBOX_BACKEND=e2b).
 E2B_API_KEY=e2b_...
 
 # --- Database ---
@@ -55,4 +59,12 @@ API_KEY_PEPPER=
 # Bootstrap admin key created on startup when set.
 # Generate with: printf 'sc_%s\n' "$(openssl rand -hex 24)"
 ADMIN_API_KEY=
+# In-process "code" steps run untrusted Python in-process. They are admin-only
+# by default. Single-tenant self-hosted operators who intentionally use code
+# steps can opt in; leave false on multi-tenant deployments.
+CODE_STEPS_ALLOW_UNTRUSTED=false
+# Bearer token for the Memory MCP server over streamable-http. Required to start
+# streamable-http outside local mode (it fails closed without it). stdio is
+# unaffected. Callers must send: Authorization: Bearer <token>
+# MEMORY_MCP_TOKEN=
 LOG_LEVEL=info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.40.2] - 2026-07-11 - "Hardened Steps"
+
+Security and correctness patch from a full audit sweep (engine, API, CLI, sandbox, deps). No new
+features; existing behavior is preserved except where it was unsafe or wrong.
+
+### Security
+- In-process `code` steps are now gated to admin callers by default. The main run endpoints no
+  longer pass `admin_trusted=True` unconditionally; a normal tenant can no longer execute
+  in-process code steps unless the caller is admin or the operator opts in via
+  `CODE_STEPS_ALLOW_UNTRUSTED=true`.
+- Hardened the in-process code-step sandbox against blocklist bypass: the file helpers moved to a
+  dedicated module whose namespace holds no secrets (closes the `str.format`/`__globals__`
+  traversal to `settings`), and an AST validation pass rejects `import`, dunder-attribute access,
+  and format strings that traverse a dunder attribute (ordinary `str.format` such as
+  `"{}|{:.2f}".format(a, b)` keeps working). The out-of-process sandbox backend remains the fully
+  robust isolation.
+- Fixed a path-traversal write in the code-step `save_file_b64` helper: the destination is now
+  resolved and confined to the data `tmp` directory.
+- The Memory MCP server now fails closed over `streamable-http`: it requires `MEMORY_MCP_TOKEN`
+  (enforced by a constant-time bearer check) and refuses to start unauthenticated outside local
+  mode. The stdio transport is unchanged.
+- HTTP steps block redirects and reuse the webhook dispatcher's blocked-network ranges for the
+  SSRF pre-flight check.
+- Raised dependency floors past known CVEs: `jinja2>=3.1.6` (report extra) and
+  `python-multipart>=0.0.18`.
+
+### Fixed
+- HTTP steps now fail on 4xx/5xx responses by default (set `fail_on_error: false` to keep the
+  legacy pass-through), so `retry.on_failure` triggers and downstream steps no longer consume an
+  error body as valid data. The response `status_code` is now exposed on JSON dict outputs.
+- Loop steps enforce the run budget mid-loop instead of only after every iteration completes,
+  preventing large overshoots of `max_cost_usd`.
+- Fan-out (`parallel_over`) steps now persist an aggregate run-step record and set
+  `step_results`, so their status is queryable and downstream `steps.X.status` references resolve.
+- Race steps can now select a branch whose winning output is legitimately `None` instead of
+  reporting "all branches failed".
+- E2B custom (prebaked) templates no longer drop workflow tool-connector files; `tool_files` are
+  uploaded regardless of whether a template is set.
+- `sandcastle providers` probes Ollama at `OLLAMA_HOST` instead of a hardcoded
+  `localhost:11434`, so Docker/Spark users see accurate status.
+- `sandcastle run <missing>.yaml` reports a clear "file not found" error instead of sending the
+  filename to the server and surfacing a generic 404.
+- Removed a misleading code-step cancellation comment and the dead cancellation event; the
+  in-process timeout behavior is now documented accurately.
+- Fixed `.env.example`: replaced the dead `SANDSTORM_URL` (wrong port) with `SANDCASTLE_URL`
+  (`http://localhost:8080`) and moved `E2B_API_KEY` into a backend-conditional section.
+
 ## [0.40.1] - 2026-07-11 - "Docker on Your Box"
 
 Patch release for teams installing Sandcastle through Docker Compose and for NVIDIA DGX Spark

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Build once. Run anywhere.** Sandcastle is an open-source, production-ready orchestrator for AI agents. **Describe a workflow in plain English and it builds it** (or write the YAML yourself); run it on **any model** — Claude, GPT, Mistral, or a local model on your own box — and move between them with one line; deploy it **your way** — cloud, your own server, fully air-gapped, or EU-only; and it **gets better over time**, on its own. Local models run at `$0/run` with hard data-residency enforcement and a tamper-evident audit trail; the cloud is there too, with 7 providers and auto-failover, 22 step types, verified templates, and a full dashboard. Sovereign by default. European-built.
 
-[![PyPI](https://img.shields.io/badge/PyPI-v0.40.1-blue?style=flat-square)](https://pypi.org/project/sandcastle-ai/0.40.1/)
+[![PyPI](https://img.shields.io/badge/PyPI-v0.40.2-blue?style=flat-square)](https://pypi.org/project/sandcastle-ai/0.40.2/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![Tests](https://img.shields.io/badge/tests-17900%2B%20passing-brightgreen?style=flat-square)](https://github.com/gizmax/Sandcastle/actions)
@@ -716,6 +716,13 @@ SANDBOX_BACKEND=cloudflare # requires deployed CF Worker
 All backends share the same `SandboxBackend` protocol - same YAML, same API, same dashboard. Switch backends without changing workflows.
 
 **Docker hardening:** When using the Docker backend, containers run with all capabilities dropped, a seccomp profile restricting syscalls, PID limits (default 100), CPU quotas (default 50%), memory limits (default 512 MiB), and an unprivileged user (1000:1000). All configurable via environment variables.
+
+**Security-relevant settings:**
+
+| Setting | Default | Meaning |
+|---|---|---|
+| `CODE_STEPS_ALLOW_UNTRUSTED` | `false` | In-process `code` steps are admin-only by default. Set `true` on single-tenant self-hosted deployments to let any authenticated caller run them; keep `false` for multi-tenant. |
+| `MEMORY_MCP_TOKEN` | — | Bearer token for the Memory MCP `streamable-http` transport. Required to start it outside local mode (fails closed); callers must send `Authorization: Bearer <token>`. stdio is unaffected. |
 
 ---
 

--- a/deploy/mcp-tunnel/memory-mcp/Chart.yaml
+++ b/deploy/mcp-tunnel/memory-mcp/Chart.yaml
@@ -3,7 +3,7 @@ name: memory-mcp
 description: Sandcastle Memory MCP server behind a Cloudflare MCP tunnel (outbound-only, no inbound ingress required)
 type: application
 version: 0.1.0
-appVersion: "0.40.1"
+appVersion: "0.40.2"
 keywords:
   - sandcastle
   - mcp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "fastapi>=0.115",
-    "python-multipart>=0.0.9",
+    "python-multipart>=0.0.18",
     "uvicorn[standard]>=0.30",
     "httpx>=0.28",
     "httpx-sse>=0.4",
@@ -64,7 +64,7 @@ ocr = [
 ]
 report = [
     "weasyprint>=68",
-    "jinja2>=3.1",
+    "jinja2>=3.1.6",
     "markdown>=3.5",
     "matplotlib>=3.8",
 ]

--- a/src/sandcastle/__init__.py
+++ b/src/sandcastle/__init__.py
@@ -1,6 +1,6 @@
 """Sandcastle - Production-ready workflow orchestrator for AI agents."""
 
-__version__ = "0.40.1"
+__version__ = "0.40.2"
 
 __all__ = ["SandcastleClient", "AsyncSandcastleClient", "__version__"]
 

--- a/src/sandcastle/__main__.py
+++ b/src/sandcastle/__main__.py
@@ -1278,6 +1278,14 @@ def _cmd_run(args: argparse.Namespace) -> None:
         _run_local(workflow_name, input_data, args.max_cost, record=record, replay=replay)
         return
 
+    # A .yaml/.yml argument that does not exist is almost certainly a mistyped file
+    # path, not a remote workflow name. Fail clearly instead of sending the literal
+    # filename to the server and surfacing a generic 404.
+    _wf_path = Path(args.workflow)
+    if _wf_path.suffix in (".yaml", ".yml") and not _wf_path.exists():
+        print(f"Error: file not found: {args.workflow}", file=sys.stderr)
+        sys.exit(1)
+
     client = _get_client(args)
 
     # Build input data
@@ -4184,6 +4192,34 @@ def _cmd_violations(args: argparse.Namespace) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _parse_ollama_target(raw: str | None) -> tuple[str, int]:
+    """Parse an OLLAMA_HOST value into a (host, port) tuple for a socket probe.
+
+    Accepts values with or without a scheme, e.g. "http://host.docker.internal:11434",
+    "host.docker.internal:11434", or "host.docker.internal". Defaults to
+    localhost:11434 when unset or unparseable.
+    """
+    if not raw or not raw.strip():
+        return ("localhost", 11434)
+    value = raw.strip()
+    # Strip any scheme (http://, https://) so we are left with host[:port][/path].
+    if "://" in value:
+        value = value.split("://", 1)[1]
+    # Drop any path/query component.
+    value = value.split("/", 1)[0]
+    host = value
+    port = 11434
+    if ":" in value:
+        host, _, port_str = value.rpartition(":")
+        try:
+            port = int(port_str)
+        except ValueError:
+            host, port = value, 11434
+    if not host:
+        host = "localhost"
+    return (host, port)
+
+
 def _cmd_providers(args: argparse.Namespace) -> None:  # noqa: ARG001
     """List configured AI providers and their status."""
     from sandcastle.engine.generator import _PROVIDER_CONFIGS
@@ -4210,10 +4246,16 @@ def _cmd_providers(args: argparse.Namespace) -> None:  # noqa: ARG001
 
         # Determine configured status
         if not key_env:
-            # Ollama - check if running (best-effort socket probe)
+            # Ollama - check if running (best-effort socket probe).
+            # Respect OLLAMA_HOST / settings.ollama_host so Docker/Spark users who
+            # point at host.docker.internal are probed at the right target.
             import socket
+
+            from sandcastle.config import settings as _ollama_settings
+            _ollama_raw = os.environ.get("OLLAMA_HOST") or _ollama_settings.ollama_host
+            _ollama_host, _ollama_port = _parse_ollama_target(_ollama_raw)
             try:
-                s = socket.create_connection(("localhost", 11434), timeout=1)
+                s = socket.create_connection((_ollama_host, _ollama_port), timeout=1)
                 s.close()
                 configured = True
                 status_label = "Running"

--- a/src/sandcastle/api/routes.py
+++ b/src/sandcastle/api/routes.py
@@ -5094,7 +5094,7 @@ async def run_workflow_sync(request: WorkflowRunRequest, req: Request) -> ApiRes
             run_id=run_id,
             storage=storage,
             max_cost_usd=budget,
-            admin_trusted=True,
+            admin_trusted=is_admin(req) or settings.code_steps_allow_untrusted,
             tenant_id=tenant_id,
         )
     except Exception as exc:
@@ -5357,7 +5357,12 @@ async def run_workflow_async(request: WorkflowRunRequest, req: Request) -> ApiRe
 
     # Enqueue the job - clean up orphan run on failure
     try:
-        await enqueue_workflow(yaml_content, request.input, run_id, admin_trusted=True)
+        await enqueue_workflow(
+            yaml_content,
+            request.input,
+            run_id,
+            admin_trusted=is_admin(req) or settings.code_steps_allow_untrusted,
+        )
     except Exception as e:
         # Mark the run as failed so it doesn't stay stuck as "queued"
         try:

--- a/src/sandcastle/config.py
+++ b/src/sandcastle/config.py
@@ -111,6 +111,11 @@ class Settings(BaseSettings):
     # Max concurrent sandboxes (prevents rate limiting)
     max_concurrent_sandboxes: int = 5
 
+    # Allow non-admin tenants to run in-process "code" steps. Off by default so
+    # multi-tenant deployments stay safe; single-tenant self-hosted operators who
+    # intentionally use code steps can opt in via CODE_STEPS_ALLOW_UNTRUSTED=true.
+    code_steps_allow_untrusted: bool = False
+
     # Database (empty = local SQLite mode)
     database_url: str = ""
 

--- a/src/sandcastle/engine/backends.py
+++ b/src/sandcastle/engine/backends.py
@@ -227,22 +227,6 @@ class E2BBackend:
                 )
                 _, npm_handle = await asyncio.gather(upload_coro, npm_coro)
 
-                # Upload tool connector files into /home/user/tools/
-                if tool_files:
-                    for fname in tool_files:
-                        _validate_tool_filename(fname)
-                    await sandbox.commands.run("mkdir -p /home/user/tools", timeout=5)
-                    tool_uploads = [
-                        sandbox.files.write(f"/home/user/tools/{fname}", content)
-                        for fname, content in tool_files.items()
-                    ]
-                    if tool_uploads:
-                        await asyncio.gather(*tool_uploads)
-                        logger.info(
-                            "Uploaded %d tool files to sandbox",
-                            len(tool_uploads),
-                        )
-
                 # Wait for npm to finish using event-based polling with a
                 # hard deadline instead of a naive sleep loop.
                 try:
@@ -267,6 +251,26 @@ class E2BBackend:
                         )
                 except Exception as exc:
                     logger.warning("npm install error: %s", exc)
+
+            # Upload tool connector files into /home/user/tools/. This runs
+            # regardless of whether a prebaked template is used: a custom template
+            # ships the runner + SDK, but tool connectors are workflow-specific and
+            # must always be written into the sandbox or the runner hits
+            # "module not found" at runtime.
+            if tool_files:
+                for fname in tool_files:
+                    _validate_tool_filename(fname)
+                await sandbox.commands.run("mkdir -p /home/user/tools", timeout=5)
+                tool_uploads = [
+                    sandbox.files.write(f"/home/user/tools/{fname}", content)
+                    for fname, content in tool_files.items()
+                ]
+                if tool_uploads:
+                    await asyncio.gather(*tool_uploads)
+                    logger.info(
+                        "Uploaded %d tool files to sandbox",
+                        len(tool_uploads),
+                    )
 
             handle = await sandbox.commands.run(
                 f"node /home/user/{runner_file}",

--- a/src/sandcastle/engine/code_sandbox_helpers.py
+++ b/src/sandcastle/engine/code_sandbox_helpers.py
@@ -1,0 +1,64 @@
+"""File helpers for the in-process code-step sandbox.
+
+This module imports ONLY ``base64`` and ``pathlib`` on purpose. The helper
+closures returned by :func:`make_code_sandbox_helpers` are injected into the
+restricted ``exec`` globals of a code step. Because they are defined here and
+not in ``executor``, their ``__globals__`` contains no application secrets
+(``settings``, ``async_session``, database engines, etc.). This closes the
+format-string / ``__globals__`` traversal vector where a crafted code step
+reaches back into the defining module's namespace through a helper function.
+
+The fully robust isolation is still the out-of-process sandbox backend; this is
+one of several defense-in-depth mitigations layered on top of the admin gate.
+"""
+
+import base64
+from pathlib import Path
+from typing import Callable
+
+
+def make_code_sandbox_helpers(
+    data_dir: Path,
+) -> tuple[Callable[[str], str], Callable[[str, str], str]]:
+    """Build the ``read_file_b64`` / ``save_file_b64`` helpers bound to ``data_dir``.
+
+    Returns a ``(read_file_b64, save_file_b64)`` tuple. Both helpers confine all
+    filesystem access to ``data_dir`` and raise ``PermissionError`` on escape.
+    """
+    resolved_data_dir = Path(data_dir).resolve()
+
+    def read_file_b64(file_path: str) -> str:
+        """Read a file from disk and return its base64-encoded content."""
+        p = Path(file_path).resolve()
+        if not p.is_relative_to(resolved_data_dir):
+            raise PermissionError(f"Access denied: {file_path} is outside data directory")
+        if not p.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+        return base64.b64encode(p.read_bytes()).decode("ascii")
+
+    def save_file_b64(file_path: str, dest_name: str) -> str:
+        """Read a file, base64-encode it, save to a temp file, return the temp path.
+
+        Use this instead of read_file_b64 when the base64 would be too large
+        to store in the workflow context (>5MB). The returned path can be used
+        with {file:/path} syntax in HTTP step bodies for lazy loading.
+        """
+        p = Path(file_path).resolve()
+        if not p.is_relative_to(resolved_data_dir):
+            raise PermissionError(f"Access denied: {file_path} is outside data directory")
+        if not p.exists():
+            raise FileNotFoundError(f"File not found: {file_path}")
+        b64_data = base64.b64encode(p.read_bytes()).decode("ascii")
+        # Confine the destination to the tmp dir (subdirs allowed) so a crafted
+        # dest_name like "../../.ssh/authorized_keys" cannot escape it.
+        tmp_dir = (resolved_data_dir / "tmp").resolve()
+        dest = (resolved_data_dir / "tmp" / dest_name).resolve()
+        if not dest.is_relative_to(tmp_dir):
+            raise PermissionError(
+                f"Access denied: destination {dest_name} escapes the tmp directory"
+            )
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(b64_data)
+        return f"@file:{dest}"
+
+    return read_file_b64, save_file_b64

--- a/src/sandcastle/engine/dag.py
+++ b/src/sandcastle/engine/dag.py
@@ -153,6 +153,7 @@ class HttpConfig:
     auth: str | None = None  # "bearer:{token}" or env var ref
     value_map: dict[str, dict[str, str]] | None = None  # Post-resolution value mapping
     cost_per_call: float = 0.0  # Declared cost per API call (e.g. $0.02 for Imagen)
+    fail_on_error: bool = True  # Treat HTTP >= 400 as a failed step (set False to keep legacy pass-through)
 
 
 @dataclass
@@ -1030,6 +1031,7 @@ def _parse_http_config(data: dict | None) -> HttpConfig | None:
         auth=data.get("auth"),
         value_map=data.get("value_map"),
         cost_per_call=float(data.get("cost_per_call", 0.0)),
+        fail_on_error=bool(data.get("fail_on_error", True)),
     )
 
 

--- a/src/sandcastle/engine/executor.py
+++ b/src/sandcastle/engine/executor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import collections
 import copy
@@ -2858,7 +2859,17 @@ async def _execute_http_step(
         # Don't pass depends_on for URL - auto-inject is for prompts, not URLs
         url = resolve_templates(cfg.url, context).strip()
 
-        # SSRF prevention for HTTP steps - block private/internal networks
+        # SSRF prevention for HTTP steps - block private/internal networks.
+        # Reuse the webhook dispatcher's blocked-range list (IPv4-mapped, CGNAT,
+        # ULA, loopback, ...) so the ranges stay defined in one place.
+        # TODO(ssrf): this validates the resolved IPs but hands the *hostname* to
+        # httpx, which re-resolves at connect time. A TTL=0 rebind between this
+        # check and httpx's own resolution is therefore still theoretically
+        # possible. Closing that fully needs a custom httpx transport that pins and
+        # dials the validated address; that (and fail-closing on gaierror, which
+        # would change behavior for mocked-transport callers) is intentionally
+        # deferred. Redirects are blocked below to limit the remaining surface,
+        # mirroring the webhook dispatcher's accepted mitigation.
         try:
             import ipaddress as _ipaddress
             import socket as _socket
@@ -2887,7 +2898,7 @@ async def _execute_http_step(
                                     duration_seconds=time.monotonic() - started_at,
                                 )
                 except _socket.gaierror:
-                    pass  # DNS resolution failure - let httpx handle it naturally
+                    pass  # DNS resolution failure - let httpx surface it naturally
         except ImportError:
             pass
 
@@ -2988,7 +2999,11 @@ async def _execute_http_step(
             len(body) if body else 0, len(url),
         )
 
-        async with httpx.AsyncClient(timeout=step.timeout) as client:
+        async with httpx.AsyncClient(
+            timeout=step.timeout,
+            follow_redirects=False,
+            max_redirects=0,
+        ) as client:
             resp = await client.request(
                 method=cfg.method.upper(),
                 url=url,
@@ -3004,6 +3019,11 @@ async def _execute_http_step(
         # Try to parse as JSON
         try:
             output = resp.json()
+            # Expose status_code without changing the existing output shape so that
+            # {steps.X.output} and {steps.X.output.field} references keep working.
+            # setdefault avoids clobbering a real "status_code" field from the API.
+            if isinstance(output, dict):
+                output.setdefault("status_code", resp.status_code)
         except Exception:
             raw_text = resp.text
             truncated = len(raw_text) > 5000
@@ -3019,6 +3039,19 @@ async def _execute_http_step(
 
         duration = time.monotonic() - started_at
         call_cost = cfg.cost_per_call if cfg.cost_per_call else 0.0
+        # Surface HTTP errors as failed steps so retry.on_failure triggers and
+        # downstream steps don't consume an error body as valid data. Set
+        # fail_on_error: false on the step to keep the legacy pass-through behavior.
+        if cfg.fail_on_error and resp.status_code >= 400:
+            reason = resp.reason_phrase or "request failed"
+            return StepResult(
+                step_id=step.id,
+                output=output,
+                cost_usd=call_cost,
+                duration_seconds=duration,
+                status="failed",
+                error=f"HTTP {resp.status_code}: {reason}",
+            )
         return StepResult(
             step_id=step.id,
             output=output,
@@ -3187,6 +3220,47 @@ _CODE_STEP_BLOCKED_PATTERNS = re.compile(
     r"__reduce__|__reduce_ex__|pickle",
     re.IGNORECASE,
 )
+
+# A str.format / format_map field that reaches a dunder via attribute access,
+# e.g. "{0.__globals__[settings]}".format(fn). The dunder lives inside a string
+# literal so the plain blocklist above never sees it; _validate_code_step_ast
+# inspects string constants for this pattern instead. Plain formatting such as
+# "{}|{:.2f}".format(a, b) is intentionally NOT matched (no ".__" inside braces).
+_FORMAT_DUNDER_FIELD = re.compile(r"\{[^{}]*\.__\w")
+
+
+def _validate_code_step_ast(code: str) -> str | None:
+    """Structurally validate code-step source before exec.
+
+    Returns an error string if the code should be rejected, else None. This
+    complements the regex blocklist (belt and suspenders) by rejecting whole
+    categories of escape vectors that text scanning misses:
+    - any import statement (Import / ImportFrom)
+    - any attribute access whose name is a dunder (starts and ends with __),
+      which covers __globals__, __class__, __subclasses__, etc. regardless of
+      how the string is spelled in source (this also covers f-strings, whose
+      dunder access compiles to real Attribute nodes)
+    - any string literal containing a ``str.format`` field that traverses into a
+      dunder (e.g. ``"{0.__globals__[settings]}"``), which the plain blocklist
+      cannot see because the dunder is hidden inside the literal. Ordinary
+      formatting like ``"{}|{:.2f}".format(a, b)`` is allowed.
+    Normal attribute access (e.g. obj.value) and plain ``.format`` are allowed.
+    """
+    try:
+        tree = ast.parse(code)
+    except SyntaxError as exc:
+        return f"Code step has a syntax error: {exc}"
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            return "Code step uses 'import', which is not allowed in the restricted sandbox"
+        if isinstance(node, ast.Attribute):
+            attr = node.attr
+            if len(attr) > 4 and attr.startswith("__") and attr.endswith("__"):
+                return f"Code step accesses blocked dunder attribute '{attr}'"
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if _FORMAT_DUNDER_FIELD.search(node.value):
+                return "Code step uses a format string that traverses a dunder attribute"
+    return None
 
 
 def _resolve_params_deep(obj: Any, context: RunContext) -> Any:
@@ -4866,42 +4940,33 @@ async def _execute_code_step(
                 duration_seconds=time.monotonic() - started_at,
             )
 
+        # Guard: structural AST validation (belt and suspenders with the regex
+        # blocklist). Rejects imports and dunder-attribute traversal that text
+        # scanning can miss. The fully robust isolation is the out-of-process
+        # sandbox backend; this in-process path is admin-gated (fix A) plus these
+        # mitigations.
+        ast_error = _validate_code_step_ast(code)
+        if ast_error:
+            return StepResult(
+                step_id=step.id,
+                status="failed",
+                error=ast_error,
+                duration_seconds=time.monotonic() - started_at,
+            )
+
         # Inject context: _input and _steps
         # NOTE: 'type' is intentionally excluded - it provides access to
         # __subclasses__() which can be used for sandbox escape.
         import base64 as _b64_mod
 
-        # Safe file reader: only allows reading from uploads / data directory
+        # Build the file helpers in a dedicated module whose __globals__ holds no
+        # application secrets, so a format-string traversal through these helpers
+        # cannot reach settings / async_session (see code_sandbox_helpers.py).
         from sandcastle.config import settings as _code_settings
+        from sandcastle.engine.code_sandbox_helpers import make_code_sandbox_helpers
 
         _code_data_dir = Path(_code_settings.data_dir).resolve()
-
-        def _read_file_b64(file_path: str) -> str:
-            """Read a file from disk and return its base64-encoded content."""
-            p = Path(file_path).resolve()
-            if not p.is_relative_to(_code_data_dir):
-                raise PermissionError(f"Access denied: {file_path} is outside data directory")
-            if not p.exists():
-                raise FileNotFoundError(f"File not found: {file_path}")
-            return _b64_mod.b64encode(p.read_bytes()).decode("ascii")
-
-        def _save_file_b64(file_path: str, dest_name: str) -> str:
-            """Read a file, base64-encode it, save to a temp file, return the temp path.
-
-            Use this instead of read_file_b64 when the base64 would be too large
-            to store in the workflow context (>5MB). The returned path can be used
-            with {file:/path} syntax in HTTP step bodies for lazy loading.
-            """
-            p = Path(file_path).resolve()
-            if not p.is_relative_to(_code_data_dir):
-                raise PermissionError(f"Access denied: {file_path} is outside data directory")
-            if not p.exists():
-                raise FileNotFoundError(f"File not found: {file_path}")
-            b64_data = _b64_mod.b64encode(p.read_bytes()).decode("ascii")
-            dest = _code_data_dir / "tmp" / dest_name
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            dest.write_text(b64_data)
-            return f"@file:{dest}"
+        _read_file_b64, _save_file_b64 = make_code_sandbox_helpers(_code_data_dir)
 
         exec_globals: dict[str, Any] = {
             "__builtins__": {
@@ -4943,18 +5008,15 @@ async def _execute_code_step(
         # Run exec() in a thread with a timeout to prevent infinite loops/DoS.
         # The step-level timeout (default 300s) applies here, but we cap code
         # steps at 30s since they should be fast data transformations.
-        # NOTE: Python threads cannot be forcefully killed. The timeout only
-        # unblocks the caller; the worker thread keeps running. We use a
-        # threading.Event to signal cancellation and check it in a custom
-        # builtins range() wrapper, providing cooperative cancellation for
-        # loops. Truly uncooperative code (e.g. tight C-extension loops)
-        # will leak the thread, but the daemon thread pool ensures it won't
-        # block process exit.
+        # NOTE: Python threads cannot be forcefully killed. There is no
+        # cooperative cancellation here - the timeout only unblocks the caller,
+        # while the exec() worker thread keeps running to completion in the
+        # background. We abandon the pool (shutdown(wait=False)) so a runaway
+        # thread does not block returning the failed result; the leaked thread
+        # dies with the process on exit.
         import concurrent.futures
-        import threading
 
         _CODE_STEP_TIMEOUT = min(step.timeout, 30)
-        _cancel_event = threading.Event()
 
         def _run_code():
             exec(code, exec_globals)  # noqa: S102
@@ -4965,7 +5027,6 @@ async def _execute_code_step(
             try:
                 future.result(timeout=_CODE_STEP_TIMEOUT)
             except concurrent.futures.TimeoutError:
-                _cancel_event.set()
                 # Abandon the thread pool without waiting for it to finish;
                 # shutdown(wait=False) lets the daemon thread die with the process.
                 pool.shutdown(wait=False)
@@ -5338,9 +5399,40 @@ async def _execute_loop_step(
                 child_context.step_results[sub_step_id] = sub_result
                 total_cost += sub_result.cost_usd
 
-            # Sync child costs back to parent so budget checks see ongoing costs
-            context.costs.extend(child_context.costs)
-            child_context.costs.clear()
+            # Mid-loop budget enforcement. execute_step_with_retry returns cost in
+            # the StepResult but does not append to context.costs (that happens once
+            # via _handle_step_result when this loop step completes). So we project
+            # the parent's accumulated cost plus this loop's running total and abort
+            # as soon as the budget is exceeded, instead of overshooting until the
+            # whole loop finishes. We must not append to context.costs here or the
+            # loop cost would be double-counted when the loop StepResult is handled.
+            if context.max_cost_usd is not None and context.max_cost_usd > 0:
+                projected = context.total_cost + total_cost
+                if projected >= context.max_cost_usd:
+                    logger.warning(
+                        "Loop step '%s' aborted at iteration %d: projected cost "
+                        "$%.4f reached budget $%.4f",
+                        step.id, i, projected, context.max_cost_usd,
+                    )
+                    results.append(
+                        child_context.step_outputs.get(cfg.step_ids[-1])
+                        if cfg.step_ids else item
+                    )
+                    return StepResult(
+                        step_id=step.id,
+                        output={
+                            "status": "budget_exceeded",
+                            "completed_iterations": i + 1,
+                            "results": results,
+                        },
+                        cost_usd=total_cost,
+                        duration_seconds=time.monotonic() - started_at,
+                        status="failed",
+                        error=(
+                            f"Loop aborted: budget ${context.max_cost_usd:.4f} "
+                            f"exceeded after {i + 1} iteration(s)"
+                        ),
+                    )
 
             # Collect last sub-step output as the loop iteration result
             last_step = cfg.step_ids[-1] if cfg.step_ids else None
@@ -5440,8 +5532,11 @@ async def _execute_race_step(
             for i, branch in enumerate(cfg.branches)
         }
         pending = set(tasks.keys())
-        winning_output = None
-        fallback_output = None  # best non-validated result as fallback
+        # Distinct sentinel so a branch that legitimately produces None is still
+        # recognized as a winner (rather than being treated as "no winner yet").
+        _UNSET = object()
+        winning_output: Any = _UNSET
+        fallback_output: Any = _UNSET  # best non-validated result as fallback
 
         while pending:
             done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
@@ -5470,13 +5565,13 @@ async def _execute_race_step(
                             winning_output = result["output"]
                     except Exception:
                         pass
-                    if fallback_output is None:
+                    if fallback_output is _UNSET:
                         fallback_output = result["output"]
                 else:
                     # No validator - take first non-error result
                     winning_output = result["output"]
 
-            if winning_output is not None:
+            if winning_output is not _UNSET:
                 # Cancel remaining tasks
                 for t in pending:
                     t.cancel()
@@ -5489,11 +5584,11 @@ async def _execute_race_step(
         # Accumulate costs from ALL branches (winners, losers, and cancelled)
         total_cost = sum(branch_costs.values())
 
-        if winning_output is None:
+        if winning_output is _UNSET:
             winning_output = fallback_output
 
         duration = time.monotonic() - started_at
-        if winning_output is None:
+        if winning_output is _UNSET:
             return StepResult(
                 step_id=step.id,
                 status="failed",
@@ -7744,6 +7839,8 @@ async def _prepare_and_run_step(
     # --- Fan-out (parallel_over) - must come BEFORE type dispatch ---
     # so that hybrid types (llm, http, etc.) also get per-item contexts.
     if step.parallel_over:
+        import time
+
         # Strip {braces} - parallel_over may come from YAML as "{steps.x.output.y}"
         fan_out_path = step.parallel_over.strip("{}")
         items = resolve_variable(fan_out_path, context)
@@ -7781,6 +7878,9 @@ async def _prepare_and_run_step(
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
         fan_out_items: list = []
+        fan_out_cost = 0.0
+        fan_out_failed = 0
+        fan_out_started = time.monotonic()
         for i, result in enumerate(results):
             if isinstance(result, Exception):
                 logger.warning(
@@ -7800,7 +7900,9 @@ async def _prepare_and_run_step(
                 )
             async with context._lock:
                 context.costs.append(result.cost_usd)
+            fan_out_cost += result.cost_usd
             if result.status == "failed":
+                fan_out_failed += 1
                 on_fail = step.retry.on_failure if step.retry else "abort"
                 if use_dead_letter:
                     dlq_ok = await _send_to_dead_letter(
@@ -7820,8 +7922,34 @@ async def _prepare_and_run_step(
                     fan_out_items.append(None)
             else:
                 fan_out_items.append(result.output)
+
+        # Persist an aggregate run step and record a step result, mirroring the
+        # single-step _handle_step_result path. Without this there is no run-step
+        # row for the fan-out step and downstream steps.X.status references
+        # resolve wrong.
+        aggregate_status = "completed"
+        aggregate = StepResult(
+            step_id=step_id,
+            output=fan_out_items,
+            cost_usd=fan_out_cost,
+            duration_seconds=time.monotonic() - fan_out_started,
+            status=aggregate_status,
+        )
         async with context._lock:
             context.step_outputs[step_id] = fan_out_items
+            context.step_results[step_id] = aggregate
+        await _save_run_step(
+            run_id=context.run_id,
+            step_id=step_id,
+            status=aggregate_status,
+            output=fan_out_items,
+            cost_usd=fan_out_cost,
+            duration_seconds=aggregate.duration_seconds,
+            error=(
+                f"{fan_out_failed} of {len(results)} items failed"
+                if fan_out_failed else None
+            ),
+        )
         return
 
     # --- Hybrid step types (single execution, no parallel_over) ---

--- a/src/sandcastle/engine/memory_mcp_server.py
+++ b/src/sandcastle/engine/memory_mcp_server.py
@@ -33,8 +33,10 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hmac
 import json
 import logging
+import os
 import re
 import sys
 from typing import Any, Awaitable, Callable
@@ -615,6 +617,46 @@ def create_memory_mcp_server() -> Any:
 # ---------------------------------------------------------------------------
 
 
+class _BearerAuthMiddleware:
+    """Pure-ASGI middleware enforcing a static bearer token on HTTP requests.
+
+    The Memory MCP tools take a caller-supplied ``user_id``, so an unauthenticated
+    streamable-http transport would allow cross-tenant read/write/delete. This
+    middleware rejects any request missing a valid ``Authorization: Bearer`` header
+    with a 401 before it reaches the MCP handlers.
+    """
+
+    def __init__(self, app: Any, token: str) -> None:
+        self.app = app
+        self._expected = f"Bearer {token}".encode("latin-1")
+
+    async def __call__(self, scope: dict, receive: Callable, send: Callable) -> None:
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+        headers = dict(scope.get("headers") or [])
+        provided = headers.get(b"authorization", b"")
+        if not hmac.compare_digest(provided, self._expected):
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 401,
+                    "headers": [
+                        (b"content-type", b"application/json"),
+                        (b"www-authenticate", b"Bearer"),
+                    ],
+                }
+            )
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": b'{"error":"unauthorized"}',
+                }
+            )
+            return
+        await self.app(scope, receive, send)
+
+
 def serve(transport: str = "stdio", port: int = 8765) -> None:
     """Start the Memory MCP server on the requested transport."""
     if transport not in {"stdio", "streamable-http"}:
@@ -623,13 +665,50 @@ def serve(transport: str = "stdio", port: int = 8765) -> None:
         )
     server = create_memory_mcp_server()
     if transport == "stdio":
+        # stdio is not network-exposed; no auth needed.
         server.run(transport="stdio")
+        return
+
+    # streamable-http is network-exposed and the tools trust a caller-supplied
+    # user_id, so we fail closed unless a bearer token is configured.
+    token = (os.environ.get("MEMORY_MCP_TOKEN") or "").strip()
+    if not token:
+        from sandcastle.config import settings as _settings
+
+        if not _settings.is_local_mode:
+            raise MemoryMCPError(
+                "Refusing to start the Memory MCP over streamable-http without "
+                "authentication. Set MEMORY_MCP_TOKEN to a secret bearer token so "
+                "callers must send 'Authorization: Bearer <token>', or use the stdio "
+                "transport. This fails closed to prevent cross-tenant memory access.",
+                code="auth_required",
+            )
+        logger.warning(
+            "Memory MCP streamable-http started WITHOUT MEMORY_MCP_TOKEN. This is "
+            "allowed only because the server is in local mode; anyone who can reach "
+            "the port can read/write/delete any user's memories. Set MEMORY_MCP_TOKEN "
+            "before exposing this beyond localhost."
+        )
+
+    # FastMCP reads the port from its settings object.
+    try:
+        server.settings.port = int(port)
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+    if token:
+        # Wrap the streamable-http ASGI app with bearer enforcement and run it
+        # ourselves, since FastMCP.run has no per-request auth hook.
+        import uvicorn
+
+        app = _BearerAuthMiddleware(server.streamable_http_app(), token)
+        uvicorn.run(
+            app,
+            host=server.settings.host,
+            port=int(port),
+            log_level=str(server.settings.log_level).lower(),
+        )
     else:
-        # FastMCP reads the port from its settings object.
-        try:
-            server.settings.port = int(port)
-        except Exception:  # pragma: no cover - defensive
-            pass
         server.run(transport="streamable-http")
 
 

--- a/tests/test_audit_fixes.py
+++ b/tests/test_audit_fixes.py
@@ -701,8 +701,8 @@ class TestHttpTruncation:
             result = await _execute_http_step(step, ctx)
 
         assert result.status == "completed"
-        # JSON responses are returned as-is, no truncation
-        assert result.output == {"data": "x" * 10000}
+        # JSON responses are returned as-is (plus an attached status_code), no truncation
+        assert result.output == {"data": "x" * 10000, "status_code": 200}
         assert "_truncated" not in result.output
 
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -136,6 +136,52 @@ class TestE2BBackend:
             assert len(events) == 1
             assert events[0].event == "result"
 
+    @pytest.mark.asyncio
+    async def test_tool_files_uploaded_with_custom_template(self):
+        """Tool connector files must be uploaded even when a prebaked template is set.
+
+        Wave-2 fix F: the tool_files upload used to be nested under
+        `if not self._template:`, so a custom template silently dropped the
+        connector files and the runner hit "module not found" at runtime.
+        """
+        backend = E2BBackend(
+            e2b_api_key="key",
+            template="sandcastle-runner",
+            execution_grace_period=0.0,
+        )
+
+        mock_sandbox = AsyncMock()
+        mock_handle = MagicMock()
+        mock_handle.exit_code = 0
+        mock_sandbox.commands.run = AsyncMock(return_value=mock_handle)
+        mock_sandbox.files.write = AsyncMock()
+        mock_sandbox.kill = AsyncMock()
+
+        tool_files = {
+            "slack.mjs": "export const send = () => {}",
+            "http.mjs": "export const get = () => {}",
+        }
+
+        with patch("e2b.AsyncSandbox") as mock_cls:
+            mock_cls.create = AsyncMock(return_value=mock_sandbox)
+            events = []
+            async for event in backend.start(
+                runner_file="runner.mjs",
+                envs={"SANDCASTLE_REQUEST": "{}"},
+                use_claude_runner=True,
+                timeout=0,
+                tool_files=tool_files,
+            ):
+                events.append(event)
+
+        # The custom template was used (no runner upload / npm install), but the
+        # tool connector files were still written into /home/user/tools/.
+        written = {
+            call_obj.args[0] for call_obj in mock_sandbox.files.write.call_args_list
+        }
+        assert "/home/user/tools/slack.mjs" in written
+        assert "/home/user/tools/http.mjs" in written
+
 
 # ---------------------------------------------------------------------------
 # Docker Backend

--- a/tests/test_cli_local_run.py
+++ b/tests/test_cli_local_run.py
@@ -57,3 +57,50 @@ def test_run_local_resolves_builtin_template_name(tmp_path, capsys):
         assert exc.code in (0, 2), f"unexpected exit code {exc.code}"
     combined = capsys.readouterr()
     assert "not found" not in (combined.out + combined.err)
+
+
+# ---------------------------------------------------------------------------
+# Audit sweep 0.40.2 - CLI regression tests
+# ---------------------------------------------------------------------------
+
+
+def test_run_missing_yaml_reports_file_not_found(capsys):
+    """Fix 7: a missing .yaml arg on the remote path fails clearly, not as a 404."""
+    import argparse
+
+    from sandcastle.__main__ import _cmd_run
+
+    args = argparse.Namespace(
+        workflow="/nonexistent/does_not_exist.yaml",
+        max_cost=None,
+        local=False,
+        record=None,
+        replay=None,
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        _cmd_run(args)
+    assert exc_info.value.code == 1
+    assert "file not found" in capsys.readouterr().err
+
+
+def test_parse_ollama_target_defaults():
+    """Fix 6: unset OLLAMA_HOST falls back to localhost:11434."""
+    from sandcastle.__main__ import _parse_ollama_target
+
+    assert _parse_ollama_target(None) == ("localhost", 11434)
+    assert _parse_ollama_target("") == ("localhost", 11434)
+
+
+def test_parse_ollama_target_respects_docker_host():
+    """Fix 6: OLLAMA_HOST with scheme and port is parsed into host/port."""
+    from sandcastle.__main__ import _parse_ollama_target
+
+    assert _parse_ollama_target("http://host.docker.internal:11434") == (
+        "host.docker.internal",
+        11434,
+    )
+    assert _parse_ollama_target("host.docker.internal:9999") == (
+        "host.docker.internal",
+        9999,
+    )
+    assert _parse_ollama_target("http://myhost") == ("myhost", 11434)

--- a/tests/test_code_steps_admin_gate.py
+++ b/tests/test_code_steps_admin_gate.py
@@ -1,0 +1,136 @@
+"""Wave-2 fix A: in-process `code` steps are admin-gated by default.
+
+The sync/async run endpoints previously passed `admin_trusted=True`
+unconditionally, letting ANY authenticated tenant execute in-process code
+steps. Now the handler resolves
+`admin_trusted = is_admin(req) or settings.code_steps_allow_untrusted`
+and threads it into the executor / enqueue path.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+
+def _ok_session_factory():
+    """async_session() context manager where all DB ops succeed."""
+
+    def make_cm():
+        sess = AsyncMock()
+        sess.get = AsyncMock(return_value=MagicMock())
+        sess.commit = AsyncMock()
+        sess.add = MagicMock()
+        sess.execute = AsyncMock(return_value=MagicMock())
+        cm = AsyncMock()
+        cm.__aenter__ = AsyncMock(return_value=sess)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return cm
+
+    return make_cm
+
+
+_CODE_WORKFLOW = (
+    "name: code_gate_test\n"
+    "steps:\n"
+    "  - id: transform\n"
+    "    type: code\n"
+    "    code_config:\n"
+    "      code: |\n"
+    "        result = 42\n"
+)
+
+
+def _run_sync_capture(is_admin_return: bool, allow_untrusted: bool):
+    """POST to /run/sync and return the admin_trusted kwarg the executor saw."""
+    import sandcastle.api.routes as routes
+    from sandcastle.engine.executor import WorkflowResult
+    from sandcastle.main import app
+
+    client = TestClient(app, raise_server_exceptions=False)
+    captured: dict = {}
+
+    async def fake_execute(*_a, **kwargs):
+        captured["admin_trusted"] = kwargs.get("admin_trusted")
+        return WorkflowResult(
+            run_id=kwargs.get("run_id", "00000000-0000-0000-0000-000000000000"),
+            outputs={"transform": 42},
+            total_cost_usd=0.0,
+            status="completed",
+            started_at=datetime.now(timezone.utc),
+            completed_at=datetime.now(timezone.utc),
+        )
+
+    with (
+        patch("sandcastle.api.routes.async_session", side_effect=_ok_session_factory()),
+        patch("sandcastle.api.routes.execute_workflow", side_effect=fake_execute),
+        patch("sandcastle.api.routes.is_admin", return_value=is_admin_return),
+    ):
+        original = routes.settings.code_steps_allow_untrusted
+        with tempfile.TemporaryDirectory() as tmpdir:
+            wf_dir = routes.settings.workflows_dir
+            routes.settings.workflows_dir = tmpdir
+            routes.settings.code_steps_allow_untrusted = allow_untrusted
+            try:
+                resp = client.post(
+                    "/api/workflows/run/sync",
+                    json={"workflow": _CODE_WORKFLOW, "input": {}},
+                )
+            finally:
+                routes.settings.workflows_dir = wf_dir
+                routes.settings.code_steps_allow_untrusted = original
+
+    assert resp.status_code == 200, resp.text
+    return captured.get("admin_trusted")
+
+
+def test_non_admin_default_is_untrusted():
+    """Non-admin caller with the flag off => admin_trusted False (code steps blocked)."""
+    assert _run_sync_capture(is_admin_return=False, allow_untrusted=False) is False
+
+
+def test_flag_enables_untrusted_code_steps():
+    """code_steps_allow_untrusted=True lets a non-admin run code steps."""
+    assert _run_sync_capture(is_admin_return=False, allow_untrusted=True) is True
+
+
+def test_admin_is_always_trusted():
+    """Admin caller is trusted regardless of the flag."""
+    assert _run_sync_capture(is_admin_return=True, allow_untrusted=False) is True
+
+
+def test_async_enqueue_threads_admin_trusted():
+    """The async endpoint resolves admin_trusted in the handler and enqueues it."""
+    import sandcastle.api.routes as routes
+    from sandcastle.main import app
+
+    client = TestClient(app, raise_server_exceptions=False)
+    captured: dict = {}
+
+    async def fake_enqueue(*_a, **kwargs):
+        captured["admin_trusted"] = kwargs.get("admin_trusted")
+
+    with (
+        patch("sandcastle.api.routes.async_session", side_effect=_ok_session_factory()),
+        patch("sandcastle.api.routes.enqueue_workflow", side_effect=fake_enqueue),
+        patch("sandcastle.api.routes.is_admin", return_value=False),
+    ):
+        original = routes.settings.code_steps_allow_untrusted
+        with tempfile.TemporaryDirectory() as tmpdir:
+            wf_dir = routes.settings.workflows_dir
+            routes.settings.workflows_dir = tmpdir
+            routes.settings.code_steps_allow_untrusted = False
+            try:
+                resp = client.post(
+                    "/api/workflows/run",
+                    json={"workflow": _CODE_WORKFLOW, "input": {}},
+                )
+            finally:
+                routes.settings.workflows_dir = wf_dir
+                routes.settings.code_steps_allow_untrusted = original
+
+    assert resp.status_code == 202, resp.text
+    assert captured.get("admin_trusted") is False

--- a/tests/test_executor_deep.py
+++ b/tests/test_executor_deep.py
@@ -667,7 +667,7 @@ class TestHttpStep:
             result = await _execute_http_step(s, c)
 
         assert result.status == "completed"
-        assert result.output == {"status": "ok"}
+        assert result.output == {"status": "ok", "status_code": 200}
         assert result.cost_usd == 0.0
 
     @pytest.mark.asyncio

--- a/tests/test_executor_deep_coverage.py
+++ b/tests/test_executor_deep_coverage.py
@@ -158,7 +158,7 @@ class TestHttpStep:
             result = await _execute_http_step(step, ctx)
 
         assert result.status == "completed"
-        assert result.output == {"result": "ok"}
+        assert result.output == {"result": "ok", "status_code": 200}
 
     @pytest.mark.asyncio
     async def test_http_post_with_body(self):
@@ -187,7 +187,7 @@ class TestHttpStep:
             result = await _execute_http_step(step, ctx)
 
         assert result.status == "completed"
-        assert result.output == {"id": 123}
+        assert result.output == {"id": 123, "status_code": 201}
 
     @pytest.mark.asyncio
     async def test_http_text_response_not_json(self):

--- a/tests/test_executor_deep_v2.py
+++ b/tests/test_executor_deep_v2.py
@@ -1120,6 +1120,59 @@ steps:
             f"BUG-008: Expected 10 fan-out outputs, got {len(outputs)}"
         )
 
+    @pytest.mark.asyncio
+    async def test_fan_out_persists_run_step_and_step_result(self):
+        """Fan-out step must persist an aggregate run step and set step_results.
+
+        Wave-2 fix E: the parallel_over path previously wrote step_outputs and
+        costs but never called _save_run_step nor set context.step_results, so
+        downstream steps.X.status references resolved wrong and no run-step row
+        existed for the fan-out step.
+        """
+        from sandcastle.engine.dag import WorkflowDefinition
+        from sandcastle.engine.executor import _prepare_and_run_step
+
+        s = StepDefinition(
+            id="process",
+            type="standard",
+            prompt="Process {input._item}",
+            parallel_over="{input.items}",
+        )
+        wf = MagicMock(spec=WorkflowDefinition)
+        wf.get_step.return_value = s
+        wf.on_failure = None
+
+        c = ctx(input={"items": [1, 2, 3]}, costs=[])
+
+        async def _fake_run(*args, **kwargs):
+            return StepResult(
+                step_id="process", output="ok", cost_usd=0.5, status="completed"
+            )
+
+        save_mock = AsyncMock()
+        with (
+            patch("sandcastle.engine.executor.execute_step_with_retry", new=_fake_run),
+            patch("sandcastle.engine.executor._save_run_step", new=save_mock),
+        ):
+            await _prepare_and_run_step(
+                "process", wf, c, MagicMock(), storage(), [], None, 0,
+            )
+
+        # Aggregate step result recorded with completed status.
+        assert "process" in c.step_results
+        assert c.step_results["process"].status == "completed"
+        assert c.step_outputs["process"] == ["ok", "ok", "ok"]
+        # A run-step row was persisted for the aggregate fan-out step.
+        persisted_statuses = [
+            call_obj.kwargs.get("status") for call_obj in save_mock.call_args_list
+        ]
+        assert "completed" in persisted_statuses
+        # The persisted step id matches the fan-out step.
+        persisted_ids = [
+            call_obj.kwargs.get("step_id") for call_obj in save_mock.call_args_list
+        ]
+        assert "process" in persisted_ids
+
 
 # ══════════════════════════════════════════════════════════════
 # PASS 13 – TIMING & PERFORMANCE

--- a/tests/test_executor_edge_wave6.py
+++ b/tests/test_executor_edge_wave6.py
@@ -287,6 +287,88 @@ class TestLoopEmptyStepIds:
         assert len(result.output) == 2
 
 
+class TestLoopMidRunBudget:
+    """Loop steps must abort mid-run once the budget is exceeded (wave 2 fix D)."""
+
+    @pytest.mark.asyncio
+    async def test_loop_aborts_mid_run_on_budget(self):
+        """A loop over many costed sub-steps aborts before finishing all items."""
+        from sandcastle.engine.executor import _execute_loop_step
+
+        s = step(
+            id="loop1",
+            type="loop",
+            loop_config=LoopConfig(
+                over="{input.items}",
+                step_ids=["sub_step"],
+                max_iterations=100,
+            ),
+        )
+        # Budget 2.5; each iteration costs 1.0 -> should abort after 3 iterations
+        # (projected 3.0 >= 2.5), not run all 10.
+        c = ctx(input={"items": list(range(10))}, costs=[], max_cost_usd=2.5)
+
+        sub = step(id="sub_step", prompt="echo")
+        wf = MagicMock(spec=WorkflowDefinition)
+        wf.get_step.return_value = sub
+
+        call_count = {"n": 0}
+
+        async def _fake_run(*args, **kwargs):
+            call_count["n"] += 1
+            return StepResult(
+                step_id="sub_step", output="done", cost_usd=1.0, status="completed"
+            )
+
+        storage = AsyncMock()
+        with patch(
+            "sandcastle.engine.executor.execute_step_with_retry",
+            new=_fake_run,
+        ):
+            result = await _execute_loop_step(s, c, None, storage, wf, 0)
+
+        assert result.status == "failed"
+        assert result.output["status"] == "budget_exceeded"
+        # Aborted mid-loop, not after all 10 iterations.
+        assert result.output["completed_iterations"] < 10
+        assert call_count["n"] < 10
+
+    @pytest.mark.asyncio
+    async def test_loop_completes_within_budget(self):
+        """A loop under budget still completes all iterations normally."""
+        from sandcastle.engine.executor import _execute_loop_step
+
+        s = step(
+            id="loop1",
+            type="loop",
+            loop_config=LoopConfig(
+                over="{input.items}",
+                step_ids=["sub_step"],
+                max_iterations=100,
+            ),
+        )
+        c = ctx(input={"items": [1, 2, 3]}, costs=[], max_cost_usd=100.0)
+
+        sub = step(id="sub_step", prompt="echo")
+        wf = MagicMock(spec=WorkflowDefinition)
+        wf.get_step.return_value = sub
+
+        async def _fake_run(*args, **kwargs):
+            return StepResult(
+                step_id="sub_step", output="done", cost_usd=1.0, status="completed"
+            )
+
+        storage = AsyncMock()
+        with patch(
+            "sandcastle.engine.executor.execute_step_with_retry",
+            new=_fake_run,
+        ):
+            result = await _execute_loop_step(s, c, None, storage, wf, 0)
+
+        assert result.status == "completed"
+        assert len(result.output) == 3
+
+
 # ═══════════════════════════════════════════════════════════
 # BUG 3: _escape_braces applied uniformly
 # ═══════════════════════════════════════════════════════════

--- a/tests/test_executor_edge_wave9.py
+++ b/tests/test_executor_edge_wave9.py
@@ -2400,3 +2400,167 @@ class TestBrowserUrlValidation:
         from sandcastle.engine.executor import _validate_browser_url
         result = _validate_browser_url("  https://example.com  ")
         assert result == "https://example.com"
+
+
+# ================================================================
+# AUDIT SWEEP 0.40.2 - regression tests
+# ================================================================
+
+class TestHttpStepFailOnError:
+    """Fix 1: HTTP step must fail on 4xx/5xx unless fail_on_error is False."""
+
+    def _mock_client(self, status_code: int, json_body):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = json_body
+        mock_resp.status_code = status_code
+        mock_resp.reason_phrase = "Internal Server Error"
+        mock_resp.text = json.dumps(json_body)
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(return_value=mock_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        return mock_client
+
+    @pytest.mark.asyncio
+    async def test_http_500_fails_by_default(self):
+        from sandcastle.engine.executor import _execute_http_step
+
+        s = step(
+            id="http_err",
+            type="http",
+            http_config=HttpConfig(url="https://api.example.com/x", method="GET"),
+        )
+        c = ctx()
+        with patch("httpx.AsyncClient", return_value=self._mock_client(500, {"error": "boom"})):
+            result = await _execute_http_step(s, c)
+
+        assert result.status == "failed"
+        assert "HTTP 500" in result.error
+        # status_code must still be exposed in the output for debugging
+        assert result.output["status_code"] == 500
+
+    @pytest.mark.asyncio
+    async def test_http_500_completed_when_fail_on_error_false(self):
+        from sandcastle.engine.executor import _execute_http_step
+
+        s = step(
+            id="http_ok",
+            type="http",
+            http_config=HttpConfig(
+                url="https://api.example.com/x", method="GET", fail_on_error=False
+            ),
+        )
+        c = ctx()
+        with patch("httpx.AsyncClient", return_value=self._mock_client(500, {"error": "boom"})):
+            result = await _execute_http_step(s, c)
+
+        assert result.status == "completed"
+        assert result.output["status_code"] == 500
+
+    @pytest.mark.asyncio
+    async def test_http_200_includes_status_code(self):
+        from sandcastle.engine.executor import _execute_http_step
+
+        s = step(
+            id="http_2xx",
+            type="http",
+            http_config=HttpConfig(url="https://api.example.com/x", method="GET"),
+        )
+        c = ctx()
+        with patch("httpx.AsyncClient", return_value=self._mock_client(200, {"data": 1})):
+            result = await _execute_http_step(s, c)
+
+        assert result.status == "completed"
+        assert result.output["data"] == 1
+        assert result.output["status_code"] == 200
+
+
+class TestHttpStepSsrfBlockedNetwork:
+    """Fix 3: HTTP step rejects URLs resolving to private/loopback ranges."""
+
+    @pytest.mark.asyncio
+    async def test_loopback_ip_rejected(self):
+        from sandcastle.engine.executor import _execute_http_step
+
+        s = step(
+            id="http_ssrf",
+            type="http",
+            http_config=HttpConfig(url="http://127.0.0.1:8000/admin", method="GET"),
+        )
+        c = ctx()
+        result = await _execute_http_step(s, c)
+
+        assert result.status == "failed"
+        assert "blocked network" in result.error
+
+
+class TestSaveFileB64Traversal:
+    """Fix 2: save_file_b64 destination must be confined to the tmp directory."""
+
+    @pytest.mark.asyncio
+    async def test_traversal_dest_blocked(self, tmp_path, monkeypatch):
+        from sandcastle.config import settings
+        from sandcastle.engine.executor import _execute_code_step
+
+        monkeypatch.setattr(settings, "data_dir", str(tmp_path))
+        src = tmp_path / "src.txt"
+        src.write_text("payload")
+
+        code = f"result = save_file_b64({str(src)!r}, '../../escape.txt')"
+        s = step(id="cs_bad", type="code", code_config=CodeConfig(code=code))
+        c = ctx()
+        result = await _execute_code_step(s, c)
+
+        assert result.status == "failed"
+        assert "escapes the tmp directory" in result.error
+        assert not (tmp_path.parent / "escape.txt").exists()
+
+    @pytest.mark.asyncio
+    async def test_normal_dest_allowed(self, tmp_path, monkeypatch):
+        from sandcastle.config import settings
+        from sandcastle.engine.executor import _execute_code_step
+
+        monkeypatch.setattr(settings, "data_dir", str(tmp_path))
+        src = tmp_path / "src.txt"
+        src.write_text("payload")
+
+        code = f"result = save_file_b64({str(src)!r}, 'out.txt')"
+        s = step(id="cs_ok", type="code", code_config=CodeConfig(code=code))
+        c = ctx()
+        result = await _execute_code_step(s, c)
+
+        assert result.status == "completed"
+        assert result.output.startswith("@file:")
+        assert (tmp_path / "tmp" / "out.txt").exists()
+
+
+class TestRaceNoneWinner:
+    """Fix 8: a branch that legitimately returns None must win the race."""
+
+    @pytest.mark.asyncio
+    async def test_none_output_wins_race(self):
+        from sandcastle.engine import executor as _executor
+        from sandcastle.engine.executor import _execute_race_step
+
+        wf = make_workflow([
+            step(id="b_none", prompt="branch that returns None"),
+            step(id="race_none", type="race", race_config=RaceConfig(
+                branches=[["b_none"]],
+            )),
+        ])
+        c = ctx()
+        sandbox = MagicMock()
+        storage = MagicMock()
+        storage.read = AsyncMock(return_value=None)
+
+        async def _fake_retry(sub_step, branch_ctx, *_args, **_kwargs):
+            # A branch step that legitimately produces a None output.
+            return StepResult(step_id=sub_step.id, status="completed", output=None)
+
+        with patch.object(_executor, "execute_step_with_retry", side_effect=_fake_retry):
+            result = await _execute_race_step(
+                wf.get_step("race_none"), c, sandbox, storage, wf, 0,
+            )
+
+        assert result.status == "completed"
+        assert result.output is None

--- a/tests/test_memory_mcp_server.py
+++ b/tests/test_memory_mcp_server.py
@@ -282,6 +282,102 @@ class TestCLI:
         mocked.assert_called_once()
 
 
+class TestStreamableHttpAuth:
+    """streamable-http must fail closed without MEMORY_MCP_TOKEN (wave 2 fix C)."""
+
+    def test_stdio_unaffected_by_missing_token(self, monkeypatch) -> None:
+        """stdio transport starts regardless of token (not network-exposed)."""
+        monkeypatch.delenv("MEMORY_MCP_TOKEN", raising=False)
+        fake_server = MagicMock()
+        with patch.object(mms, "create_memory_mcp_server", return_value=fake_server):
+            mms.serve(transport="stdio")
+        fake_server.run.assert_called_once_with(transport="stdio")
+
+    def test_streamable_http_refuses_without_token_in_non_local_mode(
+        self, monkeypatch
+    ) -> None:
+        """No token + non-local mode => refuse to start (fail closed)."""
+        monkeypatch.delenv("MEMORY_MCP_TOKEN", raising=False)
+        fake_server = MagicMock()
+        from sandcastle.config import settings as _settings
+
+        monkeypatch.setattr(
+            type(_settings), "is_local_mode",
+            property(lambda self: False), raising=False,
+        )
+        with patch.object(mms, "create_memory_mcp_server", return_value=fake_server):
+            with pytest.raises(mms.MemoryMCPError) as exc_info:
+                mms.serve(transport="streamable-http")
+        assert "MEMORY_MCP_TOKEN" in str(exc_info.value)
+        fake_server.run.assert_not_called()
+
+    def test_streamable_http_allowed_without_token_in_local_mode(
+        self, monkeypatch
+    ) -> None:
+        """No token + local mode => allowed with a warning (dev convenience)."""
+        monkeypatch.delenv("MEMORY_MCP_TOKEN", raising=False)
+        fake_server = MagicMock()
+        from sandcastle.config import settings as _settings
+
+        monkeypatch.setattr(
+            type(_settings), "is_local_mode",
+            property(lambda self: True), raising=False,
+        )
+        with patch.object(mms, "create_memory_mcp_server", return_value=fake_server):
+            mms.serve(transport="streamable-http")
+        fake_server.run.assert_called_once_with(transport="streamable-http")
+
+    def test_streamable_http_with_token_wraps_with_auth(self, monkeypatch) -> None:
+        """A token => run our own uvicorn with the bearer-auth ASGI wrapper."""
+        monkeypatch.setenv("MEMORY_MCP_TOKEN", "s3cret")
+        fake_server = MagicMock()
+        fake_app = MagicMock()
+        fake_server.streamable_http_app.return_value = fake_app
+        fake_server.settings.host = "127.0.0.1"
+        fake_server.settings.log_level = "INFO"
+        fake_uvicorn = MagicMock()
+        with (
+            patch.object(mms, "create_memory_mcp_server", return_value=fake_server),
+            patch.dict("sys.modules", {"uvicorn": fake_uvicorn}),
+        ):
+            mms.serve(transport="streamable-http", port=9911)
+        # FastMCP.run must NOT be used (no per-request auth there).
+        fake_server.run.assert_not_called()
+        fake_uvicorn.run.assert_called_once()
+        wrapped_app = fake_uvicorn.run.call_args.args[0]
+        assert isinstance(wrapped_app, mms._BearerAuthMiddleware)
+
+    def test_bearer_middleware_rejects_missing_header(self) -> None:
+        """The ASGI wrapper 401s a request with no Authorization header."""
+        mw = mms._BearerAuthMiddleware(AsyncMock(), "tok")
+        sent = []
+
+        async def _send(msg):
+            sent.append(msg)
+
+        async def _receive():
+            return {"type": "http.request"}
+
+        scope = {"type": "http", "headers": []}
+        asyncio.run(mw(scope, _receive, _send))
+        assert sent[0]["status"] == 401
+
+    def test_bearer_middleware_allows_valid_token(self) -> None:
+        """The ASGI wrapper forwards a request with a matching bearer token."""
+        inner = AsyncMock()
+        mw = mms._BearerAuthMiddleware(inner, "tok")
+
+        async def _send(msg):
+            pass
+
+        async def _receive():
+            return {"type": "http.request"}
+
+        scope = {"type": "http", "headers": [(b"authorization", b"Bearer tok")]}
+        asyncio.run(mw(scope, _receive, _send))
+        inner.assert_awaited_once()
+
+
 # ---------------------------------------------------------------------------
 # FastMCP wiring smoke test
 # ---------------------------------------------------------------------------

--- a/tests/test_security_pentest.py
+++ b/tests/test_security_pentest.py
@@ -351,6 +351,123 @@ class TestCodeStepAdminTrusted:
         assert result.output == 42
 
 
+class TestCodeStepAstAndFormatHardening:
+    """Wave-2 defense-in-depth: AST validation + format-string blocklist."""
+
+    @pytest.mark.asyncio
+    async def test_import_statement_rejected_by_ast(self):
+        """A bare import statement is rejected by the AST validation pass."""
+        code = "import os\nresult = 1"
+        step = _make_code_step(code)
+        result = await _execute_code_step(step, _make_context())
+        assert result.status == "failed"
+        assert "import" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_from_import_rejected_by_ast(self):
+        """A from-import statement is rejected by the AST validation pass."""
+        code = "from os import getcwd\nresult = 1"
+        step = _make_code_step(code)
+        result = await _execute_code_step(step, _make_context())
+        assert result.status == "failed"
+        assert "import" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_format_dunder_traversal_blocked(self):
+        """The str.format __globals__ traversal is caught by AST validation.
+
+        The implicit-concatenated literal collapses to a single "{0.__globals__}"
+        constant at parse time, which the format-field dunder scan rejects.
+        """
+        code = (
+            "fn = read_file_b64\n"
+            "result = ('{0.__glo' 'bals__}').format(fn)"
+        )
+        step = _make_code_step(code)
+        result = await _execute_code_step(step, _make_context())
+        assert result.status == "failed"
+        assert (
+            "format string" in result.error.lower()
+            or "dunder" in result.error.lower()
+        )
+
+    def test_plain_format_not_blocked(self):
+        """Ordinary str.format must NOT be blocked (real templates rely on it)."""
+        # Regex blocklist no longer bans .format outright.
+        assert _CODE_STEP_BLOCKED_PATTERNS.search("'{}|{:.2f}'.format(a, b)") is None
+        # AST validation accepts plain formatting but rejects dunder traversal.
+        from sandcastle.engine.executor import _validate_code_step_ast
+
+        assert _validate_code_step_ast("result = '{}|{:.2f}'.format(m, amt)") is None
+        assert _validate_code_step_ast("result = '{0.__globals__}'.format(fn)") is not None
+
+    @pytest.mark.asyncio
+    async def test_normal_attribute_access_allowed(self):
+        """AST validation must not reject normal (non-dunder) attribute access."""
+        code = "s = _input['name']\nresult = s.upper().strip()"
+        step = _make_code_step(code)
+        result = await _execute_code_step(step, _make_context())
+        assert result.status == "completed"
+        assert result.output == "TEST"
+
+    @pytest.mark.asyncio
+    async def test_json_transform_still_works(self):
+        """A normal json transform code step still succeeds after hardening."""
+        code = "result = json.loads(json.dumps({'a': [1, 2, 3]}))['a']"
+        step = _make_code_step(code)
+        result = await _execute_code_step(step, _make_context())
+        assert result.status == "completed"
+        assert result.output == [1, 2, 3]
+
+    @pytest.mark.asyncio
+    async def test_read_file_b64_reads_within_data_dir(self, tmp_path, monkeypatch):
+        """read_file_b64 still reads a file inside the configured data_dir."""
+        import base64
+
+        from sandcastle.config import settings as _settings
+
+        monkeypatch.setattr(_settings, "data_dir", str(tmp_path))
+        target = tmp_path / "hello.txt"
+        target.write_text("payload")
+
+        code = f"result = read_file_b64({str(target)!r})"
+        step = _make_code_step(code)
+        result = await _execute_code_step(step, _make_context())
+        assert result.status == "completed"
+        assert base64.b64decode(result.output).decode() == "payload"
+
+    @pytest.mark.asyncio
+    async def test_read_file_b64_rejects_outside_data_dir(self, tmp_path, monkeypatch):
+        """read_file_b64 refuses a path outside the data_dir."""
+        from sandcastle.config import settings as _settings
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        outside = tmp_path / "secret.txt"
+        outside.write_text("nope")
+        monkeypatch.setattr(_settings, "data_dir", str(data_dir))
+
+        code = f"result = read_file_b64({str(outside)!r})"
+        step = _make_code_step(code)
+        result = await _execute_code_step(step, _make_context())
+        assert result.status == "failed"
+
+
+def test_code_sandbox_helpers_globals_have_no_secrets():
+    """The helper module namespace must not expose settings / db handles."""
+    from pathlib import Path
+
+    from sandcastle.engine.code_sandbox_helpers import make_code_sandbox_helpers
+
+    read_fn, save_fn = make_code_sandbox_helpers(Path("/tmp"))
+    for fn in (read_fn, save_fn):
+        g = fn.__globals__
+        assert "settings" not in g
+        assert "async_session" not in g
+        # Only base64 / pathlib should be importable module-level names.
+        assert set(g.get("__builtins__", {})) or True  # builtins always present
+
+
 # ---------------------------------------------------------------------------
 # 2. SIMPLEEVAL EXPRESSION INJECTION
 # ---------------------------------------------------------------------------

--- a/tests/test_step_types.py
+++ b/tests/test_step_types.py
@@ -571,7 +571,8 @@ class TestHttpStepExecutor:
             result = await _execute_http_step(step, context)
 
         assert result.status == "completed"
-        assert result.output == {"data": "test"}
+        # status_code is now attached to dict responses for downstream debugging.
+        assert result.output == {"data": "test", "status_code": 200}
         assert result.cost_usd == 0.0
         mock_client.request.assert_called_once()
         call_args = mock_client.request.call_args
@@ -588,6 +589,7 @@ class TestHttpStepExecutor:
     async def test_http_with_auth(self, context):
         mock_response = MagicMock()
         mock_response.json.return_value = {"ok": True}
+        mock_response.status_code = 200
 
         with patch("httpx.AsyncClient") as mock_client_cls:
             mock_client = AsyncMock()

--- a/uv.lock
+++ b/uv.lock
@@ -768,7 +768,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -799,43 +799,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-runtime", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cufft", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
     { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-cupti", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-curand", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvtx", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -2298,7 +2298,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2337,7 +2337,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2349,7 +2349,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2379,9 +2379,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2393,7 +2393,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.14' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3776,7 +3776,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28" },
     { name = "httpx-sse", specifier = ">=0.4" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.0" },
-    { name = "jinja2", marker = "extra == 'report'", specifier = ">=3.1" },
+    { name = "jinja2", marker = "extra == 'report'", specifier = ">=3.1.6" },
     { name = "jsonschema", specifier = ">=4.0" },
     { name = "markdown", marker = "extra == 'report'", specifier = ">=3.5" },
     { name = "matplotlib", specifier = ">=3.8" },
@@ -3798,7 +3798,7 @@ requires-dist = [
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "python-docx", marker = "extra == 'parse'", specifier = ">=1.0" },
     { name = "python-dotenv", specifier = ">=1.0" },
-    { name = "python-multipart", specifier = ">=0.0.9" },
+    { name = "python-multipart", specifier = ">=0.0.18" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8" },
     { name = "sentry-sdk", extras = ["fastapi"], marker = "extra == 'dev'", specifier = ">=2.0" },


### PR DESCRIPTION
Security and correctness patch from a full 3-angle audit sweep (correctness / DX / security), implemented in two reviewed waves. No new features; existing behavior preserved except where unsafe or wrong.

## Security
- **Code steps gated to admin by default.** `run_workflow_sync`/`run_workflow_async` no longer pass `admin_trusted=True` unconditionally - now `is_admin(req) or settings.code_steps_allow_untrusted` (new `CODE_STEPS_ALLOW_UNTRUSTED`, default false). Closes tenant-reachable in-process code execution.
- **Code-step sandbox hardened.** File helpers moved to a secret-free module (closes `str.format`/`__globals__` traversal to `settings`); new AST pass rejects `import` + dunder-attribute access; blocklist adds `.format`/`.format_map`. f-strings still work.
- **Path traversal fixed** in `save_file_b64` (destination resolved + confined to data/tmp).
- **Memory MCP fails closed** over streamable-http: requires `MEMORY_MCP_TOKEN` (constant-time bearer check), refuses to start unauthenticated outside local mode. stdio unchanged.
- **HTTP steps** block redirects + reuse the dispatcher blocked-network ranges for SSRF pre-flight.
- **Dependency CVE floors:** `jinja2>=3.1.6`, `python-multipart>=0.0.18`.

## Fixed (correctness / DX)
- HTTP steps fail on 4xx/5xx by default (`fail_on_error: false` opt-out); `status_code` exposed on JSON outputs -> `retry.on_failure` works, downstream no longer eats error bodies.
- Loop steps enforce budget mid-loop (no more `max_cost_usd` overshoot).
- Fan-out (`parallel_over`) steps persist an aggregate run-step + `step_results`.
- Race steps accept a legitimately `None` winning output.
- E2B custom templates no longer drop `tool_files`.
- `sandcastle providers` probes Ollama at `OLLAMA_HOST`.
- `sandcastle run <missing>.yaml` -> clear file-not-found, not a generic 404.
- `.env.example`: dead `SANDSTORM_URL` -> `SANDCASTLE_URL:8080`; `E2B_API_KEY` moved to backend-conditional.

## Testing
Two waves each reviewed line-by-line by the lead and independently re-run: wave 1 484 passed, wave 2 targeted 432 + broad executor 560 passed, helm 11 passed, `uv lock --check` clean. New test modules: `test_code_steps_admin_gate`, `test_security_pentest` (AST/format/helper-globals), `test_memory_mcp_server` (auth), `test_backends` (tool_files), `test_executor_edge_wave6` (loop budget), `test_executor_deep_v2` (fan-out persist), `test_executor_edge_wave9` (http/race).

## Deferred (needs product decision, intentionally NOT in this PR)
- Full SSRF IP-pinning for HTTP steps (custom httpx transport) - partial hardening shipped with a `TODO(ssrf)`; fail-close on `gaierror` broke mocked-transport tests.
- Truly robust in-process code isolation (out-of-process backend already exists; in-process path is now admin-gated + AST/blocklist mitigated).