### PR TITLE
fix(discovery): 0.41.2 - local provider discovery respects OLLAMA_HOST, wizard detects NIM/vLLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.41.2] - 2026-07-21 - "Local Discovery"
+
+### Fixed
+- Provider discovery now respects `OLLAMA_HOST` everywhere. The onboarding wizard,
+  `/health/providers`, `/advisor/status`, and the EU-residency check probed a hardcoded
+  `http://localhost:11434`, so a Docker deployment pointing at a host Ollama (e.g.
+  `host.docker.internal`) always showed "No provider detected" even though workflow
+  steps could reach it. Ollama LLM steps and the advisor test call resolve their base
+  URL the same way now.
+- The wizard and `/advisor/status` also discover a local NIM / vLLM server: any
+  OpenAI-compatible endpoint at `NIM_BASE_URL` whose `/v1/models` answers shows up as
+  a detected local provider, so a box running vLLM no longer looks empty.
+
+### Added
+- `SPARK_NIM_DEFAULT_MODEL`: the model the Spark NIM autoroute sends bare default
+  steps to (default `nim/llama-3.1-70b`). Set it to a model your local server
+  actually serves (e.g. `nim/ornith`) - the reachability probe only checks that
+  `/v1/models` answers, not that the hardcoded default exists on it.
+
 ## [0.41.1] - 2026-07-21 - "Spark, Contained"
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Build once. Run anywhere.** Sandcastle is an open-source, production-ready orchestrator for AI agents. **Describe a workflow in plain English and it builds it** (or write the YAML yourself); run it on **any model** — Claude, GPT, Mistral, or a local model on your own box — and move between them with one line; deploy it **your way** — cloud, your own server, fully air-gapped, or EU-only; and it **gets better over time**, on its own. Local models run at `$0/run` with hard data-residency enforcement and a tamper-evident audit trail; the cloud is there too, with 7 providers and auto-failover, 25 step types, verified templates, and a full dashboard. Sovereign by default. European-built.
 
-[![PyPI](https://img.shields.io/badge/PyPI-v0.41.1-blue?style=flat-square)](https://pypi.org/project/sandcastle-ai/0.41.1/)
+[![PyPI](https://img.shields.io/badge/PyPI-v0.41.2-blue?style=flat-square)](https://pypi.org/project/sandcastle-ai/0.41.2/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![Tests](https://img.shields.io/badge/tests-17154%20passing-brightgreen?style=flat-square)](https://github.com/gizmax/Sandcastle/actions)

--- a/dashboard/src/components/onboarding/OnboardingWizard.tsx
+++ b/dashboard/src/components/onboarding/OnboardingWizard.tsx
@@ -88,6 +88,40 @@ function StepConnect({ onNext, onSkip }: { onNext: () => void; onSkip: () => voi
     }
   };
 
+  // Cloud key entry is available in both states: as the fallback when nothing
+  // local is detected, and as an addition when local providers are already running.
+  const cloudKeyInput = (
+    <>
+      <label className="block text-sm font-medium text-foreground">
+        Paste an Anthropic, Mistral, or OpenAI API key
+      </label>
+      <div className="flex gap-2">
+        <input
+          type="password"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          placeholder="sk-..."
+          className="flex-1 rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-accent/40"
+        />
+        <button
+          onClick={() => void handleSaveKey()}
+          disabled={saving || !apiKey.trim()}
+          className={cn(
+            "rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground",
+            "hover:bg-accent-hover transition-colors",
+            "disabled:opacity-50 disabled:cursor-not-allowed"
+          )}
+        >
+          {saving ? "Saving..." : "Save"}
+        </button>
+      </div>
+      {saveError && <p className="text-xs text-error">{saveError}</p>}
+      {saveSuccess && (
+        <p className="text-xs text-success font-medium">Key saved! You can continue.</p>
+      )}
+    </>
+  );
+
   return (
     <div className="space-y-6">
       <div className="text-center">
@@ -127,6 +161,10 @@ function StepConnect({ onNext, onSkip }: { onNext: () => void; onSkip: () => voi
               <span className="text-xs font-semibold text-success">Ready!</span>
             </div>
           ))}
+          <p className="text-center text-xs text-muted-foreground">
+            or add a cloud provider
+          </p>
+          {cloudKeyInput}
         </div>
       ) : (
         <div className="space-y-3">
@@ -140,33 +178,7 @@ function StepConnect({ onNext, onSkip }: { onNext: () => void; onSkip: () => voi
             </code>
           </div>
           <p className="text-center text-xs text-muted-foreground">or use the cloud</p>
-          <label className="block text-sm font-medium text-foreground">
-            Paste an Anthropic, Mistral, or OpenAI API key
-          </label>
-          <div className="flex gap-2">
-            <input
-              type="password"
-              value={apiKey}
-              onChange={(e) => setApiKey(e.target.value)}
-              placeholder="sk-..."
-              className="flex-1 rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-accent/40"
-            />
-            <button
-              onClick={() => void handleSaveKey()}
-              disabled={saving || !apiKey.trim()}
-              className={cn(
-                "rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground",
-                "hover:bg-accent-hover transition-colors",
-                "disabled:opacity-50 disabled:cursor-not-allowed"
-              )}
-            >
-              {saving ? "Saving..." : "Save"}
-            </button>
-          </div>
-          {saveError && <p className="text-xs text-error">{saveError}</p>}
-          {saveSuccess && (
-            <p className="text-xs text-success font-medium">Key saved! You can continue.</p>
-          )}
+          {cloudKeyInput}
         </div>
       )}
 

--- a/deploy/mcp-tunnel/memory-mcp/Chart.yaml
+++ b/deploy/mcp-tunnel/memory-mcp/Chart.yaml
@@ -3,7 +3,7 @@ name: memory-mcp
 description: Sandcastle Memory MCP server behind a Cloudflare MCP tunnel (outbound-only, no inbound ingress required)
 type: application
 version: 0.1.0
-appVersion: "0.41.1"
+appVersion: "0.41.2"
 keywords:
   - sandcastle
   - mcp

--- a/src/sandcastle/__init__.py
+++ b/src/sandcastle/__init__.py
@@ -1,6 +1,6 @@
 """Sandcastle - Production-ready workflow orchestrator for AI agents."""
 
-__version__ = "0.41.1"
+__version__ = "0.41.2"
 
 __all__ = ["SandcastleClient", "AsyncSandcastleClient", "__version__"]
 

--- a/src/sandcastle/api/routes.py
+++ b/src/sandcastle/api/routes.py
@@ -711,10 +711,21 @@ async def get_provider_health() -> ApiResponse:
             headers = headers_fn(api_key) if headers_fn else {}
 
             if provider_name == "ollama":
-                # Ollama: check /api/tags (no auth needed)
-                url = "http://localhost:11434/api/tags"
+                # Ollama: check /api/tags (no auth needed). Respect OLLAMA_HOST so
+                # Docker deployments probe the host's server, not container localhost.
+                from sandcastle.engine.providers import ollama_base_url
+
+                url = ollama_base_url() + "/api/tags"
                 async with httpx.AsyncClient(timeout=5.0) as client:
                     resp = await client.get(url)
+                    resp.raise_for_status()
+            elif provider_name == "nim":
+                # Local NIM / vLLM (OpenAI-compatible): /v1/models answers, no auth
+                from sandcastle.config import settings as _nim_s
+
+                nim_base = (_nim_s.nim_base_url or "http://localhost:8000").rstrip("/")
+                async with httpx.AsyncClient(timeout=5.0) as client:
+                    resp = await client.get(nim_base + "/v1/models")
                     resp.raise_for_status()
             elif key_env == "ANTHROPIC_API_KEY":
                 # Anthropic: minimal messages call - 400 = reachable (bad request ok)
@@ -729,13 +740,17 @@ async def get_provider_health() -> ApiResponse:
                         resp.raise_for_status()
             else:
                 # OpenAI-compatible providers
+                from sandcastle.engine.generator import resolve_provider_api_url
+
                 body = {
                     "model": cfg.get("model", "gpt-4o-mini"),
                     "max_tokens": 1,
                     "messages": [{"role": "user", "content": "ping"}],
                 }
                 async with httpx.AsyncClient(timeout=5.0) as client:
-                    resp = await client.post(cfg["api_url"], json=body, headers=headers)
+                    resp = await client.post(
+                        resolve_provider_api_url(cfg), json=body, headers=headers
+                    )
                     if resp.status_code not in (200, 400, 404):
                         resp.raise_for_status()
 
@@ -753,6 +768,9 @@ async def get_provider_health() -> ApiResponse:
     results: dict = {}
     for name, cfg in _PROVIDER_CONFIGS.items():
         results[name] = await _check_provider(name, cfg)
+    # Local NIM / vLLM is not an advisor provider (stays out of _PROVIDER_CONFIGS)
+    # but the onboarding wizard should still discover it as a local endpoint.
+    results["nim"] = await _check_provider("nim", {"api_key_env": "", "region": "local"})
 
     # Store cache
     get_provider_health._cache = results  # type: ignore[attr-defined]
@@ -4136,12 +4154,24 @@ async def advisor_status() -> ApiResponse:
     mistral_configured = bool(settings.mistral_api_key)
     openai_configured = bool(settings.openai_api_key)
 
-    # Detect Ollama by probing localhost
+    # Detect Ollama by probing the effective host (OLLAMA_HOST-aware for Docker)
+    from sandcastle.engine.providers import ollama_base_url as _ollama_base
+
     ollama_running = False
     try:
         async with httpx.AsyncClient(timeout=1.0) as client:
-            resp = await client.get("http://localhost:11434/api/tags")
+            resp = await client.get(_ollama_base() + "/api/tags")
             ollama_running = resp.status_code == 200
+    except Exception:
+        pass
+
+    # Detect a local NIM / vLLM (OpenAI-compatible) at nim_base_url
+    nim_running = False
+    try:
+        _nim_base = (settings.nim_base_url or "http://localhost:8000").rstrip("/")
+        async with httpx.AsyncClient(timeout=1.0) as client:
+            resp = await client.get(_nim_base + "/v1/models")
+            nim_running = resp.status_code == 200
     except Exception:
         pass
 
@@ -4173,6 +4203,13 @@ async def advisor_status() -> ApiResponse:
             region="local",
             configured=ollama_running,
             status="running" if ollama_running else "not_detected",
+        ),
+        ProviderStatusEntry(
+            id="nim",
+            name="Local NIM / vLLM (OpenAI-compatible)",
+            region="local",
+            configured=nim_running,
+            status="running" if nim_running else "not_detected",
         ),
     ]
 
@@ -4212,11 +4249,13 @@ async def advisor_configure(request: AdvisorConfigureRequest) -> ApiResponse:
     # Item 6: When EU mode is enabled, verify at least one EU/local provider is configured
     if request.data_residency == "eu":
         mistral_configured = bool(settings.mistral_api_key)
-        # Detect Ollama
+        # Detect Ollama (OLLAMA_HOST-aware for Docker)
+        from sandcastle.engine.providers import ollama_base_url as _ollama_base
+
         ollama_running = False
         try:
             async with httpx.AsyncClient(timeout=1.0) as _client:
-                _r = await _client.get("http://localhost:11434/api/tags")
+                _r = await _client.get(_ollama_base() + "/api/tags")
                 ollama_running = _r.status_code == 200
         except Exception:
             pass
@@ -4298,7 +4337,9 @@ async def advisor_test_connection(req: Request) -> ApiResponse:
             ).model_dump(),
         )
 
-    api_url = cfg["api_url"]
+    from sandcastle.engine.generator import resolve_provider_api_url
+
+    api_url = resolve_provider_api_url(cfg)
     model = cfg["model"]
     headers = cfg["headers_fn"](api_key)
     # Pass is_anthropic explicitly so the request body format matches the

--- a/src/sandcastle/config.py
+++ b/src/sandcastle/config.py
@@ -58,6 +58,11 @@ class Settings(BaseSettings):
     # AUTOROUTE=false. nim_probe_timeout_ms bounds the reachability probe.
     spark_nim_autoroute: bool = True
     nim_probe_timeout_ms: int = 2000
+    # Model the autoroute sends bare default steps to. Must be a model id the local
+    # OpenAI-compatible server actually serves - e.g. "nim/ornith" for a vLLM started
+    # with --served-model-name ornith. The reachability probe only checks /v1/models
+    # answers, not that this model exists on it.
+    spark_nim_default_model: str = "nim/llama-3.1-70b"
 
     # Overnight Self-Tune: the evolution loop may add a LoRA fine-tune mutation that
     # trains a local adapter on a workflow's own eval data and A/B-promotes it. Off by

--- a/src/sandcastle/engine/generator.py
+++ b/src/sandcastle/engine/generator.py
@@ -727,6 +727,25 @@ def _resolve_model_for_tier(provider_name: str, quality_tier: str) -> str | None
 # ---------------------------------------------------------------------------
 
 # Provider configuration - configurable via env vars
+def resolve_provider_api_url(cfg: dict) -> str:
+    """Resolve a provider config's ``api_url``, expanding local-endpoint templates.
+
+    ``{omlx_base_url}`` and ``{ollama_host}`` are read at call time (not import time)
+    so Docker deployments that inject OLLAMA_HOST reach the host's server instead of
+    the container's localhost.
+    """
+    api_url = cfg.get("api_url", "")
+    if "{omlx_base_url}" in api_url:
+        from sandcastle.config import settings as _s
+
+        api_url = api_url.format(omlx_base_url=_s.omlx_base_url.rstrip("/"))
+    if "{ollama_host}" in api_url:
+        from sandcastle.engine.providers import ollama_base_url
+
+        api_url = api_url.format(ollama_host=ollama_base_url())
+    return api_url
+
+
 _PROVIDER_CONFIGS = {
     "anthropic": {
         "api_url": "https://api.anthropic.com/v1/messages",
@@ -760,7 +779,7 @@ _PROVIDER_CONFIGS = {
         },
     },
     "ollama": {
-        "api_url": "http://localhost:11434/v1/chat/completions",
+        "api_url": "{ollama_host}/v1/chat/completions",
         "model": "llama3.2",
         "api_key_env": "",  # Ollama doesn't need a key
         "region": "local",
@@ -810,11 +829,8 @@ def _get_advisor_config() -> dict:
 
     config = dict(_PROVIDER_CONFIGS[provider])
 
-    # Resolve dynamic base URL for oMLX provider
-    if "{omlx_base_url}" in config.get("api_url", ""):
-        config["api_url"] = config["api_url"].format(
-            omlx_base_url=settings.omlx_base_url.rstrip("/")
-        )
+    # Resolve dynamic base URLs for local providers
+    config["api_url"] = resolve_provider_api_url(config)
 
     model_override = os.environ.get("SANDCASTLE_ADVISOR_MODEL", "")
     if model_override:
@@ -1073,12 +1089,8 @@ async def _call_advisor_llm(
     for i, provider_name in enumerate(providers_to_try):
         cfg = dict(_PROVIDER_CONFIGS[provider_name])
         api_url = cfg["api_url"]
-        # Resolve dynamic base URL for oMLX provider
-        if "{omlx_base_url}" in api_url:
-            from sandcastle.config import settings as _settings
-            api_url = api_url.format(
-                omlx_base_url=_settings.omlx_base_url.rstrip("/")
-            )
+        # Resolve dynamic base URLs for local providers
+        api_url = resolve_provider_api_url(cfg)
         provider_region = cfg.get("region", "us")
         is_anthropic = cfg.get("api_key_env") == "ANTHROPIC_API_KEY"
 

--- a/src/sandcastle/engine/providers.py
+++ b/src/sandcastle/engine/providers.py
@@ -187,6 +187,21 @@ def is_known_model(model_str: str) -> bool:
 
 # The local model the Spark auto-route targets (a static nim/* registry entry).
 _SPARK_NIM_DEFAULT = "nim/llama-3.1-70b"
+
+
+def ollama_base_url() -> str:
+    """Effective Ollama base URL - live OLLAMA_HOST env wins, then settings, then localhost.
+
+    The live env check matters in Docker: the settings singleton is created at import
+    time, and detection endpoints must see an OLLAMA_HOST injected later (tests, exec).
+    """
+    from sandcastle.config import settings
+
+    return (
+        os.environ.get("OLLAMA_HOST")
+        or getattr(settings, "ollama_host", "")
+        or "http://localhost:11434"
+    ).rstrip("/")
 # Cache the reachability probe per base_url with a short TTL so the hot path is
 # cheap but a NIM that starts after Sandcastle is still picked up.
 _NIM_REACHABLE_CACHE: dict[str, tuple[bool, float]] = {}
@@ -242,7 +257,7 @@ def maybe_spark_nim_route(model_str: str) -> str:
         return model_str
     if not is_nim_reachable():
         return model_str
-    return _SPARK_NIM_DEFAULT
+    return settings.spark_nim_default_model or _SPARK_NIM_DEFAULT
 
 
 def get_api_key(model_info: ModelInfo) -> str:
@@ -284,6 +299,10 @@ def resolve_base_url(model_info: ModelInfo) -> str:
         from sandcastle.config import settings
         base = settings.omlx_base_url or "http://localhost:8080"
         return base.rstrip("/") + "/v1"
+    if model_info.provider == "ollama":
+        # Respect OLLAMA_HOST / settings.ollama_host so Docker deployments where
+        # Ollama runs on the host (not in the container) reach the right endpoint.
+        return ollama_base_url() + "/v1"
     if model_info.provider == "nim":
         from sandcastle.config import settings
         base = settings.nim_base_url or "http://localhost:8000"

--- a/tests/test_generator_deep.py
+++ b/tests/test_generator_deep.py
@@ -120,11 +120,12 @@ class TestProviderConfigs:
         for name, cfg in _PROVIDER_CONFIGS.items():
             assert "api_url" in cfg, f"{name} missing api_url"
             url = cfg["api_url"]
-            # oMLX uses a runtime-resolved placeholder ({omlx_base_url}/...)
-            # so it doesn't start with http. Strip the placeholder before
-            # validating the rest of the URL shape.
-            if "{omlx_base_url}" in url:
-                url = url.replace("{omlx_base_url}", "http://localhost:8000")
+            # Local providers use runtime-resolved placeholders ({omlx_base_url},
+            # {ollama_host}) so they don't start with http. Resolve them the same
+            # way production does before validating the URL shape.
+            if "{" in url:
+                from sandcastle.engine.generator import resolve_provider_api_url
+                url = resolve_provider_api_url(cfg)
             assert url.startswith("http"), f"{name} api_url invalid"
 
     def test_all_providers_have_model(self):

--- a/tests/test_local_provider_discovery.py
+++ b/tests/test_local_provider_discovery.py
@@ -1,0 +1,119 @@
+"""Tests for 0.41.2 local provider discovery (OLLAMA_HOST-aware probes + NIM detection).
+
+Docker deployments run Ollama / vLLM on the host, not in the container, so every
+discovery probe must honour OLLAMA_HOST / NIM_BASE_URL instead of localhost.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from sandcastle.config import settings
+
+
+def _make_client() -> TestClient:
+    from sandcastle.api.routes import router
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _clear_health_cache() -> None:
+    import sandcastle.api.routes as routes_module
+
+    endpoint = routes_module.get_provider_health
+    for attr in ("_cache", "_cache_ts"):
+        if hasattr(endpoint, attr):
+            delattr(endpoint, attr)
+
+
+def _mock_async_client(mock_client_cls, status_code: int = 200):
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.raise_for_status = MagicMock()
+    mock_instance = AsyncMock()
+    mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+    mock_instance.__aexit__ = AsyncMock(return_value=False)
+    mock_instance.post = AsyncMock(return_value=mock_resp)
+    mock_instance.get = AsyncMock(return_value=mock_resp)
+    mock_client_cls.return_value = mock_instance
+    return mock_instance
+
+
+class TestHealthProvidersLocalDiscovery:
+    def test_nim_included_in_health_providers(self):
+        """/health/providers must report the local NIM/vLLM endpoint."""
+        client = _make_client()
+        _clear_health_cache()
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            _mock_async_client(mock_client_cls)
+            resp = client.get("/health/providers")
+        data = resp.json()["data"]
+        assert "nim" in data
+        assert data["nim"]["region"] == "local"
+        assert data["nim"]["status"] == "ok"
+
+    def test_ollama_probe_uses_ollama_host_env(self, monkeypatch):
+        """The Ollama probe must target OLLAMA_HOST, not hardcoded localhost."""
+        monkeypatch.setenv("OLLAMA_HOST", "http://host.docker.internal:11434")
+        client = _make_client()
+        _clear_health_cache()
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_instance = _mock_async_client(mock_client_cls)
+            client.get("/health/providers")
+        get_urls = [c.args[0] for c in mock_instance.get.await_args_list if c.args]
+        assert "http://host.docker.internal:11434/api/tags" in get_urls
+
+    def test_nim_probe_uses_nim_base_url(self, monkeypatch):
+        """The NIM probe must target settings.nim_base_url."""
+        monkeypatch.setattr(settings, "nim_base_url", "http://host.docker.internal:18000")
+        client = _make_client()
+        _clear_health_cache()
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_instance = _mock_async_client(mock_client_cls)
+            client.get("/health/providers")
+        get_urls = [c.args[0] for c in mock_instance.get.await_args_list if c.args]
+        assert "http://host.docker.internal:18000/v1/models" in get_urls
+
+
+class TestAdvisorStatusLocalDiscovery:
+    def test_advisor_status_lists_nim(self):
+        """/advisor/status must include a nim entry with local region."""
+        client = _make_client()
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            _mock_async_client(mock_client_cls)
+            resp = client.get("/advisor/status")
+        providers = resp.json()["data"]["available_providers"]
+        by_id = {p["id"]: p for p in providers}
+        assert "nim" in by_id
+        assert by_id["nim"]["region"] == "local"
+        assert by_id["nim"]["status"] == "running"
+
+    def test_advisor_status_ollama_uses_env_host(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_HOST", "http://host.docker.internal:11434")
+        client = _make_client()
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_instance = _mock_async_client(mock_client_cls)
+            client.get("/advisor/status")
+        get_urls = [c.args[0] for c in mock_instance.get.await_args_list if c.args]
+        assert "http://host.docker.internal:11434/api/tags" in get_urls
+
+
+class TestGeneratorApiUrlResolution:
+    def test_ollama_api_url_resolves_from_env(self, monkeypatch):
+        from sandcastle.engine.generator import _PROVIDER_CONFIGS, resolve_provider_api_url
+
+        monkeypatch.setenv("OLLAMA_HOST", "http://host.docker.internal:11434")
+        url = resolve_provider_api_url(_PROVIDER_CONFIGS["ollama"])
+        assert url == "http://host.docker.internal:11434/v1/chat/completions"
+
+    def test_static_urls_pass_through(self):
+        from sandcastle.engine.generator import _PROVIDER_CONFIGS, resolve_provider_api_url
+
+        url = resolve_provider_api_url(_PROVIDER_CONFIGS["anthropic"])
+        assert url == "https://api.anthropic.com/v1/messages"

--- a/tests/test_provider_integration_v28.py
+++ b/tests/test_provider_integration_v28.py
@@ -228,10 +228,11 @@ class TestProviderConfigs:
         """Provider API URL should match the expected pattern."""
         cfg = _PROVIDER_CONFIGS[provider]
         expected_pattern = PROVIDER_API_URLS[provider]
-        # omlx uses a template variable
-        url = cfg["api_url"]
-        if provider == "omlx":
-            url = url.replace("{omlx_base_url}", "http://localhost:8080")
+        # Local providers use template variables resolved at call time; resolve
+        # them the same way production does (with no env override this yields
+        # the localhost defaults the patterns below expect).
+        from sandcastle.engine.generator import resolve_provider_api_url
+        url = resolve_provider_api_url(cfg)
         assert expected_pattern in url, (
             f"Provider '{provider}' API URL '{url}' does not contain "
             f"expected pattern '{expected_pattern}'"

--- a/tests/test_spark_autoroute.py
+++ b/tests/test_spark_autoroute.py
@@ -85,3 +85,37 @@ def test_noop_when_unreachable(monkeypatch):
 def test_noop_under_eu_residency(monkeypatch):
     _spark(monkeypatch, residency="eu")
     assert maybe_spark_nim_route("sonnet") == "sonnet"
+
+
+def test_configurable_default_model(monkeypatch):
+    _spark(monkeypatch)
+    monkeypatch.setattr(settings, "spark_nim_default_model", "nim/ornith")
+    assert maybe_spark_nim_route("sonnet") == "nim/ornith"
+
+
+def test_empty_default_model_falls_back(monkeypatch):
+    _spark(monkeypatch)
+    monkeypatch.setattr(settings, "spark_nim_default_model", "")
+    assert maybe_spark_nim_route("sonnet") == "nim/llama-3.1-70b"
+
+
+# ---- ollama_base_url --------------------------------------------------------
+
+
+def test_ollama_base_url_env_wins(monkeypatch):
+    monkeypatch.setenv("OLLAMA_HOST", "http://host.docker.internal:11434/")
+    assert providers.ollama_base_url() == "http://host.docker.internal:11434"
+
+
+def test_ollama_base_url_settings_fallback(monkeypatch):
+    monkeypatch.delenv("OLLAMA_HOST", raising=False)
+    monkeypatch.setattr(settings, "ollama_host", "http://myhost:11434")
+    assert providers.ollama_base_url() == "http://myhost:11434"
+
+
+def test_ollama_resolve_base_url_respects_host(monkeypatch):
+    from sandcastle.engine.providers import resolve_base_url, resolve_model
+
+    monkeypatch.setenv("OLLAMA_HOST", "http://host.docker.internal:11434")
+    info = resolve_model("ollama")
+    assert resolve_base_url(info) == "http://host.docker.internal:11434/v1"


### PR DESCRIPTION
## 0.41.2 - "Local Discovery"

Third finding from the GB10 deployment: the local-first story silently breaks in Docker. Steps could reach a host Ollama via OLLAMA_HOST, but every discovery surface probed hardcoded localhost, so the onboarding wizard reported "No provider detected" on a box with two working local model servers.

### Fixed
- `ollama_base_url()` (env OLLAMA_HOST > settings.ollama_host > localhost) used by the wizard probe (`/health/providers`), `/advisor/status`, the EU-residency check, the advisor test call, generator api_url templates, and ollama LLM step base URLs.
- `/health/providers` and `/advisor/status` also probe `NIM_BASE_URL/v1/models`, so a local vLLM (e.g. GB10 serving ornith/aeon) is discovered as a local provider. Discovery only - NIM stays out of the advisor failover pool.
- Onboarding wizard: cloud API key entry stays available when local providers are detected (was either/or).

### Added
- `SPARK_NIM_DEFAULT_MODEL`: the Spark autoroute target must be a model the local server actually serves; the hardcoded `nim/llama-3.1-70b` 404s on servers with different served names. Verified on GB10: `maybe_spark_nim_route("sonnet") -> nim/ornith`.

### Verification
- Full python suite: **17194 passed, 13 skipped, 0 failed**
- Dashboard: **1008 passed** (55 files)
- Live on GB10 hardware from this branch: wizard shows ollama (8.8ms) + nim (8.2ms) as local Ready providers; autoroute targets nim/ornith
- Helm chart tests 11/11 (appVersion 0.41.2)

Merging publishes 0.41.2 to PyPI via OIDC trusted publishing.