### PR TITLE
fix(db): Postgres migrations fail on fresh install - enum double-create + duplicate index

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "src/**"
       - "tests/**"
+      - "alembic/**"
+      - "alembic.ini"
       - "dashboard/**"
       - "deploy/cookbooks/**"
       - "cf-sandbox-worker/**"
@@ -78,6 +80,55 @@ jobs:
       - name: Run pytest
         run: |
           python -m pytest tests/ -q --tb=line --timeout=60
+
+  postgres-migrations:
+    name: PostgreSQL migrations
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: sandcastle
+          POSTGRES_PASSWORD: sandcastle
+          POSTGRES_DB: sandcastle
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U sandcastle -d sandcastle"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql+asyncpg://sandcastle:sandcastle@localhost:5432/sandcastle
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          # hatchling force-includes dashboard/dist; an empty dir satisfies it
+          # without pulling the whole Node toolchain into this job.
+          mkdir -p dashboard/dist
+          pip install -e .
+
+      - name: Apply migrations (customer CLI path)
+        run: python -m sandcastle db migrate
+
+      - name: Re-run migrations (container restart scenario)
+        run: python -m sandcastle db migrate
+
+      - name: Verify current revision is the migration head
+        run: |
+          current_revision="$(python -m alembic current)"
+          head_revision="$(python -m alembic heads | awk 'NR == 1 { print $1 }')"
+          printf '%s\n' "$current_revision"
+          grep -Fq "$head_revision" <<< "$current_revision"
 
   dashboard:
     name: Dashboard build + tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.40.4] - 2026-07-18 - "Fresh Install Fixed"
+
+### Fixed
+- **PostgreSQL migrations failed on fresh installs** - the docker compose `migrate` service exited
+  with `DuplicateObjectError: type "runstatus" already exists`, so a new deployment never started.
+  Three latent bugs in the migration chain (enum double-create in 001, `create_type` silently
+  ignored on generic `sa.Enum` in 005/006, duplicate `ix_runs_parent_run_id` index in 007) are
+  fixed, and 007's downgrade now restores the index 003 expects. Existing databases are
+  unaffected (already-applied revisions never re-run).
+- New `postgres-migrations` CI job runs `python -m sandcastle db migrate` twice against a real
+  `postgres:16` service on every PR touching migrations, Docker, or compose files, so migration
+  regressions can no longer ship undetected (the test suite runs on SQLite).
+
 ## [0.40.3] - 2026-07-11 - "Deeper Isolation"
 
 Follow-up hardening that finishes the three deferred items from the 0.40.2 audit sweep. Defaults

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Build once. Run anywhere.** Sandcastle is an open-source, production-ready orchestrator for AI agents. **Describe a workflow in plain English and it builds it** (or write the YAML yourself); run it on **any model** — Claude, GPT, Mistral, or a local model on your own box — and move between them with one line; deploy it **your way** — cloud, your own server, fully air-gapped, or EU-only; and it **gets better over time**, on its own. Local models run at `$0/run` with hard data-residency enforcement and a tamper-evident audit trail; the cloud is there too, with 7 providers and auto-failover, 22 step types, verified templates, and a full dashboard. Sovereign by default. European-built.
 
-[![PyPI](https://img.shields.io/badge/PyPI-v0.40.3-blue?style=flat-square)](https://pypi.org/project/sandcastle-ai/0.40.3/)
+[![PyPI](https://img.shields.io/badge/PyPI-v0.40.4-blue?style=flat-square)](https://pypi.org/project/sandcastle-ai/0.40.4/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![Tests](https://img.shields.io/badge/tests-17900%2B%20passing-brightgreen?style=flat-square)](https://github.com/gizmax/Sandcastle/actions)

--- a/alembic/versions/001_initial_schema.py
+++ b/alembic/versions/001_initial_schema.py
@@ -22,11 +22,11 @@ def upgrade() -> None:
     # Enums
     run_status = postgresql.ENUM(
         "queued", "running", "completed", "failed", "partial",
-        name="runstatus", create_type=True,
+        name="runstatus", create_type=False,
     )
     step_status = postgresql.ENUM(
         "pending", "running", "completed", "failed", "skipped",
-        name="stepstatus", create_type=True,
+        name="stepstatus", create_type=False,
     )
 
     run_status.create(op.get_bind(), checkfirst=True)

--- a/alembic/versions/005_approval_gates.py
+++ b/alembic/versions/005_approval_gates.py
@@ -10,7 +10,7 @@ from typing import Sequence
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import ENUM, JSONB, UUID
 
 
 revision: str = "005"
@@ -43,7 +43,9 @@ def upgrade() -> None:
         sa.Column("step_id", sa.String(255), nullable=False),
         sa.Column(
             "status",
-            sa.Enum(
+            # postgresql.ENUM, not sa.Enum: create_type is only honored by the
+            # dialect type, and the type is already created explicitly above.
+            ENUM(
                 "pending", "approved", "rejected", "skipped", "timed_out",
                 name="approvalstatus", create_type=False,
             ),

--- a/alembic/versions/006_autopilot_experiments.py
+++ b/alembic/versions/006_autopilot_experiments.py
@@ -10,7 +10,7 @@ from typing import Sequence
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import ENUM, JSONB, UUID
 
 
 revision: str = "006"
@@ -33,7 +33,9 @@ def upgrade() -> None:
         sa.Column("step_id", sa.String(255), nullable=False),
         sa.Column(
             "status",
-            sa.Enum(
+            # postgresql.ENUM, not sa.Enum: create_type is only honored by the
+            # dialect type, and the type is already created explicitly above.
+            ENUM(
                 "running", "completed", "cancelled",
                 name="experimentstatus", create_type=False,
             ),

--- a/alembic/versions/007_hierarchical_workflows.py
+++ b/alembic/versions/007_hierarchical_workflows.py
@@ -27,7 +27,10 @@ def upgrade() -> None:
     # Add sub_run_ids to run_steps
     op.add_column("run_steps", sa.Column("sub_run_ids", JSONB, nullable=True))
 
-    # Index for finding child runs
+    # Index for finding child runs. Migration 003 already created a plain index
+    # under this name; replace it with the partial one instead of failing on the
+    # duplicate name.
+    op.execute("DROP INDEX IF EXISTS ix_runs_parent_run_id")
     op.create_index(
         "ix_runs_parent_run_id",
         "runs",
@@ -37,7 +40,10 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # Restore the plain index from 003 that upgrade() replaced, so 003's own
+    # downgrade can drop it.
     op.drop_index("ix_runs_parent_run_id", table_name="runs")
+    op.create_index("ix_runs_parent_run_id", "runs", ["parent_run_id"])
     op.drop_column("run_steps", "sub_run_ids")
     op.drop_column("runs", "depth")
     op.drop_column("runs", "sub_workflow_of_step")

--- a/deploy/mcp-tunnel/memory-mcp/Chart.yaml
+++ b/deploy/mcp-tunnel/memory-mcp/Chart.yaml
@@ -3,7 +3,7 @@ name: memory-mcp
 description: Sandcastle Memory MCP server behind a Cloudflare MCP tunnel (outbound-only, no inbound ingress required)
 type: application
 version: 0.1.0
-appVersion: "0.40.3"
+appVersion: "0.40.4"
 keywords:
   - sandcastle
   - mcp

--- a/src/sandcastle/__init__.py
+++ b/src/sandcastle/__init__.py
@@ -1,6 +1,6 @@
 """Sandcastle - Production-ready workflow orchestrator for AI agents."""
 
-__version__ = "0.40.3"
+__version__ = "0.40.4"
 
 __all__ = ["SandcastleClient", "AsyncSandcastleClient", "__version__"]
 


### PR DESCRIPTION
Fixes the customer-reported P0: the `migrate` compose service exits 1 on a fresh PostgreSQL, so a new deployment never starts (reported by Tomas Bielik / Peter Hrnciar after updating; 0.40.1 made the Postgres compose the default install path, which is why this surfaced now).

## Root cause (reproduced on real PostgreSQL 16)
Three latent bugs in the migration chain, never exercised because tests run on SQLite and offline `--sql` does not validate:
1. **001** - `postgresql.ENUM(create_type=True)` columns re-create `runstatus`/`stepstatus` during `create_table` after the explicit `.create(checkfirst=True)` -> `DuplicateObjectError` under current SQLAlchemy 2.0.x. Now `create_type=False`.
2. **005/006** - generic `sa.Enum` silently ignores `create_type=False` (it is a `postgresql.ENUM`-only kwarg) -> same double-create for `approvalstatus`/`experimentstatus`. Swapped for `postgresql.ENUM(create_type=False)`.
3. **007** - recreates `ix_runs_parent_run_id` (already created by 003) without dropping it -> `DuplicateTableError`. Now `DROP INDEX IF EXISTS` first; downgrade restores the plain index so 003's downgrade keeps working (cross-review finding).

Editing applied migrations is safe here: existing DBs past those revisions never re-run them; fresh installs currently cannot install at all.

## CI guard
New `postgres-migrations` job: real `postgres:16` service, installs the package (`mkdir -p dashboard/dist` satisfies the hatchling force-include without the Node toolchain), runs the actual customer path `python -m sandcastle db migrate` twice (fresh + container-restart), verifies revision. Workflow now also triggers on `alembic/**`, Docker and compose file changes.

## Verification (real PostgreSQL 16, run by lead)
- Fresh DB -> `python -m sandcastle db migrate` -> "Migrations applied successfully." (001-014)
- `alembic downgrade base` -> all 14 downgrades pass -> re-upgrade passes -> second migrate run passes
- CI-fallback simulation in a bare venv verified; workflow YAML validated

Cross-model review (Codex read-only) found the 007 downgrade regression; fixed and re-verified.