### PR TITLE
fix(lint): restore os import lost in squash merge - unblocks 0.43.0 publish

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -77,6 +77,9 @@ jobs:
               print(f"{name}: {', '.join(sorted(services))}")
           PY
 
+      - name: Lint (same gate as publish.yml - keep them in sync)
+        run: ruff check src/
+
       - name: Run pytest
         run: |
           python -m pytest tests/ -q --tb=line --timeout=60

--- a/src/sandcastle/main.py
+++ b/src/sandcastle/main.py
@@ -42,6 +42,7 @@ async def _validate_providers() -> None:
     providers but never blocks startup - this is informational only.
     """
     import asyncio
+    import os
     import time
 
     import httpx


### PR DESCRIPTION
F821 in _validate_providers blocked the publish lint gate. One line; ruff clean; targeted tests pass. This is the second publish blocked by the lint gate existing only in publish.yml - finding #18 (add lint to PR CI) is now urgent.