### PR TITLE
feat(assistant): 0.42.1 - advisor-backed Run Assistant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.42.1] - 2026-07-21 - "Assistant, Actually"
+
+### Fixed
+- The Run Assistant is now a real assistant. The dashboard sidebar previously
+  answered from client-side English keyword patterns with no model behind it,
+  so non-English questions (and any question outside the patterns) got canned
+  replies. New `POST /api/runs/{run_id}/assistant` serializes the run
+  (status, steps, errors, output tails - secret-scrubbed, tenant-scoped) and
+  answers via the advisor LLM, which on a local-first box means your own
+  model. Answers follow the language of the question. The old heuristics
+  remain only as an offline fallback when no provider is configured
+  (the endpoint says NO_PROVIDER explicitly).
+
 ## [0.42.0] - 2026-07-21 - "Your Box, Your Default"
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Build once. Run anywhere.** Sandcastle is an open-source, production-ready orchestrator for AI agents. **Describe a workflow in plain English and it builds it** (or write the YAML yourself); run it on **any model** — Claude, GPT, Mistral, or a local model on your own box — and move between them with one line; deploy it **your way** — cloud, your own server, fully air-gapped, or EU-only; and it **gets better over time**, on its own. Local models run at `$0/run` with hard data-residency enforcement and a tamper-evident audit trail; the cloud is there too, with 7 providers and auto-failover, 25 step types, verified templates, and a full dashboard. Sovereign by default. European-built.
 
-[![PyPI](https://img.shields.io/badge/PyPI-v0.42.0-blue?style=flat-square)](https://pypi.org/project/sandcastle-ai/0.42.0/)
+[![PyPI](https://img.shields.io/badge/PyPI-v0.42.1-blue?style=flat-square)](https://pypi.org/project/sandcastle-ai/0.42.1/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![Tests](https://img.shields.io/badge/tests-17154%20passing-brightgreen?style=flat-square)](https://github.com/gizmax/Sandcastle/actions)

--- a/dashboard/src/__tests__/run-assistant.test.tsx
+++ b/dashboard/src/__tests__/run-assistant.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Run Assistant sidebar (0.42.1): advisor-backed answers with local fallback.
+ * - sends the question to POST /runs/{id}/assistant and renders the answer
+ * - falls back to the built-in heuristics when the endpoint fails (NO_PROVIDER)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { AiChatSidebar } from "@/components/runs/AiChatSidebar";
+import { api } from "@/api/client";
+
+vi.mock("@/api/client", () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+const mockApi = api as unknown as { post: ReturnType<typeof vi.fn> };
+
+// jsdom nema scrollIntoView
+window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+const RUN = {
+  run_id: "11111111-2222-3333-4444-555555555555",
+  workflow_name: "lucerna-articles",
+  status: "failed",
+  input_data: null,
+  outputs: null,
+  total_cost_usd: 0.02,
+  max_cost_usd: null,
+  started_at: new Date().toISOString(),
+  completed_at: new Date().toISOString(),
+  error: null,
+  steps: [
+    {
+      step_id: "search-web",
+      status: "failed",
+      attempt: 1,
+      error: "Sandbox backend 'e2b' is not available",
+      cost_usd: 0.001,
+      duration_seconds: 2,
+    },
+  ],
+};
+
+function renderSidebar() {
+  return render(
+    <AiChatSidebar open={true} onClose={() => {}} run={RUN as never} />
+  );
+}
+
+async function ask(question: string) {
+  const input = screen.getByPlaceholderText(/ask about this run/i);
+  fireEvent.change(input, { target: { value: question } });
+  await act(async () => {
+    fireEvent.submit(input.closest("form") as HTMLFormElement);
+  });
+}
+
+describe("AiChatSidebar (advisor-backed)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends the question to the assistant endpoint and renders the answer", async () => {
+    mockApi.post.mockResolvedValue({
+      data: { answer: "Krok search-web selhal: sandbox e2b neni dostupny." },
+      error: null,
+    });
+
+    renderSidebar();
+    await ask("proc to spadlo?");
+
+    await waitFor(() => {
+      expect(mockApi.post).toHaveBeenCalledWith(
+        `/runs/${RUN.run_id}/assistant`,
+        expect.objectContaining({ question: "proc to spadlo?" })
+      );
+      expect(
+        screen.getByText(/sandbox e2b neni dostupny/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("falls back to local heuristics when the endpoint fails", async () => {
+    mockApi.post.mockResolvedValue({
+      data: null,
+      error: { code: "NO_PROVIDER", message: "No AI provider is configured." },
+    });
+
+    renderSidebar();
+    await ask("Why did this fail?");
+
+    await waitFor(() => {
+      // Heuristic fallback quotes the failing step and its captured error
+      expect(screen.getByText(/search-web/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Sandbox backend 'e2b' is not available/)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/dashboard/src/components/runs/AiChatSidebar.tsx
+++ b/dashboard/src/components/runs/AiChatSidebar.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Sparkles, X, Send } from "lucide-react";
 import { api } from "@/api/client";
-import { cn, formatDuration, formatCost } from "@/lib/utils";
+import { cn, formatDuration, formatCost, randomId } from "@/lib/utils";
 
 interface Step {
   step_id: string;
@@ -306,7 +306,7 @@ export function AiChatSidebar({ open, onClose, run }: AiChatSidebarProps) {
       if (!text.trim() || typing) return;
       const question = text.trim();
       const userMsg: ChatMessage = {
-        id: crypto.randomUUID(),
+        id: randomId(),
         role: "user",
         text: question,
         timestamp: new Date(),
@@ -334,7 +334,7 @@ export function AiChatSidebar({ open, onClose, run }: AiChatSidebarProps) {
           response = generateResponse(question, run);
         }
         const assistantMsg: ChatMessage = {
-          id: crypto.randomUUID(),
+          id: randomId(),
           role: "assistant",
           text: response,
           timestamp: new Date(),

--- a/dashboard/src/components/runs/AiChatSidebar.tsx
+++ b/dashboard/src/components/runs/AiChatSidebar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Sparkles, X, Send } from "lucide-react";
+import { api } from "@/api/client";
 import { cn, formatDuration, formatCost } from "@/lib/utils";
 
 interface Step {
@@ -303,19 +304,35 @@ export function AiChatSidebar({ open, onClose, run }: AiChatSidebarProps) {
   const sendMessage = useCallback(
     (text: string) => {
       if (!text.trim() || typing) return;
+      const question = text.trim();
       const userMsg: ChatMessage = {
         id: crypto.randomUUID(),
         role: "user",
-        text: text.trim(),
+        text: question,
         timestamp: new Date(),
       };
       setMessages((prev) => [...prev, userMsg]);
       setInput("");
       setTyping(true);
 
-      const delay = 500 + Math.random() * 300;
-      setTimeout(() => {
-        const response = generateResponse(text, run);
+      void (async () => {
+        // Ask the advisor-backed Run Assistant; fall back to the local
+        // heuristics when no provider is configured or the call fails.
+        let response: string;
+        try {
+          const history = messages.slice(-10).map((m) => ({
+            role: m.role,
+            text: m.text,
+          }));
+          const res = await api.post<{ answer: string }>(
+            `/runs/${run.run_id}/assistant`,
+            { question, history }
+          );
+          if (res.error || !res.data?.answer) throw new Error(res.error?.message);
+          response = res.data.answer;
+        } catch {
+          response = generateResponse(question, run);
+        }
         const assistantMsg: ChatMessage = {
           id: crypto.randomUUID(),
           role: "assistant",
@@ -324,9 +341,9 @@ export function AiChatSidebar({ open, onClose, run }: AiChatSidebarProps) {
         };
         setMessages((prev) => [...prev, assistantMsg]);
         setTyping(false);
-      }, delay);
+      })();
     },
-    [run, typing]
+    [run, typing, messages]
   );
 
   const handleSubmit = useCallback(

--- a/dashboard/src/components/workflows/GenerateChatModal.tsx
+++ b/dashboard/src/components/workflows/GenerateChatModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { X, Wand2, Loader2, CheckCircle, AlertTriangle, Send, ChevronDown, ChevronRight, MessageSquare, Plus } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { cn, randomId } from "@/lib/utils";
 import { api } from "@/api/client";
 
 interface GenerateResult {
@@ -80,7 +80,7 @@ export function GenerateChatModal({ open, onClose, onSelect, existingYaml }: Gen
     const text = input.trim();
     if (!text || loading) return;
 
-    const userMsg: ChatMessage = { id: crypto.randomUUID(), role: "user", content: text };
+    const userMsg: ChatMessage = { id: randomId(), role: "user", content: text };
     const newMessages = [...messages, userMsg];
     setMessages(newMessages);
     setInput("");
@@ -126,12 +126,12 @@ export function GenerateChatModal({ open, onClose, onSelect, existingYaml }: Gen
         setCurrentYaml(data.yaml_content);
         setMessages((prev) => [
           ...prev,
-          { id: crypto.randomUUID(), role: "assistant", content: data.message, yaml: yamlResult },
+          { id: randomId(), role: "assistant", content: data.message, yaml: yamlResult },
         ]);
       } else {
         setMessages((prev) => [
           ...prev,
-          { id: crypto.randomUUID(), role: "assistant", content: data.message },
+          { id: randomId(), role: "assistant", content: data.message },
         ]);
       }
     }
@@ -168,7 +168,7 @@ export function GenerateChatModal({ open, onClose, onSelect, existingYaml }: Gen
     setInput(text);
     // Use a microtask to allow state to update before sending
     setTimeout(() => {
-      const userMsg: ChatMessage = { id: crypto.randomUUID(), role: "user", content: text };
+      const userMsg: ChatMessage = { id: randomId(), role: "user", content: text };
       const currentMessages = messagesRef.current;
       const newMessages = [...currentMessages, userMsg];
       setMessages(newMessages);
@@ -210,12 +210,12 @@ export function GenerateChatModal({ open, onClose, onSelect, existingYaml }: Gen
             setCurrentYaml(data.yaml_content);
             setMessages((prev) => [
               ...prev,
-              { id: crypto.randomUUID(), role: "assistant", content: data.message, yaml: yamlResult },
+              { id: randomId(), role: "assistant", content: data.message, yaml: yamlResult },
             ]);
           } else {
             setMessages((prev) => [
               ...prev,
-              { id: crypto.randomUUID(), role: "assistant", content: data.message },
+              { id: randomId(), role: "assistant", content: data.message },
             ]);
           }
         }

--- a/dashboard/src/lib/utils.ts
+++ b/dashboard/src/lib/utils.ts
@@ -129,3 +129,21 @@ export function formatHeartbeatAge(seconds: number | null): string {
   if (hours < 24) return `${hours}h ago`;
   return `${Math.floor(hours / 24)}d ago`;
 }
+
+/**
+ * Random id for client-side keys. crypto.randomUUID only exists in secure
+ * contexts (https / localhost) - a dashboard served over plain http from a
+ * LAN box (http://192.168.x.x:8080) has crypto but no randomUUID, and calling
+ * it throws, silently killing every handler that minted an id. Fall back to
+ * getRandomValues, then Math.random.
+ */
+export function randomId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+    const bytes = crypto.getRandomValues(new Uint8Array(16));
+    return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  }
+  return `${Date.now().toString(16)}-${Math.random().toString(16).slice(2)}`;
+}

--- a/deploy/mcp-tunnel/memory-mcp/Chart.yaml
+++ b/deploy/mcp-tunnel/memory-mcp/Chart.yaml
@@ -3,7 +3,7 @@ name: memory-mcp
 description: Sandcastle Memory MCP server behind a Cloudflare MCP tunnel (outbound-only, no inbound ingress required)
 type: application
 version: 0.1.0
-appVersion: "0.42.0"
+appVersion: "0.42.1"
 keywords:
   - sandcastle
   - mcp

--- a/src/sandcastle/__init__.py
+++ b/src/sandcastle/__init__.py
@@ -1,6 +1,6 @@
 """Sandcastle - Production-ready workflow orchestrator for AI agents."""
 
-__version__ = "0.42.0"
+__version__ = "0.42.1"
 
 __all__ = ["SandcastleClient", "AsyncSandcastleClient", "__version__"]
 

--- a/src/sandcastle/api/routes.py
+++ b/src/sandcastle/api/routes.py
@@ -89,6 +89,7 @@ from sandcastle.api.schemas import (
     ProviderStatusEntry,
     ReplayRequest,
     RoutingDecisionResponse,
+    RunAssistantRequest,
     RunCompareResponse,
     RunEstimateRequest,
     RunForkResponse,
@@ -4158,6 +4159,103 @@ async def advisor_explain_error(req: Request, request: ExplainErrorRequest) -> A
             ).model_dump(),
         )
     return ApiResponse(data=result)
+
+
+@router.post("/runs/{run_id}/assistant")
+async def run_assistant(run_id: str, req: Request, request: RunAssistantRequest) -> ApiResponse:
+    """Answer a question about a specific run via the advisor LLM (Run Assistant)."""
+    await execution_limiter.check(req)
+    from sandcastle.engine.generator import _resolve_api_key, _scrub_secrets, run_assistant_answer
+
+    tenant_id = get_tenant_id(req)
+    try:
+        run_uuid = uuid.UUID(run_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail=ApiResponse(
+                error=ErrorResponse(code="INVALID_ID", message="Invalid run ID format")
+            ).model_dump(),
+        )
+
+    async with async_session() as session:
+        stmt = (
+            select(Run)
+            .options(selectinload(Run.steps))
+            .where(Run.id == run_uuid)
+        )
+        stmt = _apply_tenant_filter(stmt, tenant_id, Run.tenant_id)
+        result = await session.execute(stmt)
+        run = result.scalar_one_or_none()
+
+    if not run:
+        raise HTTPException(
+            status_code=404,
+            detail=ApiResponse(
+                error=ErrorResponse(code="NOT_FOUND", message="Run not found")
+            ).model_dump(),
+        )
+
+    # No usable provider: tell the client explicitly so it can fall back to its
+    # local heuristics instead of surfacing an opaque 502.
+    try:
+        _has_provider = bool(_resolve_api_key())
+    except Exception:
+        _has_provider = False
+    if not _has_provider:
+        raise HTTPException(
+            status_code=400,
+            detail=ApiResponse(
+                error=ErrorResponse(
+                    code="NO_PROVIDER",
+                    message=(
+                        "No AI provider is configured. Add a provider key or run a "
+                        "local model to enable the Run Assistant."
+                    ),
+                )
+            ).model_dump(),
+        )
+
+    # Serialize the run for the LLM - secret-scrubbed, output tails truncated.
+    lines = [
+        f"Workflow: {run.workflow_name}",
+        f"Run id: {run.id}",
+        f"Status: {run.status.value if hasattr(run.status, 'value') else run.status}",
+        f"Started: {run.started_at} | Completed: {run.completed_at}",
+        f"Total cost USD: {run.total_cost_usd}",
+    ]
+    if run.error:
+        lines.append(f"Run-level error: {_scrub_secrets(str(run.error)[:2000])}")
+    steps = list(run.steps or [])
+    lines.append(f"Steps ({len(steps)}):")
+    for s in steps:
+        status = s.status.value if hasattr(s.status, "value") else s.status
+        entry = f"- {s.step_id} [{status}] attempt={s.attempt}"
+        if s.error:
+            entry += f" error: {_scrub_secrets(str(s.error)[:1500])}"
+        if s.output_data and str(status).lower() == "completed":
+            entry += f" output_tail: {_scrub_secrets(str(s.output_data)[-500:])}"
+        lines.append(entry)
+    run_context = "\n".join(lines)
+
+    try:
+        answer = await run_assistant_answer(
+            question=request.question,
+            run_context=run_context,
+            history=[t.model_dump() for t in request.history],
+        )
+    except Exception as exc:
+        logger.error("Run assistant failed for %s: %s", run_id, exc)
+        raise HTTPException(
+            status_code=502,
+            detail=ApiResponse(
+                error=ErrorResponse(
+                    code="ASSISTANT_FAILED",
+                    message="Run assistant could not generate an answer",
+                )
+            ).model_dump(),
+        )
+    return ApiResponse(data={"answer": answer})
 
 
 @router.get("/advisor/status")

--- a/src/sandcastle/api/schemas.py
+++ b/src/sandcastle/api/schemas.py
@@ -271,6 +271,20 @@ class GenerateChatRequest(BaseModel):
     )
 
 
+class RunAssistantTurn(BaseModel):
+    """One prior turn of the Run Assistant conversation."""
+
+    role: str = Field(..., pattern="^(user|assistant)$")
+    text: str = Field(..., min_length=1, max_length=4000)
+
+
+class RunAssistantRequest(BaseModel):
+    """Ask the Run Assistant a question about a specific run."""
+
+    question: str = Field(..., min_length=1, max_length=4000)
+    history: list[RunAssistantTurn] = Field(default_factory=list, max_length=20)
+
+
 class ExplainErrorRequest(BaseModel):
     """Request to explain a step failure using AI."""
 

--- a/src/sandcastle/engine/generator.py
+++ b/src/sandcastle/engine/generator.py
@@ -1831,6 +1831,53 @@ Guidelines:
 """
 
 
+_RUN_ASSISTANT_SYSTEM = """You are the Run Assistant for Sandcastle, an AI workflow
+orchestration platform. The user is looking at one specific workflow run and asks
+questions about it. You are given the full run context (status, steps, errors,
+outputs, cost, timing) below.
+
+Guidelines:
+- Ground every statement in the provided run data. Never invent steps, errors, or
+  numbers that are not in the context.
+- Answer in the same language the user asks in.
+- Be concise and concrete. When the user asks why something failed, quote the
+  failing step id and its actual error, then explain the likely cause and a fix.
+- When the run succeeded, say so plainly instead of hunting for problems.
+- Plain text or minimal markdown (bold, lists). No JSON, no code fences unless
+  quoting an error verbatim."""
+
+
+async def run_assistant_answer(
+    question: str,
+    run_context: str,
+    history: list[dict] | None = None,
+) -> str:
+    """Answer a user question about a specific run via the advisor LLM.
+
+    *run_context* is a pre-serialized, secret-scrubbed description of the run.
+    *history* carries prior turns as [{"role": "user"|"assistant", "text": ...}].
+    Raises on provider failure - the caller decides the fallback.
+    """
+    convo: list[str] = []
+    for turn in (history or [])[-10:]:
+        role = "User" if turn.get("role") == "user" else "Assistant"
+        text = str(turn.get("text", ""))[:1000]
+        if text:
+            convo.append(f"{role}: {text}")
+    history_block = ("\n\nConversation so far:\n" + "\n".join(convo)) if convo else ""
+
+    user_msg = (
+        f"RUN CONTEXT:\n{run_context}{history_block}\n\nUser question: {question}"
+    )
+    # SLO routing: purpose="chat" -> high tier (a local workflow_default_model wins)
+    return await _call_advisor_llm(
+        system=_RUN_ASSISTANT_SYSTEM,
+        user=user_msg,
+        max_tokens=1024,
+        purpose="chat",
+    )
+
+
 async def explain_error(
     step_id: str,
     step_type: str,

--- a/tests/test_run_assistant.py
+++ b/tests/test_run_assistant.py
@@ -1,0 +1,133 @@
+"""Tests for the Run Assistant endpoint (POST /runs/{run_id}/assistant).
+
+0.42.1: the dashboard's Run Assistant is backed by the advisor LLM instead of
+client-side regex heuristics. The endpoint serializes the run (status, steps,
+errors, output tails - secret-scrubbed) and answers via _call_advisor_llm.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from sandcastle.main import app
+from sandcastle.models.db import Run, RunStatus, RunStep, StepStatus, async_session
+
+client = TestClient(app)
+
+
+async def _seed_run(status: RunStatus = RunStatus.FAILED, error: str | None = "boom") -> Run:
+    now = datetime.now(timezone.utc)
+    async with async_session() as session:
+        run = Run(
+            id=uuid.uuid4(),
+            workflow_name="lucerna-articles",
+            status=status,
+            input_data={"q": "Lucerna"},
+            total_cost_usd=0.02,
+            started_at=now - timedelta(seconds=30),
+            completed_at=now,
+            error=error,
+        )
+        session.add(run)
+        await session.commit()
+        await session.refresh(run)
+        step = RunStep(
+            run_id=run.id,
+            step_id="search-web",
+            status=StepStatus.FAILED if status == RunStatus.FAILED else StepStatus.COMPLETED,
+            error="Sandbox backend 'e2b' is not available" if status == RunStatus.FAILED else None,
+            output_data=None if status == RunStatus.FAILED else {"articles": 5},
+            cost_usd=0.001,
+            duration_seconds=2.0,
+        )
+        session.add(step)
+        await session.commit()
+        return run
+
+
+@pytest.mark.asyncio
+async def test_answers_via_advisor_with_run_context():
+    run = await _seed_run()
+    with patch(
+        "sandcastle.engine.generator.run_assistant_answer",
+        new=AsyncMock(return_value="Krok search-web selhal: sandbox e2b neni dostupny."),
+    ) as mock_answer, patch(
+        "sandcastle.engine.generator._resolve_api_key", return_value="key"
+    ):
+        resp = client.post(
+            f"/api/runs/{run.id}/assistant", json={"question": "proc to spadlo?"}
+        )
+    assert resp.status_code == 200
+    assert "search-web" in resp.json()["data"]["answer"]
+    # The run context handed to the LLM must carry the real step error
+    ctx = mock_answer.call_args.kwargs["run_context"]
+    assert "search-web" in ctx
+    assert "Sandbox backend 'e2b' is not available" in ctx
+    assert mock_answer.call_args.kwargs["question"] == "proc to spadlo?"
+
+
+@pytest.mark.asyncio
+async def test_history_is_forwarded_and_bounded():
+    run = await _seed_run(status=RunStatus.COMPLETED, error=None)
+    history = [{"role": "user", "text": "ahoj"}, {"role": "assistant", "text": "zdravim"}]
+    with patch(
+        "sandcastle.engine.generator.run_assistant_answer",
+        new=AsyncMock(return_value="ok"),
+    ) as mock_answer, patch(
+        "sandcastle.engine.generator._resolve_api_key", return_value="key"
+    ):
+        resp = client.post(
+            f"/api/runs/{run.id}/assistant",
+            json={"question": "shrn to", "history": history},
+        )
+    assert resp.status_code == 200
+    assert mock_answer.call_args.kwargs["history"] == history
+
+
+@pytest.mark.asyncio
+async def test_no_provider_returns_400_no_provider():
+    run = await _seed_run()
+    with patch("sandcastle.engine.generator._resolve_api_key", return_value=""):
+        resp = client.post(
+            f"/api/runs/{run.id}/assistant", json={"question": "why?"}
+        )
+    assert resp.status_code == 400
+    assert "NO_PROVIDER" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_unknown_run_404():
+    with patch("sandcastle.engine.generator._resolve_api_key", return_value="key"):
+        resp = client.post(
+            f"/api/runs/{uuid.uuid4()}/assistant", json={"question": "why?"}
+        )
+    assert resp.status_code == 404
+
+
+def test_invalid_run_id_400():
+    resp = client.post("/api/runs/not-a-uuid/assistant", json={"question": "why?"})
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_advisor_failure_returns_502():
+    run = await _seed_run()
+    with patch(
+        "sandcastle.engine.generator.run_assistant_answer",
+        new=AsyncMock(side_effect=RuntimeError("upstream")),
+    ), patch("sandcastle.engine.generator._resolve_api_key", return_value="key"):
+        resp = client.post(
+            f"/api/runs/{run.id}/assistant", json={"question": "why?"}
+        )
+    assert resp.status_code == 502
+    assert "ASSISTANT_FAILED" in resp.text
+
+
+def test_question_required():
+    resp = client.post(f"/api/runs/{uuid.uuid4()}/assistant", json={"question": ""})
+    assert resp.status_code == 422


### PR DESCRIPTION
## 0.42.1 - "Assistant, Actually"

The dashboard's Run Assistant was a client-side English keyword matcher with no model behind it: non-English questions (and any question outside the patterns) got canned replies, even on a box with working local models.

### Added
- `POST /api/runs/{run_id}/assistant` - tenant-scoped run fetch; serializes status, steps, errors, and output tails (secret-scrubbed via the same scrubber as error explain) and answers via the advisor LLM (`purpose=chat`). On a local-first box that means the user's own model (`workflow_default_model`). Carries up to 10 turns of conversation history. Answers follow the language of the question (system prompt grounds every statement in the provided run data).
- Explicit `NO_PROVIDER` 400 lets the client fall back cleanly; `ASSISTANT_FAILED` 502 on upstream errors.

### Changed
- `AiChatSidebar` posts to the endpoint; the old heuristics remain only as the offline fallback when the endpoint fails.

### Verification
- Full python suite: **17215 passed, 13 skipped, 0 failed**
- Dashboard: **1012 passed** (56 files) including 2 new sidebar tests (advisor answer render + heuristic fallback)
- 7 new endpoint tests: run context carries the real step error, history forwarding, NO_PROVIDER/404/422/502 paths

Merging publishes 0.42.1 to PyPI via OIDC trusted publishing.