### PR TITLE
chore(lint): unblock 0.42.2 publish - unused imports in main.py

### DIFF
--- a/src/sandcastle/main.py
+++ b/src/sandcastle/main.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -23,7 +22,7 @@ from sandcastle.api.environments_admin import router as environments_admin_route
 from sandcastle.api.mesh import router as mesh_router
 from sandcastle.api.routes import router
 from sandcastle.api.security_headers import security_headers_middleware
-from sandcastle.config import Settings, settings, validate_server_bind
+from sandcastle.config import settings, validate_server_bind
 
 # Configure logging
 logging.basicConfig(


### PR DESCRIPTION
The publish workflow's lint gate failed on F401/F811 left by the db_settings.py refactor (#282), blocking the 0.42.2 PyPI publish. `ruff check src/` is clean after this. Merging re-triggers publish; 0.42.2 is not yet on PyPI so the version check will let it through.