### PR TITLE
feat(models): 0.42.0 - default model picker, workflow_default_model, dynamic ollama/<tag>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.42.0] - 2026-07-21 - "Your Box, Your Default"
+
+### Added
+- **Default model picker.** New `workflow_default_model` setting: steps without an
+  explicit `model:` use it instead of the built-in default. Settable from the
+  onboarding wizard - detected local providers now list their models (Ollama tags,
+  vLLM/NIM served ids) and one click makes one the default - or via
+  `PATCH /api/settings {"workflow_default_model": "nim/ornith"}`. Values are
+  validated against the model registry at write time; unknown strings are rejected
+  with `UNKNOWN_MODEL` before they can break a run. Empty string clears it.
+- **Dynamic `ollama/<tag>` models.** Any locally pulled Ollama model resolves like
+  `nim/<id>` always has (`ollama/qwen3:8b`, region `local`, $0), with the same
+  character discipline against injection. The base URL honours `OLLAMA_HOST`.
+- `/health/providers` includes a `models` list for reachable local providers
+  (up to 20 each), which is what the wizard picker renders.
+
+### Changed
+- A step whose model is the bare default now resolves: `workflow_default_model`
+  (when set) -> Spark NIM autoroute (when applicable) -> `sonnet`. Explicit
+  non-default models are never rewritten. Note that `model: sonnet` written
+  explicitly counts as the bare default - the same convention the Spark autoroute
+  has used since 0.33.
+- The onboarding wizard keeps the cloud API key entry visible when local
+  providers are detected (was either/or), so you can add Anthropic, Mistral, or
+  OpenAI keys alongside a local model.
+
 ## [0.41.2] - 2026-07-21 - "Local Discovery"
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/health/providers` includes a `models` list for reachable local providers
   (up to 20 each), which is what the wizard picker renders.
 
+### Fixed
+- The workflow generator ("describe it in plain English") no longer demands a
+  cloud API key on a box that runs local models. Advisor provider resolution
+  picks, in order: `SANDCASTLE_ADVISOR_PROVIDER`, any cloud provider with a
+  configured key, the local provider named by `workflow_default_model`, and on
+  a Spark a reachable local NIM/vLLM. Local generation calls use the model you
+  picked (e.g. `ornith`), not a hardcoded catalogue name.
+
 ### Changed
 - A step whose model is the bare default now resolves: `workflow_default_model`
   (when set) -> Spark NIM autoroute (when applicable) -> `sonnet`. Explicit

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Build once. Run anywhere.** Sandcastle is an open-source, production-ready orchestrator for AI agents. **Describe a workflow in plain English and it builds it** (or write the YAML yourself); run it on **any model** — Claude, GPT, Mistral, or a local model on your own box — and move between them with one line; deploy it **your way** — cloud, your own server, fully air-gapped, or EU-only; and it **gets better over time**, on its own. Local models run at `$0/run` with hard data-residency enforcement and a tamper-evident audit trail; the cloud is there too, with 7 providers and auto-failover, 25 step types, verified templates, and a full dashboard. Sovereign by default. European-built.
 
-[![PyPI](https://img.shields.io/badge/PyPI-v0.41.2-blue?style=flat-square)](https://pypi.org/project/sandcastle-ai/0.41.2/)
+[![PyPI](https://img.shields.io/badge/PyPI-v0.42.0-blue?style=flat-square)](https://pypi.org/project/sandcastle-ai/0.42.0/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![Tests](https://img.shields.io/badge/tests-17154%20passing-brightgreen?style=flat-square)](https://github.com/gizmax/Sandcastle/actions)

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashboard",
-  "version": "0.33.0",
+  "version": "0.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashboard",
-      "version": "0.41.0",
+      "version": "0.42.0",
       "dependencies": {
         "@fontsource/bricolage-grotesque": "^5.2.10",
         "@xyflow/react": "^12.10.2",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dashboard",
   "private": true,
-  "version": "0.41.0",
+  "version": "0.42.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/dashboard/src/__tests__/v27-onboarding.test.tsx
+++ b/dashboard/src/__tests__/v27-onboarding.test.tsx
@@ -667,6 +667,60 @@ describe("OnboardingWizard (guided beginner flow)", () => {
     expect(screen.getByText("Ready!")).toBeInTheDocument();
   });
 
+  it("Connect keeps the cloud key input when local providers are detected", async () => {
+    mockApi.get.mockResolvedValue(okResponse({
+      ollama: { status: "running", latency_ms: 8, region: "local" },
+    }));
+
+    await act(async () => {
+      renderWizard(mockOnFinish);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("Get Started"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Ready!")).toBeInTheDocument();
+    });
+    expect(screen.getByText("or add a cloud provider")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("sk-...")).toBeInTheDocument();
+  });
+
+  it("Connect lets the user pick a default model from detected providers", async () => {
+    mockApi.get.mockResolvedValue(okResponse({
+      ollama: { status: "running", latency_ms: 8, region: "local", models: ["qwen3:8b"] },
+      nim: { status: "ok", latency_ms: 4, region: "local", models: ["ornith"] },
+    }));
+    mockApi.patch.mockResolvedValue(okResponse({ workflow_default_model: "nim/ornith" }));
+
+    await act(async () => {
+      renderWizard(mockOnFinish);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("Get Started"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Pick a default model")).toBeInTheDocument();
+    });
+    expect(screen.getByText("ollama/qwen3:8b")).toBeInTheDocument();
+    expect(screen.getByText("nim/ornith")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("nim/ornith"));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("Set as default"));
+    });
+
+    await waitFor(() => {
+      expect(mockApi.patch).toHaveBeenCalledWith("/settings", {
+        workflow_default_model: "nim/ornith",
+      });
+      expect(screen.getByText("Default model set!")).toBeInTheDocument();
+    });
+  });
+
   it("Skip selects Everything density and marks onboarding done", async () => {
     mockApi.get.mockResolvedValue(okResponse({}));
 

--- a/dashboard/src/components/onboarding/OnboardingWizard.tsx
+++ b/dashboard/src/components/onboarding/OnboardingWizard.tsx
@@ -19,7 +19,19 @@ export interface SelectedTemplate {
 }
 
 interface HealthProviders {
-  [key: string]: { status: string; latency_ms: number | null; region: string };
+  [key: string]: {
+    status: string;
+    latency_ms: number | null;
+    region: string;
+    models?: string[];
+  };
+}
+
+/** Model string the backend expects for a provider's model (nim/<id>, ollama/<tag>). */
+function modelStringFor(providerId: string, model: string): string {
+  if (providerId === "ollama") return `ollama/${model}`;
+  if (providerId === "nim") return `nim/${model}`;
+  return model;
 }
 
 interface OnboardingWizardProps {
@@ -50,6 +62,10 @@ function StepConnect({ onNext, onSkip }: { onNext: () => void; onSkip: () => voi
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
+  const [selectedModel, setSelectedModel] = useState<string | null>(null);
+  const [savedModel, setSavedModel] = useState<string | null>(null);
+  const [modelSaving, setModelSaving] = useState(false);
+  const [modelError, setModelError] = useState<string | null>(null);
 
   useEffect(() => {
     void (async () => {
@@ -71,6 +87,21 @@ function StepConnect({ onNext, onSkip }: { onNext: () => void; onSkip: () => voi
     : [];
   const hasReady = readyProviders.length > 0;
   const hasLocal = readyProviders.some(([, v]) => v.region === "local");
+
+  const handleSaveModel = async () => {
+    if (!selectedModel) return;
+    setModelSaving(true);
+    setModelError(null);
+    try {
+      const res = await api.patch("/settings", { workflow_default_model: selectedModel });
+      if (res.error) throw new Error(res.error.message);
+      setSavedModel(selectedModel);
+    } catch {
+      setModelError("Could not save the default model.");
+    } finally {
+      setModelSaving(false);
+    }
+  };
 
   const handleSaveKey = async () => {
     if (!apiKey.trim()) return;
@@ -161,6 +192,70 @@ function StepConnect({ onNext, onSkip }: { onNext: () => void; onSkip: () => voi
               <span className="text-xs font-semibold text-success">Ready!</span>
             </div>
           ))}
+          {readyProviders.some(([, info]) => info.models?.length) && (
+            <div className="rounded-xl border border-border bg-background p-3 space-y-2">
+              <p className="text-sm font-medium text-foreground">
+                Pick a default model
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Steps without an explicit <code>model:</code> will use it. You can
+                always override per step in the workflow YAML.
+              </p>
+              <div className="space-y-1.5 max-h-44 overflow-y-auto">
+                {readyProviders.flatMap(([id, info]) =>
+                  (info.models ?? []).map((m) => {
+                    const value = modelStringFor(id, m);
+                    return (
+                      <label
+                        key={value}
+                        className={cn(
+                          "flex items-center gap-2 rounded-lg border px-3 py-1.5 text-sm cursor-pointer transition-colors",
+                          selectedModel === value
+                            ? "border-accent bg-accent/10 text-foreground"
+                            : "border-border text-muted-foreground hover:border-accent/40"
+                        )}
+                      >
+                        <input
+                          type="radio"
+                          name="default-model"
+                          className="accent-current"
+                          checked={selectedModel === value}
+                          onChange={() => setSelectedModel(value)}
+                        />
+                        <span className="font-mono text-xs">{value}</span>
+                        <span className="ml-auto text-[10px] uppercase tracking-wide text-muted-foreground">
+                          {id}
+                        </span>
+                      </label>
+                    );
+                  })
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => void handleSaveModel()}
+                  disabled={modelSaving || !selectedModel || savedModel === selectedModel}
+                  className={cn(
+                    "rounded-lg bg-accent px-4 py-1.5 text-sm font-medium text-accent-foreground",
+                    "hover:bg-accent-hover transition-colors",
+                    "disabled:opacity-50 disabled:cursor-not-allowed"
+                  )}
+                >
+                  {modelSaving
+                    ? "Saving..."
+                    : savedModel === selectedModel && savedModel
+                      ? "Saved"
+                      : "Set as default"}
+                </button>
+                {savedModel && savedModel === selectedModel && (
+                  <span className="text-xs text-success font-medium">
+                    Default model set!
+                  </span>
+                )}
+              </div>
+              {modelError && <p className="text-xs text-error">{modelError}</p>}
+            </div>
+          )}
           <p className="text-center text-xs text-muted-foreground">
             or add a cloud provider
           </p>

--- a/deploy/mcp-tunnel/memory-mcp/Chart.yaml
+++ b/deploy/mcp-tunnel/memory-mcp/Chart.yaml
@@ -3,7 +3,7 @@ name: memory-mcp
 description: Sandcastle Memory MCP server behind a Cloudflare MCP tunnel (outbound-only, no inbound ingress required)
 type: application
 version: 0.1.0
-appVersion: "0.41.2"
+appVersion: "0.42.0"
 keywords:
   - sandcastle
   - mcp

--- a/site/eu-ai-act/index.html
+++ b/site/eu-ai-act/index.html
@@ -514,7 +514,7 @@
       <a class="brand" href="/" aria-label="Sandcastle home">
         <span class="glyph" aria-hidden="true">🏰</span>
         <span>Sandcastle</span>
-        <span class="tm">v0.41.0</span>
+        <span class="tm">v0.42.0</span>
       </a>
       <nav class="primary" aria-label="Primary">
         <a class="muted" href="/pricing/">Pricing</a>

--- a/site/index.html
+++ b/site/index.html
@@ -608,7 +608,7 @@
       <a class="brand" href="/" aria-label="Sandcastle home">
         <span class="glyph" aria-hidden="true">🏰</span>
         <span>Sandcastle</span>
-        <span class="tm">v0.41.0</span>
+        <span class="tm">v0.42.0</span>
       </a>
       <nav class="primary" aria-label="Primary">
         <a class="muted" href="/pricing/">Pricing</a>

--- a/site/pricing/index.html
+++ b/site/pricing/index.html
@@ -472,7 +472,7 @@
       <a class="brand" href="/" aria-label="Sandcastle home">
         <span class="glyph" aria-hidden="true">🏰</span>
         <span>Sandcastle</span>
-        <span class="tm">v0.41.0</span>
+        <span class="tm">v0.42.0</span>
       </a>
       <nav class="primary" aria-label="Primary">
         <a class="muted" href="/pricing/" aria-current="page">Pricing</a>

--- a/site/security/index.html
+++ b/site/security/index.html
@@ -464,7 +464,7 @@
       <a class="brand" href="/" aria-label="Sandcastle home">
         <span class="glyph" aria-hidden="true">🏰</span>
         <span>Sandcastle</span>
-        <span class="tm">v0.41.0</span>
+        <span class="tm">v0.42.0</span>
       </a>
       <nav class="primary" aria-label="Primary">
         <a class="muted" href="/pricing/">Pricing</a>

--- a/site/whatsnew/index.html
+++ b/site/whatsnew/index.html
@@ -497,7 +497,7 @@
       <a class="brand" href="/" aria-label="Sandcastle home">
         <span class="glyph" aria-hidden="true">🏰</span>
         <span>Sandcastle</span>
-        <span class="tm">v0.41.0</span>
+        <span class="tm">v0.42.0</span>
       </a>
       <nav class="primary" aria-label="Primary">
         <a class="muted" href="/pricing/">Pricing</a>
@@ -530,9 +530,9 @@
           <aside class="latest-stamp" aria-label="Latest release">
             <div class="ls-cap"><span>Latest release</span><span class="dot" aria-hidden="true"></span></div>
             <div class="ls-body">
-              <span class="ls-ver">v0.41.0</span>
-              <div class="ls-name">Trust, Verified</div>
-              <div class="ls-meta"><span>July&nbsp;21,&nbsp;2026</span><span><a href="#v0-41-0">Read&nbsp;↓</a></span></div>
+              <span class="ls-ver">v0.42.0</span>
+              <div class="ls-name">Your Box, Your Default</div>
+              <div class="ls-meta"><span>July&nbsp;21,&nbsp;2026</span><span><a href="#v0-42-0">Read&nbsp;↓</a></span></div>
             </div>
           </aside>
         </div>
@@ -545,12 +545,51 @@
     <section class="log" aria-label="Release log">
       <div class="wrap">
 
+        <!-- ===================== v0.42.0 ===================== -->
+        <article class="entry is-latest reveal" id="v0-42-0" aria-labelledby="t-0420">
+          <div class="entry-margin">
+            <span class="ver">v0.42.0</span>
+            <span class="ver-date">July 21, 2026</span>
+            <span class="ver-tag">★ Latest</span>
+            <div class="ver-rule" aria-hidden="true"></div>
+          </div>
+          <div class="entry-body">
+            <h2 class="entry-title" id="t-0420">Your Box, Your Default</h2>
+            <p class="entry-lede">
+              Born on real hardware: deploying to an NVIDIA DGX Spark exposed how much of the local-first story assumed bare metal. Now the Docker deployment discovers what your box actually runs - a host Ollama, a local vLLM - lists its models in the onboarding wizard, and one click makes one the default for every step that doesn't name a model. Cloud keys stay one paste away, side by side.
+            </p>
+
+            <ul class="feats">
+              <li class="feat">
+                <span class="feat-chip headline">local · headline</span>
+                <div class="feat-text">
+                  <h3>Default model picker</h3>
+                  <p>New <code>workflow_default_model</code> setting: steps without an explicit <code>model:</code> use it instead of the built-in default. Pick it in the wizard from detected local models or set it via <code>PATCH /api/settings</code> - values are validated against the model registry before they can ever break a run.</p>
+                </div>
+              </li>
+              <li class="feat">
+                <span class="feat-chip feat-new">local</span>
+                <div class="feat-text">
+                  <h3>Any Ollama model, first-class</h3>
+                  <p><code>ollama/&lt;tag&gt;</code> now resolves dynamically like <code>nim/&lt;id&gt;</code> always has - any locally pulled model at <code>$0/run</code>, region local, with the same injection-safe character discipline. Base URLs honour <code>OLLAMA_HOST</code> everywhere.</p>
+                </div>
+              </li>
+              <li class="feat">
+                <span class="feat-chip feat-new">discovery</span>
+                <div class="feat-text">
+                  <h3>Docker finds your local models</h3>
+                  <p>Provider discovery (0.41.2) respects <code>OLLAMA_HOST</code> and probes <code>NIM_BASE_URL</code>, so a containerized Sandcastle detects the host&rsquo;s Ollama and any OpenAI-compatible vLLM. <code>/health/providers</code> now returns each local provider&rsquo;s model list. And Spark Mode works in Docker via the new <code>docker-compose.gpu.yml</code> override (0.41.1).</p>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </article>
+
         <!-- ===================== v0.41.0 ===================== -->
-        <article class="entry is-latest reveal" id="v0-41-0" aria-labelledby="t-0410">
+        <article class="entry reveal" id="v0-41-0" aria-labelledby="t-0410">
           <div class="entry-margin">
             <span class="ver">v0.41.0</span>
             <span class="ver-date">July 21, 2026</span>
-            <span class="ver-tag">★ Latest</span>
             <div class="ver-rule" aria-hidden="true"></div>
           </div>
           <div class="entry-body">

--- a/src/sandcastle/__init__.py
+++ b/src/sandcastle/__init__.py
@@ -1,6 +1,6 @@
 """Sandcastle - Production-ready workflow orchestrator for AI agents."""
 
-__version__ = "0.41.2"
+__version__ = "0.42.0"
 
 __all__ = ["SandcastleClient", "AsyncSandcastleClient", "__version__"]
 

--- a/src/sandcastle/api/routes.py
+++ b/src/sandcastle/api/routes.py
@@ -784,9 +784,6 @@ async def get_provider_health() -> ApiResponse:
     results: dict = {}
     for name, cfg in _PROVIDER_CONFIGS.items():
         results[name] = await _check_provider(name, cfg)
-    # Local NIM / vLLM is not an advisor provider (stays out of _PROVIDER_CONFIGS)
-    # but the onboarding wizard should still discover it as a local endpoint.
-    results["nim"] = await _check_provider("nim", {"api_key_env": "", "region": "local"})
 
     # Store cache
     get_provider_health._cache = results  # type: ignore[attr-defined]
@@ -4353,10 +4350,14 @@ async def advisor_test_connection(req: Request) -> ApiResponse:
             ).model_dump(),
         )
 
-    from sandcastle.engine.generator import resolve_provider_api_url
+    from sandcastle.engine.generator import _local_advisor_model, resolve_provider_api_url
 
     api_url = resolve_provider_api_url(cfg)
-    model = cfg["model"]
+    model = (
+        (_local_advisor_model(provider, cfg) or cfg["model"])
+        if provider in ("nim", "ollama")
+        else cfg["model"]
+    )
     headers = cfg["headers_fn"](api_key)
     # Pass is_anthropic explicitly so the request body format matches the
     # provider being tested, not the currently configured global provider.

--- a/src/sandcastle/api/routes.py
+++ b/src/sandcastle/api/routes.py
@@ -710,6 +710,7 @@ async def get_provider_health() -> ApiResponse:
             headers_fn = cfg.get("headers_fn")
             headers = headers_fn(api_key) if headers_fn else {}
 
+            models: list[str] = []
             if provider_name == "ollama":
                 # Ollama: check /api/tags (no auth needed). Respect OLLAMA_HOST so
                 # Docker deployments probe the host's server, not container localhost.
@@ -719,6 +720,12 @@ async def get_provider_health() -> ApiResponse:
                 async with httpx.AsyncClient(timeout=5.0) as client:
                     resp = await client.get(url)
                     resp.raise_for_status()
+                    try:
+                        models = [
+                            m["name"] for m in resp.json().get("models", []) if m.get("name")
+                        ][:20]
+                    except Exception:  # noqa: BLE001 - model list is best-effort
+                        models = []
             elif provider_name == "nim":
                 # Local NIM / vLLM (OpenAI-compatible): /v1/models answers, no auth
                 from sandcastle.config import settings as _nim_s
@@ -727,6 +734,12 @@ async def get_provider_health() -> ApiResponse:
                 async with httpx.AsyncClient(timeout=5.0) as client:
                     resp = await client.get(nim_base + "/v1/models")
                     resp.raise_for_status()
+                    try:
+                        models = [
+                            m["id"] for m in resp.json().get("data", []) if m.get("id")
+                        ][:20]
+                    except Exception:  # noqa: BLE001 - model list is best-effort
+                        models = []
             elif key_env == "ANTHROPIC_API_KEY":
                 # Anthropic: minimal messages call - 400 = reachable (bad request ok)
                 body = {
@@ -755,7 +768,10 @@ async def get_provider_health() -> ApiResponse:
                         resp.raise_for_status()
 
             latency_ms = round((time.monotonic() - start) * 1000, 1)
-            return {"status": "ok", "latency_ms": latency_ms, "region": region}
+            entry: dict = {"status": "ok", "latency_ms": latency_ms, "region": region}
+            if models:
+                entry["models"] = models
+            return entry
         except Exception as exc:
             latency_ms = round((time.monotonic() - start) * 1000, 1)
             return {
@@ -9688,6 +9704,7 @@ def _mask(value: str) -> str:
 def _build_settings_response() -> SettingsResponse:
     """Build a SettingsResponse from the current runtime settings."""
     return SettingsResponse(
+        workflow_default_model=settings.workflow_default_model,
         anthropic_api_key=_mask(settings.anthropic_api_key),
         e2b_api_key=_mask(settings.e2b_api_key),
         openai_api_key=_mask(settings.openai_api_key),
@@ -9765,10 +9782,33 @@ async def update_settings(
         "default_max_cost_usd",
         "log_level",
         "max_workflow_depth",
+        "workflow_default_model",
     }
 
     # Collect non-None updates (schema already validated all constraints)
     raw_updates = {k: v for k, v in request.model_dump().items() if v is not None}
+
+    # workflow_default_model must resolve to a known/valid model string (empty clears
+    # it). Reject unknowns here so a typo never reaches the DB and breaks runs later.
+    _wdm = raw_updates.get("workflow_default_model")
+    if _wdm:
+        from sandcastle.engine.providers import resolve_model as _resolve_model
+
+        try:
+            _resolve_model(_wdm)
+        except KeyError:
+            raise HTTPException(
+                status_code=400,
+                detail=ApiResponse(
+                    error=ErrorResponse(
+                        code="UNKNOWN_MODEL",
+                        message=(
+                            f"'{_wdm}' is not a known model. Use a registered model, "
+                            "nim/<id>, or ollama/<tag>."
+                        ),
+                    )
+                ).model_dump(),
+            )
 
     # Defense-in-depth: strip any fields not in the allowlist (should not happen
     # if SettingsUpdateRequest is kept in sync, but guards against future drift)

--- a/src/sandcastle/api/schemas.py
+++ b/src/sandcastle/api/schemas.py
@@ -894,6 +894,7 @@ class OptimizerStatsResponse(BaseModel):
 class SettingsResponse(BaseModel):
     """Current server settings."""
 
+    workflow_default_model: str = ""
     # Credentials (masked - only last 4 chars shown)
     anthropic_api_key: str = ""
     e2b_api_key: str = ""
@@ -939,6 +940,10 @@ class SettingsUpdateRequest(BaseModel):
     default_max_cost_usd: float | None = Field(None, ge=0)
     log_level: str | None = Field(None, pattern="^(debug|info|warning|error)$", max_length=50)
     max_workflow_depth: int | None = Field(None, ge=1, le=20)
+    # Global default model for steps without an explicit `model:`. Empty string
+    # clears it (back to the built-in default). Validated against resolve_model
+    # in the route so an unknown model never reaches the DB.
+    workflow_default_model: str | None = Field(None, max_length=200)
 
 
 # --- Tool Registry ---

--- a/src/sandcastle/config.py
+++ b/src/sandcastle/config.py
@@ -64,6 +64,12 @@ class Settings(BaseSettings):
     # answers, not that this model exists on it.
     spark_nim_default_model: str = "nim/llama-3.1-70b"
 
+    # Global default model for workflow steps that don't set an explicit `model:`.
+    # Empty = the built-in default ("sonnet", plus Spark autoroute when applicable).
+    # Settable at runtime via PATCH /api/settings (validated against resolve_model)
+    # and picked in the onboarding wizard from detected local providers.
+    workflow_default_model: str = ""
+
     # Overnight Self-Tune: the evolution loop may add a LoRA fine-tune mutation that
     # trains a local adapter on a workflow's own eval data and A/B-promotes it. Off by
     # default; the trainer is a deterministic mock unless trainer_backend="gpu" (real

--- a/src/sandcastle/engine/executor.py
+++ b/src/sandcastle/engine/executor.py
@@ -2834,16 +2834,16 @@ async def _execute_llm_step(
     import httpx
 
     from sandcastle.engine.providers import (
+        effective_model,
         get_api_key,
-        maybe_spark_nim_route,
         resolve_base_url,
         resolve_model,
     )
 
     started_at = time.monotonic()
-    # Spark Mode: route the bare default model to a reachable local NIM ($0, on-box).
-    # No-op off-Spark / when disabled / when NIM is down (see maybe_spark_nim_route).
-    model_info = resolve_model(maybe_spark_nim_route(step.model))
+    # Bare-default steps use the configured workflow_default_model (if any), then the
+    # Spark NIM autoroute. Explicit models pass through untouched (see effective_model).
+    model_info = resolve_model(effective_model(step.model))
     _enforce_data_residency(model_info)
     api_key = get_api_key(model_info)
 
@@ -4882,7 +4882,12 @@ async def _execute_report_step(
     import httpx
 
     from sandcastle.engine.dag import ReportConfig
-    from sandcastle.engine.providers import get_api_key, resolve_base_url, resolve_model
+    from sandcastle.engine.providers import (
+        effective_model,
+        get_api_key,
+        resolve_base_url,
+        resolve_model,
+    )
 
     started_at = time.monotonic()
     cfg = step.report_config or ReportConfig()
@@ -4907,8 +4912,8 @@ async def _execute_report_step(
         "Start directly with ## sections."
     )
 
-    # LLM call to generate report content
-    model_info = resolve_model(step.model)
+    # LLM call to generate report content (bare default honours workflow_default_model)
+    model_info = resolve_model(effective_model(step.model))
     _enforce_data_residency(model_info)
     api_key = get_api_key(model_info)
 
@@ -7084,12 +7089,12 @@ async def _browser_computer_use_mode(
 
     import httpx
 
-    from sandcastle.engine.providers import get_api_key, resolve_model
+    from sandcastle.engine.providers import effective_model, get_api_key, resolve_model
 
     if replay_screenshots is None:
         replay_screenshots = []
 
-    model_info = resolve_model(step.model)
+    model_info = resolve_model(effective_model(step.model))
     _enforce_data_residency(model_info)
     api_key = get_api_key(model_info)
 

--- a/src/sandcastle/engine/generator.py
+++ b/src/sandcastle/engine/generator.py
@@ -707,6 +707,13 @@ ADVISOR_MODEL_TIERS: dict[str, dict[str, str]] = {
         "medium": "MiniMax-M2.5",
         "low": "MiniMax-M2.5",
     },
+    "nim": {
+        # A local vLLM serves user-selected models; the user's workflow_default_model
+        # (resolved via _local_advisor_model) takes precedence over these fallbacks.
+        "high": "llama-3.1-70b",
+        "medium": "llama-3.1-70b",
+        "low": "llama-3.1-70b",
+    },
 }
 
 
@@ -743,6 +750,11 @@ def resolve_provider_api_url(cfg: dict) -> str:
         from sandcastle.engine.providers import ollama_base_url
 
         api_url = api_url.format(ollama_host=ollama_base_url())
+    if "{nim_base_url}" in api_url:
+        from sandcastle.config import settings as _s
+
+        _nim_base = getattr(_s, "nim_base_url", "") or "http://localhost:8000"
+        api_url = api_url.format(nim_base_url=str(_nim_base).rstrip("/"))
     return api_url
 
 
@@ -806,7 +818,38 @@ _PROVIDER_CONFIGS = {
         "region": "local",
         "headers_fn": lambda _: {"Content-Type": "application/json"},
     },
+    "nim": {
+        # Local NIM / vLLM (OpenAI-compatible). Model is resolved at call time
+        # from workflow_default_model / spark_nim_default_model - a vLLM serves
+        # whatever --served-model-name it was started with.
+        "api_url": "{nim_base_url}/v1/chat/completions",
+        "model": "llama-3.1-70b",
+        "api_key_env": "",  # local inference needs no key
+        "region": "local",
+        "headers_fn": lambda _: {"Content-Type": "application/json"},
+    },
 }
+
+
+def _local_advisor_model(provider: str, cfg: dict) -> str:
+    """User-selected model id for a local provider's advisor/generation calls.
+
+    Returns the id from ``workflow_default_model`` when it belongs to *provider*,
+    else the Spark NIM default (for nim) when set, else "" - callers fall back to
+    SLO tiers / the config's static default. Strict isinstance checks keep test
+    doubles (MagicMock settings) from leaking truthy non-strings in here.
+    """
+    from sandcastle.config import settings
+
+    wdm = getattr(settings, "workflow_default_model", "")
+    prefix = provider + "/"
+    if isinstance(wdm, str) and wdm.startswith(prefix):
+        return wdm[len(prefix):]
+    if provider == "nim":
+        spark_default = getattr(settings, "spark_nim_default_model", "")
+        if isinstance(spark_default, str) and spark_default.startswith("nim/"):
+            return spark_default[len("nim/"):]
+    return ""
 
 
 def _get_advisor_config() -> dict:
@@ -823,14 +866,16 @@ def _get_advisor_config() -> dict:
 
     from sandcastle.config import settings
 
-    provider = os.environ.get("SANDCASTLE_ADVISOR_PROVIDER", "anthropic").lower()
-    if provider not in _PROVIDER_CONFIGS:
-        provider = "anthropic"
+    provider = _resolve_provider_name()
 
     config = dict(_PROVIDER_CONFIGS[provider])
 
     # Resolve dynamic base URLs for local providers
     config["api_url"] = resolve_provider_api_url(config)
+
+    # Local providers serve user-selected models; resolve at call time.
+    if provider in ("nim", "ollama"):
+        config["model"] = _local_advisor_model(provider, config) or config.get("model", "")
 
     model_override = os.environ.get("SANDCASTLE_ADVISOR_MODEL", "")
     if model_override:
@@ -964,12 +1009,54 @@ _TIMEOUT = 60
 
 
 def _resolve_provider_name() -> str:
-    """Return the current advisor provider name (e.g. 'anthropic', 'mistral')."""
+    """Return the current advisor provider name (e.g. 'anthropic', 'mistral').
+
+    SANDCASTLE_ADVISOR_PROVIDER always wins. Without it, prefer a provider that
+    is actually usable instead of hardcoding Anthropic: first a cloud provider
+    with a configured key, then the local provider the user picked as
+    workflow_default_model, then a reachable local NIM or Ollama. A box running
+    only local models (e.g. a DGX Spark) can generate workflows out of the box.
+    """
     import os
-    provider = os.environ.get("SANDCASTLE_ADVISOR_PROVIDER", "anthropic").lower()
-    if provider not in _PROVIDER_CONFIGS:
-        return "anthropic"
-    return provider
+
+    provider = os.environ.get("SANDCASTLE_ADVISOR_PROVIDER", "").lower()
+    if provider in _PROVIDER_CONFIGS:
+        return provider
+
+    # 1) Cloud providers with a configured key, historical default first. The
+    #    isinstance check keeps MagicMock auto-attributes (test doubles) from
+    #    counting as configured keys.
+    for name in ("anthropic", "mistral", "openai", "minimax", "google"):
+        cfg = _PROVIDER_CONFIGS.get(name, {})
+        key_env = cfg.get("api_key_env", "")
+        if key_env:
+            key = _resolve_api_key_for_provider(name)
+            if isinstance(key, str) and key:
+                return name
+
+    # 2) The user's chosen default model, when it names a local provider.
+    #    Strict type checks: settings may be a test double whose auto-attributes
+    #    are truthy non-strings, and this path must stay deterministic.
+    from sandcastle.config import settings as _s
+
+    wdm = getattr(_s, "workflow_default_model", "")
+    if isinstance(wdm, str):
+        if wdm.startswith("nim/"):
+            return "nim"
+        if wdm == "ollama" or wdm.startswith("ollama/"):
+            return "ollama"
+
+    # 3) On a Spark, a reachable local NIM/vLLM serves as the generator. The probe
+    #    is Spark-gated so off-Spark resolution stays deterministic (no network
+    #    calls in the default path, no cache-dependent test behavior).
+    if getattr(_s, "spark_mode", False) is True:
+        from sandcastle.engine.providers import is_nim_reachable
+
+        if is_nim_reachable():
+            return "nim"
+
+    # 4) Nothing usable - keep the historical default; callers surface NO_PROVIDER.
+    return "anthropic"
 
 
 def _resolve_api_key_for_provider(provider_name: str) -> str:
@@ -1099,8 +1186,18 @@ async def _call_advisor_llm(
             model = model_override
             model_selected_by = "user_override"
         else:
+            local_model = (
+                _local_advisor_model(provider_name, cfg)
+                if provider_name in ("nim", "ollama")
+                else ""
+            )
             tier_model = _resolve_model_for_tier(provider_name, quality_tier)
-            if tier_model:
+            if local_model:
+                # The user's workflow_default_model wins for local providers - a
+                # vLLM serves only its --served-model-name, not tier-map defaults.
+                model = local_model
+                model_selected_by = "local_default"
+            elif tier_model:
                 model = tier_model
                 model_selected_by = "slo_routing"
             else:

--- a/src/sandcastle/engine/providers.py
+++ b/src/sandcastle/engine/providers.py
@@ -137,6 +137,18 @@ def _valid_nim_id(model_str: str) -> bool:
     return bool(rest) and ".." not in rest and _NIM_ID_RE.match(rest) is not None
 
 
+def _valid_ollama_id(model_str: str) -> bool:
+    """True if *model_str* is a well-formed dynamic ``ollama/<tag>`` model string.
+
+    Ollama serves whatever models are pulled locally (``ollama pull qwen3:8b``), so
+    the catalogue is not hardcoded. Same character discipline as NIM ids.
+    """
+    if not (isinstance(model_str, str) and model_str.startswith("ollama/")):
+        return False
+    rest = model_str[len("ollama/"):]
+    return bool(rest) and ".." not in rest and _NIM_ID_RE.match(rest) is not None
+
+
 def _valid_adapter_id(model_str: str) -> bool:
     """True if *model_str* is a well-formed ``adapter/<id>`` (Self-Tune adapter)."""
     return (
@@ -161,6 +173,13 @@ def resolve_model(model_str: str) -> ModelInfo:
         return ModelInfo(
             "nim", model_str[len("nim/"):], "runner-openai.mjs",
             "NIM_API_KEY", "http://localhost:8000/v1", 0.0, 0.0, region="local",
+        )
+    if _valid_ollama_id(model_str):
+        # Dynamic ollama/<tag> - any locally pulled model. Base URL comes from
+        # resolve_base_url (OLLAMA_HOST-aware), the placeholder here is unused.
+        return ModelInfo(
+            "ollama", model_str[len("ollama/"):], "runner-openai.mjs",
+            "", "http://localhost:11434/v1", 0.0, 0.0, region="local",
         )
     if _valid_adapter_id(model_str):
         # A locally-trained LoRA adapter (Overnight Self-Tune), served by the local
@@ -258,6 +277,25 @@ def maybe_spark_nim_route(model_str: str) -> str:
     if not is_nim_reachable():
         return model_str
     return settings.spark_nim_default_model or _SPARK_NIM_DEFAULT
+
+
+def effective_model(model_str: str) -> str:
+    """Resolve the effective model for a step: user default first, then Spark autoroute.
+
+    ``"sonnet"`` is the parse-time default (StepDefinition.model), so a step without an
+    explicit ``model:`` is indistinguishable from ``model: sonnet`` here - both count as
+    "the bare default", exactly as :func:`maybe_spark_nim_route` has always treated
+    them. When ``settings.workflow_default_model`` is set, it replaces the bare default
+    (and the autoroute then no-ops, because the result is no longer "sonnet"). Explicit
+    non-default models are never touched.
+    """
+    if model_str == "sonnet":
+        from sandcastle.config import settings
+
+        configured = getattr(settings, "workflow_default_model", "") or ""
+        if configured:
+            return configured
+    return maybe_spark_nim_route(model_str)
 
 
 def get_api_key(model_info: ModelInfo) -> str:

--- a/src/sandcastle/engine/providers.py
+++ b/src/sandcastle/engine/providers.py
@@ -198,8 +198,13 @@ def resolve_model(model_str: str) -> ModelInfo:
 
 
 def is_known_model(model_str: str) -> bool:
-    """True if registered, a valid ``nim/<id>``, or an ``adapter/<id>`` string."""
-    return model_str in KNOWN_MODELS or _valid_nim_id(model_str) or _valid_adapter_id(model_str)
+    """True if registered, a valid ``nim/<id>``/``ollama/<tag>``, or an ``adapter/<id>``."""
+    return (
+        model_str in KNOWN_MODELS
+        or _valid_nim_id(model_str)
+        or _valid_ollama_id(model_str)
+        or _valid_adapter_id(model_str)
+    )
 
 
 # --- Spark Mode: auto-route the default model to a local NIM ------------------

--- a/src/sandcastle/main.py
+++ b/src/sandcastle/main.py
@@ -65,8 +65,14 @@ async def _validate_providers() -> None:
                 base = settings.omlx_base_url.rstrip("/")
                 health_url = f"{base}/v1/models"  # OpenAI-compatible endpoint
                 unreachable_msg = f"omlx server not running at {base}"
+            elif provider_name == "nim":
+                base = (settings.nim_base_url or "http://localhost:8000").rstrip("/")
+                health_url = f"{base}/v1/models"  # OpenAI-compatible endpoint
+                unreachable_msg = f"NIM/vLLM server not running at {base}"
             else:
-                base = settings.ollama_host.rstrip("/")
+                from sandcastle.engine.providers import ollama_base_url
+
+                base = ollama_base_url()
                 health_url = f"{base}/api/tags"
                 unreachable_msg = f"Ollama not running at {base}"
             start = time.monotonic()

--- a/src/sandcastle/main.py
+++ b/src/sandcastle/main.py
@@ -333,6 +333,7 @@ async def lifespan(app: FastAPI):
             "anthropic_api_key", "e2b_api_key", "openai_api_key",
             "mistral_api_key", "minimax_api_key", "openrouter_api_key",
             "default_max_cost_usd", "log_level", "max_workflow_depth",
+            "workflow_default_model",
         }
         # Keys in restorable settings that may be stored encrypted
         _ENCRYPTED_RESTORABLE = {

--- a/tests/test_local_provider_discovery.py
+++ b/tests/test_local_provider_discovery.py
@@ -117,3 +117,87 @@ class TestGeneratorApiUrlResolution:
 
         url = resolve_provider_api_url(_PROVIDER_CONFIGS["anthropic"])
         assert url == "https://api.anthropic.com/v1/messages"
+
+
+class TestWorkflowDefaultModel:
+    """0.42: workflow_default_model setting + effective_model + dynamic ollama/<tag>."""
+
+    def test_effective_model_replaces_bare_default(self, monkeypatch):
+        from sandcastle.engine.providers import effective_model
+
+        monkeypatch.setattr(settings, "workflow_default_model", "nim/ornith")
+        assert effective_model("sonnet") == "nim/ornith"
+
+    def test_effective_model_respects_explicit(self, monkeypatch):
+        from sandcastle.engine.providers import effective_model
+
+        monkeypatch.setattr(settings, "workflow_default_model", "nim/ornith")
+        assert effective_model("opus") == "opus"
+        assert effective_model("mistral/large") == "mistral/large"
+
+    def test_effective_model_empty_falls_through_to_autoroute(self, monkeypatch):
+        import sandcastle.engine.providers as providers
+
+        monkeypatch.setattr(settings, "workflow_default_model", "")
+        monkeypatch.setattr(
+            providers, "maybe_spark_nim_route", lambda m: "AUTOROUTED" if m == "sonnet" else m
+        )
+        assert providers.effective_model("sonnet") == "AUTOROUTED"
+
+    def test_dynamic_ollama_model_resolves(self):
+        from sandcastle.engine.providers import resolve_model
+
+        info = resolve_model("ollama/qwen3:8b")
+        assert info.provider == "ollama"
+        assert info.api_model_id == "qwen3:8b"
+        assert info.region == "local"
+        assert info.input_price_per_m == 0.0
+
+    def test_dynamic_ollama_rejects_traversal(self):
+        from sandcastle.engine.providers import resolve_model
+
+        with pytest.raises(KeyError):
+            resolve_model("ollama/../etc/passwd")
+
+    def test_settings_patch_rejects_unknown_model(self):
+        client = _make_client()
+        resp = client.patch(
+            "/settings", json={"workflow_default_model": "definitely-not-a-model"}
+        )
+        assert resp.status_code == 400
+        assert "UNKNOWN_MODEL" in resp.text
+
+    def test_settings_patch_accepts_dynamic_models(self, monkeypatch):
+        client = _make_client()
+        for model in ("nim/ornith", "ollama/qwen3:8b", "opus"):
+            resp = client.patch("/settings", json={"workflow_default_model": model})
+            assert resp.status_code == 200, f"{model}: {resp.text}"
+            assert resp.json()["data"]["workflow_default_model"] == model
+        # empty string clears it
+        resp = client.patch("/settings", json={"workflow_default_model": ""})
+        assert resp.status_code == 200
+
+    def test_health_providers_includes_models_list(self, monkeypatch):
+        """Local provider entries carry a models list when the probe returns one."""
+        client = _make_client()
+        _clear_health_cache()
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.raise_for_status = MagicMock()
+            mock_resp.json = MagicMock(
+                return_value={
+                    "models": [{"name": "qwen3:8b"}, {"name": "gpt-oss:120b"}],
+                    "data": [{"id": "ornith"}, {"id": "aeon"}],
+                }
+            )
+            mock_instance = AsyncMock()
+            mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_instance.__aexit__ = AsyncMock(return_value=False)
+            mock_instance.post = AsyncMock(return_value=mock_resp)
+            mock_instance.get = AsyncMock(return_value=mock_resp)
+            mock_client_cls.return_value = mock_instance
+            resp = client.get("/health/providers")
+        data = resp.json()["data"]
+        assert data["ollama"]["models"] == ["qwen3:8b", "gpt-oss:120b"]
+        assert data["nim"]["models"] == ["ornith", "aeon"]

--- a/tests/test_local_provider_discovery.py
+++ b/tests/test_local_provider_discovery.py
@@ -201,3 +201,67 @@ class TestWorkflowDefaultModel:
         data = resp.json()["data"]
         assert data["ollama"]["models"] == ["qwen3:8b", "gpt-oss:120b"]
         assert data["nim"]["models"] == ["ornith", "aeon"]
+
+
+class TestAdvisorProviderResolution:
+    """0.42: the generator picks a usable provider instead of hardcoding Anthropic."""
+
+    def _clear_provider_env(self, monkeypatch):
+        for var in (
+            "SANDCASTLE_ADVISOR_PROVIDER", "ANTHROPIC_API_KEY", "OPENAI_API_KEY",
+            "MISTRAL_API_KEY", "OPENROUTER_API_KEY", "MINIMAX_API_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        for attr in (
+            "anthropic_api_key", "openai_api_key", "mistral_api_key",
+            "openrouter_api_key", "minimax_api_key",
+        ):
+            monkeypatch.setattr(settings, attr, "")
+
+    def test_explicit_env_always_wins(self, monkeypatch):
+        from sandcastle.engine.generator import _resolve_provider_name
+
+        monkeypatch.setenv("SANDCASTLE_ADVISOR_PROVIDER", "mistral")
+        assert _resolve_provider_name() == "mistral"
+
+    def test_cloud_key_beats_local_default(self, monkeypatch):
+        from sandcastle.engine.generator import _resolve_provider_name
+
+        self._clear_provider_env(monkeypatch)
+        monkeypatch.setattr(settings, "anthropic_api_key", "sk-ant-test")
+        monkeypatch.setattr(settings, "workflow_default_model", "nim/ornith")
+        assert _resolve_provider_name() == "anthropic"
+
+    def test_local_default_model_selects_nim(self, monkeypatch):
+        from sandcastle.engine.generator import _resolve_provider_name
+
+        self._clear_provider_env(monkeypatch)
+        monkeypatch.setattr(settings, "workflow_default_model", "nim/ornith")
+        assert _resolve_provider_name() == "nim"
+
+    def test_local_default_model_selects_ollama(self, monkeypatch):
+        from sandcastle.engine.generator import _resolve_provider_name
+
+        self._clear_provider_env(monkeypatch)
+        monkeypatch.setattr(settings, "workflow_default_model", "ollama/qwen3:8b")
+        assert _resolve_provider_name() == "ollama"
+
+    def test_no_provider_defaults_to_anthropic_off_spark(self, monkeypatch):
+        from sandcastle.engine.generator import _resolve_provider_name
+
+        self._clear_provider_env(monkeypatch)
+        monkeypatch.setattr(settings, "workflow_default_model", "")
+        monkeypatch.setenv("SANDCASTLE_SPARK_MODE", "off")
+        assert _resolve_provider_name() == "anthropic"
+
+    def test_nim_advisor_uses_user_model(self, monkeypatch):
+        from sandcastle.engine.generator import _get_advisor_config
+
+        self._clear_provider_env(monkeypatch)
+        monkeypatch.setattr(settings, "workflow_default_model", "nim/ornith")
+        monkeypatch.setattr(settings, "nim_base_url", "http://host.docker.internal:18000")
+        monkeypatch.setattr(settings, "data_residency", "")
+        monkeypatch.delenv("SANDCASTLE_ADVISOR_MODEL", raising=False)
+        cfg = _get_advisor_config()
+        assert cfg["model"] == "ornith"
+        assert cfg["api_url"] == "http://host.docker.internal:18000/v1/chat/completions"


### PR DESCRIPTION
## 0.42.0 - "Your Box, Your Default"

The onboarding wizard now finishes what discovery (0.41.2) started: detected local providers list their models and one click makes one the default for every step that doesn't name a model.

### Added
- **`workflow_default_model` setting** - steps without an explicit `model:` use it instead of the built-in default. Persisted via `PATCH /api/settings`, validated against `resolve_model` at write time (`UNKNOWN_MODEL` on typos - a bad value can never reach the DB), restored from DB at startup. Empty string clears it.
- **`effective_model()`** - single resolution entry point: user default first, then Spark NIM autoroute. Applied at the standard LLM, report, and computer-use steps. Classify and gate keep their intentional cheap `haiku` defaults. Explicit non-default models are never rewritten.
- **Dynamic `ollama/<tag>`** - any locally pulled Ollama model resolves like `nim/<id>` always has (region `local`, $0), same injection-safe character discipline, base URL honours `OLLAMA_HOST`.
- **`/health/providers` models list** - reachable local providers return up to 20 model names; the wizard picker renders them.

### Changed
- Bare-default resolution order: `workflow_default_model` (when set) -> Spark autoroute (when applicable) -> `sonnet`. Explicit `model: sonnet` counts as the bare default - the same convention the Spark autoroute has used since 0.33 (noted in CHANGELOG).
- Wizard keeps cloud API key entry visible alongside detected local providers.

### Verification
- Full python suite: **17202 passed, 13 skipped, 0 failed** (12:27)
- Dashboard: **1010 passed** (55 files) including 2 new wizard tests (picker + cloud-key coexistence)
- Live on GB10 hardware from this branch: wizard lists 6 models (2 vLLM + 4 Ollama), `PATCH /settings {"workflow_default_model": "nim/ornith"}` accepted, `UNKNOWN_MODEL` rejected, version 0.42.0 in container
- Helm chart tests 11/11

Merging publishes 0.42.0 to PyPI via OIDC trusted publishing.