### PR TITLE
fix(docker): 0.42.2 - persist WORKFLOWS_DIR in a shared volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The official image includes the `memory` extras (mem0ai, fastembed): the
   Agent Memory page failed with "No module named 'mem0'" in Docker
   deployments.
+- Key-less rescue for explicit cloud models: hub templates hardcode models
+  like `haiku`, so on a box with no cloud keys every template step died with
+  an auth error. When the resolved provider's key is missing and a local
+  `workflow_default_model` is set, the step now runs on the local default
+  (with a warning). Steps whose provider is keyed run untouched.
 - Docker: `WORKFLOWS_DIR` is now a shared, persistent volume (`app_workflows`)
   on the `sandcastle`, `scheduler`, and `worker` services. User-created and
   generated workflows previously lived in each container's own filesystem, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.42.2] - 2026-07-21 - "Workflows That Stay"
+
+### Fixed
+- Docker: `WORKFLOWS_DIR` is now a shared, persistent volume (`app_workflows`)
+  on the `sandcastle`, `scheduler`, and `worker` services. User-created and
+  generated workflows previously lived in each container's own filesystem, so
+  they silently vanished on every rebuild - after which "Replay from Step"
+  failed with `WORKFLOW_NOT_FOUND` - and the API, worker, and scheduler could
+  each see a different copy. Existing deployments: workflows created before
+  this fix were stored inside the old containers and cannot be recovered;
+  re-save or re-generate them once, after which they persist.
+
 ## [0.42.1] - 2026-07-21 - "Assistant, Actually"
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.42.2] - 2026-07-21 - "Workflows That Stay"
 
 ### Fixed
+- Docker sandbox backend: every step failed with `[400] container rootfs is
+  marked read-only` on newer Docker daemons (verified on 29.2.1), which reject
+  `put_archive` into a `ReadonlyRootfs` container. `/home/user` is now an
+  anonymous volume: the runner upload lands on the volume while the rootfs
+  stays read-only, and `AutoRemove` cleans the volume up with the container.
+  Verified on GB10: reproduces without the volume, passes with it.
 - Docker: `WORKFLOWS_DIR` is now a shared, persistent volume (`app_workflows`)
   on the `sandcastle`, `scheduler`, and `worker` services. User-created and
   generated workflows previously lived in each container's own filesystem, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   anonymous volume: the runner upload lands on the volume while the rootfs
   stays read-only, and `AutoRemove` cleans the volume up with the container.
   Verified on GB10: reproduces without the volume, passes with it.
+- Docker sandbox backend: log streaming crashed with "object async_generator
+  can't be used in 'await' expression" on aiodocker 0.27+, where
+  `log(follow=True)` returns an async generator instead of a coroutine.
+  Both API shapes are handled now.
 - Docker: `WORKFLOWS_DIR` is now a shared, persistent volume (`app_workflows`)
   on the `sandcastle`, `scheduler`, and `worker` services. User-created and
   generated workflows previously lived in each container's own filesystem, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   can't be used in 'await' expression" on aiodocker 0.27+, where
   `log(follow=True)` returns an async generator instead of a coroutine.
   Both API shapes are handled now.
+- Sandboxed agent steps honour `workflow_default_model`: bare-default steps in
+  the docker/e2b sandbox previously picked the Claude runner even when the
+  default points at a local model, failing with "Not logged in" on boxes
+  without an Anthropic key.
+- Runner image ships `curl` (+ ca-certificates, jq). Agents had no way to
+  reach the web from bash steps at all - observed trying curl, wget, python3,
+  and apt-get in turn, then finishing with an empty result.
+- OpenAI-compatible runner: when the model ends on an empty final message, the
+  step result falls back to the last non-empty assistant text instead of
+  reporting an empty output as success.
 - Docker: `WORKFLOWS_DIR` is now a shared, persistent volume (`app_workflows`)
   on the `sandcastle`, `scheduler`, and `worker` services. User-created and
   generated workflows previously lived in each container's own filesystem, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenAI-compatible runner: when the model ends on an empty final message, the
   step result falls back to the last non-empty assistant text instead of
   reporting an empty output as success.
+- The official image includes the `memory` extras (mem0ai, fastembed): the
+  Agent Memory page failed with "No module named 'mem0'" in Docker
+  deployments.
 - Docker: `WORKFLOWS_DIR` is now a shared, persistent volume (`app_workflows`)
   on the `sandcastle`, `scheduler`, and `worker` services. User-created and
   generated workflows previously lived in each container's own filesystem, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   worker executed steps with the container env defaults regardless of what
   the user configured. Note: the worker reads them at startup; restart it
   after changing settings.
+- "Replay from Step" works for runs started from hub templates: the workflow
+  loader falls back to the template catalog (matched by the YAML's declared
+  `name:`) when the workflow is not in the user's workflows directory.
 - Docker: `WORKFLOWS_DIR` is now a shared, persistent volume (`app_workflows`)
   on the `sandcastle`, `scheduler`, and `worker` services. User-created and
   generated workflows previously lived in each container's own filesystem, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an auth error. When the resolved provider's key is missing and a local
   `workflow_default_model` is set, the step now runs on the local default
   (with a warning). Steps whose provider is keyed run untouched.
+- The arq worker restores dashboard-managed settings from the DB at startup
+  (shared `restore_db_settings`). Provider keys and `workflow_default_model`
+  saved via the dashboard previously applied only to the API process - the
+  worker executed steps with the container env defaults regardless of what
+  the user configured. Note: the worker reads them at startup; restart it
+  after changing settings.
 - Docker: `WORKFLOWS_DIR` is now a shared, persistent volume (`app_workflows`)
   on the `sandcastle`, `scheduler`, and `worker` services. User-created and
   generated workflows previously lived in each container's own filesystem, so

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,11 @@ COPY --from=dashboard-builder /dashboard/dist dashboard/dist/
 # Build a wheel and install into a virtual environment
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
-RUN pip install --no-cache-dir ".[docker]"
+# docker: aiodocker for the docker sandbox backend. memory: mem0ai + fastembed
+# for Agent Memory - the dashboard ships the Memory page, so the official image
+# must be able to back it (a missing module surfaced as "Failed to initialize
+# local Mem0 backend" at runtime).
+RUN pip install --no-cache-dir ".[docker,memory]"
 
 
 # -- Runtime stage --

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -6,6 +6,13 @@ ARG OPENAI_VERSION=6.46.0
 
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
+# Basic fetch/parse tools for agent bash steps. Without curl the sandbox has
+# no way to reach the web at all: agents were observed trying curl, wget,
+# python3, and apt-get in turn, then giving up with an empty result.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates jq \
+    && rm -rf /var/lib/apt/lists/*
+
 # Reuse the image's existing non-root `node` user (uid 1000) - creating a new
 # uid-1000 user fails because `node` already owns it. /home/user stays the
 # contract path used by backends, connectors, and templates.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Build once. Run anywhere.** Sandcastle is an open-source, production-ready orchestrator for AI agents. **Describe a workflow in plain English and it builds it** (or write the YAML yourself); run it on **any model** — Claude, GPT, Mistral, or a local model on your own box — and move between them with one line; deploy it **your way** — cloud, your own server, fully air-gapped, or EU-only; and it **gets better over time**, on its own. Local models run at `$0/run` with hard data-residency enforcement and a tamper-evident audit trail; the cloud is there too, with 7 providers and auto-failover, 25 step types, verified templates, and a full dashboard. Sovereign by default. European-built.
 
-[![PyPI](https://img.shields.io/badge/PyPI-v0.42.1-blue?style=flat-square)](https://pypi.org/project/sandcastle-ai/0.42.1/)
+[![PyPI](https://img.shields.io/badge/PyPI-v0.42.2-blue?style=flat-square)](https://pypi.org/project/sandcastle-ai/0.42.2/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![Tests](https://img.shields.io/badge/tests-17154%20passing-brightgreen?style=flat-square)](https://github.com/gizmax/Sandcastle/actions)

--- a/deploy/mcp-tunnel/memory-mcp/Chart.yaml
+++ b/deploy/mcp-tunnel/memory-mcp/Chart.yaml
@@ -3,7 +3,7 @@ name: memory-mcp
 description: Sandcastle Memory MCP server behind a Cloudflare MCP tunnel (outbound-only, no inbound ingress required)
 type: application
 version: 0.1.0
-appVersion: "0.42.1"
+appVersion: "0.42.2"
 keywords:
   - sandcastle
   - mcp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,11 @@ services:
       SCHEDULER_ENABLED: "false"
     volumes:
       - app_data:/app/data
+      # WORKFLOWS_DIR must be a shared, persistent volume: user-created workflows
+      # otherwise live in the container filesystem and silently vanish on every
+      # rebuild (breaking replay), and the API/worker/scheduler would each see a
+      # different copy.
+      - app_workflows:/app/workflows
 
   scheduler:
     <<: [*sandcastle-build, *sandcastle-env]
@@ -91,6 +96,11 @@ services:
       SCHEDULER_ENABLED: "true"
     volumes:
       - app_data:/app/data
+      # WORKFLOWS_DIR must be a shared, persistent volume: user-created workflows
+      # otherwise live in the container filesystem and silently vanish on every
+      # rebuild (breaking replay), and the API/worker/scheduler would each see a
+      # different copy.
+      - app_workflows:/app/workflows
 
   worker:
     <<: [*sandcastle-build, *sandcastle-env]
@@ -113,8 +123,14 @@ services:
       ADMIN_API_KEY: ""
     volumes:
       - app_data:/app/data
+      # WORKFLOWS_DIR must be a shared, persistent volume: user-created workflows
+      # otherwise live in the container filesystem and silently vanish on every
+      # rebuild (breaking replay), and the API/worker/scheduler would each see a
+      # different copy.
+      - app_workflows:/app/workflows
 
 volumes:
   pg_data:
   redis_data:
   app_data:
+  app_workflows:

--- a/src/sandcastle/__init__.py
+++ b/src/sandcastle/__init__.py
@@ -1,6 +1,6 @@
 """Sandcastle - Production-ready workflow orchestrator for AI agents."""
 
-__version__ = "0.42.1"
+__version__ = "0.42.2"
 
 __all__ = ["SandcastleClient", "AsyncSandcastleClient", "__version__"]
 

--- a/src/sandcastle/api/routes.py
+++ b/src/sandcastle/api/routes.py
@@ -422,7 +422,18 @@ async def _load_versioned_workflow_yaml(
                 workflow_name,
                 workflow_version,
             )
-    return _load_workflow_yaml(workflow_name)
+    try:
+        return _load_workflow_yaml(workflow_name)
+    except FileNotFoundError:
+        # Runs started from a hub template have no file in workflows_dir; the
+        # template catalog is the source of truth for them (finding: replay of
+        # template runs failed with WORKFLOW_NOT_FOUND).
+        from sandcastle.templates import find_template_yaml_by_workflow_name
+
+        template_yaml = find_template_yaml_by_workflow_name(workflow_name)
+        if template_yaml is not None:
+            return template_yaml
+        raise
 
 
 async def _resolve_workflow_request(request: WorkflowRunRequest) -> tuple[str, int | None]:

--- a/src/sandcastle/db_settings.py
+++ b/src/sandcastle/db_settings.py
@@ -1,0 +1,104 @@
+"""Restore dashboard-managed settings from the database into the runtime config.
+
+Shared by the API lifespan (main.py) and the arq worker startup: without the
+worker-side call, settings saved via PATCH /api/settings (provider API keys,
+workflow_default_model, ...) only ever applied to the API process, so workflow
+steps executed by the worker ran with the container's env defaults instead of
+what the user configured in the dashboard.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# Only restore settings that are safe to change at runtime. Security-critical
+# settings (auth, encryption, DB, Redis) must come from environment variables
+# and cannot be overridden from the DB.
+_RESTORABLE_SETTINGS = {
+    "anthropic_api_key", "e2b_api_key", "openai_api_key",
+    "mistral_api_key", "minimax_api_key", "openrouter_api_key",
+    "default_max_cost_usd", "log_level", "max_workflow_depth",
+    "workflow_default_model",
+}
+# Keys in restorable settings that may be stored encrypted
+_ENCRYPTED_RESTORABLE = {
+    "anthropic_api_key", "e2b_api_key", "openai_api_key",
+    "mistral_api_key", "minimax_api_key", "openrouter_api_key",
+}
+
+
+def _maybe_decrypt(key: str, value: str) -> str | None:
+    """Decrypt a Fernet-encrypted value; None means skip this setting."""
+    if isinstance(value, str) and value.startswith("gAAAAA"):
+        try:
+            from sandcastle.engine.crypto import decrypt_credentials
+
+            decrypted = decrypt_credentials(value)
+            if isinstance(decrypted, dict) and "v" in decrypted:
+                return decrypted["v"]
+        except Exception:
+            logger.warning("Could not decrypt saved setting '%s', skipping", key)
+            return None
+    return value
+
+
+async def restore_db_settings() -> int:
+    """Apply DB-persisted settings to the live config; returns count applied."""
+    from sqlalchemy import select as sa_select
+
+    from sandcastle.config import Settings, settings
+    from sandcastle.models.db import Setting, async_session
+
+    async with async_session() as session:
+        result = await session.execute(sa_select(Setting))
+        saved = {s.key: s.value for s in result.scalars().all()}
+
+    applied = 0
+    for key, value in saved.items():
+        if key not in _RESTORABLE_SETTINGS:
+            if hasattr(settings, key):
+                logger.debug("Skipping non-restorable saved setting '%s'", key)
+            continue
+        if not hasattr(settings, key):
+            continue
+        if key in _ENCRYPTED_RESTORABLE:
+            value = _maybe_decrypt(key, value)
+            if value is None:
+                continue
+        field_type = type(getattr(settings, key))
+        try:
+            if field_type is bool:
+                coerced: object = value.lower() in ("true", "1", "yes")
+            elif field_type is int:
+                coerced = int(value)
+            elif field_type is float:
+                coerced = float(value)
+            else:
+                coerced = value
+            # Validate through Pydantic to enforce field validators
+            validated = Settings.model_validate({**settings.model_dump(), key: coerced})
+            setattr(settings, key, getattr(validated, key))
+            applied += 1
+        except Exception as e:
+            # Never log the value - it may be an API key or secret
+            logger.warning(f"Ignoring invalid saved setting {key}=<redacted>: {e}")
+
+    if saved:
+        logger.info(f"Loaded {applied} saved settings from database")
+
+    # Restore tool credentials (TOOL_* keys) into os.environ so connectors work
+    tool_cred_count = 0
+    for key, value in saved.items():
+        if key.startswith("TOOL_") and value:
+            value = _maybe_decrypt(key, value)
+            if value is None:
+                continue
+            os.environ[key] = value
+            tool_cred_count += 1
+    if tool_cred_count:
+        logger.info(f"Restored {tool_cred_count} tool credential(s) from database")
+
+    return applied

--- a/src/sandcastle/engine/backends.py
+++ b/src/sandcastle/engine/backends.py
@@ -470,6 +470,11 @@ class DockerBackend:
                 "Env": [f"{k}={v}" for k, v in envs.items()],
                 "WorkingDir": "/home/user",
                 "User": "1000:1000",
+                # Anonymous volume: put_archive into a ReadonlyRootfs container is
+                # rejected by newer Docker daemons ("container rootfs is marked
+                # read-only"); a volume-backed /home/user stays writable while the
+                # rootfs stays read-only. AutoRemove cleans anonymous volumes up.
+                "Volumes": {"/home/user": {}},
                 "NetworkMode": "bridge",
                 "HostConfig": {
                     "AutoRemove": True,

--- a/src/sandcastle/engine/backends.py
+++ b/src/sandcastle/engine/backends.py
@@ -523,9 +523,14 @@ class DockerBackend:
             # Without this, a hanging container would block forever
             # since container.log(follow=True) never returns.
             await container.start()
-            logs = await container.log(
-                stdout=True, stderr=True, follow=True
-            )
+            # aiodocker API drift: log(follow=True) returns a coroutine resolving
+            # to a list in older releases, but an async generator directly in
+            # 0.27+ - awaiting the generator raises TypeError. Support both.
+            import inspect as _inspect
+
+            logs = container.log(stdout=True, stderr=True, follow=True)
+            if _inspect.isawaitable(logs):
+                logs = await logs
 
             deadline = time.monotonic() + timeout + 30.0  # 30s grace
             async for line in logs:

--- a/src/sandcastle/engine/providers.py
+++ b/src/sandcastle/engine/providers.py
@@ -8,12 +8,15 @@ OpenAI-compatible runner (runner-openai.mjs).
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 import threading
 import time
 from dataclasses import dataclass
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -284,6 +287,39 @@ def maybe_spark_nim_route(model_str: str) -> str:
     return settings.spark_nim_default_model or _SPARK_NIM_DEFAULT
 
 
+def runnable_model(model_str: str) -> str:
+    """Rescue a step whose resolved provider has no API key configured.
+
+    Applied AFTER :func:`effective_model`. When the resolved model needs a key
+    that is absent (e.g. a hub template's explicit ``haiku`` on a box with no
+    Anthropic key) and the user has picked a local ``workflow_default_model``,
+    the step runs on that local model instead of failing with a guaranteed
+    auth error. Steps whose provider is keyed or key-less local run untouched -
+    this never downgrades a working configuration, it only rescues a doomed one.
+    """
+    from sandcastle.config import settings
+
+    fallback = getattr(settings, "workflow_default_model", "")
+    if not (isinstance(fallback, str) and fallback) or model_str == fallback:
+        return model_str
+    try:
+        info = resolve_model(model_str)
+    except KeyError:
+        return model_str
+    if info.region == "local" or not info.api_key_env:
+        return model_str
+    if get_api_key(info):
+        return model_str
+    logger.warning(
+        "Model '%s' needs %s which is not configured - running the step on the "
+        "local default '%s' instead",
+        model_str,
+        info.api_key_env,
+        fallback,
+    )
+    return fallback
+
+
 def effective_model(model_str: str) -> str:
     """Resolve the effective model for a step: user default first, then Spark autoroute.
 
@@ -300,7 +336,9 @@ def effective_model(model_str: str) -> str:
         configured = getattr(settings, "workflow_default_model", "") or ""
         if configured:
             return configured
-    return maybe_spark_nim_route(model_str)
+    # Rescue explicit models whose provider has no key configured (hub templates
+    # hardcode cloud models; on a key-less local-first box they would all fail).
+    return runnable_model(maybe_spark_nim_route(model_str))
 
 
 def get_api_key(model_info: ModelInfo) -> str:

--- a/src/sandcastle/engine/runner-openai.mjs
+++ b/src/sandcastle/engine/runner-openai.mjs
@@ -194,6 +194,18 @@ function trackUsage(usage) {
   totalOutputTokens += usage.completion_tokens || 0;
 }
 
+
+// Final answer: the model sometimes ends on an empty message (e.g. after tool
+// flailing). Fall back to the last non-empty assistant text so the step never
+// reports an empty result when the agent actually said something along the way.
+function finalResult(messages, content) {
+  if (content) return content;
+  const prior = messages
+    .filter((m) => m.role === "assistant" && typeof m.content === "string" && m.content.trim())
+    .pop();
+  return prior ? prior.content : "";
+}
+
 function totalCost() {
   return totalInputTokens * inputPrice + totalOutputTokens * outputPrice;
 }
@@ -327,7 +339,7 @@ async function run() {
       // No tool calls - agent is done
       emit({
         type: "result",
-        result: msg.content || "",
+        result: finalResult(messages, msg.content),
         total_cost_usd: totalCost(),
         num_turns: turn,
       });
@@ -372,7 +384,7 @@ async function run() {
     if (choice.finish_reason === "stop") {
       emit({
         type: "result",
-        result: msg.content || "",
+        result: finalResult(messages, msg.content),
         total_cost_usd: totalCost(),
         num_turns: turn,
       });
@@ -384,7 +396,7 @@ async function run() {
   const lastAssistant = messages.filter((m) => m.role === "assistant").pop();
   emit({
     type: "result",
-    result: lastAssistant?.content || "",
+    result: finalResult(messages, lastAssistant?.content),
     total_cost_usd: totalCost(),
     num_turns: turn,
   });

--- a/src/sandcastle/engine/sandshore.py
+++ b/src/sandcastle/engine/sandshore.py
@@ -456,12 +456,16 @@ class SandshoreRuntime:
         Returns (envs, runner_file, use_claude_runner, tool_files).
         """
         from sandcastle.engine.providers import (
+            effective_model,
             get_api_key,
             resolve_base_url,
             resolve_model,
         )
 
-        model_str = request.get("model", "sonnet")
+        # Bare-default steps honour workflow_default_model / Spark autoroute here
+        # too - sandboxed agent steps otherwise pick the Claude runner on a box
+        # whose default is a local model, and fail without an Anthropic login.
+        model_str = effective_model(request.get("model", "sonnet"))
         try:
             model_info = resolve_model(model_str)
         except KeyError:

--- a/src/sandcastle/main.py
+++ b/src/sandcastle/main.py
@@ -323,89 +323,14 @@ async def lifespan(app: FastAPI):
             "Sandcastle starting in production mode (PostgreSQL + Redis + S3)"
         )
 
-    # Load saved settings from DB
+    # Load saved settings from DB (shared with the arq worker startup, which
+    # must see dashboard-managed settings too - see sandcastle/db_settings.py)
     from sqlalchemy import select as sa_select
 
-    from sandcastle.models.db import ApiKey, Setting, async_session
+    from sandcastle.db_settings import restore_db_settings
+    from sandcastle.models.db import ApiKey, async_session
 
-    async with async_session() as session:
-        result = await session.execute(sa_select(Setting))
-        saved = {s.key: s.value for s in result.scalars().all()}
-
-        # Only restore settings that are safe to change at runtime.
-        # Security-critical settings (auth, encryption, DB, Redis) must come
-        # from environment variables and cannot be overridden from the DB.
-        _RESTORABLE_SETTINGS = {
-            "anthropic_api_key", "e2b_api_key", "openai_api_key",
-            "mistral_api_key", "minimax_api_key", "openrouter_api_key",
-            "default_max_cost_usd", "log_level", "max_workflow_depth",
-            "workflow_default_model",
-        }
-        # Keys in restorable settings that may be stored encrypted
-        _ENCRYPTED_RESTORABLE = {
-            "anthropic_api_key", "e2b_api_key", "openai_api_key",
-            "mistral_api_key", "minimax_api_key", "openrouter_api_key",
-        }
-        for key, value in saved.items():
-            if key not in _RESTORABLE_SETTINGS:
-                if hasattr(settings, key):
-                    logger.debug(
-                        "Skipping non-restorable saved setting '%s'", key
-                    )
-                continue
-            if hasattr(settings, key):
-                # Decrypt encrypted credential values from DB
-                if key in _ENCRYPTED_RESTORABLE and isinstance(value, str) and value.startswith("gAAAAA"):
-                    try:
-                        from sandcastle.engine.crypto import decrypt_credentials
-                        decrypted = decrypt_credentials(value)
-                        if isinstance(decrypted, dict) and "v" in decrypted:
-                            value = decrypted["v"]
-                    except Exception:
-                        logger.warning("Could not decrypt saved setting '%s', skipping", key)
-                        continue
-                field_type = type(getattr(settings, key))
-                try:
-                    if field_type is bool:
-                        coerced = value.lower() in ("true", "1", "yes")
-                    elif field_type is int:
-                        coerced = int(value)
-                    elif field_type is float:
-                        coerced = float(value)
-                    else:
-                        coerced = value
-                    # Validate through Pydantic to enforce field validators
-                    validated = Settings.model_validate(
-                        {**settings.model_dump(), key: coerced}
-                    )
-                    setattr(settings, key, getattr(validated, key))
-                except Exception as e:
-                    # Never log the value - it may be an API key or secret
-                    logger.warning(
-                        f"Ignoring invalid saved setting {key}=<redacted>: {e}"
-                    )
-
-        if saved:
-            logger.info(f"Loaded {len(saved)} saved settings from database")
-
-        # Restore tool credentials (TOOL_* keys) into os.environ so connectors work
-        tool_cred_count = 0
-        for key, value in saved.items():
-            if key.startswith("TOOL_") and value:
-                # Decrypt if encrypted
-                if isinstance(value, str) and value.startswith("gAAAAA"):
-                    try:
-                        from sandcastle.engine.crypto import decrypt_credentials
-                        decrypted = decrypt_credentials(value)
-                        if isinstance(decrypted, dict) and "v" in decrypted:
-                            value = decrypted["v"]
-                    except Exception:
-                        logger.warning("Could not decrypt tool credential '%s', skipping", key)
-                        continue
-                os.environ[key] = value
-                tool_cred_count += 1
-        if tool_cred_count:
-            logger.info(f"Restored {tool_cred_count} tool credential(s) from database")
+    await restore_db_settings()
 
     failed_count, reenqueued_count = await _cleanup_orphaned_runs()
     if failed_count or reenqueued_count:

--- a/src/sandcastle/queue/worker.py
+++ b/src/sandcastle/queue/worker.py
@@ -338,6 +338,15 @@ async def _recover_stuck_runs() -> None:
 async def startup(ctx: dict) -> None:
     """Worker startup hook."""
     logger.info("Sandcastle worker starting up")
+    # Dashboard-managed settings (provider API keys, workflow_default_model, ...)
+    # live in the DB; without this the worker executed steps with env defaults
+    # regardless of what the user configured.
+    try:
+        from sandcastle.db_settings import restore_db_settings
+
+        await restore_db_settings()
+    except Exception as e:  # noqa: BLE001 - startup must not die on a bad setting
+        logger.warning("Could not restore DB settings on worker startup: %s", e)
     await _recover_stuck_runs()
 
 

--- a/src/sandcastle/templates/__init__.py
+++ b/src/sandcastle/templates/__init__.py
@@ -124,6 +124,37 @@ def list_templates() -> list[TemplateInfo]:
     return templates
 
 
+def find_template_yaml_by_workflow_name(workflow_name: str) -> str | None:
+    """Return a template's YAML whose declared workflow ``name:`` matches.
+
+    Runs started from a hub template record the workflow name declared inside
+    the YAML (e.g. ``seo-content-writer``), which need not match the template
+    file stem (``seo_content.yaml``). Replay uses this as a fallback when the
+    workflow is not in the user's workflows directory. Returns None when no
+    template declares that name.
+    """
+    import re as _re
+
+    if not workflow_name:
+        return None
+    pattern = _re.compile(
+        r"^name:\s*['\"]?" + _re.escape(workflow_name) + r"['\"]?\s*$", _re.M
+    )
+    search_dirs = [_TEMPLATES_DIR]
+    community_dir = _TEMPLATES_DIR / "community"
+    if community_dir.is_dir():
+        search_dirs.append(community_dir)
+    for dir_path in search_dirs:
+        for path in sorted([*dir_path.glob("*.yaml"), *dir_path.glob("*.yml")]):
+            try:
+                content = path.read_text()
+            except OSError:
+                continue
+            if pattern.search(content):
+                return content
+    return None
+
+
 def get_template(name: str) -> tuple[str, TemplateInfo]:
     """Get a template's raw YAML content and metadata by name.
 

--- a/tests/test_cross_cutting_audit.py
+++ b/tests/test_cross_cutting_audit.py
@@ -67,14 +67,22 @@ class TestSettingsSecurityBoundary:
             )
 
     def test_startup_restorable_settings_match_api_mutable(self):
-        """The startup DB restore allowlist must match the API mutable settings."""
-        import inspect
+        """The DB restore allowlist (shared by API lifespan and worker startup)
+        must exist and never include security-critical settings."""
+        from sandcastle import db_settings as restore_module
         from sandcastle import main as main_module
+        import inspect
 
-        source = inspect.getsource(main_module.lifespan)
-        assert "_RESTORABLE_SETTINGS" in source, (
-            "Startup must use a _RESTORABLE_SETTINGS allowlist"
-        )
+        allowlist = restore_module._RESTORABLE_SETTINGS
+        for key in ("auth_required", "webhook_secret", "database_url", "redis_url"):
+            assert key not in allowlist, (
+                f"Security-critical setting '{key}' must NOT be restorable from DB"
+            )
+        # Both processes must actually use the shared restore
+        assert "restore_db_settings" in inspect.getsource(main_module.lifespan)
+        from sandcastle.queue import worker as worker_module
+
+        assert "restore_db_settings" in inspect.getsource(worker_module.startup)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_db_settings_restore.py
+++ b/tests/test_db_settings_restore.py
@@ -1,0 +1,44 @@
+"""restore_db_settings is shared by the API lifespan and the arq worker startup.
+
+Without the worker-side call, dashboard-managed settings (provider keys,
+workflow_default_model) never reached the process that actually executes steps.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sandcastle.config import settings
+from sandcastle.db_settings import restore_db_settings
+from sandcastle.models.db import Setting, async_session
+
+
+async def _seed(key: str, value: str) -> None:
+    async with async_session() as session:
+        await session.merge(Setting(key=key, value=value))
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_restores_workflow_default_model(monkeypatch):
+    monkeypatch.setattr(settings, "workflow_default_model", "")
+    await _seed("workflow_default_model", "nim/ornith")
+    applied = await restore_db_settings()
+    assert applied >= 1
+    assert settings.workflow_default_model == "nim/ornith"
+
+
+@pytest.mark.asyncio
+async def test_non_restorable_keys_skipped(monkeypatch):
+    before = settings.auth_required
+    await _seed("auth_required", "true" if not before else "false")
+    await restore_db_settings()
+    assert settings.auth_required == before
+
+
+@pytest.mark.asyncio
+async def test_invalid_value_ignored(monkeypatch):
+    before = settings.max_workflow_depth
+    await _seed("max_workflow_depth", "not-a-number")
+    await restore_db_settings()
+    assert settings.max_workflow_depth == before

--- a/tests/test_db_settings_restore.py
+++ b/tests/test_db_settings_restore.py
@@ -42,3 +42,35 @@ async def test_invalid_value_ignored(monkeypatch):
     await _seed("max_workflow_depth", "not-a-number")
     await restore_db_settings()
     assert settings.max_workflow_depth == before
+
+
+class TestTemplateReplayFallback:
+    """Replay of runs started from hub templates loads YAML from the catalog."""
+
+    def test_find_template_by_declared_name(self):
+        from sandcastle.templates import find_template_yaml_by_workflow_name
+
+        yaml_content = find_template_yaml_by_workflow_name("seo-content-writer")
+        assert yaml_content is not None
+        assert "name: seo-content-writer" in yaml_content
+
+    def test_unknown_name_returns_none(self):
+        from sandcastle.templates import find_template_yaml_by_workflow_name
+
+        assert find_template_yaml_by_workflow_name("no-such-workflow-xyz") is None
+
+    @pytest.mark.asyncio
+    async def test_versioned_loader_falls_back_to_template(self, monkeypatch, tmp_path):
+        from sandcastle.api.routes import _load_versioned_workflow_yaml
+
+        monkeypatch.setattr(settings, "workflows_dir", str(tmp_path))  # empty dir
+        yaml_content = await _load_versioned_workflow_yaml("seo-content-writer", None)
+        assert "name: seo-content-writer" in yaml_content
+
+    @pytest.mark.asyncio
+    async def test_versioned_loader_still_raises_for_unknown(self, monkeypatch, tmp_path):
+        from sandcastle.api.routes import _load_versioned_workflow_yaml
+
+        monkeypatch.setattr(settings, "workflows_dir", str(tmp_path))
+        with pytest.raises(FileNotFoundError):
+            await _load_versioned_workflow_yaml("no-such-workflow-xyz", None)

--- a/tests/test_local_provider_discovery.py
+++ b/tests/test_local_provider_discovery.py
@@ -129,9 +129,12 @@ class TestWorkflowDefaultModel:
         assert effective_model("sonnet") == "nim/ornith"
 
     def test_effective_model_respects_explicit(self, monkeypatch):
+        """Explicit models with a configured key are never rewritten."""
         from sandcastle.engine.providers import effective_model
 
         monkeypatch.setattr(settings, "workflow_default_model", "nim/ornith")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
         assert effective_model("opus") == "opus"
         assert effective_model("mistral/large") == "mistral/large"
 
@@ -265,3 +268,40 @@ class TestAdvisorProviderResolution:
         cfg = _get_advisor_config()
         assert cfg["model"] == "ornith"
         assert cfg["api_url"] == "http://host.docker.internal:18000/v1/chat/completions"
+
+
+class TestRunnableModelRescue:
+    """0.42.2: explicit cloud models without a key fall back to the local default."""
+
+    def test_unkeyed_explicit_model_rescued(self, monkeypatch):
+        from sandcastle.engine.providers import effective_model
+
+        monkeypatch.setattr(settings, "workflow_default_model", "nim/ornith")
+        monkeypatch.setattr(settings, "anthropic_api_key", "")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("SANDCASTLE_SPARK_MODE", "off")
+        assert effective_model("haiku") == "nim/ornith"
+
+    def test_keyed_explicit_model_untouched(self, monkeypatch):
+        from sandcastle.engine.providers import effective_model
+
+        monkeypatch.setattr(settings, "workflow_default_model", "nim/ornith")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("SANDCASTLE_SPARK_MODE", "off")
+        assert effective_model("haiku") == "haiku"
+
+    def test_local_models_never_rescued(self, monkeypatch):
+        from sandcastle.engine.providers import effective_model
+
+        monkeypatch.setattr(settings, "workflow_default_model", "nim/ornith")
+        monkeypatch.setenv("SANDCASTLE_SPARK_MODE", "off")
+        assert effective_model("ollama/qwen3:8b") == "ollama/qwen3:8b"
+
+    def test_no_default_no_rescue(self, monkeypatch):
+        from sandcastle.engine.providers import effective_model
+
+        monkeypatch.setattr(settings, "workflow_default_model", "")
+        monkeypatch.setattr(settings, "anthropic_api_key", "")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("SANDCASTLE_SPARK_MODE", "off")
+        assert effective_model("haiku") == "haiku"

--- a/tests/test_sandbox_security.py
+++ b/tests/test_sandbox_security.py
@@ -265,6 +265,10 @@ class TestDockerBackendHardening:
         assert host_config.get("ReadonlyRootfs") is True
         assert host_config.get("MemorySwap") == host_config.get("Memory")
         assert "/tmp" in host_config.get("Tmpfs", {})
+        # put_archive into a ReadonlyRootfs container is rejected by newer Docker
+        # daemons unless the target path is volume-backed; /home/user must be an
+        # anonymous volume or every step fails with "rootfs is marked read-only".
+        assert "/home/user" in captured_config.get("Volumes", {})
 
     @pytest.mark.asyncio
     async def test_docker_config_has_no_new_privileges(self, tmp_path):


### PR DESCRIPTION
## 0.42.2 - "Workflows That Stay"

Finding #8 from the GB10 deployment: `WORKFLOWS_DIR=/app/workflows` had no volume behind it.

**Impact:** user-created and generated workflows lived in each container's own filesystem, so every rebuild silently wiped them - after which "Replay from Step" fails with `WORKFLOW_NOT_FOUND` - and the API, worker, and scheduler each saw a different copy of the directory.

**Fix:** new `app_workflows` volume shared by `sandcastle`, `scheduler`, and `worker`, matching the existing `app_data` pattern. One-line note for existing deployments in the CHANGELOG (workflows created before the fix were stored in old containers and cannot be recovered; re-save once and they persist).

### Verification
- Merged compose config valid on the GB10 host; worker mounts now show `/app/data /app/workflows /var/run/docker.sock`
- Helm chart tests 11/11 (appVersion 0.42.2)

Merging publishes 0.42.2 to PyPI via OIDC trusted publishing.