### PR TITLE
fix(docker): 0.41.1 - GPU passthrough override for Spark Mode + worker healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.41.1] - 2026-07-21 - "Spark, Contained"
+
+### Fixed
+
+- Docker: new `docker-compose.gpu.yml` override passes the NVIDIA GPU through to the
+  `sandcastle` and `worker` containers. Without it, Spark Mode detection (which is
+  fail-closed and probes `nvidia-smi` in-process) silently reported `is_spark=False`
+  in the official compose deployment, even on a real DGX Spark. Verified on GB10
+  hardware: with the override, containers detect Spark Mode and auto-lift worker
+  concurrency. Requires nvidia-container-toolkit on the host.
+- Docker: the `worker` service now uses a process-based healthcheck. It inherited the
+  image's HTTP healthcheck but runs the arq queue worker with no HTTP server, so it
+  was reported permanently unhealthy and `docker compose up --wait` could never
+  succeed.
+
 ## [0.41.0] - 2026-07-21 - "Trust, Verified"
 
 A full adversarial audit of the engine, API, persistence, dashboard, and deployment, followed by

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Build once. Run anywhere.** Sandcastle is an open-source, production-ready orchestrator for AI agents. **Describe a workflow in plain English and it builds it** (or write the YAML yourself); run it on **any model** — Claude, GPT, Mistral, or a local model on your own box — and move between them with one line; deploy it **your way** — cloud, your own server, fully air-gapped, or EU-only; and it **gets better over time**, on its own. Local models run at `$0/run` with hard data-residency enforcement and a tamper-evident audit trail; the cloud is there too, with 7 providers and auto-failover, 25 step types, verified templates, and a full dashboard. Sovereign by default. European-built.
 
-[![PyPI](https://img.shields.io/badge/PyPI-v0.41.0-blue?style=flat-square)](https://pypi.org/project/sandcastle-ai/0.41.0/)
+[![PyPI](https://img.shields.io/badge/PyPI-v0.41.1-blue?style=flat-square)](https://pypi.org/project/sandcastle-ai/0.41.1/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![Tests](https://img.shields.io/badge/tests-17154%20passing-brightgreen?style=flat-square)](https://github.com/gizmax/Sandcastle/actions)
@@ -255,6 +255,13 @@ OLLAMA_HOST=http://localhost:11434 sandcastle serve   # Spark Mode auto-detects 
 
 Override detection anytime with `SANDCASTLE_SPARK_MODE=on|off`. On any non-Spark machine nothing
 changes — detection is fail-closed.
+
+**Spark Mode in Docker.** The plain `docker-compose.yml` does not pass the GPU through, so Spark
+Mode stays off in containers. With nvidia-container-toolkit installed on the Spark host, run:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
+```
 
 **Overnight Self-Tune** goes one step further: with `pip install 'sandcastle-ai[training]'`,
 `TRAINER_BACKEND=gpu`, and `EVOLUTION_AUTO_FINETUNE=true`, the evolution loop fine-tunes a real

--- a/deploy/mcp-tunnel/memory-mcp/Chart.yaml
+++ b/deploy/mcp-tunnel/memory-mcp/Chart.yaml
@@ -3,7 +3,7 @@ name: memory-mcp
 description: Sandcastle Memory MCP server behind a Cloudflare MCP tunnel (outbound-only, no inbound ingress required)
 type: application
 version: 0.1.0
-appVersion: "0.41.0"
+appVersion: "0.41.1"
 keywords:
   - sandcastle
   - mcp

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -1,0 +1,19 @@
+# GPU override for Spark Mode. nvidia-container-toolkit injects nvidia-smi only when the GPU is
+# reserved; detection is fail-closed.
+# Usage: docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
+
+x-gpu: &gpu
+  deploy:
+    resources:
+      reservations:
+        devices:
+          - driver: nvidia
+            count: all
+            capabilities: [gpu]
+
+services:
+  sandcastle:
+    <<: *gpu
+
+  worker:
+    <<: *gpu

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,13 @@ services:
     <<: [*sandcastle-build, *sandcastle-env]
     restart: unless-stopped
     command: ["arq", "sandcastle.queue.worker.WorkerSettings"]
+    # The arq worker serves no HTTP, so the image HEALTHCHECK can never pass.
+    healthcheck:
+      test: ["CMD-SHELL", "grep -aq arq /proc/1/cmdline"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     depends_on:
       redis:
         condition: service_healthy

--- a/src/sandcastle/__init__.py
+++ b/src/sandcastle/__init__.py
@@ -1,6 +1,6 @@
 """Sandcastle - Production-ready workflow orchestrator for AI agents."""
 
-__version__ = "0.41.0"
+__version__ = "0.41.1"
 
 __all__ = ["SandcastleClient", "AsyncSandcastleClient", "__version__"]
 


### PR DESCRIPTION
## 0.41.1 - "Spark, Contained"

Two Docker deployment defects found during a verified 0.41.0 deployment on real NVIDIA DGX Spark (GB10) hardware. Both are architecture-independent and affect every compose user.

### Fixed

**1. Spark Mode silently never activates in the official Docker deployment.**
Spark detection probes `nvidia-smi` in-process and is fail-closed; `python:3.12-slim` has no `nvidia-smi` and `docker-compose.yml` passes no GPU through, so containers reported `is_spark=False` with no warning even on a real DGX Spark. New `docker-compose.gpu.yml` override reserves the GPU on the `sandcastle` and `worker` services so nvidia-container-toolkit injects the driver binaries.

Verified on GB10 hardware: with the override, `is_spark=True` inside the container, `unified_mem_gb=121`, concurrency auto-lift 5 -> 40, `spark_nim_autoroute=True`.

**2. Worker service permanently unhealthy.**
The image HEALTHCHECK curls `/api/health`, but the worker runs `arq` with no HTTP server, so the probe failed forever and `docker compose up --wait` could never succeed. The worker now uses a zero-dependency process probe (`grep -aq arq /proc/1/cmdline`) - empirically verified against the live worker container on GB10 (PID 1 is the arq process, no entrypoint wrapper).

### Release chores
Version 0.41.1 in `__init__.py`, README badge, Helm `appVersion`; CHANGELOG entry. Dashboard and site labels intentionally not bumped (patch-release convention, matches 0.40.x).

### Verification
- `docker compose config` valid for base and merged files (run on the GB10 host)
- GPU reservation lands on exactly `sandcastle` + `worker` in the merged config
- Healthcheck probe exits 0 against the live worker container
- `tests/test_helm_chart.py` 11/11 (appVersion == __version__)

Merging publishes 0.41.1 to PyPI via OIDC trusted publishing.