### PR TITLE
chore(release): 0.41.0 - Trust, Verified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,107 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.41.0] - 2026-07-21 - "Trust, Verified"
+
+A full adversarial audit of the engine, API, persistence, dashboard, and deployment, followed by
+a hardening pass on everything it found. 17,000+ tests, three consecutive randomized-order soak
+runs, zero flakes.
+
+### ⚠️ Upgrade notes (read before upgrading)
+
+- **Database: plan a short maintenance window.** Migrations 015–017 create the missing tables
+  and columns, convert legacy lowercase PostgreSQL enum labels to the ORM's member names
+  (`running` → `RUNNING`, …), convert JSON columns to JSONB, and add indexes. These take strong
+  table locks on `runs`, `run_steps`, `approval_requests`, and `autopilot_experiments` and are
+  **not** rolling-deploy safe. Quiesce API/worker/scheduler, back up, then run
+  `sandcastle db migrate` (or let the Docker CMD do it) before starting 0.41.0 everywhere.
+  Sandcastle < 0.41 cannot read the migrated enum labels. If you ever wrote to
+  `workflow_versions` with direct SQL, verify `SELECT DISTINCT status FROM workflow_versions`
+  only contains draft/staging/production/archived values — the migration preflights this and
+  stops with a clear error listing the offending values.
+- **`sandcastle serve` now binds `127.0.0.1` by default**, and binding a non-loopback host with
+  `AUTH_REQUIRED=false` is refused (exit 2) unless you set `SANDCASTLE_ALLOW_INSECURE_BIND=true`.
+  Docker/compose deployments pass the host explicitly and are unaffected.
+- **HTTP step `@file:` references now require an admin-trusted run** and stay confined to
+  `DATA_DIR`. Non-admin workflows using `@file:` will fail the step.
+- **Published MCP workflow tools now call the authenticated API** instead of executing in
+  process; the MCP server needs a reachable Sandcastle API and a valid key. The MCP manifest is
+  stdio-only (the never-served `streamable-http` claim and HTTP discovery route are gone).
+- **`retry:` is now honored by every step type** (`http`, `code`, `llm`, …), including
+  `on_failure: fallback` — workflows that always had retry configured will now actually retry,
+  which means more attempts (and cost) than before. Deterministic failures (4xx, validation,
+  trust, SSRF, residency) are no longer retried at all.
+- **Docker image defaults to a single Uvicorn worker** (`UVICORN_WORKERS:-1`), because every
+  worker runs the full application lifespan. Scale out with more containers, or set
+  `UVICORN_WORKERS` deliberately with `SCHEDULER_ENABLED=false`.
+- **Agent webhooks without `ANTHROPIC_WEBHOOK_SECRET` are rejected (403)** whenever
+  `AUTH_REQUIRED=true`; set the secret or disable auth for local development.
+- **A2A `tasks/send` returns `submitted` immediately** and enqueues the run; clients must poll
+  `tasks/get` instead of expecting inline completion. `tasks/cancel` now signals the worker
+  instead of forcing the DB status.
+- **Tool connectors receive a minimal environment** (PATH/HOME/locale/temp) plus only their own
+  registered `TOOL_*` credentials — connectors relying on inherited provider keys or other
+  variables must declare them.
+- **Code-step subprocess failures fail closed** by default; set
+  `SANDCASTLE_CODE_STEPS_ALLOW_INPROCESS_FALLBACK=true` to restore the legacy in-process
+  fallback.
+- **Run SSE streams end after 600s** with an error event; long-lived clients should reconnect.
+- **Runner/E2B images run as the base image's `node` user** (still uid/gid 1000); scripts
+  referencing the `runner` username must use `node`.
+
+### Security
+- Closed an authentication bypass on `/admin/environments/*` (root-mounted router skipped the
+  auth middleware and `is_admin()` returned true for any caller), with real-middleware
+  regression tests; `is_admin()` now requires a successfully authenticated API key.
+- `@file:` confinement (resolve + `is_relative_to(data_dir)`, off-loop reads) and the
+  admin-trusted gate above; the HTTP step no longer sends an env var *name* as the Bearer token
+  when the variable is unset.
+- Webhook delivery resolves once, validates, and pins the TCP connection to that exact IP (TLS
+  SNI preserved) — the DNS-rebinding TOCTOU is closed on the webhook path too.
+- Tool connectors no longer inherit the full process environment (DB URLs, provider keys, other
+  tools' credentials); code-subprocess infrastructure failures fail closed by default.
+- Self-update uses `sys.executable` instead of PATH-resolved `pip`/`python`, verifies the
+  installed version strictly, and stores `.env` backups under `data_dir/backups/` with `0600`.
+- `context_source: custom` shell execution, code steps, and `@file:` all sit behind the same
+  `admin_trusted` flag, persisted on the run row so restarts/resumes keep it.
+
+### Fixed
+- **PostgreSQL production installs**: 10 unmigrated tables + missing columns (migration 015),
+  enum labels reconciled with the ORM (016), JSON→JSONB + index alignment (017); `alembic check`
+  with `compare_type`/`compare_server_default` and a live enum round-trip smoke test now run in
+  CI.
+- Engine cost accounting: LLM cost survives post-query failures and aggregates across retries;
+  `WorkflowPaused` carries accrued cost and completed siblings are checkpointed, so approval
+  resumes no longer double-pay. Sub-workflow/delegate fan-out splits the budget across children.
+- API robustness: idempotency race returns the existing run instead of 5xx; batch polling honors
+  all terminal statuses; uploads stream in bounded chunks; background tasks keep strong refs;
+  run/result persistence is JSON-coerced (`datetime`, `UUID`, custom objects can't lose a run).
+- Queue/scheduler: startup cleanup re-enqueues Redis-queued runs with their versioned YAML and
+  trust flag; approval-timeout retries with a bounded sweep; audit hash chain serializes appends
+  per scope and failed audit writes roll back via SAVEPOINT; local-mode jobs get the same
+  timeout arq enforces; `list_schedules` tolerates pending jobs.
+- Dashboard: Evolution page matches the real API (tenant filters everywhere, latest-wins
+  status); admin SSE uses authenticated fetch; WorkflowBuilder YAML is escaped via js-yaml;
+  SSE chunk-boundary parsing fixed; mock fixtures lazy-loaded out of the production bundle; CSV
+  formula-injection guard.
+- Docker: runner/E2B image builds (uid collision with the `node` user), compose scheduler port,
+  `DATA_DIR`/`WORKFLOWS_DIR` container defaults, cookbook blockers; CI now builds all three
+  images and boots the API against `/api/health`.
+
+### Added
+- `llm_config.temperature` / `max_tokens` per-step overrides (parsed, validated, sent to both
+  provider families).
+- `GET /api/evolution` (tenant-scoped, admin-gated) and real frontend↔backend contract tests
+  (`tests/test_dashboard_api_contract.py`, `tests/test_workflows_valid.py` — every shipped and
+  community workflow must parse+validate).
+- `sandcastle memory-mcp serve` and `sandcastle tools validate` (documented but previously
+  unwired).
+- Hub: canonical `hub/registry.json` (283 templates) with the site registry generated from it;
+  seeded community gallery restored with 35 real workflows; CI validates both registries
+  (schema, sha256, dead links).
+- Test infrastructure: randomized-order soak hardening (per-test `os.environ`, settings
+  singleton, and scheduler job isolation) — three consecutive 17k-test clean runs.
+
 ## [0.40.4] - 2026-07-18 - "Fresh Install Fixed"
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Build once. Run anywhere.** Sandcastle is an open-source, production-ready orchestrator for AI agents. **Describe a workflow in plain English and it builds it** (or write the YAML yourself); run it on **any model** — Claude, GPT, Mistral, or a local model on your own box — and move between them with one line; deploy it **your way** — cloud, your own server, fully air-gapped, or EU-only; and it **gets better over time**, on its own. Local models run at `$0/run` with hard data-residency enforcement and a tamper-evident audit trail; the cloud is there too, with 7 providers and auto-failover, 25 step types, verified templates, and a full dashboard. Sovereign by default. European-built.
 
-[![PyPI](https://img.shields.io/badge/PyPI-v0.40.4-blue?style=flat-square)](https://pypi.org/project/sandcastle-ai/0.40.4/)
+[![PyPI](https://img.shields.io/badge/PyPI-v0.41.0-blue?style=flat-square)](https://pypi.org/project/sandcastle-ai/0.41.0/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![Tests](https://img.shields.io/badge/tests-17154%20passing-brightgreen?style=flat-square)](https://github.com/gizmax/Sandcastle/actions)

--- a/alembic/versions/016_enum_reconciliation.py
+++ b/alembic/versions/016_enum_reconciliation.py
@@ -146,6 +146,21 @@ def _recreate_enum(
 
 
 def _convert_workflow_version_status_to_enum() -> None:
+    # Preflight: historical VARCHAR values must all map onto the enum labels.
+    # A direct-SQL/legacy value would otherwise fail the cast mid-migration
+    # with a cryptic error.
+    invalid = op.get_bind().execute(
+        sa.text(
+            "SELECT DISTINCT status FROM workflow_versions "
+            "WHERE UPPER(status) NOT IN ('DRAFT', 'STAGING', 'PRODUCTION', 'ARCHIVED')"
+        )
+    ).scalars().all()
+    if invalid:
+        raise RuntimeError(
+            "workflow_versions.status contains values that cannot map to "
+            f"workflowversionstatus: {invalid}. Fix or remove these rows before "
+            "running this migration."
+        )
     op.execute(
         "CREATE TYPE workflowversionstatus AS ENUM ('DRAFT', 'STAGING', 'PRODUCTION', 'ARCHIVED')"
     )

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "dashboard",
-      "version": "0.33.0",
+      "version": "0.41.0",
       "dependencies": {
         "@fontsource/bricolage-grotesque": "^5.2.10",
         "@xyflow/react": "^12.10.2",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.40.0",
+  "version": "0.41.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/deploy/mcp-tunnel/memory-mcp/Chart.yaml
+++ b/deploy/mcp-tunnel/memory-mcp/Chart.yaml
@@ -3,7 +3,7 @@ name: memory-mcp
 description: Sandcastle Memory MCP server behind a Cloudflare MCP tunnel (outbound-only, no inbound ingress required)
 type: application
 version: 0.1.0
-appVersion: "0.40.4"
+appVersion: "0.41.0"
 keywords:
   - sandcastle
   - mcp

--- a/hub/community/api-forge/api-change-review.yaml
+++ b/hub/community/api-forge/api-change-review.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/audit-trail/evidence-request-pack.yaml
+++ b/hub/community/audit-trail/evidence-request-pack.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/care-desk/escalation-summarizer.yaml
+++ b/hub/community/care-desk/escalation-summarizer.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/care-path/visit-brief.yaml
+++ b/hub/community/care-path/visit-brief.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/clinic-ops/referral-prioritizer.yaml
+++ b/hub/community/clinic-ops/referral-prioritizer.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/community-catalyst/volunteer-brief.yaml
+++ b/hub/community/community-catalyst/volunteer-brief.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/compliance-craft/policy-gap-scan.yaml
+++ b/hub/community/compliance-craft/policy-gap-scan.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/content-queen/content-calendar.yaml
+++ b/hub/community/content-queen/content-calendar.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/demand-weaver/campaign-brief-studio.yaml
+++ b/hub/community/demand-weaver/campaign-brief-studio.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/devrel-bot/release-notes-pro.yaml
+++ b/hub/community/devrel-bot/release-notes-pro.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/health-navigator/intake-summary.yaml
+++ b/hub/community/health-navigator/intake-summary.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/helpstack/knowledge-gap-finder.yaml
+++ b/hub/community/helpstack/knowledge-gap-finder.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/k8s-ops/incident-responder.yaml
+++ b/hub/community/k8s-ops/incident-responder.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/lawtech-ai/contract-reviewer-pro.yaml
+++ b/hub/community/lawtech-ai/contract-reviewer-pro.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/ledger-lark/cash-reconciliation.yaml
+++ b/hub/community/ledger-lark/cash-reconciliation.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/model-garden/prompt-regression-check.yaml
+++ b/hub/community/model-garden/prompt-regression-check.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/people-ops/coaching-summary.yaml
+++ b/hub/community/people-ops/coaching-summary.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/pipeline-mate/renewal-brief.yaml
+++ b/hub/community/pipeline-mate/renewal-brief.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/pricewatch/pricing-tracker.yaml
+++ b/hub/community/pricewatch/pricing-tracker.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/privacy-map/dpia-starter.yaml
+++ b/hub/community/privacy-map/dpia-starter.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/promptwright/eval-runbook.yaml
+++ b/hub/community/promptwright/eval-runbook.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/prospect-lens/account-research.yaml
+++ b/hub/community/prospect-lens/account-research.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/research-rover/decision-memo.yaml
+++ b/hub/community/research-rover/decision-memo.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/risk-ledger/vendor-control-check.yaml
+++ b/hub/community/risk-ledger/vendor-control-check.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/sarah-ml/churn-predictor-v2.yaml
+++ b/hub/community/sarah-ml/churn-predictor-v2.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/seo-orbit/keyword-cluster-planner.yaml
+++ b/hub/community/seo-orbit/keyword-cluster-planner.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/social-sage/social-repurposer.yaml
+++ b/hub/community/social-sage/social-repurposer.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/solopreneur-kit/client-onboarding.yaml
+++ b/hub/community/solopreneur-kit/client-onboarding.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/studio-spark/meeting-to-action.yaml
+++ b/hub/community/studio-spark/meeting-to-action.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/supportflow/multi-channel-router.yaml
+++ b/hub/community/supportflow/multi-channel-router.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/talent-mesh/interview-loop-kit.yaml
+++ b/hub/community/talent-mesh/interview-loop-kit.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/test-harbor/flaky-test-triage.yaml
+++ b/hub/community/test-harbor/flaky-test-triage.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/trace-tuner/agent-trace-review.yaml
+++ b/hub/community/trace-tuner/agent-trace-review.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/treasury-tide/covenant-monitor.yaml
+++ b/hub/community/treasury-tide/covenant-monitor.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/community/voice-of-user/feedback-theme-miner.yaml
+++ b/hub/community/voice-of-user/feedback-theme-miner.yaml
@@ -38,4 +38,3 @@ steps:
       Working brief: {steps.assess-request.output}
 
       Use concise headings, clear ownership where relevant, and explicit follow-up questions.
-

--- a/hub/registry.json
+++ b/hub/registry.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generated_at": "2026-07-21T04:53:28Z",
+  "generated_at": "2026-07-21T13:31:59Z",
   "templates": [
     {
       "slug": "amira-dev/freelancer-proposal",
@@ -19253,7 +19253,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "760519d1b6aaf220ede2b58a3e6817703fafcba8c8513dfeabbd17d4aef1904d",
+      "sha256": "ceb1e4ab120d5247710ae59d5e6edc263485676e9c780036ce06f1fd9a187b67",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19301,7 +19301,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "83a2d1e6ebbf8276095ad2649a9307312173663cfab759ab200a2334aa2ab15b",
+      "sha256": "14ea2967164aeaa754a2b7498392acad1e53821a0eda711ed9afeddcfe26bbd2",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19349,7 +19349,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "0745181f89b4399ec7ea78e282a508458dd51fca92e36c0a41bef32ca0c0e153",
+      "sha256": "22b51581637eba021be473fc33c82ed8eb18671d52e336e16464d79ac01f9b9d",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19397,7 +19397,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "ba5f85ec8ed912303860149aa6c83ed93a129b27c4b5696888c4e9cb23244c28",
+      "sha256": "98664298e88aa0f3d2c11437b9ef250e3599514d1b45279e77487d6c2b74199c",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19445,7 +19445,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "43555ce383d8321034737171e564fe9284bd59e3b567084bd269560752069180",
+      "sha256": "095d1d545c2d8ae355555c7643c54ac2101217289abe8457997d3b236cdee8e9",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19493,7 +19493,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "cc0b5b8251e2404b20c6e8aa8980b2c877d1a62b447fb8f5361bb7eed73f1daf",
+      "sha256": "fa9fe793b4d4223166bda66d892290e9690f0b99716ed354e72ccae268c88d0b",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19541,7 +19541,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "aac5bbf9ce825b3a3062f23baa5a528a07d3a3cb4f3ce1174f439cd2db8911bc",
+      "sha256": "106c669e2d7a3f4d65ee41301d3d4a3194b421563e0a1622321cf9ecf91eea5f",
       "remix_count": 1,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19589,7 +19589,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "3023bc14e70f7fca618e0ab72b1290ba9d9c743f1f84a890a15d9d5d097cd93b",
+      "sha256": "6d6dd8b53c7372b90db8e855b0850e23c7d6cac4e00571a489125539f2313682",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19637,7 +19637,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "6b095f50c9ca428662c6b39fe67bde6bd93ad1a88a5c79ee91a149f40b0fb05b",
+      "sha256": "702bb0dead85fb50ce7e2041d28b4433fde18f359ae7aa0c672d1ae2fa4a7da1",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19685,7 +19685,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "767506c28321304b41be6cf3ce785d74b709509d18c341b3200ff8152df03b4d",
+      "sha256": "4b9578eb3561e21dcfd896fd4d989bc1210db4cf5d18e0c1c7cfa420ba05fdcb",
       "remix_count": 1,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19733,7 +19733,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "fa093227f690ecc42aa207952c62d3720708aeab78e9f135cc328c52f3242ff9",
+      "sha256": "1537d04dae76bc95eabcf732d53382f2b5e81e58240cd2a2f61201f87e4825ec",
       "remix_count": 1,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19781,7 +19781,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "b69226ff0ea5c35cdfbfa5af3d226bc1a693fbc99741f4b91b4d7a5831e3e58f",
+      "sha256": "0d12071e66beb58f7849e8ba9476f78d001f34a0cc265dd376eefcea1b7d7b29",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19829,7 +19829,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "5a5f5ef4c4728a3f6730651dbaf1ecc81b78a9d8356040a39c08b26916c9e9a6",
+      "sha256": "87cc27a0cd5b5728bc5a7b72ba6e3924ecda5ab291cfdc35b3da2eb2e3dc0f62",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19877,7 +19877,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "7e637eb8a3f30534fd905da0fdfa1e4425b1016dd9a827a76652eacfc5ae95e3",
+      "sha256": "b5a405e7f805b39bc31359f960504af97c630b8ee06b1fbf767538318d5645ae",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19925,7 +19925,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "500bbb541550137859cfd4ae3ca59e17669e83ddf607004ac8dd2cf2bede4256",
+      "sha256": "ae3e08c6d027b02a6c8788ed7835dfdd55cdd2e3e059cd39c32d6394bcb3b40a",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19973,7 +19973,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "a3ac302620ea4cf4bc07daad1c7d834fb87c14ab4c688e7ada04f20362b271cc",
+      "sha256": "34c0ee98e12b20326d364c921cead9d967ee57d5cace76bab7c9e8e172852c7c",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20021,7 +20021,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "6a75e38bba84532b3d4cf0ede0186703936caf3e46aebda5bb842ff4e7aaff82",
+      "sha256": "a5fcfd39e4c24ac157425f2674b1720a6081f88c8548a99b25c98acd277d19ee",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20069,7 +20069,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "da4a5d28264d9b1d355dcc861bd8070d7f4cbac471700d9555db6b24f9a8d6b8",
+      "sha256": "1838272aeb2fe65d769ae000ffc951f0d8f4eed05940f20dc099a5d9f799c315",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20117,7 +20117,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "406bb88010112f1f0e2c25fe1c688a98a35ef15cbb325089cf2674ee71d52c51",
+      "sha256": "155fc176d3f358a6541db1cad68cb372dd19f943fb0d5ca26ab3bc9e8063e674",
       "remix_count": 1,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20165,7 +20165,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "9896c9a3f1fb2894a215d6577d81c69c766ce9c5528d31c7de08f38f6fccb9d5",
+      "sha256": "0a882eeba2ec82c722673e284e987cd6c171854581188a6771e436871d9c38bd",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20213,7 +20213,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "1e39b7f335fd83de823f2fdc4bbe731cb65cfebb2813ea8e5fbe83e9050dfe01",
+      "sha256": "ba30aaab7774d26ea7cf0f172c3159eabcee5589ab3d8c7c93ffc6b49045c7ee",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20261,7 +20261,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "0f3a01f38adeab5bb754d5a9cfbe1618991c9595ceeaa17ce9a5a36e3c451ae0",
+      "sha256": "e29ca15d28eda2cad99143da048a028d5b469019cdf214aff695769667ee62e0",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20309,7 +20309,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "b381627fa5523e85d81f47faa524d51fd7ed72729faa31f8fbaf47e04689f3f3",
+      "sha256": "fe8fc1be68bc527d1829febdb49addebd0cf63bd5c725371bf0eb9dc41abcc5e",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20357,7 +20357,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "39d7443eba5971a8e2b50418b20737e5efa91f055af5a647a99a8e5a3bbcd416",
+      "sha256": "84c25fc04f425271dd5634aed4bd84c2bc4fe479ab1a9109cba26a6d4155babe",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20405,7 +20405,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "6962b8267a92e92f3ec531b9c997956dc964565dac8714b4798d131a633be8f3",
+      "sha256": "810ca6cf1197b44bd2e2bff2d423481382d75f94c2c9c7150b5e69d0c95d3033",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20453,7 +20453,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "8531a0dea375bd9749b06e04730aeeb1d03c716a56712c10787c68c9522b91c4",
+      "sha256": "cc92a1b9fff77eab9d8dcc0b21883ebdc2f7613ba3681ca90db08b13c1511864",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20501,7 +20501,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "47c2603a8beda4b3700fff03228b85417ace5cee45b0eeeced58bd8c765120b6",
+      "sha256": "88c05a337ec78895b90a5ee1147be262074a0b625f7855a94365736061ec60e2",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20549,7 +20549,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "7689597baa62c771ca18f938921274ae500b120acbf4d04716b535cafdc32e92",
+      "sha256": "0a90b92403b34b3a1c2936254f2b208dcff47b9555cd552230623c60e178e67f",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20597,7 +20597,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "c1d7b8bb9b999b42501d91f1770023c9838c74dc4c4b070284b0577173216136",
+      "sha256": "7ea977afb0a97d0db323172d820c3559c3fee7c476f95ae6b0abca42d381bc54",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20645,7 +20645,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "db8453b613e4d031a690e7069958f33399099cbbe5039e9fe227b5abbcaab7c9",
+      "sha256": "6053ac35b74020b63e232298abbb9dcef73e00bdf0ab5fd7cb95639359da5ad5",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20693,7 +20693,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "371b16fc6d863b81664c96ce346841b650bcdd5c49a2396cd18c62a42d2f6b3a",
+      "sha256": "af2d1f515f8a13efa12ae4dbc9d312ddb33cca884b794a79a9d5ea7c98c233c7",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20741,7 +20741,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "40d6ab0ee5ed9c0a3877924a12480a8abf510668d73c1a8fd8dd2eccafdfd569",
+      "sha256": "ea87da1c33adeeef1a2c884166b716d1264e30ea0263a6cf6b1d9f500e43bcb6",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20789,7 +20789,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "29952a004fa9c945ec9658889ed760aa512ec7efc4a7de09d3da05602e825813",
+      "sha256": "5ff32795da0f9152c7c7bc62a9bb715e2c931409276c553ea1a19a6d388fd019",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20837,7 +20837,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "72a0f0dfc3713339a45a045af09b0c0473016f4470593945350e02eb1d395813",
+      "sha256": "b0b1bd8ca41c752300decaf530a934e598c5f176ff6d394c2af0dffb552bc180",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20885,7 +20885,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "abe5f437163471df83909bb25d92255feae4a8f8507c8122ccec760bd91c396f",
+      "sha256": "e26c02167f28b33213a260bdd744ad340e69f87abf69eb9cd7bc0b6a44db7aeb",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20967,7 +20967,7 @@
     "total_templates": 283,
     "total_authors": 49,
     "total_downloads": 8055,
-    "last_updated": "2026-07-21T04:53:28Z"
+    "last_updated": "2026-07-21T13:31:59Z"
   },
   "collections": [
     {

--- a/site/eu-ai-act/index.html
+++ b/site/eu-ai-act/index.html
@@ -514,7 +514,7 @@
       <a class="brand" href="/" aria-label="Sandcastle home">
         <span class="glyph" aria-hidden="true">🏰</span>
         <span>Sandcastle</span>
-        <span class="tm">v0.40.0</span>
+        <span class="tm">v0.41.0</span>
       </a>
       <nav class="primary" aria-label="Primary">
         <a class="muted" href="/pricing/">Pricing</a>

--- a/site/hub/registry.json
+++ b/site/hub/registry.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generated_at": "2026-07-21T04:53:28Z",
+  "generated_at": "2026-07-21T13:31:59Z",
   "templates": [
     {
       "slug": "amira-dev/freelancer-proposal",
@@ -19253,7 +19253,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "760519d1b6aaf220ede2b58a3e6817703fafcba8c8513dfeabbd17d4aef1904d",
+      "sha256": "ceb1e4ab120d5247710ae59d5e6edc263485676e9c780036ce06f1fd9a187b67",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19301,7 +19301,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "83a2d1e6ebbf8276095ad2649a9307312173663cfab759ab200a2334aa2ab15b",
+      "sha256": "14ea2967164aeaa754a2b7498392acad1e53821a0eda711ed9afeddcfe26bbd2",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19349,7 +19349,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "0745181f89b4399ec7ea78e282a508458dd51fca92e36c0a41bef32ca0c0e153",
+      "sha256": "22b51581637eba021be473fc33c82ed8eb18671d52e336e16464d79ac01f9b9d",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19397,7 +19397,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "ba5f85ec8ed912303860149aa6c83ed93a129b27c4b5696888c4e9cb23244c28",
+      "sha256": "98664298e88aa0f3d2c11437b9ef250e3599514d1b45279e77487d6c2b74199c",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19445,7 +19445,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "43555ce383d8321034737171e564fe9284bd59e3b567084bd269560752069180",
+      "sha256": "095d1d545c2d8ae355555c7643c54ac2101217289abe8457997d3b236cdee8e9",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19493,7 +19493,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "cc0b5b8251e2404b20c6e8aa8980b2c877d1a62b447fb8f5361bb7eed73f1daf",
+      "sha256": "fa9fe793b4d4223166bda66d892290e9690f0b99716ed354e72ccae268c88d0b",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19541,7 +19541,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "aac5bbf9ce825b3a3062f23baa5a528a07d3a3cb4f3ce1174f439cd2db8911bc",
+      "sha256": "106c669e2d7a3f4d65ee41301d3d4a3194b421563e0a1622321cf9ecf91eea5f",
       "remix_count": 1,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19589,7 +19589,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "3023bc14e70f7fca618e0ab72b1290ba9d9c743f1f84a890a15d9d5d097cd93b",
+      "sha256": "6d6dd8b53c7372b90db8e855b0850e23c7d6cac4e00571a489125539f2313682",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19637,7 +19637,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "6b095f50c9ca428662c6b39fe67bde6bd93ad1a88a5c79ee91a149f40b0fb05b",
+      "sha256": "702bb0dead85fb50ce7e2041d28b4433fde18f359ae7aa0c672d1ae2fa4a7da1",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19685,7 +19685,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "767506c28321304b41be6cf3ce785d74b709509d18c341b3200ff8152df03b4d",
+      "sha256": "4b9578eb3561e21dcfd896fd4d989bc1210db4cf5d18e0c1c7cfa420ba05fdcb",
       "remix_count": 1,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19733,7 +19733,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "fa093227f690ecc42aa207952c62d3720708aeab78e9f135cc328c52f3242ff9",
+      "sha256": "1537d04dae76bc95eabcf732d53382f2b5e81e58240cd2a2f61201f87e4825ec",
       "remix_count": 1,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19781,7 +19781,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "b69226ff0ea5c35cdfbfa5af3d226bc1a693fbc99741f4b91b4d7a5831e3e58f",
+      "sha256": "0d12071e66beb58f7849e8ba9476f78d001f34a0cc265dd376eefcea1b7d7b29",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19829,7 +19829,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "5a5f5ef4c4728a3f6730651dbaf1ecc81b78a9d8356040a39c08b26916c9e9a6",
+      "sha256": "87cc27a0cd5b5728bc5a7b72ba6e3924ecda5ab291cfdc35b3da2eb2e3dc0f62",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19877,7 +19877,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "7e637eb8a3f30534fd905da0fdfa1e4425b1016dd9a827a76652eacfc5ae95e3",
+      "sha256": "b5a405e7f805b39bc31359f960504af97c630b8ee06b1fbf767538318d5645ae",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19925,7 +19925,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "500bbb541550137859cfd4ae3ca59e17669e83ddf607004ac8dd2cf2bede4256",
+      "sha256": "ae3e08c6d027b02a6c8788ed7835dfdd55cdd2e3e059cd39c32d6394bcb3b40a",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -19973,7 +19973,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "a3ac302620ea4cf4bc07daad1c7d834fb87c14ab4c688e7ada04f20362b271cc",
+      "sha256": "34c0ee98e12b20326d364c921cead9d967ee57d5cace76bab7c9e8e172852c7c",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20021,7 +20021,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "6a75e38bba84532b3d4cf0ede0186703936caf3e46aebda5bb842ff4e7aaff82",
+      "sha256": "a5fcfd39e4c24ac157425f2674b1720a6081f88c8548a99b25c98acd277d19ee",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20069,7 +20069,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "da4a5d28264d9b1d355dcc861bd8070d7f4cbac471700d9555db6b24f9a8d6b8",
+      "sha256": "1838272aeb2fe65d769ae000ffc951f0d8f4eed05940f20dc099a5d9f799c315",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20117,7 +20117,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "406bb88010112f1f0e2c25fe1c688a98a35ef15cbb325089cf2674ee71d52c51",
+      "sha256": "155fc176d3f358a6541db1cad68cb372dd19f943fb0d5ca26ab3bc9e8063e674",
       "remix_count": 1,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20165,7 +20165,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "9896c9a3f1fb2894a215d6577d81c69c766ce9c5528d31c7de08f38f6fccb9d5",
+      "sha256": "0a882eeba2ec82c722673e284e987cd6c171854581188a6771e436871d9c38bd",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20213,7 +20213,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "1e39b7f335fd83de823f2fdc4bbe731cb65cfebb2813ea8e5fbe83e9050dfe01",
+      "sha256": "ba30aaab7774d26ea7cf0f172c3159eabcee5589ab3d8c7c93ffc6b49045c7ee",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20261,7 +20261,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "0f3a01f38adeab5bb754d5a9cfbe1618991c9595ceeaa17ce9a5a36e3c451ae0",
+      "sha256": "e29ca15d28eda2cad99143da048a028d5b469019cdf214aff695769667ee62e0",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20309,7 +20309,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "b381627fa5523e85d81f47faa524d51fd7ed72729faa31f8fbaf47e04689f3f3",
+      "sha256": "fe8fc1be68bc527d1829febdb49addebd0cf63bd5c725371bf0eb9dc41abcc5e",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20357,7 +20357,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "39d7443eba5971a8e2b50418b20737e5efa91f055af5a647a99a8e5a3bbcd416",
+      "sha256": "84c25fc04f425271dd5634aed4bd84c2bc4fe479ab1a9109cba26a6d4155babe",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20405,7 +20405,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "6962b8267a92e92f3ec531b9c997956dc964565dac8714b4798d131a633be8f3",
+      "sha256": "810ca6cf1197b44bd2e2bff2d423481382d75f94c2c9c7150b5e69d0c95d3033",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20453,7 +20453,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "8531a0dea375bd9749b06e04730aeeb1d03c716a56712c10787c68c9522b91c4",
+      "sha256": "cc92a1b9fff77eab9d8dcc0b21883ebdc2f7613ba3681ca90db08b13c1511864",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20501,7 +20501,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "47c2603a8beda4b3700fff03228b85417ace5cee45b0eeeced58bd8c765120b6",
+      "sha256": "88c05a337ec78895b90a5ee1147be262074a0b625f7855a94365736061ec60e2",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20549,7 +20549,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "7689597baa62c771ca18f938921274ae500b120acbf4d04716b535cafdc32e92",
+      "sha256": "0a90b92403b34b3a1c2936254f2b208dcff47b9555cd552230623c60e178e67f",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20597,7 +20597,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "c1d7b8bb9b999b42501d91f1770023c9838c74dc4c4b070284b0577173216136",
+      "sha256": "7ea977afb0a97d0db323172d820c3559c3fee7c476f95ae6b0abca42d381bc54",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20645,7 +20645,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "db8453b613e4d031a690e7069958f33399099cbbe5039e9fe227b5abbcaab7c9",
+      "sha256": "6053ac35b74020b63e232298abbb9dcef73e00bdf0ab5fd7cb95639359da5ad5",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20693,7 +20693,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "371b16fc6d863b81664c96ce346841b650bcdd5c49a2396cd18c62a42d2f6b3a",
+      "sha256": "af2d1f515f8a13efa12ae4dbc9d312ddb33cca884b794a79a9d5ea7c98c233c7",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20741,7 +20741,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "40d6ab0ee5ed9c0a3877924a12480a8abf510668d73c1a8fd8dd2eccafdfd569",
+      "sha256": "ea87da1c33adeeef1a2c884166b716d1264e30ea0263a6cf6b1d9f500e43bcb6",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20789,7 +20789,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "29952a004fa9c945ec9658889ed760aa512ec7efc4a7de09d3da05602e825813",
+      "sha256": "5ff32795da0f9152c7c7bc62a9bb715e2c931409276c553ea1a19a6d388fd019",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20837,7 +20837,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "72a0f0dfc3713339a45a045af09b0c0473016f4470593945350e02eb1d395813",
+      "sha256": "b0b1bd8ca41c752300decaf530a934e598c5f176ff6d394c2af0dffb552bc180",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20885,7 +20885,7 @@
         "sonnet"
       ],
       "step_count": 2,
-      "sha256": "abe5f437163471df83909bb25d92255feae4a8f8507c8122ccec760bd91c396f",
+      "sha256": "e26c02167f28b33213a260bdd744ad340e69f87abf69eb9cd7bc0b6a44db7aeb",
       "remix_count": 0,
       "estimated_cost_per_run": 0.025,
       "avg_execution_time": "~8s"
@@ -20967,7 +20967,7 @@
     "total_templates": 283,
     "total_authors": 49,
     "total_downloads": 8055,
-    "last_updated": "2026-07-21T04:53:28Z"
+    "last_updated": "2026-07-21T13:31:59Z"
   },
   "collections": [
     {

--- a/site/index.html
+++ b/site/index.html
@@ -608,7 +608,7 @@
       <a class="brand" href="/" aria-label="Sandcastle home">
         <span class="glyph" aria-hidden="true">🏰</span>
         <span>Sandcastle</span>
-        <span class="tm">v0.40.0</span>
+        <span class="tm">v0.41.0</span>
       </a>
       <nav class="primary" aria-label="Primary">
         <a class="muted" href="/pricing/">Pricing</a>

--- a/site/pricing/index.html
+++ b/site/pricing/index.html
@@ -472,7 +472,7 @@
       <a class="brand" href="/" aria-label="Sandcastle home">
         <span class="glyph" aria-hidden="true">🏰</span>
         <span>Sandcastle</span>
-        <span class="tm">v0.40.0</span>
+        <span class="tm">v0.41.0</span>
       </a>
       <nav class="primary" aria-label="Primary">
         <a class="muted" href="/pricing/" aria-current="page">Pricing</a>

--- a/site/security/index.html
+++ b/site/security/index.html
@@ -464,7 +464,7 @@
       <a class="brand" href="/" aria-label="Sandcastle home">
         <span class="glyph" aria-hidden="true">🏰</span>
         <span>Sandcastle</span>
-        <span class="tm">v0.40.0</span>
+        <span class="tm">v0.41.0</span>
       </a>
       <nav class="primary" aria-label="Primary">
         <a class="muted" href="/pricing/">Pricing</a>

--- a/site/whatsnew/index.html
+++ b/site/whatsnew/index.html
@@ -497,7 +497,7 @@
       <a class="brand" href="/" aria-label="Sandcastle home">
         <span class="glyph" aria-hidden="true">🏰</span>
         <span>Sandcastle</span>
-        <span class="tm">v0.40.0</span>
+        <span class="tm">v0.41.0</span>
       </a>
       <nav class="primary" aria-label="Primary">
         <a class="muted" href="/pricing/">Pricing</a>
@@ -530,9 +530,9 @@
           <aside class="latest-stamp" aria-label="Latest release">
             <div class="ls-cap"><span>Latest release</span><span class="dot" aria-hidden="true"></span></div>
             <div class="ls-body">
-              <span class="ls-ver">v0.40.0</span>
-              <div class="ls-name">Build Once, Run Anywhere</div>
-              <div class="ls-meta"><span>June&nbsp;11,&nbsp;2026</span><span><a href="#v0-40-0">Read&nbsp;↓</a></span></div>
+              <span class="ls-ver">v0.41.0</span>
+              <div class="ls-name">Trust, Verified</div>
+              <div class="ls-meta"><span>July&nbsp;21,&nbsp;2026</span><span><a href="#v0-41-0">Read&nbsp;↓</a></span></div>
             </div>
           </aside>
         </div>
@@ -545,12 +545,72 @@
     <section class="log" aria-label="Release log">
       <div class="wrap">
 
+        <!-- ===================== v0.41.0 ===================== -->
+        <article class="entry is-latest reveal" id="v0-41-0" aria-labelledby="t-0410">
+          <div class="entry-margin">
+            <span class="ver">v0.41.0</span>
+            <span class="ver-date">July 21, 2026</span>
+            <span class="ver-tag">★ Latest</span>
+            <div class="ver-rule" aria-hidden="true"></div>
+          </div>
+          <div class="entry-body">
+            <h2 class="entry-title" id="t-0410">Trust, Verified</h2>
+            <p class="entry-lede">
+              A full adversarial audit of the engine, API, persistence, dashboard, and deployment — and a hardening pass on everything it found. Closed an authentication bypass on admin endpoints, made workflow file reads tenant-safe, reconciled the PostgreSQL schema with the ORM down to enum labels, made retries honest about what they cost, and put the whole suite on randomized-order soak: <strong>17,000+ tests, three consecutive clean runs, zero flakes</strong>. Includes breaking changes — read the <a href="https://github.com/gizmax/Sandcastle/blob/main/CHANGELOG.md">upgrade notes</a> and plan a short maintenance window for the database migration.
+            </p>
+
+            <ul class="feats">
+              <li class="feat">
+                <span class="feat-chip headline">security · headline</span>
+                <div class="feat-text">
+                  <h3>Admin surface locked down</h3>
+                  <p><code>/admin/environments</code> no longer bypasses API-key auth, <code>is_admin</code> requires a genuinely authenticated key, and the server refuses to bind a public interface without <code>AUTH_REQUIRED=true</code> unless you explicitly opt out. Tool connectors and code steps run with minimal, credential-scoped environments.</p>
+                </div>
+              </li>
+              <li class="feat">
+                <span class="feat-chip feat-new">security</span>
+                <div class="feat-text">
+                  <h3>Tenant-safe file reads</h3>
+                  <p>HTTP step <code>@file:</code> references now require an admin-trusted run and stay confined to <code>DATA_DIR</code> — no more cross-tenant artifact reads via injected workflow bodies. Webhook delivery pins the validated IP at connect time, closing the DNS-rebinding window for good.</p>
+                </div>
+              </li>
+              <li class="feat">
+                <span class="feat-chip feat-new">engine</span>
+                <div class="feat-text">
+                  <h3>Honest retries, honest budgets</h3>
+                  <p><code>retry:</code> now works on every step type, fatal errors (4xx, validation, policy) stop retrying instead of re-paying for doomed calls, and paid LLM cost is counted even when a step fails after the API call — budget limits hold to the cent, including across approval pauses and resumes.</p>
+                </div>
+              </li>
+              <li class="feat">
+                <span class="feat-chip feat-new">db</span>
+                <div class="feat-text">
+                  <h3>PostgreSQL reconciled</h3>
+                  <p>Migrations 015–017 create the missing tables and columns, convert legacy lowercase enum labels to the ORM's member names, and align JSONB and indexes. <code>alembic check</code> runs in CI against a live Postgres with an enum round-trip smoke test, so schema drift can't ship silently again.</p>
+                </div>
+              </li>
+              <li class="feat">
+                <span class="feat-chip feat-new">dashboard</span>
+                <div class="feat-text">
+                  <h3>Dashboard that matches the backend</h3>
+                  <p>Evolution page speaks the real API (tenant-scoped <code>GET /api/evolution</code>), admin SSE streams authenticate properly, generated YAML is injection-safe, and a contract test fails CI if the frontend ever calls an endpoint that doesn't exist.</p>
+                </div>
+              </li>
+              <li class="feat">
+                <span class="feat-chip feat-new">ci</span>
+                <div class="feat-text">
+                  <h3>Soak-tested, Docker-built</h3>
+                  <p>The suite now runs randomized-order in development (three environment/state pollution classes fixed at the root), and CI builds the main, runner, and E2B images and boots the API against a health check on every change.</p>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </article>
+
         <!-- ===================== v0.40.0 ===================== -->
-        <article class="entry is-latest reveal" id="v0-40-0" aria-labelledby="t-0400">
+        <article class="entry reveal" id="v0-40-0" aria-labelledby="t-0400">
           <div class="entry-margin">
             <span class="ver">v0.40.0</span>
             <span class="ver-date">June 11, 2026</span>
-            <span class="ver-tag">★ Latest</span>
             <div class="ver-rule" aria-hidden="true"></div>
           </div>
           <div class="entry-body">

--- a/src/sandcastle/__init__.py
+++ b/src/sandcastle/__init__.py
@@ -1,6 +1,6 @@
 """Sandcastle - Production-ready workflow orchestrator for AI agents."""
 
-__version__ = "0.40.4"
+__version__ = "0.41.0"
 
 __all__ = ["SandcastleClient", "AsyncSandcastleClient", "__version__"]
 

--- a/tests/test_persistence_migration_cleanup.py
+++ b/tests/test_persistence_migration_cleanup.py
@@ -137,7 +137,12 @@ def test_persistence_drift_adds_deploying_to_postgresql_enum():
     """The new experiment status is emitted only for PostgreSQL."""
     module = _migration_module()
     operations = MagicMock()
-    operations.get_bind.return_value = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+    operations.get_bind.return_value = SimpleNamespace(
+        dialect=SimpleNamespace(name="postgresql"),
+        execute=lambda *_args, **_kwargs: SimpleNamespace(
+            scalars=lambda: SimpleNamespace(all=lambda: [])
+        ),
+    )
 
     with patch.object(module, "op", operations):
         module._add_deploying_experimentstatus()
@@ -183,7 +188,12 @@ def test_enum_reconciliation_uses_uppercase_orm_member_names_on_postgresql():
         status.name for status in WorkflowVersionStatus
     )
     operations = MagicMock()
-    operations.get_bind.return_value = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+    operations.get_bind.return_value = SimpleNamespace(
+        dialect=SimpleNamespace(name="postgresql"),
+        execute=lambda *_args, **_kwargs: SimpleNamespace(
+            scalars=lambda: SimpleNamespace(all=lambda: [])
+        ),
+    )
 
     with patch.object(module, "op", operations):
         module.upgrade()
@@ -235,7 +245,12 @@ def test_pg_drift_reconciliation_converts_json_and_creates_missing_indexes():
     """PostgreSQL gets jsonb columns and the model-declared performance indexes."""
     module = _migration_module("017")
     operations = MagicMock()
-    operations.get_bind.return_value = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+    operations.get_bind.return_value = SimpleNamespace(
+        dialect=SimpleNamespace(name="postgresql"),
+        execute=lambda *_args, **_kwargs: SimpleNamespace(
+            scalars=lambda: SimpleNamespace(all=lambda: [])
+        ),
+    )
 
     with patch.object(module, "op", operations):
         module.upgrade()


### PR DESCRIPTION
## 0.41.0 - "Trust, Verified"

Release commit for 0.41.0. Version bumped across package, README badge, dashboard, Helm `appVersion`, site labels, and the What's New entry; CHANGELOG carries the full upgrade notes.

### Contents
- Version bump 0.40.4 -> 0.41.0 (12 files, all consistent)
- CHANGELOG with upgrade notes: maintenance window for migrations 015-017 (enum label + JSONB reconciliation, table locks, **not** rolling-deploy safe) and every behavior change (bind guard, `@file:` gate, MCP auth, hybrid retry semantics, A2A async model, SSE caps, image defaults)
- Migration 016 preflights `workflow_versions.status` and stops with a clear error listing un-mappable legacy values (verified against live Postgres: clean fail on `experimental`, clean migrate after fix)
- Strip blank-at-EOF in community workflows

### Verification
- Python suite: **17182 passed, 13 skipped, 0 failed** (706s)
- Dashboard suite: **1008 passed** (55 files)
- Helm `appVersion` matches `__version__` (0.41.0)
- No stale 0.40.x references outside CHANGELOG history

### Breaking changes
This release contains breaking changes. Operators must read the upgrade notes in CHANGELOG.md and plan a short maintenance window for the database migration before deploying.

Merging publishes 0.41.0 to PyPI via OIDC trusted publishing.